### PR TITLE
[logcat-parse] Support repeated handles.

### DIFF
--- a/tools/logcat-parse/PeerInfo.cs
+++ b/tools/logcat-parse/PeerInfo.cs
@@ -146,6 +146,10 @@ namespace Xamarin.Android.Tools.LogcatParse {
 			set {state |= PeerInfoState.Finalized;}
 		}
 
+		public bool Alive {
+			get {return state == PeerInfoState.Alive;}
+		}
+
 		public string                       JniType     {get; internal set;}
 		public string                       McwType     {get; internal set;}
 

--- a/tools/logcat-parse/Tests/GrefsTest.cs
+++ b/tools/logcat-parse/Tests/GrefsTest.cs
@@ -398,6 +398,56 @@ namespace Xamarin.Android.Tools.LogcatParse.Tests {
 					peer.GetStackTraceForHandle ("0x100492/G"));
 			}
 		}
+
+		[Test]
+		public void RepeatedThreadHandles ()
+		{
+			using (var source = new StreamReader (Assembly.GetExecutingAssembly ().GetManifestResourceStream ("stdio-repeated-handles"))) {
+				var info = Grefs.Parse (source, options: GrefParseOptions.ThrowOnCountMismatch);
+				Assert.AreEqual (2, info.AllocatedPeers.Count);
+				Assert.AreEqual (1, info.AlivePeers.Count ());
+				Assert.AreEqual (1, info.GrefCount);
+				Assert.AreEqual (0, info.WeakGrefCount);
+
+				var peer = info.AllocatedPeers [0];
+				Assert.IsTrue (peer.Collected);
+				Assert.IsTrue (peer.Disposed);
+				Assert.IsFalse (peer.Finalized);
+				Assert.AreEqual ("java/lang/String", peer.JniType);
+				Assert.AreEqual ("Java.Lang.String", peer.McwType);
+
+				Assert.AreEqual ("'(null)'(3)", peer.CreatedOnThread);
+				Assert.AreEqual ("'(null)'(3)", peer.DestroyedOnThread);
+
+				Assert.AreEqual ("0x41e29778", peer.KeyHandle);
+				Assert.AreEqual (2, peer.Handles.Count);
+				Assert.IsTrue (peer.Handles.Contains ("0x4a00009/L"));
+				Assert.IsTrue (peer.Handles.Contains ("0x19004aa/G"));
+
+				Assert.AreEqual (
+					"  at Doesn't Matter",
+					peer.GetStackTraceForHandle ("0x19004aa/G"));
+
+				peer = info.AllocatedPeers [1];
+				Assert.IsFalse (peer.Collected);
+				Assert.IsFalse (peer.Disposed);
+				Assert.IsFalse (peer.Finalized);
+				Assert.AreEqual ("java/lang/String", peer.JniType);
+				Assert.AreEqual ("Java.Lang.String", peer.McwType);
+
+				Assert.AreEqual ("'(null)'(3)", peer.CreatedOnThread);
+				Assert.AreEqual (null,          peer.DestroyedOnThread);
+
+				Assert.AreEqual ("0x41e29778", peer.KeyHandle);
+				Assert.AreEqual (2, peer.Handles.Count);
+				Assert.IsTrue (peer.Handles.Contains ("0x4a00009/L"));
+				Assert.IsTrue (peer.Handles.Contains ("0x19004aa/G"));
+
+				Assert.AreEqual (
+					"  at Doesn't Matter",
+					peer.GetStackTraceForHandle ("0x19004aa/G"));
+			}
+		}
 	}
 }
 

--- a/tools/logcat-parse/Tests/LogcatParse-Tests.csproj
+++ b/tools/logcat-parse/Tests/LogcatParse-Tests.csproj
@@ -84,5 +84,8 @@
     <EmbeddedResource Include="Resources\stdio-Finalized-threads.txt">
       <LogicalName>stdio-Finalized-threads</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="Resources\stdio-repeated-handles.txt">
+      <LogicalName>stdio-repeated-handles</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/tools/logcat-parse/Tests/Resources/stdio-repeated-handles.txt
+++ b/tools/logcat-parse/Tests/Resources/stdio-repeated-handles.txt
@@ -1,0 +1,9 @@
+﻿+g+ grefc 1 gwrefc 0 obj-handle 0x4a00009/L -> new-handle 0x19004aa/G from thread '(null)'(3)
+  at Doesn't Matter
+handle 0x19004aa; key_handle 0x41e29778: Java Type: `java/lang/String`; MCW type: `Java.Lang.String`
+Disposing handle 0x19004aa
+-g- grefc 0 gwrefc 0 handle 0x19004aa/G from thread '(null)'(3)
+  at Doesn't Matter
++g+ grefc 1 gwrefc 0 obj-handle 0x4a00009/L -> new-handle 0x19004aa/G from thread '(null)'(3)
+  at Doesn't Matter
+handle 0x19004aa; key_handle 0x41e29778: Java Type: `java/lang/String`; MCW type: `Java.Lang.String`


### PR DESCRIPTION
I've come across some log files which would contain *several thousand*
global references, as per the `grefc` values, but when processing via
logcat-parse `grefs.AlivePeers.Count()` would invariably return `11`,
or some other ludicrously low value given the input.

On further investigation, a problem is with repeated handle values.
Once a handle has been disposed, there's no reason why it couldn't be
reused again:

	+g+ grefc 1 gwrefc 0 obj-handle 0x4a00009/L -> new-handle 0x19004aa/G from thread '(null)'(3)
	-g- grefc 0 gwrefc 0 handle 0x19004aa/G from thread '(null)'(3)
	# OK, created + destroyed an instance...

	+g+ grefc 1 gwrefc 0 obj-handle 0x4a00009/L -> new-handle 0x19004aa/G from thread '(null)'(3)
	# OK, created a *different* instance

Unfortunately, `logcat-parse` would treat the second +g+ as if it were
an alias of the originally created instance. As such,
`grefs.AlivePeers.Count()` would return 0, not 1, which is wrong.

To better support this, keep a separate `alive` list of peers, and
only consult the "alive" list when performing handle lookups. This
prevents the original -- dead! -- PeerInfo from being reused, allowing
us to have (more?) accurate peer information.