### PR TITLE
Add Linux build support.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,9 @@ ATESTS = \
 XBUILD = xbuild $(if $(V),/v:diag,)
 NUNIT_CONSOLE = packages/NUnit.Runners.2.6.3/tools/nunit-console.exe
 
-all: bin/Build$(CONFIGURATION)/JdkInfo.props src/Java.Runtime.Environment/Java.Runtime.Environment.dll.config \
+BUILD_PROPS = bin/Build$(CONFIGURATION)/JdkInfo.props bin/Build$(CONFIGURATION)/MonoInfo.props
+
+all: $(BUILD_PROPS)  src/Java.Runtime.Environment/Java.Runtime.Environment.dll.config \
 		$(PACKAGES) $(DEPENDENCIES) $(TESTS) $(XA_INTEGRATION_OUTPUTS)
 
 xa-all: $(XA_INTEGRATION_OUTPUTS)
@@ -56,6 +58,7 @@ clean:
 	-rm src/Java.Runtime.Environment/Java.Runtime.Environment.dll.config
 
 include build-tools/scripts/jdk.mk
+include build-tools/scripts/mono.mk
 
 $(PACKAGES) $(NUNIT_CONSOLE):
 	nuget restore

--- a/build-tools/scripts/mono.mk
+++ b/build-tools/scripts/mono.mk
@@ -1,0 +1,32 @@
+
+ifeq ($(OS),Darwin)
+JI_MONO_FRAMEWORK_PATH = /Library/Frameworks/Mono.framework/monosgen-2.0.1.dylib
+JI_MONO_INCLUDE_PATHS = /Library/Frameworks/Mono.framework/Headers/mono-2.0
+JI_MONO_LIBS = -L /Library/Frameworks/Mono.framework/Libraries -lmonosgen-2.0
+endif
+ifeq ($(OS),Linux)
+JI_MONO_FRAMEWORK_PATH = $(shell pkg-config --variable=libdir mono-2)/libmonosgen-2.0.so
+JI_MONO_INCLUDE_PATHS = $(shell pkg-config --variable=includedir mono-2)
+JI_MONO_LIBS = -L $(shell pkg-config --variable=libdir mono-2) -lmonosgen-2.0
+endif
+
+
+
+$(JI_MONO_FRAMEWORK_PATH):
+	@echo "error: No Mono framework found\!";
+	@exit 1
+
+bin/Build$(CONFIGURATION)/MonoInfo.props: $(JI_MONO_INCLUDE_PATHS) $(JI_MONO_FRAMEWORK_PATH)
+	-mkdir -p `dirname "$@"`
+	-rm "$@"
+	echo '<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">' > "$@"
+	echo '  <PropertyGroup>' >> "$@"
+	echo "    <MonoFrameworkPath>$(JI_MONO_FRAMEWORK_PATH)</MonoFrameworkPath>" >> "$@"
+	echo '    <MonoLibs>$(JI_MONO_LIBS)</MonoLibs>'
+	echo '  </PropertyGroup>' >> "$@"
+	echo '  <ItemGroup>' >> "$@"
+	for p in $(JI_MONO_INCLUDE_PATHS); do \
+		echo "    <MonoIncludePath Include=\"$$p\" />" >> "$@"; \
+	done
+	echo '  </ItemGroup>' >> "$@"
+	echo '</Project>' >> "$@"

--- a/src/java-interop/java-interop.mdproj
+++ b/src/java-interop/java-interop.mdproj
@@ -7,11 +7,6 @@
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{BB0AB9F7-0979-41A7-B7A9-877260655F94}</ProjectGuid>
-    <Includes>
-      <Includes>
-        <Include>/Library/Frameworks/Mono.framework/Headers/mono-2.0</Include>
-      </Includes>
-    </Includes>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -32,6 +27,7 @@
     <SourceDirectory>.</SourceDirectory>
   </PropertyGroup>
   <Import Project="$(JNIEnvGenPath)\JdkInfo.props" Condition="Exists('$(JNIEnvGenPath)\JdkInfo.props')" />
+  <Import Project="$(JNIEnvGenPath)\MonoInfo.props" Condition="Exists('$(JNIEnvGenPath)\MonoInfo.props')" />
   <ItemGroup>
     <None Include="java-interop.h" />
     <None Include="java-interop-gc-bridge.h" />
@@ -51,13 +47,11 @@
       <Arch>-m64</Arch>
     </MacLibLipo>
   </ItemGroup>
-  <ItemGroup>
-    <Include Include="\Library\Frameworks\Mono.framework\Headers\mono-2.0" />
-  </ItemGroup>
   <PropertyGroup>
     <BuildDependsOn>
       BuildJni_c;
       BuildMac;
