### PR TITLE
[Java.Interop.Tools.JavaCallableWrappers] Fix android.app.Application

### DIFF
--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
@@ -543,8 +543,13 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 
 		void GenerateBody (StreamWriter sw)
 		{
-			foreach (Signature ctor in ctors)
+			foreach (Signature ctor in ctors) {
+				if (string.IsNullOrEmpty (ctor.Params) && JniType.IsApplication (type))
+					continue;
 				GenerateConstructor (ctor, sw);
+			}
+
+			GenerateApplicationConstructor (sw);
 
 			foreach (JavaFieldInfo field in exported_fields)
 				GenerateExportedField (field, sw);
@@ -752,6 +757,19 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 				sw.WriteLine ("\t\tif (getClass () == {0}.class)", name);
 				sw.WriteLine ("\t\t\tmono.android.TypeManager.Activate (\"{0}\", \"{1}\", this, new java.lang.Object[] {{ {2} }});", type.GetAssemblyQualifiedName (), ctor.ManagedParameters, ctor.ActivateCall);
 			}
+			sw.WriteLine ("\t}");
+		}
+
+		void GenerateApplicationConstructor (StreamWriter sw)
+		{
+			if (!JniType.IsApplication (type)) {
+				return;
+			}
+
+			sw.WriteLine ();
+			sw.WriteLine ("\tpublic {0} ()", name);
+			sw.WriteLine ("\t{");
+			sw.WriteLine ("\t\tmono.MonoPackageManager.setContext (this);");
 			sw.WriteLine ("\t}");
 		}
 


### PR DESCRIPTION
android.app.Application is special: Android contructs it before the
mono runtime has been initialized, requiring that the
[activation constructor][0] be used for all Android.App.Application
subclasses:

	[Application]
	partial class MyApp : Android.App.Application {
		public MyApp (IntPtr r, JniHandleOwnership transfer)
			: base (r, transfer)
		{
		}
	}

As a consequence of this, the Android.App.Application..ctor() default
constructor *is never used in normal use*, which means that the linker
is free to remove it.

This in turn means that in Release (linked) apps, *no* constructor
would be present in the `MyApp` Java Callable Wrappers, because
constructor generation requires that the binding assembly contain the
constructor to emit.

This is kinda/sorta fine, in that the Java compiler-provided default
constructor would still be emitted, allowing the `MyApp`
Java Callable Wrapper to be constructed, but that's only true so long
as the default constructor is sufficient.

Unfortunately, the default constructor isn't always sufficient: on
certain Android versions (API <= 15), the Application instance isn't
provided to the bootstrap `MonoRuntimeProvider.attachInfo()` method,
which means that the Android.App.Application.Context property returns
the wrong value.

Fixing this requires updating the Java Callable Wrapper of the
Application subclass to contain code to preserve the first Application
instance created in the process, which in turn means the default
Application constructor is no longer sufficient.

Update JavaCallableWrapperGenerator so that (in Debug builds) the
default Application constructor is skipped, and in *all*
configurations a custom constructor is generated within the
Java Callable Wrapper for android.app.Application subclasses.

[0]: https://developer.xamarin.com/guides/android/under_the_hood/architecture/#Java_Activation