### PR TITLE
[Xamarin.Android.Tools.bytecode] Add JavaDoc importing

### DIFF
--- a/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
@@ -11,11 +11,20 @@ using System.Text;
 
 namespace Xamarin.Android.Tools.Bytecode {
 
+	public enum JavaDocletType {
+		DroidDoc,
+		Java6,
+		Java7,
+		Java8,
+	}
+
 	public class ClassPath {
 
 		IList<ClassFile> classFiles = new List<ClassFile> ();
 
 		public string ApiSource { get; set; }
+
+		public JavaDocletType DocletType { get; set; }
 
 		public IEnumerable<string> DocumentationPaths { get; set; }
 
@@ -213,9 +222,19 @@ namespace Xamarin.Android.Tools.Bytecode {
 			}
 		}
 
+		AndroidDocScraper CreateDocScraper (string dir)
+		{
+			switch (DocletType) {
+			default: return new DroidDocScraper (dir);
+			case JavaDocletType.Java6: return new JavaDocScraper (dir);
+			case JavaDocletType.Java7: return new Java7DocScraper (dir);
+			case JavaDocletType.Java8: return new Java8DocScraper (dir);
+			}
+		}
+
 		void FixupParametersFromDocs (XElement api, string path)
 		{
-			var jdoc = new DroidDocScraper (path);
+			var jdoc = CreateDocScraper (path);
 			var elements = api.XPathSelectElements ("./package/class[@visibility = 'public' or @visibility = 'protected']").ToList ();
 			elements.AddRange (api.XPathSelectElements ("./package/interface[@visibility = 'public' or @visibility = 'protected']"));
 			foreach (var elem in elements) {


### PR DESCRIPTION
Import class-parse changes from monodroid/a438c473.

Add `class-parse --docstype=TYPE` option, to control the *type* of the
HTML Javadocs provided via `class-parse --docspath`.

This allows using a Java 6, Java 7, or Java 8 documentation scraper
instead of an Android documentation scraper.