+      BuildUnixLibraries;
       $(BuildDependsOn)
     </BuildDependsOn>
   </PropertyGroup>
@@ -72,7 +66,7 @@
     <Exec Command="$(Runtime) &quot;$(JNIEnvGenPath)\jnienv-gen.exe&quot; jni.g.cs jni.c" />
   </Target>
   <Target Name="BuildMac"
-      Condition=" '$(OS)' != 'Windows_NT' "
+      Condition=" '$(OS)' != 'Windows_NT' And Exists ('/Library/Frameworks/')"
       DependsOnTargets="BuildMacLibraries"
       Inputs="@(MacLibLipo)"
       Outputs="$(OutputPath)\lib$(OutputName).dylib">
@@ -83,7 +77,7 @@
     <Exec Command="lipo $(_Files) -create -output $(OutputPath)\lib$(OutputName).dylib" />
   </Target>
   <Target Name="BuildMacLibraries"
-      Condition=" '$(OS)' != 'Windows_NT' "
+      Condition=" '$(OS)' != 'Windows_NT' And Exists ('/Library/Frameworks/')"
       Inputs="@(Compile)"
       Outputs="@(MacLibLipo)">
     <PropertyGroup>
@@ -94,15 +88,35 @@
     </ItemGroup>
     <PropertyGroup>
       <_CppFlags>@(_Defines -&gt; '-D%(Identity)', ' ')</_CppFlags>
-      <_Includes>@(Include-&gt;'-I %(Identity)', ' ') @(JdkIncludePath-&gt;'-I %(Identity)', ' ')</_Includes>
+      <_Includes>@(MonoIncludePath-&gt;'-I %(Identity)', ' ') @(JdkIncludePath-&gt;'-I %(Identity)', ' ')</_Includes>
       <_LinkFlags>-fvisibility=hidden -Wl,-undefined -Wl,suppress -Wl,-flat_namespace</_LinkFlags>
-      <_Libs>-L /Library/Frameworks/Mono.framework/Libraries -lmonosgen-2.0 </_Libs>
+      <_Libs>$(MonoLibs)</_Libs>
       <_Files>@(Compile -&gt; '%(Identity)', ' ')</_Files>
     </PropertyGroup>
     <MakeDir Directories="obj" />
     <Exec Command="gcc -g -shared -o &quot;%(MacLibLipo.Identity)&quot; %(MacLibLipo.Arch) $(_CppFlags) $(_LinkFlags) $(_Libs) $(_Includes) $(_Files)" />
     <!-- Mono 4.4.0 (mono-4.4.0-branch/a3fabf1) has an incorrect shared library name. Fix it -->
     <Exec Command="install_name_tool -change /private/tmp/source-mono-4.4.0/bockbuild-mono-4.4.0-branch/profiles/mono-mac-xamarin/package-root/lib/libmonosgen-2.0.1.dylib /Library/Frameworks/Mono.framework/Libraries/libmonosgen-2.0.1.dylib &quot;%(MacLibLipo.Identity)&quot;" />
+  </Target>
+  <Target Name="BuildUnixLibraries"
+      Condition=" '$(OS)' != 'Windows_NT' And !Exists ('/Library/Frameworks/')"
+      Inputs="@(Compile)"
+      Outputs="$(OutputPath)\lib$(OutputName).so">
+    <PropertyGroup>
+      <_FixedDefines>$(DefineSymbols.Replace(' ', ';'))</_FixedDefines>
+    </PropertyGroup>
+    <ItemGroup>
+      <_Defines Include="$(_FixedDefines)" />
+    </ItemGroup>
+    <PropertyGroup>
+      <_CppFlags>@(_Defines -&gt; '-D%(Identity)', ' ')</_CppFlags>
+      <_Includes>@(MonoIncludePath-&gt;'-I %(Identity)', ' ') @(JdkIncludePath-&gt;'-I %(Identity)', ' ')</_Includes>
+      <_LinkFlags>-fvisibility=hidden -Wl,-undefined -Wl,suppress -Wl,-flat_namespace -fPIC</_LinkFlags>
+      <_Libs>$(MonoLibs)</_Libs>
+      <_Files>@(Compile -&gt; '%(Identity)', ' ')</_Files>
+    </PropertyGroup>
+    <MakeDir Directories="obj" />
+    <Exec Command="gcc -g -shared -std=c99 -o $(OutputPath)\lib$(OutputName).so $(_CppFlags) $(_LinkFlags) $(_Libs) $(_Includes) $(_Files)" />
   </Target>
   <Target Name="Clean">
     <RemoveDir Directories="obj" />


### PR DESCRIPTION
Now there is MonoInfo.props which is similar to JdkInfo.props.

OSX detection is as hacky as xamarin-android so far.

Recreating PR due to fork management failure at github after open-sourcing.