### PR TITLE
[Xamarin.Android.Tools.Bytecode-Tests] Copy nunit.framework to $(OutputPath)

### DIFF
--- a/src/Xamarin.Android.Tools.Bytecode/Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj
@@ -35,7 +35,6 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="nunit.framework">
       <HintPath>..\..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
-      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Copy `nunit.framework.dll` to `$(OutputPath)` for
`Xamarin.Android.Tools.Bytecode-Tests` so `nunit.framework.dll` can be
found when running "out of tree" `nunit-console.exe` invocations:

	$ ANDROID_SDK_PATH=... mono \
		path/to/Java.Interop/packages/NUnit.Runners.2.6.3/tools/nunit-console.exe \
		path/to/Java.Interop/bin/TestDebug/Xamarin.Android.Tools.Bytecode-Tests.dll
	Can't find custom attr constructor image: path/to/Java.Interop/bin/TestDebug/Xamarin.Android.Tools.Bytecode-Tests.dll mtoken: 0x0a000017

...which makes me sad. :-(

Remove the `%(Reference.Private)` metadata so that `nunit.framework.dll`
is copied to `$(OutputPath)`, fixing the above error.