### PR TITLE
[generator] Qualify Java.Lang.Object.Handle references

### DIFF
--- a/tools/generator/ArraySymbol.cs
+++ b/tools/generator/ArraySymbol.cs
@@ -64,6 +64,11 @@ namespace MonoDroid.Generation {
 			get { return true; }
 		}
 
+		public string GetObjectHandleProperty (string variable)
+		{
+			return sym.GetObjectHandleProperty (variable);
+		}
+
 		public string GetGenericType (Dictionary<string, string> mappings)
 		{
 			return null;

--- a/tools/generator/CharSequenceSymbol.cs
+++ b/tools/generator/CharSequenceSymbol.cs
@@ -41,6 +41,11 @@ namespace MonoDroid.Generation {
 			get { return null; }
 		}
 
+		public string GetObjectHandleProperty (string variable)
+		{
+			return $"((global::Java.Lang.Object) {variable}).Handle";
+		}
+
 		public string GetGenericType (Dictionary<string, string> mappings)
 		{
 			return null;

--- a/tools/generator/ClassGen.cs
+++ b/tools/generator/ClassGen.cs
@@ -371,6 +371,7 @@ namespace MonoDroid.Generation {
 
 		public override void Generate (StreamWriter sw, string indent, CodeGenerationOptions opt, GenerationInfo gen_info)
 		{
+			opt.ContextTypes.Push (this);
 			gen_info.TypeRegistrations.Add (new KeyValuePair<string, string>(RawJniName, AssemblyQualifiedName));
 			bool is_enum = base_symbol != null && base_symbol.FullName == "Java.Lang.Enum";
 			if (is_enum)
@@ -497,6 +498,7 @@ namespace MonoDroid.Generation {
 				sw.WriteLine ();
 				GenerateInvoker (sw, indent, opt);
 			}
+			opt.ContextTypes.Pop ();
 		}
 
 		class InterfaceExtensionInfo {

--- a/tools/generator/CollectionSymbol.cs
+++ b/tools/generator/CollectionSymbol.cs
@@ -52,6 +52,11 @@ namespace MonoDroid.Generation {
 			get { return null; }
 		}
 
+		public string GetObjectHandleProperty (string variable)
+		{
+			return $"((global::Java.Lang.Object) {variable}).Handle";
+		}
+
 		public string GetGenericType (Dictionary<string, string> mappings)
 		{
 			return null;

--- a/tools/generator/EnumSymbol.cs
+++ b/tools/generator/EnumSymbol.cs
@@ -46,6 +46,11 @@ namespace MonoDroid.Generation {
 			get { return null; }
 		}
 
+		public string GetObjectHandleProperty (string variable)
+		{
+			return null;
+		}
+
 		public string GetGenericType (Dictionary<string, string> mappings)
 		{
 			return null;

--- a/tools/generator/FormatSymbol.cs
+++ b/tools/generator/FormatSymbol.cs
@@ -61,6 +61,11 @@ namespace MonoDroid.Generation {
 			get { return null; }
 		}
 
+		public string GetObjectHandleProperty (string variable)
+		{
+			return null;
+		}
+
 		public string GetGenericType (Dictionary<string, string> mappings)
 		{
 			return null;

--- a/tools/generator/GenBase.cs
+++ b/tools/generator/GenBase.cs
@@ -175,6 +175,15 @@ namespace MonoDroid.Generation {
 			}
 		}
 
+		public string GetObjectHandleProperty (string variable)
+		{
+			var handleType  = "Java.Lang.Object";
+			if (FullName == "Java.Lang.Throwable" || Ancestors ().Any (a => a.FullName == "Java.Lang.Throwable"))
+				handleType  = "Java.Lang.Throwable";
+
+			return $"((global::{handleType}) {variable}).Handle";
+		}
+
 		protected IEnumerable<InterfaceGen> GetAllImplementedInterfaces ()
 		{
 			var set = new HashSet<InterfaceGen> ();

--- a/tools/generator/GeneratedEnumSymbol.cs
+++ b/tools/generator/GeneratedEnumSymbol.cs
@@ -77,6 +77,11 @@ namespace MonoDroid.Generation
 			get { return enum_type; }
 		}
 
+		public string GetObjectHandleProperty (string variable)
+		{
+			return null;
+		}
+
 		public string[] PreCallback (CodeGenerationOptions opt, string var_name, bool owned)
 		{
 			throw new NotSupportedException (string.Format ("{0} does not support PreCallback", this.GetType ().Name));

--- a/tools/generator/GenericSymbol.cs
+++ b/tools/generator/GenericSymbol.cs
@@ -63,6 +63,11 @@ namespace MonoDroid.Generation {
 			get { return type_params; }
 		}
 
+		public string GetObjectHandleProperty (string variable)
+		{
+			return gen.GetObjectHandleProperty (variable);
+		}
+
 		string MapTypeParams (Dictionary<string, string> mappings)
 		{
 			StringBuilder sb = new StringBuilder ();

--- a/tools/generator/GenericTypeParameter.cs
+++ b/tools/generator/GenericTypeParameter.cs
@@ -63,6 +63,11 @@ namespace MonoDroid.Generation {
 			get { return null; }
 		}
 
+		public string GetObjectHandleProperty (string variable)
+		{
+			return null;
+		}
+
 		public string FromNative (CodeGenerationOptions opt, string varname, bool owned)
 		{
 			return String.Format ("({0}) global::Java.Lang.Object.GetObject<{3}> ({1}, {2})", type, varname, owned ? "JniHandleOwnership.TransferLocalRef" : "JniHandleOwnership.DoNotTransfer", opt.GetOutputName (FullName));

--- a/tools/generator/ISymbol.cs
+++ b/tools/generator/ISymbol.cs
@@ -14,6 +14,8 @@ namespace MonoDroid.Generation {
 		bool   IsArray { get; }
 		string ElementType { get; }
 
+		string GetObjectHandleProperty (string variable);
+
 		string GetGenericType (Dictionary<string, string> mappings);
 
 		string FromNative (CodeGenerationOptions opt, string var_name, bool owned);

--- a/tools/generator/InterfaceGen.cs
+++ b/tools/generator/InterfaceGen.cs
@@ -126,7 +126,7 @@ namespace MonoDroid.Generation {
 			if (String.IsNullOrEmpty (Marshaler))
 				return String.Format ("JNIEnv.ToLocalJniHandle ({0})", varname);
 			else
-				return String.Format ("{0}.Handle", varname);
+				return GetObjectHandleProperty (varname);
 			*/
 		}
 
@@ -242,7 +242,7 @@ namespace MonoDroid.Generation {
 			sw.WriteLine ();
 			sw.WriteLine ("{0}\tpublic {1}Invoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)", indent, Name);
 			sw.WriteLine ("{0}\t{{", indent);
-			sw.WriteLine ("{0}\t\tIntPtr local_ref = JNIEnv.GetObjectClass (Handle);", indent);
+			sw.WriteLine ("{0}\t\tIntPtr local_ref = JNIEnv.GetObjectClass ({1});", indent, opt.ContextType.GetObjectHandleProperty ("this"));
 			sw.WriteLine ("{0}\t\tthis.class_ref = JNIEnv.NewGlobalRef (local_ref);", indent);
 			sw.WriteLine ("{0}\t\tJNIEnv.DeleteLocalRef (local_ref);", indent);
 			sw.WriteLine ("{0}\t}}", indent);
@@ -399,7 +399,7 @@ namespace MonoDroid.Generation {
 			sw.WriteLine ("{0}\t\t\tglobal::Android.Runtime.JNIEnv.StartCreateInstance (\"{1}\", \"()V\"),", indent, jniClass);
 			sw.WriteLine ("{0}\t\t\tJniHandleOwnership.TransferLocalRef)", indent);
 			sw.WriteLine ("{0}\t{{", indent);
-			sw.WriteLine ("{0}\t\tglobal::Android.Runtime.JNIEnv.FinishCreateInstance (Handle, \"()V\");", indent);
+			sw.WriteLine ("{0}\t\tglobal::Android.Runtime.JNIEnv.FinishCreateInstance ({1}, \"()V\");", indent, GetObjectHandleProperty ("this"));
 			if (needs_sender)
 				sw.WriteLine ("{0}\t\tthis.sender = sender;", indent);
 			sw.WriteLine ("{0}\t}}", indent);
@@ -660,6 +660,7 @@ namespace MonoDroid.Generation {
 
 		public override void Generate (StreamWriter sw, string indent, CodeGenerationOptions opt, GenerationInfo gen_info)
 		{
+			opt.ContextTypes.Push (this);
 			// interfaces don't nest, so generate as siblings
 			foreach (GenBase nest in NestedTypes) {
 				nest.Generate (sw, indent, opt, gen_info);
@@ -719,6 +720,7 @@ namespace MonoDroid.Generation {
 				GenerateExtensionsDeclaration (sw, indent, opt, null);
 			GenerateInvoker (sw, indent, opt);
 			GenerateEventHandler (sw, indent, opt);
+			opt.ContextTypes.Pop ();
 		}
 
 		public override void Generate (CodeGenerationOptions opt, GenerationInfo gen_info)

--- a/tools/generator/JavaInteropCodeGenerator.cs
+++ b/tools/generator/JavaInteropCodeGenerator.cs
@@ -115,7 +115,7 @@ namespace MonoDroid.Generation {
 					? "(" + ctor.Parameters.JniNestedDerivedSignature + ")V"
 					: ctor.JniSignature);
 			sw.WriteLine ();
-			sw.WriteLine ("{0}if (Handle != IntPtr.Zero)", indent);
+			sw.WriteLine ("{0}if ({1} != IntPtr.Zero)", indent, opt.ContextType.GetObjectHandleProperty ("this"));
 			sw.WriteLine ("{0}\treturn;", indent);
 			sw.WriteLine ();
 			foreach (string prep in ctor.Parameters.GetCallPrep (opt))

--- a/tools/generator/Method.cs
+++ b/tools/generator/Method.cs
@@ -657,7 +657,8 @@ namespace MonoDroid.Generation {
 				sw.WriteLine ("{0}{1}", indent, prep);
 			Parameters.WriteCallArgs (sw, indent, opt, invoker:true);
 			string env_method = "Call" + RetVal.CallMethodPrefix + "Method";
-			string call = "JNIEnv." + env_method + " (Handle, " + EscapedIdName + Parameters.GetCallArgs (opt, invoker:true) + ")";
+			string call = "JNIEnv." + env_method + " (" +
+				opt.ContextType.GetObjectHandleProperty ("this") + ", " + EscapedIdName + Parameters.GetCallArgs (opt, invoker:true) + ")";
 			if (IsVoid)
 				sw.WriteLine ("{0}{1};", indent, call);
 			else

--- a/tools/generator/Parameter.cs
+++ b/tools/generator/Parameter.cs
@@ -38,8 +38,9 @@ namespace MonoDroid.Generation {
 				return c;
 			if (!NeedsPrep)
 				return c;
+			var h = sym.GetObjectHandleProperty (c);
 			if (sym.PreCall (opt, Name).Length == 0)
-				return string.Format ("({0} == null) ? IntPtr.Zero : {0}.Handle", c);
+				return string.Format ("({0} == null) ? IntPtr.Zero : {1}", c, h);
 			return c;
 		}
 

--- a/tools/generator/StreamSymbol.cs
+++ b/tools/generator/StreamSymbol.cs
@@ -54,6 +54,11 @@ namespace MonoDroid.Generation {
 			get { return null; }
 		}
 
+		public string GetObjectHandleProperty (string variable)
+		{
+			return $"((global::Java.Lang.Object) {variable}).Handle";
+		}
+
 		public string GetGenericType (Dictionary<string, string> mappings)
 		{
 			return null;

--- a/tools/generator/StringSymbol.cs
+++ b/tools/generator/StringSymbol.cs
@@ -44,6 +44,11 @@ namespace MonoDroid.Generation {
 			get { return null; }
 		}
 
+		public string GetObjectHandleProperty (string variable)
+		{
+			return $"((global::Java.Lang.Object) {variable}).Handle";
+		}
+
 		public string GetGenericType (Dictionary<string, string> mappings)
 		{
 			return null;

--- a/tools/generator/Tests-Core/expected.ji/Android.Text.ISpannable.cs
+++ b/tools/generator/Tests-Core/expected.ji/Android.Text.ISpannable.cs
@@ -57,7 +57,7 @@ namespace Android.Text {
 
 		public ISpannableInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
 		{
-			IntPtr local_ref = JNIEnv.GetObjectClass (Handle);
+			IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
 			this.class_ref = JNIEnv.NewGlobalRef (local_ref);
 			JNIEnv.DeleteLocalRef (local_ref);
 		}
@@ -86,8 +86,8 @@ namespace Android.Text {
 			if (id_getSpanFlags_Ljava_lang_Object_ == IntPtr.Zero)
 				id_getSpanFlags_Ljava_lang_Object_ = JNIEnv.GetMethodID (class_ref, "getSpanFlags", "(Ljava/lang/Object;)I");
 			JValue* __args = stackalloc JValue [1];
-			__args [0] = new JValue ((tag == null) ? IntPtr.Zero : tag.Handle);
-			Android.Text.SpanTypes __ret = (Android.Text.SpanTypes) JNIEnv.CallIntMethod (Handle, id_getSpanFlags_Ljava_lang_Object_, __args);
+			__args [0] = new JValue ((tag == null) ? IntPtr.Zero : ((global::Java.Lang.Object) tag).Handle);
+			Android.Text.SpanTypes __ret = (Android.Text.SpanTypes) JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getSpanFlags_Ljava_lang_Object_, __args);
 			return __ret;
 		}
 

--- a/tools/generator/Tests-Core/expected.ji/Android.Text.ISpanned.cs
+++ b/tools/generator/Tests-Core/expected.ji/Android.Text.ISpanned.cs
@@ -62,7 +62,7 @@ namespace Android.Text {
 
 		public ISpannedInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
 		{
-			IntPtr local_ref = JNIEnv.GetObjectClass (Handle);
+			IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
 			this.class_ref = JNIEnv.NewGlobalRef (local_ref);
 			JNIEnv.DeleteLocalRef (local_ref);
 		}
@@ -91,8 +91,8 @@ namespace Android.Text {
 			if (id_getSpanFlags_Ljava_lang_Object_ == IntPtr.Zero)
 				id_getSpanFlags_Ljava_lang_Object_ = JNIEnv.GetMethodID (class_ref, "getSpanFlags", "(Ljava/lang/Object;)I");
 			JValue* __args = stackalloc JValue [1];
-			__args [0] = new JValue ((tag == null) ? IntPtr.Zero : tag.Handle);
-			Android.Text.SpanTypes __ret = (Android.Text.SpanTypes) JNIEnv.CallIntMethod (Handle, id_getSpanFlags_Ljava_lang_Object_, __args);
+			__args [0] = new JValue ((tag == null) ? IntPtr.Zero : ((global::Java.Lang.Object) tag).Handle);
+			Android.Text.SpanTypes __ret = (Android.Text.SpanTypes) JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getSpanFlags_Ljava_lang_Object_, __args);
 			return __ret;
 		}
 

--- a/tools/generator/Tests-Core/expected.ji/Android.Text.SpannableString.cs
+++ b/tools/generator/Tests-Core/expected.ji/Android.Text.SpannableString.cs
@@ -37,7 +37,7 @@ namespace Android.Text {
 		{
 			const string __id = "(Ljava/lang/CharSequence;)V";
 
-			if (Handle != IntPtr.Zero)
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
 				return;
 
 			IntPtr native_source = CharSequence.ToLocalJniHandle (source);
@@ -58,7 +58,7 @@ namespace Android.Text {
 		{
 			const string __id = "(Ljava/lang/CharSequence;)V";
 
-			if (Handle != IntPtr.Zero)
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
 				return;
 
 			IntPtr native_source = CharSequence.ToLocalJniHandle (source);
@@ -98,7 +98,7 @@ namespace Android.Text {
 			const string __id = "getSpanFlags.(Ljava/lang/Object;)I";
 			try {
 				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
-				__args [0] = new JniArgumentValue ((what == null) ? IntPtr.Zero : what.Handle);
+				__args [0] = new JniArgumentValue ((what == null) ? IntPtr.Zero : ((global::Java.Lang.Object) what).Handle);
 				var __rm = _members.InstanceMethods.InvokeVirtualInt32Method (__id, this, __args);
 				return (Android.Text.SpanTypes) __rm;
 			} finally {

--- a/tools/generator/Tests-Core/expected.ji/Android.Text.SpannableStringInternal.cs
+++ b/tools/generator/Tests-Core/expected.ji/Android.Text.SpannableStringInternal.cs
@@ -56,7 +56,7 @@ namespace Android.Text {
 			const string __id = "getSpanFlags.(Ljava/lang/Object;)I";
 			try {
 				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
-				__args [0] = new JniArgumentValue ((p0 == null) ? IntPtr.Zero : p0.Handle);
+				__args [0] = new JniArgumentValue ((p0 == null) ? IntPtr.Zero : ((global::Java.Lang.Object) p0).Handle);
 				var __rm = _members.InstanceMethods.InvokeVirtualInt32Method (__id, this, __args);
 				return (Android.Text.SpanTypes) __rm;
 			} finally {

--- a/tools/generator/Tests-Core/expected.ji/Android.Views.View.cs
+++ b/tools/generator/Tests-Core/expected.ji/Android.Views.View.cs
@@ -65,7 +65,7 @@ namespace Android.Views {
 
 			public IOnClickListenerInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
 			{
-				IntPtr local_ref = JNIEnv.GetObjectClass (Handle);
+				IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
 				this.class_ref = JNIEnv.NewGlobalRef (local_ref);
 				JNIEnv.DeleteLocalRef (local_ref);
 			}
@@ -93,8 +93,8 @@ namespace Android.Views {
 				if (id_onClick_Landroid_view_View_ == IntPtr.Zero)
 					id_onClick_Landroid_view_View_ = JNIEnv.GetMethodID (class_ref, "onClick", "(Landroid/view/View;)V");
 				JValue* __args = stackalloc JValue [1];
-				__args [0] = new JValue ((v == null) ? IntPtr.Zero : v.Handle);
-				JNIEnv.CallVoidMethod (Handle, id_onClick_Landroid_view_View_, __args);
+				__args [0] = new JValue ((v == null) ? IntPtr.Zero : ((global::Java.Lang.Object) v).Handle);
+				JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_onClick_Landroid_view_View_, __args);
 			}
 
 		}
@@ -107,7 +107,7 @@ namespace Android.Views {
 					global::Android.Runtime.JNIEnv.StartCreateInstance ("mono/android/view/View_OnClickListenerImplementor", "()V"),
 					JniHandleOwnership.TransferLocalRef)
 			{
-				global::Android.Runtime.JNIEnv.FinishCreateInstance (Handle, "()V");
+				global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "()V");
 			}
 
 #pragma warning disable 0649
@@ -173,7 +173,7 @@ namespace Android.Views {
 			const string __id = "setOnClickListener.(Landroid/view/View$OnClickListener;)V";
 			try {
 				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
-				__args [0] = new JniArgumentValue ((l == null) ? IntPtr.Zero : l.Handle);
+				__args [0] = new JniArgumentValue ((l == null) ? IntPtr.Zero : ((global::Java.Lang.Object) l).Handle);
 				_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, __args);
 			} finally {
 			}

--- a/tools/generator/Tests-Core/expected/Android.Text.ISpannable.cs
+++ b/tools/generator/Tests-Core/expected/Android.Text.ISpannable.cs
@@ -48,7 +48,7 @@ namespace Android.Text {
 
 		public ISpannableInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
 		{
-			IntPtr local_ref = JNIEnv.GetObjectClass (Handle);
+			IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
 			this.class_ref = JNIEnv.NewGlobalRef (local_ref);
 			JNIEnv.DeleteLocalRef (local_ref);
 		}
@@ -78,7 +78,7 @@ namespace Android.Text {
 				id_getSpanFlags_Ljava_lang_Object_ = JNIEnv.GetMethodID (class_ref, "getSpanFlags", "(Ljava/lang/Object;)I");
 			JValue* __args = stackalloc JValue [1];
 			__args [0] = new JValue (tag);
-			Android.Text.SpanTypes __ret = (Android.Text.SpanTypes) JNIEnv.CallIntMethod (Handle, id_getSpanFlags_Ljava_lang_Object_, __args);
+			Android.Text.SpanTypes __ret = (Android.Text.SpanTypes) JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getSpanFlags_Ljava_lang_Object_, __args);
 			return __ret;
 		}
 

--- a/tools/generator/Tests-Core/expected/Android.Text.ISpanned.cs
+++ b/tools/generator/Tests-Core/expected/Android.Text.ISpanned.cs
@@ -53,7 +53,7 @@ namespace Android.Text {
 
 		public ISpannedInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
 		{
-			IntPtr local_ref = JNIEnv.GetObjectClass (Handle);
+			IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
 			this.class_ref = JNIEnv.NewGlobalRef (local_ref);
 			JNIEnv.DeleteLocalRef (local_ref);
 		}
@@ -83,7 +83,7 @@ namespace Android.Text {
 				id_getSpanFlags_Ljava_lang_Object_ = JNIEnv.GetMethodID (class_ref, "getSpanFlags", "(Ljava/lang/Object;)I");
 			JValue* __args = stackalloc JValue [1];
 			__args [0] = new JValue (tag);
-			Android.Text.SpanTypes __ret = (Android.Text.SpanTypes) JNIEnv.CallIntMethod (Handle, id_getSpanFlags_Ljava_lang_Object_, __args);
+			Android.Text.SpanTypes __ret = (Android.Text.SpanTypes) JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getSpanFlags_Ljava_lang_Object_, __args);
 			return __ret;
 		}
 

--- a/tools/generator/Tests-Core/expected/Android.Text.SpannableString.cs
+++ b/tools/generator/Tests-Core/expected/Android.Text.SpannableString.cs
@@ -31,7 +31,7 @@ namespace Android.Text {
 		public unsafe SpannableString (Java.Lang.ICharSequence source)
 			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 		{
-			if (Handle != IntPtr.Zero)
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
 				return;
 
 			IntPtr native_source = CharSequence.ToLocalJniHandle (source);
@@ -42,7 +42,7 @@ namespace Android.Text {
 					SetHandle (
 							global::Android.Runtime.JNIEnv.StartCreateInstance (GetType (), "(Ljava/lang/CharSequence;)V", __args),
 							JniHandleOwnership.TransferLocalRef);
-					global::Android.Runtime.JNIEnv.FinishCreateInstance (Handle, "(Ljava/lang/CharSequence;)V", __args);
+					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "(Ljava/lang/CharSequence;)V", __args);
 					return;
 				}
 
@@ -51,7 +51,7 @@ namespace Android.Text {
 				SetHandle (
 						global::Android.Runtime.JNIEnv.StartCreateInstance (class_ref, id_ctor_Ljava_lang_CharSequence_, __args),
 						JniHandleOwnership.TransferLocalRef);
-				JNIEnv.FinishCreateInstance (Handle, class_ref, id_ctor_Ljava_lang_CharSequence_, __args);
+				JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, class_ref, id_ctor_Ljava_lang_CharSequence_, __args);
 			} finally {
 				JNIEnv.DeleteLocalRef (native_source);
 			}
@@ -61,7 +61,7 @@ namespace Android.Text {
 		public unsafe SpannableString (string source)
 			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 		{
-			if (Handle != IntPtr.Zero)
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
 				return;
 
 			IntPtr native_source = CharSequence.ToLocalJniHandle (source);
@@ -72,7 +72,7 @@ namespace Android.Text {
 					SetHandle (
 							global::Android.Runtime.JNIEnv.StartCreateInstance (GetType (), "(Ljava/lang/CharSequence;)V", __args),
 							JniHandleOwnership.TransferLocalRef);
-					global::Android.Runtime.JNIEnv.FinishCreateInstance (Handle, "(Ljava/lang/CharSequence;)V", __args);
+					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "(Ljava/lang/CharSequence;)V", __args);
 					return;
 				}
 
@@ -81,7 +81,7 @@ namespace Android.Text {
 				SetHandle (
 						global::Android.Runtime.JNIEnv.StartCreateInstance (class_ref, id_ctor_Ljava_lang_CharSequence_, __args),
 						JniHandleOwnership.TransferLocalRef);
-				JNIEnv.FinishCreateInstance (Handle, class_ref, id_ctor_Ljava_lang_CharSequence_, __args);
+				JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, class_ref, id_ctor_Ljava_lang_CharSequence_, __args);
 			} finally {
 				JNIEnv.DeleteLocalRef (native_source);
 			}
@@ -118,9 +118,9 @@ namespace Android.Text {
 
 				Android.Text.SpanTypes __ret;
 				if (GetType () == ThresholdType)
-					__ret = (Android.Text.SpanTypes) JNIEnv.CallIntMethod  (Handle, id_getSpanFlags_Ljava_lang_Object_, __args);
+					__ret = (Android.Text.SpanTypes) JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getSpanFlags_Ljava_lang_Object_, __args);
 				else
-					__ret = (Android.Text.SpanTypes) JNIEnv.CallNonvirtualIntMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "getSpanFlags", "(Ljava/lang/Object;)I"), __args);
+					__ret = (Android.Text.SpanTypes) JNIEnv.CallNonvirtualIntMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "getSpanFlags", "(Ljava/lang/Object;)I"), __args);
 				return __ret;
 			} finally {
 			}

--- a/tools/generator/Tests-Core/expected/Android.Text.SpannableStringInternal.cs
+++ b/tools/generator/Tests-Core/expected/Android.Text.SpannableStringInternal.cs
@@ -57,9 +57,9 @@ namespace Android.Text {
 
 				Android.Text.SpanTypes __ret;
 				if (GetType () == ThresholdType)
-					__ret = (Android.Text.SpanTypes) JNIEnv.CallIntMethod  (Handle, id_getSpanFlags_Ljava_lang_Object_, __args);
+					__ret = (Android.Text.SpanTypes) JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getSpanFlags_Ljava_lang_Object_, __args);
 				else
-					__ret = (Android.Text.SpanTypes) JNIEnv.CallNonvirtualIntMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "getSpanFlags", "(Ljava/lang/Object;)I"), __args);
+					__ret = (Android.Text.SpanTypes) JNIEnv.CallNonvirtualIntMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "getSpanFlags", "(Ljava/lang/Object;)I"), __args);
 				return __ret;
 			} finally {
 			}

--- a/tools/generator/Tests-Core/expected/Android.Views.View.cs
+++ b/tools/generator/Tests-Core/expected/Android.Views.View.cs
@@ -56,7 +56,7 @@ namespace Android.Views {
 
 			public IOnClickListenerInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
 			{
-				IntPtr local_ref = JNIEnv.GetObjectClass (Handle);
+				IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
 				this.class_ref = JNIEnv.NewGlobalRef (local_ref);
 				JNIEnv.DeleteLocalRef (local_ref);
 			}
@@ -85,7 +85,7 @@ namespace Android.Views {
 					id_onClick_Landroid_view_View_ = JNIEnv.GetMethodID (class_ref, "onClick", "(Landroid/view/View;)V");
 				JValue* __args = stackalloc JValue [1];
 				__args [0] = new JValue (v);
-				JNIEnv.CallVoidMethod (Handle, id_onClick_Landroid_view_View_, __args);
+				JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_onClick_Landroid_view_View_, __args);
 			}
 
 		}
@@ -98,7 +98,7 @@ namespace Android.Views {
 					global::Android.Runtime.JNIEnv.StartCreateInstance ("mono/android/view/View_OnClickListenerImplementor", "()V"),
 					JniHandleOwnership.TransferLocalRef)
 			{
-				global::Android.Runtime.JNIEnv.FinishCreateInstance (Handle, "()V");
+				global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "()V");
 			}
 
 #pragma warning disable 0649
@@ -165,9 +165,9 @@ namespace Android.Views {
 				__args [0] = new JValue (l);
 
 				if (GetType () == ThresholdType)
-					JNIEnv.CallVoidMethod  (Handle, id_setOnClickListener_Landroid_view_View_OnClickListener_, __args);
+					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_setOnClickListener_Landroid_view_View_OnClickListener_, __args);
 				else
-					JNIEnv.CallNonvirtualVoidMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "setOnClickListener", "(Landroid/view/View$OnClickListener;)V"), __args);
+					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "setOnClickListener", "(Landroid/view/View$OnClickListener;)V"), __args);
 			} finally {
 			}
 		}
@@ -202,9 +202,9 @@ namespace Android.Views {
 				__args [0] = new JValue (native_views);
 
 				if (GetType () == ThresholdType)
-					JNIEnv.CallVoidMethod  (Handle, id_addTouchables_Ljava_util_ArrayList_, __args);
+					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_addTouchables_Ljava_util_ArrayList_, __args);
 				else
-					JNIEnv.CallNonvirtualVoidMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "addTouchables", "(Ljava/util/ArrayList;)V"), __args);
+					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "addTouchables", "(Ljava/util/ArrayList;)V"), __args);
 			} finally {
 				JNIEnv.DeleteLocalRef (native_views);
 			}

--- a/tools/generator/Tests/SupportFiles/JavaObject.cs
+++ b/tools/generator/Tests/SupportFiles/JavaObject.cs
@@ -122,6 +122,46 @@ namespace Java.Lang {
 			throw new NotImplementedException ();
 		}
 	}
+
+	public partial class Throwable : global::System.Exception, IJavaObject, IDisposable {
+
+		public IntPtr Handle { get; set; }
+
+		protected virtual IntPtr ThresholdClass {
+			get;
+			set;
+		}
+
+		protected virtual global::System.Type ThresholdType {
+			get;
+			set;
+		}
+
+		public Throwable ()
+		{
+			throw new NotImplementedException ();
+		}
+
+		public Throwable (IntPtr handle, JniHandleOwnership transfer)
+		{
+			throw new NotImplementedException ();
+		}
+
+		protected void SetHandle(IntPtr instance, JniHandleOwnership ownership)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public void Dispose()
+		{
+			throw new NotImplementedException ();
+		}
+
+		protected virtual void Dispose (bool disposing)
+		{
+			throw new NotImplementedException ();
+		}
+	}
 }
 namespace Java.Lang {
 

--- a/tools/generator/Tests/SupportFiles/Java_Lang_Throwable.cs
+++ b/tools/generator/Tests/SupportFiles/Java_Lang_Throwable.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text;
+
+using Java.Interop;
+
+using Android.Runtime;
+
+namespace Java.Lang
+{
+	public partial class Throwable : System.Exception, IJavaPeerable
+	{
+		public virtual JniPeerMembers JniPeerMembers {
+			get { return null; }
+		}
+
+		public int JniIdentityHashCode {
+			get { return 0; }
+		}
+
+		public JniObjectReference PeerReference {
+			get { return default (JniObjectReference); }
+		}
+
+		public JniManagedPeerStates JniManagedPeerState {
+			get { return 0; }
+		}
+
+		public void DisposeUnlessReferenced ()
+		{
+		}
+
+		public void UnregisterFromRuntime ()
+		{
+		}
+
+		public void Disposed ()
+		{
+		}
+
+		public void Finalized ()
+		{
+		}
+
+		public void SetJniIdentityHashCode (int value)
+		{
+		}
+
+		public void SetJniManagedPeerState (JniManagedPeerStates value)
+		{
+		}
+
+		public void SetPeerReference (JniObjectReference value)
+		{
+		}
+	}
+}

--- a/tools/generator/Tests/expected.ji/Adapters/Xamarin.Test.AbsSpinner.cs
+++ b/tools/generator/Tests/expected.ji/Adapters/Xamarin.Test.AbsSpinner.cs
@@ -80,7 +80,7 @@ namespace Xamarin.Test {
 				const string __id = "setAdapter.(Lxamarin/test/SpinnerAdapter;)V";
 				try {
 					JniArgumentValue* __args = stackalloc JniArgumentValue [1];
-					__args [0] = new JniArgumentValue ((value == null) ? IntPtr.Zero : value.Handle);
+					__args [0] = new JniArgumentValue ((value == null) ? IntPtr.Zero : ((global::Java.Lang.Object) value).Handle);
 					_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, __args);
 				} finally {
 				}

--- a/tools/generator/Tests/expected.ji/Adapters/Xamarin.Test.IAdapter.cs
+++ b/tools/generator/Tests/expected.ji/Adapters/Xamarin.Test.IAdapter.cs
@@ -57,7 +57,7 @@ namespace Xamarin.Test {
 
 		public IAdapterInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
 		{
-			IntPtr local_ref = JNIEnv.GetObjectClass (Handle);
+			IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
 			this.class_ref = JNIEnv.NewGlobalRef (local_ref);
 			JNIEnv.DeleteLocalRef (local_ref);
 		}

--- a/tools/generator/Tests/expected.ji/Adapters/Xamarin.Test.ISpinnerAdapter.cs
+++ b/tools/generator/Tests/expected.ji/Adapters/Xamarin.Test.ISpinnerAdapter.cs
@@ -57,7 +57,7 @@ namespace Xamarin.Test {
 
 		public ISpinnerAdapterInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
 		{
-			IntPtr local_ref = JNIEnv.GetObjectClass (Handle);
+			IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
 			this.class_ref = JNIEnv.NewGlobalRef (local_ref);
 			JNIEnv.DeleteLocalRef (local_ref);
 		}

--- a/tools/generator/Tests/expected.ji/Constructors/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected.ji/Constructors/Xamarin.Test.SomeObject.cs
@@ -37,7 +37,7 @@ namespace Xamarin.Test {
 		{
 			const string __id = "()V";
 
-			if (Handle != IntPtr.Zero)
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
 				return;
 
 			try {
@@ -55,7 +55,7 @@ namespace Xamarin.Test {
 		{
 			const string __id = "(I)V";
 
-			if (Handle != IntPtr.Zero)
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
 				return;
 
 			try {

--- a/tools/generator/Tests/expected.ji/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
+++ b/tools/generator/Tests/expected.ji/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
@@ -69,7 +69,7 @@ namespace Xamarin.Test {
 
 				public IFactoryInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
 				{
-					IntPtr local_ref = JNIEnv.GetObjectClass (Handle);
+					IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
 					this.class_ref = JNIEnv.NewGlobalRef (local_ref);
 					JNIEnv.DeleteLocalRef (local_ref);
 				}
@@ -97,7 +97,7 @@ namespace Xamarin.Test {
 						id_build_I = JNIEnv.GetMethodID (class_ref, "build", "(I)Lxamarin/test/NotificationCompatBase$Action;");
 					JValue* __args = stackalloc JValue [1];
 					__args [0] = new JValue (p0);
-					return global::Java.Lang.Object.GetObject<global::Xamarin.Test.NotificationCompatBase.Action> (JNIEnv.CallObjectMethod (Handle, id_build_I, __args), JniHandleOwnership.TransferLocalRef);
+					return global::Java.Lang.Object.GetObject<global::Xamarin.Test.NotificationCompatBase.Action> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_build_I, __args), JniHandleOwnership.TransferLocalRef);
 				}
 
 			}
@@ -157,12 +157,12 @@ namespace Xamarin.Test {
 			{
 				string __id = "(L" + global::Android.Runtime.JNIEnv.GetJniName (GetType ().DeclaringType) + ";)V";
 
-				if (Handle != IntPtr.Zero)
+				if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
 					return;
 
 				try {
 					JniArgumentValue* __args = stackalloc JniArgumentValue [1];
-					__args [0] = new JniArgumentValue ((__self == null) ? IntPtr.Zero : __self.Handle);
+					__args [0] = new JniArgumentValue ((__self == null) ? IntPtr.Zero : ((global::Java.Lang.Object) __self).Handle);
 					var __r = _members.InstanceMethods.StartCreateInstance (__id, GetType (), __args);
 					SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
 					_members.InstanceMethods.FinishCreateInstance (__id, this, __args);

--- a/tools/generator/Tests/expected.ji/NormalMethods/Xamarin.Test.A.cs
+++ b/tools/generator/Tests/expected.ji/NormalMethods/Xamarin.Test.A.cs
@@ -67,7 +67,54 @@ namespace Xamarin.Test {
 
 		}
 
+		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/A", typeof (A));
+		internal static IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
 		protected A (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		static Delegate cb_getHandle;
+#pragma warning disable 0169
+		static Delegate GetGetHandleHandler ()
+		{
+			if (cb_getHandle == null)
+				cb_getHandle = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, int>) n_GetHandle);
+			return cb_getHandle;
+		}
+
+		static int n_GetHandle (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Xamarin.Test.A __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.A> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return __this.GetHandle ();
+		}
+#pragma warning restore 0169
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='A']/method[@name='getHandle' and count(parameter)=0]"
+		[Register ("getHandle", "()I", "GetGetHandleHandler")]
+		public virtual unsafe int GetHandle ()
+		{
+			const string __id = "getHandle.()I";
+			try {
+				var __rm = _members.InstanceMethods.InvokeVirtualInt32Method (__id, this, null);
+				return __rm;
+			} finally {
+			}
+		}
 
 	}
 }

--- a/tools/generator/Tests/expected.ji/NormalMethods/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected.ji/NormalMethods/Xamarin.Test.SomeObject.cs
@@ -30,6 +30,60 @@ namespace Xamarin.Test {
 
 		protected SomeObject (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
 
+		// Metadata.xml XPath constructor reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/constructor[@name='SomeObject' and count(parameter)=1 and parameter[1][@type='java.lang.Class&lt;? extends xamarin.test.SomeObject&gt;']]"
+		[Register (".ctor", "(Ljava/lang/Class;)V", "")]
+		public unsafe SomeObject (global::Java.Lang.Class c)
+			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		{
+			const string __id = "(Ljava/lang/Class;)V";
+
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+				return;
+
+			try {
+				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+				__args [0] = new JniArgumentValue ((c == null) ? IntPtr.Zero : ((global::Java.Lang.Object) c).Handle);
+				var __r = _members.InstanceMethods.StartCreateInstance (__id, GetType (), __args);
+				SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
+				_members.InstanceMethods.FinishCreateInstance (__id, this, __args);
+			} finally {
+			}
+		}
+
+		static Delegate cb_handle_Ljava_lang_Object_Ljava_lang_Throwable_;
+#pragma warning disable 0169
+		static Delegate GetHandle_Ljava_lang_Object_Ljava_lang_Throwable_Handler ()
+		{
+			if (cb_handle_Ljava_lang_Object_Ljava_lang_Throwable_ == null)
+				cb_handle_Ljava_lang_Object_Ljava_lang_Throwable_ = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr, IntPtr, int>) n_Handle_Ljava_lang_Object_Ljava_lang_Throwable_);
+			return cb_handle_Ljava_lang_Object_Ljava_lang_Throwable_;
+		}
+
+		static int n_Handle_Ljava_lang_Object_Ljava_lang_Throwable_ (IntPtr jnienv, IntPtr native__this, IntPtr native_o, IntPtr native_t)
+		{
+			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			global::Java.Lang.Object o = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_o, JniHandleOwnership.DoNotTransfer);
+			global::Java.Lang.Throwable t = global::Java.Lang.Object.GetObject<global::Java.Lang.Throwable> (native_t, JniHandleOwnership.DoNotTransfer);
+			int __ret = __this.Handle (o, t);
+			return __ret;
+		}
+#pragma warning restore 0169
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/method[@name='handle' and count(parameter)=2 and parameter[1][@type='java.lang.Object'] and parameter[2][@type='java.lang.Throwable']]"
+		[Register ("handle", "(Ljava/lang/Object;Ljava/lang/Throwable;)I", "GetHandle_Ljava_lang_Object_Ljava_lang_Throwable_Handler")]
+		public virtual unsafe int Handle (global::Java.Lang.Object o, global::Java.Lang.Throwable t)
+		{
+			const string __id = "handle.(Ljava/lang/Object;Ljava/lang/Throwable;)I";
+			try {
+				JniArgumentValue* __args = stackalloc JniArgumentValue [2];
+				__args [0] = new JniArgumentValue ((o == null) ? IntPtr.Zero : ((global::Java.Lang.Object) o).Handle);
+				__args [1] = new JniArgumentValue ((t == null) ? IntPtr.Zero : ((global::Java.Lang.Throwable) t).Handle);
+				var __rm = _members.InstanceMethods.InvokeVirtualInt32Method (__id, this, __args);
+				return __rm;
+			} finally {
+			}
+		}
+
 		static Delegate cb_IntegerMethod;
 #pragma warning disable 0169
 		static Delegate GetIntegerMethodHandler ()
@@ -169,7 +223,7 @@ namespace Xamarin.Test {
 				JniArgumentValue* __args = stackalloc JniArgumentValue [3];
 				__args [0] = new JniArgumentValue (native_astring);
 				__args [1] = new JniArgumentValue (anint);
-				__args [2] = new JniArgumentValue ((anObject == null) ? IntPtr.Zero : anObject.Handle);
+				__args [2] = new JniArgumentValue ((anObject == null) ? IntPtr.Zero : ((global::Java.Lang.Object) anObject).Handle);
 				_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, __args);
 			} finally {
 				JNIEnv.DeleteLocalRef (native_astring);

--- a/tools/generator/Tests/expected.ji/NormalProperties/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected.ji/NormalProperties/Xamarin.Test.SomeObject.cs
@@ -207,7 +207,7 @@ namespace Xamarin.Test {
 				const string __id = "setSomeObjectProperty.(Ljava/lang/Object;)V";
 				try {
 					JniArgumentValue* __args = stackalloc JniArgumentValue [1];
-					__args [0] = new JniArgumentValue ((value == null) ? IntPtr.Zero : value.Handle);
+					__args [0] = new JniArgumentValue ((value == null) ? IntPtr.Zero : ((global::Java.Lang.Object) value).Handle);
 					_members.InstanceMethods.InvokeAbstractVoidMethod (__id, this, __args);
 				} finally {
 				}

--- a/tools/generator/Tests/expected.ji/StaticProperties/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected.ji/StaticProperties/Xamarin.Test.SomeObject.cs
@@ -99,7 +99,7 @@ namespace Xamarin.Test {
 			const string __id = "setSomeObject.(Ljava/lang/Object;)V";
 			try {
 				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
-				__args [0] = new JniArgumentValue ((newvalue == null) ? IntPtr.Zero : newvalue.Handle);
+				__args [0] = new JniArgumentValue ((newvalue == null) ? IntPtr.Zero : ((global::Java.Lang.Object) newvalue).Handle);
 				_members.StaticMethods.InvokeVoidMethod (__id, __args);
 			} finally {
 			}

--- a/tools/generator/Tests/expected.ji/Streams/Java.IO.FilterOutputStream.cs
+++ b/tools/generator/Tests/expected.ji/Streams/Java.IO.FilterOutputStream.cs
@@ -37,7 +37,7 @@ namespace Java.IO {
 		{
 			const string __id = "(Ljava/io/OutputStream;)V";
 
-			if (Handle != IntPtr.Zero)
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
 				return;
 
 			IntPtr native__out = global::Android.Runtime.OutputStreamAdapter.ToLocalJniHandle (@out);

--- a/tools/generator/Tests/expected.ji/Streams/Java.IO.IOException.cs
+++ b/tools/generator/Tests/expected.ji/Streams/Java.IO.IOException.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Java.IO {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='java.io']/class[@name='IOException']"
+	[global::Android.Runtime.Register ("java/io/IOException", DoNotGenerateAcw=true)]
+	public abstract partial class IOException : global::Java.Lang.Throwable {
+
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/io/IOException", typeof (IOException));
+		internal static new IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+		protected IOException (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		static Delegate cb_printStackTrace;
+#pragma warning disable 0169
+		static Delegate GetPrintStackTraceHandler ()
+		{
+			if (cb_printStackTrace == null)
+				cb_printStackTrace = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr>) n_PrintStackTrace);
+			return cb_printStackTrace;
+		}
+
+		static void n_PrintStackTrace (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Java.IO.IOException __this = global::Java.Lang.Object.GetObject<global::Java.IO.IOException> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			__this.PrintStackTrace ();
+		}
+#pragma warning restore 0169
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='java.io']/class[@name='IOException']/method[@name='printStackTrace' and count(parameter)=0]"
+		[Register ("printStackTrace", "()V", "GetPrintStackTraceHandler")]
+		public virtual unsafe void PrintStackTrace ()
+		{
+			const string __id = "printStackTrace.()V";
+			try {
+				_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, null);
+			} finally {
+			}
+		}
+
+	}
+
+	[global::Android.Runtime.Register ("java/io/IOException", DoNotGenerateAcw=true)]
+	internal partial class IOExceptionInvoker : IOException {
+
+		public IOExceptionInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
+
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/io/IOException", typeof (IOExceptionInvoker));
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+	}
+
+}

--- a/tools/generator/Tests/expected.ji/Streams/Java.IO.InputStream.cs
+++ b/tools/generator/Tests/expected.ji/Streams/Java.IO.InputStream.cs
@@ -37,7 +37,7 @@ namespace Java.IO {
 		{
 			const string __id = "()V";
 
-			if (Handle != IntPtr.Zero)
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
 				return;
 
 			try {

--- a/tools/generator/Tests/expected.ji/Streams/Java.IO.OutputStream.cs
+++ b/tools/generator/Tests/expected.ji/Streams/Java.IO.OutputStream.cs
@@ -37,7 +37,7 @@ namespace Java.IO {
 		{
 			const string __id = "()V";
 
-			if (Handle != IntPtr.Zero)
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
 				return;
 
 			try {

--- a/tools/generator/Tests/expected.ji/Streams/Java.Lang.Throwable.cs
+++ b/tools/generator/Tests/expected.ji/Streams/Java.Lang.Throwable.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Java.Lang {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Throwable']"
+	[global::Android.Runtime.Register ("java/lang/Throwable", DoNotGenerateAcw=true)]
+	public partial class Throwable  {
+
+		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Throwable", typeof (Throwable));
+		internal static IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
+		static Delegate cb_getMessage;
+#pragma warning disable 0169
+		static Delegate GetGetMessageHandler ()
+		{
+			if (cb_getMessage == null)
+				cb_getMessage = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_GetMessage);
+			return cb_getMessage;
+		}
+
+		static IntPtr n_GetMessage (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Java.Lang.Throwable __this = global::Java.Lang.Object.GetObject<global::Java.Lang.Throwable> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.NewString (__this.Message);
+		}
+#pragma warning restore 0169
+
+		public virtual unsafe string Message {
+			// Metadata.xml XPath method reference: path="/api/package[@name='java.lang']/class[@name='Throwable']/method[@name='getMessage' and count(parameter)=0]"
+			[Register ("getMessage", "()Ljava/lang/String;", "GetGetMessageHandler")]
+			get {
+				const string __id = "getMessage.()Ljava/lang/String;";
+				try {
+					var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, null);
+					return JNIEnv.GetString (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+				} finally {
+				}
+			}
+		}
+
+	}
+}

--- a/tools/generator/Tests/expected.ji/TestInterface/Test.ME.GenericImplementation.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Test.ME.GenericImplementation.cs
@@ -37,7 +37,7 @@ namespace Test.ME {
 		{
 			const string __id = "()V";
 
-			if (Handle != IntPtr.Zero)
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
 				return;
 
 			try {

--- a/tools/generator/Tests/expected.ji/TestInterface/Test.ME.GenericStringImplementation.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Test.ME.GenericStringImplementation.cs
@@ -37,7 +37,7 @@ namespace Test.ME {
 		{
 			const string __id = "()V";
 
-			if (Handle != IntPtr.Zero)
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
 				return;
 
 			try {

--- a/tools/generator/Tests/expected.ji/TestInterface/Test.ME.IGenericInterface.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Test.ME.IGenericInterface.cs
@@ -62,7 +62,7 @@ namespace Test.ME {
 
 		public IGenericInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
 		{
-			IntPtr local_ref = JNIEnv.GetObjectClass (Handle);
+			IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
 			this.class_ref = JNIEnv.NewGlobalRef (local_ref);
 			JNIEnv.DeleteLocalRef (local_ref);
 		}
@@ -92,7 +92,7 @@ namespace Test.ME {
 			IntPtr native_value = JNIEnv.ToLocalJniHandle (value);
 			JValue* __args = stackalloc JValue [1];
 			__args [0] = new JValue (native_value);
-			JNIEnv.CallVoidMethod (Handle, id_SetObject_Ljava_lang_Object_, __args);
+			JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_SetObject_Ljava_lang_Object_, __args);
 			JNIEnv.DeleteLocalRef (native_value);
 		}
 

--- a/tools/generator/Tests/expected.ji/TestInterface/Test.ME.ITestInterface.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Test.ME.ITestInterface.cs
@@ -96,7 +96,7 @@ namespace Test.ME {
 
 		public ITestInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
 		{
-			IntPtr local_ref = JNIEnv.GetObjectClass (Handle);
+			IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
 			this.class_ref = JNIEnv.NewGlobalRef (local_ref);
 			JNIEnv.DeleteLocalRef (local_ref);
 		}
@@ -125,8 +125,8 @@ namespace Test.ME {
 			if (id_getSpanFlags_Ljava_lang_Object_ == IntPtr.Zero)
 				id_getSpanFlags_Ljava_lang_Object_ = JNIEnv.GetMethodID (class_ref, "getSpanFlags", "(Ljava/lang/Object;)I");
 			JValue* __args = stackalloc JValue [1];
-			__args [0] = new JValue ((tag == null) ? IntPtr.Zero : tag.Handle);
-			int __ret = JNIEnv.CallIntMethod (Handle, id_getSpanFlags_Ljava_lang_Object_, __args);
+			__args [0] = new JValue ((tag == null) ? IntPtr.Zero : ((global::Java.Lang.Object) tag).Handle);
+			int __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getSpanFlags_Ljava_lang_Object_, __args);
 			return __ret;
 		}
 

--- a/tools/generator/Tests/expected.ji/TestInterface/Test.ME.TestInterfaceImplementation.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Test.ME.TestInterfaceImplementation.cs
@@ -59,7 +59,7 @@ namespace Test.ME {
 		{
 			const string __id = "()V";
 
-			if (Handle != IntPtr.Zero)
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
 				return;
 
 			try {
@@ -116,7 +116,7 @@ namespace Test.ME {
 			const string __id = "getSpanFlags.(Ljava/lang/Object;)I";
 			try {
 				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
-				__args [0] = new JniArgumentValue ((tag == null) ? IntPtr.Zero : tag.Handle);
+				__args [0] = new JniArgumentValue ((tag == null) ? IntPtr.Zero : ((global::Java.Lang.Object) tag).Handle);
 				var __rm = _members.InstanceMethods.InvokeAbstractInt32Method (__id, this, __args);
 				return __rm;
 			} finally {

--- a/tools/generator/Tests/expected.ji/java.lang.Enum/Java.Lang.IComparable.cs
+++ b/tools/generator/Tests/expected.ji/java.lang.Enum/Java.Lang.IComparable.cs
@@ -62,7 +62,7 @@ namespace Java.Lang {
 
 		public IComparableInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
 		{
-			IntPtr local_ref = JNIEnv.GetObjectClass (Handle);
+			IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
 			this.class_ref = JNIEnv.NewGlobalRef (local_ref);
 			JNIEnv.DeleteLocalRef (local_ref);
 		}
@@ -93,7 +93,7 @@ namespace Java.Lang {
 			IntPtr native_another = JNIEnv.ToLocalJniHandle (another);
 			JValue* __args = stackalloc JValue [1];
 			__args [0] = new JValue (native_another);
-			int __ret = JNIEnv.CallIntMethod (Handle, id_compareTo_Ljava_lang_Object_, __args);
+			int __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_compareTo_Ljava_lang_Object_, __args);
 			JNIEnv.DeleteLocalRef (native_another);
 			return __ret;
 		}

--- a/tools/generator/Tests/expected/Adapters/Xamarin.Test.AbsSpinner.cs
+++ b/tools/generator/Tests/expected/Adapters/Xamarin.Test.AbsSpinner.cs
@@ -69,9 +69,9 @@ namespace Xamarin.Test {
 				try {
 
 					if (GetType () == ThresholdType)
-						return global::Java.Lang.Object.GetObject<global::Xamarin.Test.ISpinnerAdapter> (JNIEnv.CallObjectMethod  (Handle, id_getAdapter), JniHandleOwnership.TransferLocalRef);
+						return global::Java.Lang.Object.GetObject<global::Xamarin.Test.ISpinnerAdapter> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_getAdapter), JniHandleOwnership.TransferLocalRef);
 					else
-						return global::Java.Lang.Object.GetObject<global::Xamarin.Test.ISpinnerAdapter> (JNIEnv.CallNonvirtualObjectMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "getAdapter", "()Lxamarin/test/SpinnerAdapter;")), JniHandleOwnership.TransferLocalRef);
+						return global::Java.Lang.Object.GetObject<global::Xamarin.Test.ISpinnerAdapter> (JNIEnv.CallNonvirtualObjectMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "getAdapter", "()Lxamarin/test/SpinnerAdapter;")), JniHandleOwnership.TransferLocalRef);
 				} finally {
 				}
 			}
@@ -85,9 +85,9 @@ namespace Xamarin.Test {
 					__args [0] = new JValue (value);
 
 					if (GetType () == ThresholdType)
-						JNIEnv.CallVoidMethod  (Handle, id_setAdapter_Lxamarin_test_SpinnerAdapter_, __args);
+						JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_setAdapter_Lxamarin_test_SpinnerAdapter_, __args);
 					else
-						JNIEnv.CallNonvirtualVoidMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "setAdapter", "(Lxamarin/test/SpinnerAdapter;)V"), __args);
+						JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "setAdapter", "(Lxamarin/test/SpinnerAdapter;)V"), __args);
 				} finally {
 				}
 			}
@@ -113,7 +113,7 @@ namespace Xamarin.Test {
 				if (id_getAdapter == IntPtr.Zero)
 					id_getAdapter = JNIEnv.GetMethodID (class_ref, "getAdapter", "()Lxamarin/test/Adapter;");
 				try {
-					return (Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod  (Handle, id_getAdapter), JniHandleOwnership.TransferLocalRef);
+					return (Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_getAdapter), JniHandleOwnership.TransferLocalRef);
 				} finally {
 				}
 			}
@@ -126,7 +126,7 @@ namespace Xamarin.Test {
 				try {
 					JValue* __args = stackalloc JValue [1];
 					__args [0] = new JValue (native_value);
-					JNIEnv.CallVoidMethod  (Handle, id_setAdapter_Lxamarin_test_Adapter_, __args);
+					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_setAdapter_Lxamarin_test_Adapter_, __args);
 				} finally {
 					JNIEnv.DeleteLocalRef (native_value);
 				}

--- a/tools/generator/Tests/expected/Adapters/Xamarin.Test.AdapterView.cs
+++ b/tools/generator/Tests/expected/Adapters/Xamarin.Test.AdapterView.cs
@@ -86,7 +86,7 @@ namespace Xamarin.Test {
 				if (id_getAdapter == IntPtr.Zero)
 					id_getAdapter = JNIEnv.GetMethodID (class_ref, "getAdapter", "()Lxamarin/test/Adapter;");
 				try {
-					return (Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod  (Handle, id_getAdapter), JniHandleOwnership.TransferLocalRef);
+					return (Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_getAdapter), JniHandleOwnership.TransferLocalRef);
 				} finally {
 				}
 			}
@@ -99,7 +99,7 @@ namespace Xamarin.Test {
 				try {
 					JValue* __args = stackalloc JValue [1];
 					__args [0] = new JValue (native_value);
-					JNIEnv.CallVoidMethod  (Handle, id_setAdapter_Lxamarin_test_Adapter_, __args);
+					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_setAdapter_Lxamarin_test_Adapter_, __args);
 				} finally {
 					JNIEnv.DeleteLocalRef (native_value);
 				}

--- a/tools/generator/Tests/expected/Adapters/Xamarin.Test.GenericReturnObject.cs
+++ b/tools/generator/Tests/expected/Adapters/Xamarin.Test.GenericReturnObject.cs
@@ -51,9 +51,9 @@ namespace Xamarin.Test {
 			try {
 
 				if (GetType () == ThresholdType)
-					return global::Java.Lang.Object.GetObject<global::Xamarin.Test.AdapterView> (JNIEnv.CallObjectMethod  (Handle, id_GenericReturn), JniHandleOwnership.TransferLocalRef);
+					return global::Java.Lang.Object.GetObject<global::Xamarin.Test.AdapterView> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_GenericReturn), JniHandleOwnership.TransferLocalRef);
 				else
-					return global::Java.Lang.Object.GetObject<global::Xamarin.Test.AdapterView> (JNIEnv.CallNonvirtualObjectMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "GenericReturn", "()Lxamarin/test/AdapterView;")), JniHandleOwnership.TransferLocalRef);
+					return global::Java.Lang.Object.GetObject<global::Xamarin.Test.AdapterView> (JNIEnv.CallNonvirtualObjectMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "GenericReturn", "()Lxamarin/test/AdapterView;")), JniHandleOwnership.TransferLocalRef);
 			} finally {
 			}
 		}

--- a/tools/generator/Tests/expected/Adapters/Xamarin.Test.IAdapter.cs
+++ b/tools/generator/Tests/expected/Adapters/Xamarin.Test.IAdapter.cs
@@ -48,7 +48,7 @@ namespace Xamarin.Test {
 
 		public IAdapterInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
 		{
-			IntPtr local_ref = JNIEnv.GetObjectClass (Handle);
+			IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
 			this.class_ref = JNIEnv.NewGlobalRef (local_ref);
 			JNIEnv.DeleteLocalRef (local_ref);
 		}

--- a/tools/generator/Tests/expected/Adapters/Xamarin.Test.ISpinnerAdapter.cs
+++ b/tools/generator/Tests/expected/Adapters/Xamarin.Test.ISpinnerAdapter.cs
@@ -48,7 +48,7 @@ namespace Xamarin.Test {
 
 		public ISpinnerAdapterInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
 		{
-			IntPtr local_ref = JNIEnv.GetObjectClass (Handle);
+			IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
 			this.class_ref = JNIEnv.NewGlobalRef (local_ref);
 			JNIEnv.DeleteLocalRef (local_ref);
 		}

--- a/tools/generator/Tests/expected/Android.Graphics.Color/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected/Android.Graphics.Color/Xamarin.Test.SomeObject.cs
@@ -17,14 +17,14 @@ namespace Xamarin.Test {
 			get {
 				if (backColor_jfieldId == IntPtr.Zero)
 					backColor_jfieldId = JNIEnv.GetFieldID (class_ref, "backColor", "I");
-				int __ret = JNIEnv.GetIntField (Handle, backColor_jfieldId);
+				int __ret = JNIEnv.GetIntField (((global::Java.Lang.Object) this).Handle, backColor_jfieldId);
 				return new global::Android.Graphics.Color (__ret);
 			}
 			set {
 				if (backColor_jfieldId == IntPtr.Zero)
 					backColor_jfieldId = JNIEnv.GetFieldID (class_ref, "backColor", "I");
 				try {
-					JNIEnv.SetField (Handle, backColor_jfieldId, value.ToArgb ());
+					JNIEnv.SetField (((global::Java.Lang.Object) this).Handle, backColor_jfieldId, value.ToArgb ());
 				} finally {
 				}
 			}
@@ -106,7 +106,7 @@ namespace Xamarin.Test {
 				if (id_getSomeColor == IntPtr.Zero)
 					id_getSomeColor = JNIEnv.GetMethodID (class_ref, "getSomeColor", "()I");
 				try {
-					return new global::Android.Graphics.Color (JNIEnv.CallIntMethod  (Handle, id_getSomeColor));
+					return new global::Android.Graphics.Color (JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getSomeColor));
 				} finally {
 				}
 			}
@@ -118,7 +118,7 @@ namespace Xamarin.Test {
 				try {
 					JValue* __args = stackalloc JValue [1];
 					__args [0] = new JValue (value.ToArgb ());
-					JNIEnv.CallVoidMethod  (Handle, id_setSomeColor_I, __args);
+					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_setSomeColor_I, __args);
 				} finally {
 				}
 			}

--- a/tools/generator/Tests/expected/Arrays/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected/Arrays/Xamarin.Test.SomeObject.cs
@@ -17,14 +17,14 @@ namespace Xamarin.Test {
 			get {
 				if (myStrings_jfieldId == IntPtr.Zero)
 					myStrings_jfieldId = JNIEnv.GetFieldID (class_ref, "myStrings", "[Ljava/lang/String;");
-				return global::Android.Runtime.JavaArray<string>.FromJniHandle (JNIEnv.GetObjectField (Handle, myStrings_jfieldId), JniHandleOwnership.TransferLocalRef);
+				return global::Android.Runtime.JavaArray<string>.FromJniHandle (JNIEnv.GetObjectField (((global::Java.Lang.Object) this).Handle, myStrings_jfieldId), JniHandleOwnership.TransferLocalRef);
 			}
 			set {
 				if (myStrings_jfieldId == IntPtr.Zero)
 					myStrings_jfieldId = JNIEnv.GetFieldID (class_ref, "myStrings", "[Ljava/lang/String;");
 				IntPtr native_value = global::Android.Runtime.JavaArray<string>.ToLocalJniHandle (value);
 				try {
-					JNIEnv.SetField (Handle, myStrings_jfieldId, native_value);
+					JNIEnv.SetField (((global::Java.Lang.Object) this).Handle, myStrings_jfieldId, native_value);
 				} finally {
 					JNIEnv.DeleteLocalRef (native_value);
 				}
@@ -39,14 +39,14 @@ namespace Xamarin.Test {
 			get {
 				if (myInts_jfieldId == IntPtr.Zero)
 					myInts_jfieldId = JNIEnv.GetFieldID (class_ref, "myInts", "[I");
-				return global::Android.Runtime.JavaArray<int>.FromJniHandle (JNIEnv.GetObjectField (Handle, myInts_jfieldId), JniHandleOwnership.TransferLocalRef);
+				return global::Android.Runtime.JavaArray<int>.FromJniHandle (JNIEnv.GetObjectField (((global::Java.Lang.Object) this).Handle, myInts_jfieldId), JniHandleOwnership.TransferLocalRef);
 			}
 			set {
 				if (myInts_jfieldId == IntPtr.Zero)
 					myInts_jfieldId = JNIEnv.GetFieldID (class_ref, "myInts", "[I");
 				IntPtr native_value = global::Android.Runtime.JavaArray<int>.ToLocalJniHandle (value);
 				try {
-					JNIEnv.SetField (Handle, myInts_jfieldId, native_value);
+					JNIEnv.SetField (((global::Java.Lang.Object) this).Handle, myInts_jfieldId, native_value);
 				} finally {
 					JNIEnv.DeleteLocalRef (native_value);
 				}
@@ -61,14 +61,14 @@ namespace Xamarin.Test {
 			get {
 				if (mybools_jfieldId == IntPtr.Zero)
 					mybools_jfieldId = JNIEnv.GetFieldID (class_ref, "mybools", "[Z");
-				return global::Android.Runtime.JavaArray<bool>.FromJniHandle (JNIEnv.GetObjectField (Handle, mybools_jfieldId), JniHandleOwnership.TransferLocalRef);
+				return global::Android.Runtime.JavaArray<bool>.FromJniHandle (JNIEnv.GetObjectField (((global::Java.Lang.Object) this).Handle, mybools_jfieldId), JniHandleOwnership.TransferLocalRef);
 			}
 			set {
 				if (mybools_jfieldId == IntPtr.Zero)
 					mybools_jfieldId = JNIEnv.GetFieldID (class_ref, "mybools", "[Z");
 				IntPtr native_value = global::Android.Runtime.JavaArray<bool>.ToLocalJniHandle (value);
 				try {
-					JNIEnv.SetField (Handle, mybools_jfieldId, native_value);
+					JNIEnv.SetField (((global::Java.Lang.Object) this).Handle, mybools_jfieldId, native_value);
 				} finally {
 					JNIEnv.DeleteLocalRef (native_value);
 				}
@@ -83,14 +83,14 @@ namespace Xamarin.Test {
 			get {
 				if (myObjects_jfieldId == IntPtr.Zero)
 					myObjects_jfieldId = JNIEnv.GetFieldID (class_ref, "myObjects", "[Ljava/lang/Object;");
-				return global::Android.Runtime.JavaArray<global::Java.Lang.Object>.FromJniHandle (JNIEnv.GetObjectField (Handle, myObjects_jfieldId), JniHandleOwnership.TransferLocalRef);
+				return global::Android.Runtime.JavaArray<global::Java.Lang.Object>.FromJniHandle (JNIEnv.GetObjectField (((global::Java.Lang.Object) this).Handle, myObjects_jfieldId), JniHandleOwnership.TransferLocalRef);
 			}
 			set {
 				if (myObjects_jfieldId == IntPtr.Zero)
 					myObjects_jfieldId = JNIEnv.GetFieldID (class_ref, "myObjects", "[Ljava/lang/Object;");
 				IntPtr native_value = global::Android.Runtime.JavaArray<global::Java.Lang.Object>.ToLocalJniHandle (value);
 				try {
-					JNIEnv.SetField (Handle, myObjects_jfieldId, native_value);
+					JNIEnv.SetField (((global::Java.Lang.Object) this).Handle, myObjects_jfieldId, native_value);
 				} finally {
 					JNIEnv.DeleteLocalRef (native_value);
 				}
@@ -105,14 +105,14 @@ namespace Xamarin.Test {
 			get {
 				if (myfloats_jfieldId == IntPtr.Zero)
 					myfloats_jfieldId = JNIEnv.GetFieldID (class_ref, "myfloats", "[F");
-				return global::Android.Runtime.JavaArray<float>.FromJniHandle (JNIEnv.GetObjectField (Handle, myfloats_jfieldId), JniHandleOwnership.TransferLocalRef);
+				return global::Android.Runtime.JavaArray<float>.FromJniHandle (JNIEnv.GetObjectField (((global::Java.Lang.Object) this).Handle, myfloats_jfieldId), JniHandleOwnership.TransferLocalRef);
 			}
 			set {
 				if (myfloats_jfieldId == IntPtr.Zero)
 					myfloats_jfieldId = JNIEnv.GetFieldID (class_ref, "myfloats", "[F");
 				IntPtr native_value = global::Android.Runtime.JavaArray<float>.ToLocalJniHandle (value);
 				try {
-					JNIEnv.SetField (Handle, myfloats_jfieldId, native_value);
+					JNIEnv.SetField (((global::Java.Lang.Object) this).Handle, myfloats_jfieldId, native_value);
 				} finally {
 					JNIEnv.DeleteLocalRef (native_value);
 				}
@@ -127,14 +127,14 @@ namespace Xamarin.Test {
 			get {
 				if (mydoubles_jfieldId == IntPtr.Zero)
 					mydoubles_jfieldId = JNIEnv.GetFieldID (class_ref, "mydoubles", "[D");
-				return global::Android.Runtime.JavaArray<double>.FromJniHandle (JNIEnv.GetObjectField (Handle, mydoubles_jfieldId), JniHandleOwnership.TransferLocalRef);
+				return global::Android.Runtime.JavaArray<double>.FromJniHandle (JNIEnv.GetObjectField (((global::Java.Lang.Object) this).Handle, mydoubles_jfieldId), JniHandleOwnership.TransferLocalRef);
 			}
 			set {
 				if (mydoubles_jfieldId == IntPtr.Zero)
 					mydoubles_jfieldId = JNIEnv.GetFieldID (class_ref, "mydoubles", "[D");
 				IntPtr native_value = global::Android.Runtime.JavaArray<double>.ToLocalJniHandle (value);
 				try {
-					JNIEnv.SetField (Handle, mydoubles_jfieldId, native_value);
+					JNIEnv.SetField (((global::Java.Lang.Object) this).Handle, mydoubles_jfieldId, native_value);
 				} finally {
 					JNIEnv.DeleteLocalRef (native_value);
 				}
@@ -149,14 +149,14 @@ namespace Xamarin.Test {
 			get {
 				if (mylongs_jfieldId == IntPtr.Zero)
 					mylongs_jfieldId = JNIEnv.GetFieldID (class_ref, "mylongs", "[J");
-				return global::Android.Runtime.JavaArray<long>.FromJniHandle (JNIEnv.GetObjectField (Handle, mylongs_jfieldId), JniHandleOwnership.TransferLocalRef);
+				return global::Android.Runtime.JavaArray<long>.FromJniHandle (JNIEnv.GetObjectField (((global::Java.Lang.Object) this).Handle, mylongs_jfieldId), JniHandleOwnership.TransferLocalRef);
 			}
 			set {
 				if (mylongs_jfieldId == IntPtr.Zero)
 					mylongs_jfieldId = JNIEnv.GetFieldID (class_ref, "mylongs", "[J");
 				IntPtr native_value = global::Android.Runtime.JavaArray<long>.ToLocalJniHandle (value);
 				try {
-					JNIEnv.SetField (Handle, mylongs_jfieldId, native_value);
+					JNIEnv.SetField (((global::Java.Lang.Object) this).Handle, mylongs_jfieldId, native_value);
 				} finally {
 					JNIEnv.DeleteLocalRef (native_value);
 				}

--- a/tools/generator/Tests/expected/Constructors/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected/Constructors/Xamarin.Test.SomeObject.cs
@@ -31,7 +31,7 @@ namespace Xamarin.Test {
 		public unsafe SomeObject ()
 			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 		{
-			if (Handle != IntPtr.Zero)
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
 				return;
 
 			try {
@@ -39,7 +39,7 @@ namespace Xamarin.Test {
 					SetHandle (
 							global::Android.Runtime.JNIEnv.StartCreateInstance (GetType (), "()V"),
 							JniHandleOwnership.TransferLocalRef);
-					global::Android.Runtime.JNIEnv.FinishCreateInstance (Handle, "()V");
+					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "()V");
 					return;
 				}
 
@@ -48,7 +48,7 @@ namespace Xamarin.Test {
 				SetHandle (
 						global::Android.Runtime.JNIEnv.StartCreateInstance (class_ref, id_ctor),
 						JniHandleOwnership.TransferLocalRef);
-				JNIEnv.FinishCreateInstance (Handle, class_ref, id_ctor);
+				JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, class_ref, id_ctor);
 			} finally {
 			}
 		}
@@ -59,7 +59,7 @@ namespace Xamarin.Test {
 		public unsafe SomeObject (int aint)
 			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 		{
-			if (Handle != IntPtr.Zero)
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
 				return;
 
 			try {
@@ -69,7 +69,7 @@ namespace Xamarin.Test {
 					SetHandle (
 							global::Android.Runtime.JNIEnv.StartCreateInstance (GetType (), "(I)V", __args),
 							JniHandleOwnership.TransferLocalRef);
-					global::Android.Runtime.JNIEnv.FinishCreateInstance (Handle, "(I)V", __args);
+					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "(I)V", __args);
 					return;
 				}
 
@@ -78,7 +78,7 @@ namespace Xamarin.Test {
 				SetHandle (
 						global::Android.Runtime.JNIEnv.StartCreateInstance (class_ref, id_ctor_I, __args),
 						JniHandleOwnership.TransferLocalRef);
-				JNIEnv.FinishCreateInstance (Handle, class_ref, id_ctor_I, __args);
+				JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, class_ref, id_ctor_I, __args);
 			} finally {
 			}
 		}

--- a/tools/generator/Tests/expected/EnumerationFixup/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected/EnumerationFixup/Xamarin.Test.SomeObject.cs
@@ -69,9 +69,9 @@ namespace Xamarin.Test {
 				try {
 
 					if (GetType () == ThresholdType)
-						return (global::Xamarin.Test.SomeValues) JNIEnv.CallIntMethod  (Handle, id_getSomeObjectProperty);
+						return (global::Xamarin.Test.SomeValues) JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getSomeObjectProperty);
 					else
-						return (global::Xamarin.Test.SomeValues) JNIEnv.CallNonvirtualIntMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "getSomeObjectProperty", "()I"));
+						return (global::Xamarin.Test.SomeValues) JNIEnv.CallNonvirtualIntMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "getSomeObjectProperty", "()I"));
 				} finally {
 				}
 			}
@@ -85,9 +85,9 @@ namespace Xamarin.Test {
 					__args [0] = new JValue ((int) value);
 
 					if (GetType () == ThresholdType)
-						JNIEnv.CallVoidMethod  (Handle, id_setSomeObjectProperty_I, __args);
+						JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_setSomeObjectProperty_I, __args);
 					else
-						JNIEnv.CallNonvirtualVoidMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "setSomeObjectProperty", "(I)V"), __args);
+						JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "setSomeObjectProperty", "(I)V"), __args);
 				} finally {
 				}
 			}

--- a/tools/generator/Tests/expected/EnumerationFixup/Xamarin.Test.SomeObject2.cs
+++ b/tools/generator/Tests/expected/EnumerationFixup/Xamarin.Test.SomeObject2.cs
@@ -69,9 +69,9 @@ namespace Xamarin.Test {
 				try {
 
 					if (GetType () == ThresholdType)
-						return (global::Xamarin.Test.SomeValues) JNIEnv.CallIntMethod  (Handle, id_getSomeObjectProperty);
+						return (global::Xamarin.Test.SomeValues) JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getSomeObjectProperty);
 					else
-						return (global::Xamarin.Test.SomeValues) JNIEnv.CallNonvirtualIntMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "getSomeObjectProperty", "()I"));
+						return (global::Xamarin.Test.SomeValues) JNIEnv.CallNonvirtualIntMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "getSomeObjectProperty", "()I"));
 				} finally {
 				}
 			}
@@ -85,9 +85,9 @@ namespace Xamarin.Test {
 					__args [0] = new JValue ((int) value);
 
 					if (GetType () == ThresholdType)
-						JNIEnv.CallVoidMethod  (Handle, id_setSomeObjectProperty_I, __args);
+						JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_setSomeObjectProperty_I, __args);
 					else
-						JNIEnv.CallNonvirtualVoidMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "setSomeObjectProperty", "(I)V"), __args);
+						JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "setSomeObjectProperty", "(I)V"), __args);
 				} finally {
 				}
 			}
@@ -120,9 +120,9 @@ namespace Xamarin.Test {
 			try {
 
 				if (GetType () == ThresholdType)
-					return (global::Xamarin.Test.SomeValues[]) JNIEnv.GetArray (JNIEnv.CallObjectMethod  (Handle, id_getSomeObjectPropertyArray), JniHandleOwnership.TransferLocalRef, typeof (global::Xamarin.Test.SomeValues));
+					return (global::Xamarin.Test.SomeValues[]) JNIEnv.GetArray (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_getSomeObjectPropertyArray), JniHandleOwnership.TransferLocalRef, typeof (global::Xamarin.Test.SomeValues));
 				else
-					return (global::Xamarin.Test.SomeValues[]) JNIEnv.GetArray (JNIEnv.CallNonvirtualObjectMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "getSomeObjectPropertyArray", "()[I")), JniHandleOwnership.TransferLocalRef, typeof (global::Xamarin.Test.SomeValues));
+					return (global::Xamarin.Test.SomeValues[]) JNIEnv.GetArray (JNIEnv.CallNonvirtualObjectMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "getSomeObjectPropertyArray", "()[I")), JniHandleOwnership.TransferLocalRef, typeof (global::Xamarin.Test.SomeValues));
 			} finally {
 			}
 		}
@@ -159,9 +159,9 @@ namespace Xamarin.Test {
 				__args [0] = new JValue (native_newvalue);
 
 				if (GetType () == ThresholdType)
-					JNIEnv.CallVoidMethod  (Handle, id_setSomeObjectPropertyArray_arrayI, __args);
+					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_setSomeObjectPropertyArray_arrayI, __args);
 				else
-					JNIEnv.CallNonvirtualVoidMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "setSomeObjectPropertyArray", "([I)V"), __args);
+					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "setSomeObjectPropertyArray", "([I)V"), __args);
 			} finally {
 				if (newvalue != null) {
 					JNIEnv.CopyArray (native_newvalue, newvalue);

--- a/tools/generator/Tests/expected/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
+++ b/tools/generator/Tests/expected/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
@@ -60,7 +60,7 @@ namespace Xamarin.Test {
 
 				public IFactoryInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
 				{
-					IntPtr local_ref = JNIEnv.GetObjectClass (Handle);
+					IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
 					this.class_ref = JNIEnv.NewGlobalRef (local_ref);
 					JNIEnv.DeleteLocalRef (local_ref);
 				}
@@ -88,7 +88,7 @@ namespace Xamarin.Test {
 						id_build_I = JNIEnv.GetMethodID (class_ref, "build", "(I)Lxamarin/test/NotificationCompatBase$Action;");
 					JValue* __args = stackalloc JValue [1];
 					__args [0] = new JValue (p0);
-					return global::Java.Lang.Object.GetObject<global::Xamarin.Test.NotificationCompatBase.Action> (JNIEnv.CallObjectMethod (Handle, id_build_I, __args), JniHandleOwnership.TransferLocalRef);
+					return global::Java.Lang.Object.GetObject<global::Xamarin.Test.NotificationCompatBase.Action> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_build_I, __args), JniHandleOwnership.TransferLocalRef);
 				}
 
 			}
@@ -137,7 +137,7 @@ namespace Xamarin.Test {
 			public unsafe InstanceInner (global::Xamarin.Test.NotificationCompatBase __self)
 				: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 			{
-				if (Handle != IntPtr.Zero)
+				if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
 					return;
 
 				try {
@@ -147,7 +147,7 @@ namespace Xamarin.Test {
 						SetHandle (
 								global::Android.Runtime.JNIEnv.StartCreateInstance (GetType (), "(L" + global::Android.Runtime.JNIEnv.GetJniName (GetType ().DeclaringType) + ";)V", __args),
 								JniHandleOwnership.TransferLocalRef);
-						global::Android.Runtime.JNIEnv.FinishCreateInstance (Handle, "(L" + global::Android.Runtime.JNIEnv.GetJniName (GetType ().DeclaringType) + ";)V", __args);
+						global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "(L" + global::Android.Runtime.JNIEnv.GetJniName (GetType ().DeclaringType) + ";)V", __args);
 						return;
 					}
 
@@ -156,7 +156,7 @@ namespace Xamarin.Test {
 					SetHandle (
 							global::Android.Runtime.JNIEnv.StartCreateInstance (class_ref, id_ctor_Lxamarin_test_NotificationCompatBase_, __args),
 							JniHandleOwnership.TransferLocalRef);
-					JNIEnv.FinishCreateInstance (Handle, class_ref, id_ctor_Lxamarin_test_NotificationCompatBase_, __args);
+					JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, class_ref, id_ctor_Lxamarin_test_NotificationCompatBase_, __args);
 				} finally {
 				}
 			}

--- a/tools/generator/Tests/expected/NonStaticFields/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected/NonStaticFields/Xamarin.Test.SomeObject.cs
@@ -17,13 +17,13 @@ namespace Xamarin.Test {
 			get {
 				if (Value_jfieldId == IntPtr.Zero)
 					Value_jfieldId = JNIEnv.GetFieldID (class_ref, "Value", "I");
-				return JNIEnv.GetIntField (Handle, Value_jfieldId);
+				return JNIEnv.GetIntField (((global::Java.Lang.Object) this).Handle, Value_jfieldId);
 			}
 			set {
 				if (Value_jfieldId == IntPtr.Zero)
 					Value_jfieldId = JNIEnv.GetFieldID (class_ref, "Value", "I");
 				try {
-					JNIEnv.SetField (Handle, Value_jfieldId, value);
+					JNIEnv.SetField (((global::Java.Lang.Object) this).Handle, Value_jfieldId, value);
 				} finally {
 				}
 			}

--- a/tools/generator/Tests/expected/NormalMethods/Java.Lang.Throwable.cs
+++ b/tools/generator/Tests/expected/NormalMethods/Java.Lang.Throwable.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Java.Lang {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Throwable']"
+	[global::Android.Runtime.Register ("java/lang/Throwable", DoNotGenerateAcw=true)]
+	public partial class Throwable  {
+
+	}
+}

--- a/tools/generator/Tests/expected/NormalMethods/NormalMethods.xml
+++ b/tools/generator/Tests/expected/NormalMethods/NormalMethods.xml
@@ -3,6 +3,13 @@
 	<package name="java.lang">
 	    <class abstract="false" deprecated="not deprecated" final="false" name="Object" static="false" visibility="public">
 	    </class>
+	    <class abstract="false" deprecated="not deprecated" final="false" name="Class" extends="java.lang.Object" extends-generic-aware="java.lang.Object" static="false" visibility="public">
+	        <typeParameters>
+	            <typeParameter name="T" />
+	        </typeParameters>
+	    </class>
+	    <class abstract="false" deprecated="not deprecated" final="false" name="Throwable" extends="java.lang.Object" extends-generic-aware="java.lang.Object" static="false" visibility="public">
+	    </class>
 	    <class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object"
 	    	final="false" name="Integer" static="false" visibility="public">
 	    </class>
@@ -10,6 +17,13 @@
 	<package name="xamarin.test">
 	  <class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" 
 	  		final="false" name="SomeObject" static="false" visibility="public">
+			<constructor deprecated="not deprecated" final="false" name="SomeObject" native="false" return="int" static="false" synchronized="false" visibility="public">
+				<parameter name="c" type="java.lang.Class&lt;? extends xamarin.test.SomeObject&gt;" />
+			</constructor>
+			<method abstract="false" deprecated="not deprecated" final="false" name="handle" native="false" return="int" static="false" synchronized="false" visibility="public">
+				<parameter name="o" type="java.lang.Object" />
+				<parameter name="t" type="java.lang.Throwable" />
+			</method>
 			<method abstract="false" deprecated="not deprecated" final="false" name="IntegerMethod" native="false" return="int" static="false" synchronized="false" visibility="public">
 	  		</method>
 	  		<method abstract="false" deprecated="not deprecated" final="false" name="VoidMethod" native="false" return="void" static="false" synchronized="false" visibility="public">
@@ -34,6 +48,8 @@
 	    </class>
 		<class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object"
 			final="false" name="A" static="true" visibility="public">
+			<method abstract="false" deprecated="not deprecated" final="false" name="getHandle" native="false" return="int" static="false" synchronized="false" visibility="public">
+			</method>
 		</class>
 		<class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" 
 			final="false" name="A.B" static="true" visibility="public">

--- a/tools/generator/Tests/expected/NormalMethods/Xamarin.Test.A.cs
+++ b/tools/generator/Tests/expected/NormalMethods/Xamarin.Test.A.cs
@@ -58,16 +58,64 @@ namespace Xamarin.Test {
 					__args [0] = new JValue (index);
 
 					if (GetType () == ThresholdType)
-						return (Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod  (Handle, id_setCustomDimension_I, __args), JniHandleOwnership.TransferLocalRef);
+						return (Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_setCustomDimension_I, __args), JniHandleOwnership.TransferLocalRef);
 					else
-						return (Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallNonvirtualObjectMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "setCustomDimension", "(I)Lxamarin/test/A$B;"), __args), JniHandleOwnership.TransferLocalRef);
+						return (Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallNonvirtualObjectMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "setCustomDimension", "(I)Lxamarin/test/A$B;"), __args), JniHandleOwnership.TransferLocalRef);
 				} finally {
 				}
 			}
 
 		}
 
+		internal static IntPtr java_class_handle;
+		internal static IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("xamarin/test/A", ref java_class_handle);
+			}
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (A); }
+		}
+
 		protected A (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		static Delegate cb_getHandle;
+#pragma warning disable 0169
+		static Delegate GetGetHandleHandler ()
+		{
+			if (cb_getHandle == null)
+				cb_getHandle = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, int>) n_GetHandle);
+			return cb_getHandle;
+		}
+
+		static int n_GetHandle (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Xamarin.Test.A __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.A> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return __this.GetHandle ();
+		}
+#pragma warning restore 0169
+
+		static IntPtr id_getHandle;
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='A']/method[@name='getHandle' and count(parameter)=0]"
+		[Register ("getHandle", "()I", "GetGetHandleHandler")]
+		public virtual unsafe int GetHandle ()
+		{
+			if (id_getHandle == IntPtr.Zero)
+				id_getHandle = JNIEnv.GetMethodID (class_ref, "getHandle", "()I");
+			try {
+
+				if (GetType () == ThresholdType)
+					return JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getHandle);
+				else
+					return JNIEnv.CallNonvirtualIntMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "getHandle", "()I"));
+			} finally {
+			}
+		}
 
 	}
 }

--- a/tools/generator/Tests/expected/NormalMethods/Xamarin.Test.C.cs
+++ b/tools/generator/Tests/expected/NormalMethods/Xamarin.Test.C.cs
@@ -54,9 +54,9 @@ namespace Xamarin.Test {
 				__args [0] = new JValue (index);
 
 				if (GetType () == ThresholdType)
-					return (Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod  (Handle, id_setCustomDimension_I, __args), JniHandleOwnership.TransferLocalRef);
+					return (Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_setCustomDimension_I, __args), JniHandleOwnership.TransferLocalRef);
 				else
-					return (Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallNonvirtualObjectMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "setCustomDimension", "(I)Lxamarin/test/C;"), __args), JniHandleOwnership.TransferLocalRef);
+					return (Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallNonvirtualObjectMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "setCustomDimension", "(I)Lxamarin/test/C;"), __args), JniHandleOwnership.TransferLocalRef);
 			} finally {
 			}
 		}

--- a/tools/generator/Tests/expected/NormalMethods/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected/NormalMethods/Xamarin.Test.SomeObject.cs
@@ -25,6 +25,77 @@ namespace Xamarin.Test {
 
 		protected SomeObject (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
 
+		static IntPtr id_ctor_Ljava_lang_Class_;
+		// Metadata.xml XPath constructor reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/constructor[@name='SomeObject' and count(parameter)=1 and parameter[1][@type='java.lang.Class&lt;? extends xamarin.test.SomeObject&gt;']]"
+		[Register (".ctor", "(Ljava/lang/Class;)V", "")]
+		public unsafe SomeObject (global::Java.Lang.Class c)
+			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		{
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+				return;
+
+			try {
+				JValue* __args = stackalloc JValue [1];
+				__args [0] = new JValue (c);
+				if (GetType () != typeof (SomeObject)) {
+					SetHandle (
+							global::Android.Runtime.JNIEnv.StartCreateInstance (GetType (), "(Ljava/lang/Class;)V", __args),
+							JniHandleOwnership.TransferLocalRef);
+					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "(Ljava/lang/Class;)V", __args);
+					return;
+				}
+
+				if (id_ctor_Ljava_lang_Class_ == IntPtr.Zero)
+					id_ctor_Ljava_lang_Class_ = JNIEnv.GetMethodID (class_ref, "<init>", "(Ljava/lang/Class;)V");
+				SetHandle (
+						global::Android.Runtime.JNIEnv.StartCreateInstance (class_ref, id_ctor_Ljava_lang_Class_, __args),
+						JniHandleOwnership.TransferLocalRef);
+				JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, class_ref, id_ctor_Ljava_lang_Class_, __args);
+			} finally {
+			}
+		}
+
+		static Delegate cb_handle_Ljava_lang_Object_Ljava_lang_Throwable_;
+#pragma warning disable 0169
+		static Delegate GetHandle_Ljava_lang_Object_Ljava_lang_Throwable_Handler ()
+		{
+			if (cb_handle_Ljava_lang_Object_Ljava_lang_Throwable_ == null)
+				cb_handle_Ljava_lang_Object_Ljava_lang_Throwable_ = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr, IntPtr, int>) n_Handle_Ljava_lang_Object_Ljava_lang_Throwable_);
+			return cb_handle_Ljava_lang_Object_Ljava_lang_Throwable_;
+		}
+
+		static int n_Handle_Ljava_lang_Object_Ljava_lang_Throwable_ (IntPtr jnienv, IntPtr native__this, IntPtr native_o, IntPtr native_t)
+		{
+			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			global::Java.Lang.Object o = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_o, JniHandleOwnership.DoNotTransfer);
+			global::Java.Lang.Throwable t = global::Java.Lang.Object.GetObject<global::Java.Lang.Throwable> (native_t, JniHandleOwnership.DoNotTransfer);
+			int __ret = __this.Handle (o, t);
+			return __ret;
+		}
+#pragma warning restore 0169
+
+		static IntPtr id_handle_Ljava_lang_Object_Ljava_lang_Throwable_;
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/method[@name='handle' and count(parameter)=2 and parameter[1][@type='java.lang.Object'] and parameter[2][@type='java.lang.Throwable']]"
+		[Register ("handle", "(Ljava/lang/Object;Ljava/lang/Throwable;)I", "GetHandle_Ljava_lang_Object_Ljava_lang_Throwable_Handler")]
+		public virtual unsafe int Handle (global::Java.Lang.Object o, global::Java.Lang.Throwable t)
+		{
+			if (id_handle_Ljava_lang_Object_Ljava_lang_Throwable_ == IntPtr.Zero)
+				id_handle_Ljava_lang_Object_Ljava_lang_Throwable_ = JNIEnv.GetMethodID (class_ref, "handle", "(Ljava/lang/Object;Ljava/lang/Throwable;)I");
+			try {
+				JValue* __args = stackalloc JValue [2];
+				__args [0] = new JValue (o);
+				__args [1] = new JValue (t);
+
+				int __ret;
+				if (GetType () == ThresholdType)
+					__ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_handle_Ljava_lang_Object_Ljava_lang_Throwable_, __args);
+				else
+					__ret = JNIEnv.CallNonvirtualIntMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "handle", "(Ljava/lang/Object;Ljava/lang/Throwable;)I"), __args);
+				return __ret;
+			} finally {
+			}
+		}
+
 		static Delegate cb_IntegerMethod;
 #pragma warning disable 0169
 		static Delegate GetIntegerMethodHandler ()
@@ -51,9 +122,9 @@ namespace Xamarin.Test {
 			try {
 
 				if (GetType () == ThresholdType)
-					return JNIEnv.CallIntMethod  (Handle, id_IntegerMethod);
+					return JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_IntegerMethod);
 				else
-					return JNIEnv.CallNonvirtualIntMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "IntegerMethod", "()I"));
+					return JNIEnv.CallNonvirtualIntMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "IntegerMethod", "()I"));
 			} finally {
 			}
 		}
@@ -84,9 +155,9 @@ namespace Xamarin.Test {
 			try {
 
 				if (GetType () == ThresholdType)
-					JNIEnv.CallVoidMethod  (Handle, id_VoidMethod);
+					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_VoidMethod);
 				else
-					JNIEnv.CallNonvirtualVoidMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "VoidMethod", "()V"));
+					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "VoidMethod", "()V"));
 			} finally {
 			}
 		}
@@ -117,9 +188,9 @@ namespace Xamarin.Test {
 			try {
 
 				if (GetType () == ThresholdType)
-					return JNIEnv.GetString (JNIEnv.CallObjectMethod  (Handle, id_StringMethod), JniHandleOwnership.TransferLocalRef);
+					return JNIEnv.GetString (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_StringMethod), JniHandleOwnership.TransferLocalRef);
 				else
-					return JNIEnv.GetString (JNIEnv.CallNonvirtualObjectMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "StringMethod", "()Ljava/lang/String;")), JniHandleOwnership.TransferLocalRef);
+					return JNIEnv.GetString (JNIEnv.CallNonvirtualObjectMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "StringMethod", "()Ljava/lang/String;")), JniHandleOwnership.TransferLocalRef);
 			} finally {
 			}
 		}
@@ -150,9 +221,9 @@ namespace Xamarin.Test {
 			try {
 
 				if (GetType () == ThresholdType)
-					return global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod  (Handle, id_ObjectMethod), JniHandleOwnership.TransferLocalRef);
+					return global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_ObjectMethod), JniHandleOwnership.TransferLocalRef);
 				else
-					return global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallNonvirtualObjectMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "ObjectMethod", "()Ljava/lang/Object;")), JniHandleOwnership.TransferLocalRef);
+					return global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallNonvirtualObjectMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "ObjectMethod", "()Ljava/lang/Object;")), JniHandleOwnership.TransferLocalRef);
 			} finally {
 			}
 		}
@@ -190,9 +261,9 @@ namespace Xamarin.Test {
 				__args [2] = new JValue (anObject);
 
 				if (GetType () == ThresholdType)
-					JNIEnv.CallVoidMethod  (Handle, id_VoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object_, __args);
+					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_VoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object_, __args);
 				else
-					JNIEnv.CallNonvirtualVoidMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "VoidMethodWithParams", "(Ljava/lang/String;ILjava/lang/Object;)V"), __args);
+					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "VoidMethodWithParams", "(Ljava/lang/String;ILjava/lang/Object;)V"), __args);
 			} finally {
 				JNIEnv.DeleteLocalRef (native_astring);
 			}
@@ -225,9 +296,9 @@ namespace Xamarin.Test {
 			try {
 
 				if (GetType () == ThresholdType)
-					return JNIEnv.CallIntMethod  (Handle, id_ObsoleteMethod);
+					return JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_ObsoleteMethod);
 				else
-					return JNIEnv.CallNonvirtualIntMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "ObsoleteMethod", "()I"));
+					return JNIEnv.CallNonvirtualIntMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "ObsoleteMethod", "()I"));
 			} finally {
 			}
 		}
@@ -262,9 +333,9 @@ namespace Xamarin.Test {
 				__args [0] = new JValue (native_p0);
 
 				if (GetType () == ThresholdType)
-					JNIEnv.CallVoidMethod  (Handle, id_ArrayListTest_Ljava_util_ArrayList_, __args);
+					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_ArrayListTest_Ljava_util_ArrayList_, __args);
 				else
-					JNIEnv.CallNonvirtualVoidMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "ArrayListTest", "(Ljava/util/ArrayList;)V"), __args);
+					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "ArrayListTest", "(Ljava/util/ArrayList;)V"), __args);
 			} finally {
 				JNIEnv.DeleteLocalRef (native_p0);
 			}

--- a/tools/generator/Tests/expected/NormalProperties/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected/NormalProperties/Xamarin.Test.SomeObject.cs
@@ -164,7 +164,7 @@ namespace Xamarin.Test {
 				if (id_getSomeInteger == IntPtr.Zero)
 					id_getSomeInteger = JNIEnv.GetMethodID (class_ref, "getSomeInteger", "()I");
 				try {
-					return JNIEnv.CallIntMethod  (Handle, id_getSomeInteger);
+					return JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getSomeInteger);
 				} finally {
 				}
 			}
@@ -176,7 +176,7 @@ namespace Xamarin.Test {
 				try {
 					JValue* __args = stackalloc JValue [1];
 					__args [0] = new JValue (value);
-					JNIEnv.CallVoidMethod  (Handle, id_setSomeInteger_I, __args);
+					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_setSomeInteger_I, __args);
 				} finally {
 				}
 			}
@@ -191,7 +191,7 @@ namespace Xamarin.Test {
 				if (id_getSomeObjectProperty == IntPtr.Zero)
 					id_getSomeObjectProperty = JNIEnv.GetMethodID (class_ref, "getSomeObjectProperty", "()Ljava/lang/Object;");
 				try {
-					return global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod  (Handle, id_getSomeObjectProperty), JniHandleOwnership.TransferLocalRef);
+					return global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_getSomeObjectProperty), JniHandleOwnership.TransferLocalRef);
 				} finally {
 				}
 			}
@@ -203,7 +203,7 @@ namespace Xamarin.Test {
 				try {
 					JValue* __args = stackalloc JValue [1];
 					__args [0] = new JValue (value);
-					JNIEnv.CallVoidMethod  (Handle, id_setSomeObjectProperty_Ljava_lang_Object_, __args);
+					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_setSomeObjectProperty_Ljava_lang_Object_, __args);
 				} finally {
 				}
 			}
@@ -218,7 +218,7 @@ namespace Xamarin.Test {
 				if (id_getSomeString == IntPtr.Zero)
 					id_getSomeString = JNIEnv.GetMethodID (class_ref, "getSomeString", "()Ljava/lang/String;");
 				try {
-					return JNIEnv.GetString (JNIEnv.CallObjectMethod  (Handle, id_getSomeString), JniHandleOwnership.TransferLocalRef);
+					return JNIEnv.GetString (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_getSomeString), JniHandleOwnership.TransferLocalRef);
 				} finally {
 				}
 			}
@@ -231,7 +231,7 @@ namespace Xamarin.Test {
 				try {
 					JValue* __args = stackalloc JValue [1];
 					__args [0] = new JValue (native_value);
-					JNIEnv.CallVoidMethod  (Handle, id_setSomeString_Ljava_lang_String_, __args);
+					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_setSomeString_Ljava_lang_String_, __args);
 				} finally {
 					JNIEnv.DeleteLocalRef (native_value);
 				}

--- a/tools/generator/Tests/expected/ParameterXPath/Xamarin.Test.A.cs
+++ b/tools/generator/Tests/expected/ParameterXPath/Xamarin.Test.A.cs
@@ -56,9 +56,9 @@ namespace Xamarin.Test {
 				__args [0] = new JValue (native_adapter);
 
 				if (GetType () == ThresholdType)
-					JNIEnv.CallVoidMethod  (Handle, id_setA_Ljava_lang_Object_, __args);
+					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_setA_Ljava_lang_Object_, __args);
 				else
-					JNIEnv.CallNonvirtualVoidMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "setA", "(Ljava/lang/Object;)V"), __args);
+					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "setA", "(Ljava/lang/Object;)V"), __args);
 			} finally {
 				JNIEnv.DeleteLocalRef (native_adapter);
 			}
@@ -94,9 +94,9 @@ namespace Xamarin.Test {
 				__args [0] = new JValue (native_p0);
 
 				if (GetType () == ThresholdType)
-					JNIEnv.CallVoidMethod  (Handle, id_listTest_Ljava_util_List_, __args);
+					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_listTest_Ljava_util_List_, __args);
 				else
-					JNIEnv.CallNonvirtualVoidMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "listTest", "(Ljava/util/List;)V"), __args);
+					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "listTest", "(Ljava/util/List;)V"), __args);
 			} finally {
 				JNIEnv.DeleteLocalRef (native_p0);
 			}

--- a/tools/generator/Tests/expected/Streams/Java.IO.FilterOutputStream.cs
+++ b/tools/generator/Tests/expected/Streams/Java.IO.FilterOutputStream.cs
@@ -31,7 +31,7 @@ namespace Java.IO {
 		public unsafe FilterOutputStream (global::System.IO.Stream @out)
 			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 		{
-			if (Handle != IntPtr.Zero)
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
 				return;
 
 			IntPtr native__out = global::Android.Runtime.OutputStreamAdapter.ToLocalJniHandle (@out);
@@ -42,7 +42,7 @@ namespace Java.IO {
 					SetHandle (
 							global::Android.Runtime.JNIEnv.StartCreateInstance (GetType (), "(Ljava/io/OutputStream;)V", __args),
 							JniHandleOwnership.TransferLocalRef);
-					global::Android.Runtime.JNIEnv.FinishCreateInstance (Handle, "(Ljava/io/OutputStream;)V", __args);
+					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "(Ljava/io/OutputStream;)V", __args);
 					return;
 				}
 
@@ -51,7 +51,7 @@ namespace Java.IO {
 				SetHandle (
 						global::Android.Runtime.JNIEnv.StartCreateInstance (class_ref, id_ctor_Ljava_io_OutputStream_, __args),
 						JniHandleOwnership.TransferLocalRef);
-				JNIEnv.FinishCreateInstance (Handle, class_ref, id_ctor_Ljava_io_OutputStream_, __args);
+				JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, class_ref, id_ctor_Ljava_io_OutputStream_, __args);
 			} finally {
 				JNIEnv.DeleteLocalRef (native__out);
 			}
@@ -85,9 +85,9 @@ namespace Java.IO {
 				__args [0] = new JValue (oneByte);
 
 				if (GetType () == ThresholdType)
-					JNIEnv.CallVoidMethod  (Handle, id_write_I, __args);
+					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_write_I, __args);
 				else
-					JNIEnv.CallNonvirtualVoidMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "write", "(I)V"), __args);
+					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "write", "(I)V"), __args);
 			} finally {
 			}
 		}

--- a/tools/generator/Tests/expected/Streams/Java.IO.IOException.cs
+++ b/tools/generator/Tests/expected/Streams/Java.IO.IOException.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Java.IO {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='java.io']/class[@name='IOException']"
+	[global::Android.Runtime.Register ("java/io/IOException", DoNotGenerateAcw=true)]
+	public abstract partial class IOException : global::Java.Lang.Throwable {
+
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("java/io/IOException", ref java_class_handle);
+			}
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (IOException); }
+		}
+
+		protected IOException (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		static Delegate cb_printStackTrace;
+#pragma warning disable 0169
+		static Delegate GetPrintStackTraceHandler ()
+		{
+			if (cb_printStackTrace == null)
+				cb_printStackTrace = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr>) n_PrintStackTrace);
+			return cb_printStackTrace;
+		}
+
+		static void n_PrintStackTrace (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Java.IO.IOException __this = global::Java.Lang.Object.GetObject<global::Java.IO.IOException> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			__this.PrintStackTrace ();
+		}
+#pragma warning restore 0169
+
+		static IntPtr id_printStackTrace;
+		// Metadata.xml XPath method reference: path="/api/package[@name='java.io']/class[@name='IOException']/method[@name='printStackTrace' and count(parameter)=0]"
+		[Register ("printStackTrace", "()V", "GetPrintStackTraceHandler")]
+		public virtual unsafe void PrintStackTrace ()
+		{
+			if (id_printStackTrace == IntPtr.Zero)
+				id_printStackTrace = JNIEnv.GetMethodID (class_ref, "printStackTrace", "()V");
+			try {
+
+				if (GetType () == ThresholdType)
+					JNIEnv.CallVoidMethod (((global::Java.Lang.Throwable) this).Handle, id_printStackTrace);
+				else
+					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Throwable) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "printStackTrace", "()V"));
+			} finally {
+			}
+		}
+
+	}
+
+	[global::Android.Runtime.Register ("java/io/IOException", DoNotGenerateAcw=true)]
+	internal partial class IOExceptionInvoker : IOException {
+
+		public IOExceptionInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (IOExceptionInvoker); }
+		}
+
+	}
+
+}

--- a/tools/generator/Tests/expected/Streams/Java.IO.InputStream.cs
+++ b/tools/generator/Tests/expected/Streams/Java.IO.InputStream.cs
@@ -31,7 +31,7 @@ namespace Java.IO {
 		public unsafe InputStream ()
 			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 		{
-			if (Handle != IntPtr.Zero)
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
 				return;
 
 			try {
@@ -39,7 +39,7 @@ namespace Java.IO {
 					SetHandle (
 							global::Android.Runtime.JNIEnv.StartCreateInstance (GetType (), "()V"),
 							JniHandleOwnership.TransferLocalRef);
-					global::Android.Runtime.JNIEnv.FinishCreateInstance (Handle, "()V");
+					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "()V");
 					return;
 				}
 
@@ -48,7 +48,7 @@ namespace Java.IO {
 				SetHandle (
 						global::Android.Runtime.JNIEnv.StartCreateInstance (class_ref, id_ctor),
 						JniHandleOwnership.TransferLocalRef);
-				JNIEnv.FinishCreateInstance (Handle, class_ref, id_ctor);
+				JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, class_ref, id_ctor);
 			} finally {
 			}
 		}
@@ -79,9 +79,9 @@ namespace Java.IO {
 			try {
 
 				if (GetType () == ThresholdType)
-					return JNIEnv.CallIntMethod  (Handle, id_available);
+					return JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_available);
 				else
-					return JNIEnv.CallNonvirtualIntMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "available", "()I"));
+					return JNIEnv.CallNonvirtualIntMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "available", "()I"));
 			} finally {
 			}
 		}
@@ -112,9 +112,9 @@ namespace Java.IO {
 			try {
 
 				if (GetType () == ThresholdType)
-					JNIEnv.CallVoidMethod  (Handle, id_close);
+					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_close);
 				else
-					JNIEnv.CallNonvirtualVoidMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "close", "()V"));
+					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "close", "()V"));
 			} finally {
 			}
 		}
@@ -147,9 +147,9 @@ namespace Java.IO {
 				__args [0] = new JValue (readlimit);
 
 				if (GetType () == ThresholdType)
-					JNIEnv.CallVoidMethod  (Handle, id_mark_I, __args);
+					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_mark_I, __args);
 				else
-					JNIEnv.CallNonvirtualVoidMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "mark", "(I)V"), __args);
+					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "mark", "(I)V"), __args);
 			} finally {
 			}
 		}
@@ -180,9 +180,9 @@ namespace Java.IO {
 			try {
 
 				if (GetType () == ThresholdType)
-					return JNIEnv.CallBooleanMethod  (Handle, id_markSupported);
+					return JNIEnv.CallBooleanMethod (((global::Java.Lang.Object) this).Handle, id_markSupported);
 				else
-					return JNIEnv.CallNonvirtualBooleanMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "markSupported", "()Z"));
+					return JNIEnv.CallNonvirtualBooleanMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "markSupported", "()Z"));
 			} finally {
 			}
 		}
@@ -241,9 +241,9 @@ namespace Java.IO {
 
 				int __ret;
 				if (GetType () == ThresholdType)
-					__ret = JNIEnv.CallIntMethod  (Handle, id_read_arrayB, __args);
+					__ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_read_arrayB, __args);
 				else
-					__ret = JNIEnv.CallNonvirtualIntMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "read", "([B)I"), __args);
+					__ret = JNIEnv.CallNonvirtualIntMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "read", "([B)I"), __args);
 				return __ret;
 			} finally {
 				if (buffer != null) {
@@ -289,9 +289,9 @@ namespace Java.IO {
 
 				int __ret;
 				if (GetType () == ThresholdType)
-					__ret = JNIEnv.CallIntMethod  (Handle, id_read_arrayBII, __args);
+					__ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_read_arrayBII, __args);
 				else
-					__ret = JNIEnv.CallNonvirtualIntMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "read", "([BII)I"), __args);
+					__ret = JNIEnv.CallNonvirtualIntMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "read", "([BII)I"), __args);
 				return __ret;
 			} finally {
 				if (buffer != null) {
@@ -327,9 +327,9 @@ namespace Java.IO {
 			try {
 
 				if (GetType () == ThresholdType)
-					JNIEnv.CallVoidMethod  (Handle, id_reset);
+					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_reset);
 				else
-					JNIEnv.CallNonvirtualVoidMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "reset", "()V"));
+					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "reset", "()V"));
 			} finally {
 			}
 		}
@@ -362,9 +362,9 @@ namespace Java.IO {
 				__args [0] = new JValue (byteCount);
 
 				if (GetType () == ThresholdType)
-					return JNIEnv.CallLongMethod  (Handle, id_skip_J, __args);
+					return JNIEnv.CallLongMethod (((global::Java.Lang.Object) this).Handle, id_skip_J, __args);
 				else
-					return JNIEnv.CallNonvirtualLongMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "skip", "(J)J"), __args);
+					return JNIEnv.CallNonvirtualLongMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "skip", "(J)J"), __args);
 			} finally {
 			}
 		}
@@ -388,7 +388,7 @@ namespace Java.IO {
 			if (id_read == IntPtr.Zero)
 				id_read = JNIEnv.GetMethodID (class_ref, "read", "()I");
 			try {
-				return JNIEnv.CallIntMethod  (Handle, id_read);
+				return JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_read);
 			} finally {
 			}
 		}

--- a/tools/generator/Tests/expected/Streams/Java.IO.OutputStream.cs
+++ b/tools/generator/Tests/expected/Streams/Java.IO.OutputStream.cs
@@ -31,7 +31,7 @@ namespace Java.IO {
 		public unsafe OutputStream ()
 			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 		{
-			if (Handle != IntPtr.Zero)
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
 				return;
 
 			try {
@@ -39,7 +39,7 @@ namespace Java.IO {
 					SetHandle (
 							global::Android.Runtime.JNIEnv.StartCreateInstance (GetType (), "()V"),
 							JniHandleOwnership.TransferLocalRef);
-					global::Android.Runtime.JNIEnv.FinishCreateInstance (Handle, "()V");
+					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "()V");
 					return;
 				}
 
@@ -48,7 +48,7 @@ namespace Java.IO {
 				SetHandle (
 						global::Android.Runtime.JNIEnv.StartCreateInstance (class_ref, id_ctor),
 						JniHandleOwnership.TransferLocalRef);
-				JNIEnv.FinishCreateInstance (Handle, class_ref, id_ctor);
+				JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, class_ref, id_ctor);
 			} finally {
 			}
 		}
@@ -79,9 +79,9 @@ namespace Java.IO {
 			try {
 
 				if (GetType () == ThresholdType)
-					JNIEnv.CallVoidMethod  (Handle, id_close);
+					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_close);
 				else
-					JNIEnv.CallNonvirtualVoidMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "close", "()V"));
+					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "close", "()V"));
 			} finally {
 			}
 		}
@@ -112,9 +112,9 @@ namespace Java.IO {
 			try {
 
 				if (GetType () == ThresholdType)
-					JNIEnv.CallVoidMethod  (Handle, id_flush);
+					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_flush);
 				else
-					JNIEnv.CallNonvirtualVoidMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "flush", "()V"));
+					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "flush", "()V"));
 			} finally {
 			}
 		}
@@ -151,9 +151,9 @@ namespace Java.IO {
 				__args [0] = new JValue (native_buffer);
 
 				if (GetType () == ThresholdType)
-					JNIEnv.CallVoidMethod  (Handle, id_write_arrayB, __args);
+					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_write_arrayB, __args);
 				else
-					JNIEnv.CallNonvirtualVoidMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "write", "([B)V"), __args);
+					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "write", "([B)V"), __args);
 			} finally {
 				if (buffer != null) {
 					JNIEnv.CopyArray (native_buffer, buffer);
@@ -196,9 +196,9 @@ namespace Java.IO {
 				__args [2] = new JValue (count);
 
 				if (GetType () == ThresholdType)
-					JNIEnv.CallVoidMethod  (Handle, id_write_arrayBII, __args);
+					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_write_arrayBII, __args);
 				else
-					JNIEnv.CallNonvirtualVoidMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "write", "([BII)V"), __args);
+					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "write", "([BII)V"), __args);
 			} finally {
 				if (buffer != null) {
 					JNIEnv.CopyArray (native_buffer, buffer);
@@ -248,7 +248,7 @@ namespace Java.IO {
 			try {
 				JValue* __args = stackalloc JValue [1];
 				__args [0] = new JValue (oneByte);
-				JNIEnv.CallVoidMethod  (Handle, id_write_I, __args);
+				JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_write_I, __args);
 			} finally {
 			}
 		}

--- a/tools/generator/Tests/expected/Streams/Java.Lang.Throwable.cs
+++ b/tools/generator/Tests/expected/Streams/Java.Lang.Throwable.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Java.Lang {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Throwable']"
+	[global::Android.Runtime.Register ("java/lang/Throwable", DoNotGenerateAcw=true)]
+	public partial class Throwable  {
+
+		internal static IntPtr java_class_handle;
+		internal static IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("java/lang/Throwable", ref java_class_handle);
+			}
+		}
+
+		static Delegate cb_getMessage;
+#pragma warning disable 0169
+		static Delegate GetGetMessageHandler ()
+		{
+			if (cb_getMessage == null)
+				cb_getMessage = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_GetMessage);
+			return cb_getMessage;
+		}
+
+		static IntPtr n_GetMessage (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Java.Lang.Throwable __this = global::Java.Lang.Object.GetObject<global::Java.Lang.Throwable> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.NewString (__this.Message);
+		}
+#pragma warning restore 0169
+
+		static IntPtr id_getMessage;
+		public virtual unsafe string Message {
+			// Metadata.xml XPath method reference: path="/api/package[@name='java.lang']/class[@name='Throwable']/method[@name='getMessage' and count(parameter)=0]"
+			[Register ("getMessage", "()Ljava/lang/String;", "GetGetMessageHandler")]
+			get {
+				if (id_getMessage == IntPtr.Zero)
+					id_getMessage = JNIEnv.GetMethodID (class_ref, "getMessage", "()Ljava/lang/String;");
+				try {
+
+					if (GetType () == ThresholdType)
+						return JNIEnv.GetString (JNIEnv.CallObjectMethod (((global::Java.Lang.Throwable) this).Handle, id_getMessage), JniHandleOwnership.TransferLocalRef);
+					else
+						return JNIEnv.GetString (JNIEnv.CallNonvirtualObjectMethod (((global::Java.Lang.Throwable) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "getMessage", "()Ljava/lang/String;")), JniHandleOwnership.TransferLocalRef);
+				} finally {
+				}
+			}
+		}
+
+	}
+}

--- a/tools/generator/Tests/expected/Streams/Streams.xml
+++ b/tools/generator/Tests/expected/Streams/Streams.xml
@@ -3,8 +3,16 @@
 	<package name="java.lang">
 		<class abstract="false" deprecated="not deprecated" final="false" name="Object" static="false" visibility="public">
 		</class>
+		<class abstract="false" deprecated="not deprecated" extends="java.lang.Object" final="false" name="Throwable" static="false" visibility="public">
+			<method abstract="false" deprecated="not deprecated" final="false" name="getMessage" native="false" return="java.lang.String" static="false" synchronized="false" visibility="public">
+			</method>
+		</class>
 	</package>
 	<package name="java.io">
+		<class abstract="true" deprecated="not deprecated" extends="java.lang.Throwable" extends-generic-aware="java.lang.Throwable" final="false" name="IOException" static="false" visibility="public">
+			<method abstract="false" deprecated="not deprecated" final="false" name="printStackTrace" native="false" return="void" static="false" synchronized="false" visibility="public">
+			</method>
+		</class>
 		<!--
 			public abstract class OutputStream extends java.lang.Object {
 				public void close () throws IOException {}

--- a/tools/generator/Tests/expected/TestInterface/Test.ME.GenericImplementation.cs
+++ b/tools/generator/Tests/expected/TestInterface/Test.ME.GenericImplementation.cs
@@ -31,7 +31,7 @@ namespace Test.ME {
 		public unsafe GenericImplementation ()
 			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 		{
-			if (Handle != IntPtr.Zero)
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
 				return;
 
 			try {
@@ -39,7 +39,7 @@ namespace Test.ME {
 					SetHandle (
 							global::Android.Runtime.JNIEnv.StartCreateInstance (GetType (), "()V"),
 							JniHandleOwnership.TransferLocalRef);
-					global::Android.Runtime.JNIEnv.FinishCreateInstance (Handle, "()V");
+					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "()V");
 					return;
 				}
 
@@ -48,7 +48,7 @@ namespace Test.ME {
 				SetHandle (
 						global::Android.Runtime.JNIEnv.StartCreateInstance (class_ref, id_ctor),
 						JniHandleOwnership.TransferLocalRef);
-				JNIEnv.FinishCreateInstance (Handle, class_ref, id_ctor);
+				JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, class_ref, id_ctor);
 			} finally {
 			}
 		}
@@ -85,9 +85,9 @@ namespace Test.ME {
 				__args [0] = new JValue (native_value);
 
 				if (GetType () == ThresholdType)
-					JNIEnv.CallVoidMethod  (Handle, id_SetObject_arrayB, __args);
+					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_SetObject_arrayB, __args);
 				else
-					JNIEnv.CallNonvirtualVoidMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "SetObject", "([B)V"), __args);
+					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "SetObject", "([B)V"), __args);
 			} finally {
 				if (value != null) {
 					JNIEnv.CopyArray (native_value, value);

--- a/tools/generator/Tests/expected/TestInterface/Test.ME.GenericStringImplementation.cs
+++ b/tools/generator/Tests/expected/TestInterface/Test.ME.GenericStringImplementation.cs
@@ -31,7 +31,7 @@ namespace Test.ME {
 		public unsafe GenericStringImplementation ()
 			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 		{
-			if (Handle != IntPtr.Zero)
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
 				return;
 
 			try {
@@ -39,7 +39,7 @@ namespace Test.ME {
 					SetHandle (
 							global::Android.Runtime.JNIEnv.StartCreateInstance (GetType (), "()V"),
 							JniHandleOwnership.TransferLocalRef);
-					global::Android.Runtime.JNIEnv.FinishCreateInstance (Handle, "()V");
+					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "()V");
 					return;
 				}
 
@@ -48,7 +48,7 @@ namespace Test.ME {
 				SetHandle (
 						global::Android.Runtime.JNIEnv.StartCreateInstance (class_ref, id_ctor),
 						JniHandleOwnership.TransferLocalRef);
-				JNIEnv.FinishCreateInstance (Handle, class_ref, id_ctor);
+				JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, class_ref, id_ctor);
 			} finally {
 			}
 		}
@@ -85,9 +85,9 @@ namespace Test.ME {
 				__args [0] = new JValue (native_value);
 
 				if (GetType () == ThresholdType)
-					JNIEnv.CallVoidMethod  (Handle, id_SetObject_arrayLjava_lang_String_, __args);
+					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_SetObject_arrayLjava_lang_String_, __args);
 				else
-					JNIEnv.CallNonvirtualVoidMethod  (Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "SetObject", "([Ljava/lang/String;)V"), __args);
+					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "SetObject", "([Ljava/lang/String;)V"), __args);
 			} finally {
 				if (value != null) {
 					JNIEnv.CopyArray (native_value, value);

--- a/tools/generator/Tests/expected/TestInterface/Test.ME.IGenericInterface.cs
+++ b/tools/generator/Tests/expected/TestInterface/Test.ME.IGenericInterface.cs
@@ -53,7 +53,7 @@ namespace Test.ME {
 
 		public IGenericInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
 		{
-			IntPtr local_ref = JNIEnv.GetObjectClass (Handle);
+			IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
 			this.class_ref = JNIEnv.NewGlobalRef (local_ref);
 			JNIEnv.DeleteLocalRef (local_ref);
 		}
@@ -83,7 +83,7 @@ namespace Test.ME {
 			IntPtr native_value = JNIEnv.ToLocalJniHandle (value);
 			JValue* __args = stackalloc JValue [1];
 			__args [0] = new JValue (native_value);
-			JNIEnv.CallVoidMethod (Handle, id_SetObject_Ljava_lang_Object_, __args);
+			JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_SetObject_Ljava_lang_Object_, __args);
 			JNIEnv.DeleteLocalRef (native_value);
 		}
 

--- a/tools/generator/Tests/expected/TestInterface/Test.ME.ITestInterface.cs
+++ b/tools/generator/Tests/expected/TestInterface/Test.ME.ITestInterface.cs
@@ -88,7 +88,7 @@ namespace Test.ME {
 
 		public ITestInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
 		{
-			IntPtr local_ref = JNIEnv.GetObjectClass (Handle);
+			IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
 			this.class_ref = JNIEnv.NewGlobalRef (local_ref);
 			JNIEnv.DeleteLocalRef (local_ref);
 		}
@@ -118,7 +118,7 @@ namespace Test.ME {
 				id_getSpanFlags_Ljava_lang_Object_ = JNIEnv.GetMethodID (class_ref, "getSpanFlags", "(Ljava/lang/Object;)I");
 			JValue* __args = stackalloc JValue [1];
 			__args [0] = new JValue (tag);
-			int __ret = JNIEnv.CallIntMethod (Handle, id_getSpanFlags_Ljava_lang_Object_, __args);
+			int __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getSpanFlags_Ljava_lang_Object_, __args);
 			return __ret;
 		}
 

--- a/tools/generator/Tests/expected/TestInterface/Test.ME.TestInterfaceImplementation.cs
+++ b/tools/generator/Tests/expected/TestInterface/Test.ME.TestInterfaceImplementation.cs
@@ -54,7 +54,7 @@ namespace Test.ME {
 		public unsafe TestInterfaceImplementation ()
 			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 		{
-			if (Handle != IntPtr.Zero)
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
 				return;
 
 			try {
@@ -62,7 +62,7 @@ namespace Test.ME {
 					SetHandle (
 							global::Android.Runtime.JNIEnv.StartCreateInstance (GetType (), "()V"),
 							JniHandleOwnership.TransferLocalRef);
-					global::Android.Runtime.JNIEnv.FinishCreateInstance (Handle, "()V");
+					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "()V");
 					return;
 				}
 
@@ -71,7 +71,7 @@ namespace Test.ME {
 				SetHandle (
 						global::Android.Runtime.JNIEnv.StartCreateInstance (class_ref, id_ctor),
 						JniHandleOwnership.TransferLocalRef);
-				JNIEnv.FinishCreateInstance (Handle, class_ref, id_ctor);
+				JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, class_ref, id_ctor);
 			} finally {
 			}
 		}
@@ -119,7 +119,7 @@ namespace Test.ME {
 			try {
 				JValue* __args = stackalloc JValue [1];
 				__args [0] = new JValue (tag);
-				int __ret = JNIEnv.CallIntMethod  (Handle, id_getSpanFlags_Ljava_lang_Object_, __args);
+				int __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getSpanFlags_Ljava_lang_Object_, __args);
 				return __ret;
 			} finally {
 			}

--- a/tools/generator/Tests/expected/java.lang.Enum/Java.Lang.Enum.cs
+++ b/tools/generator/Tests/expected/java.lang.Enum/Java.Lang.Enum.cs
@@ -37,7 +37,7 @@ namespace Java.Lang {
 			try {
 				JValue* __args = stackalloc JValue [1];
 				__args [0] = new JValue (native_o);
-				int __ret = JNIEnv.CallIntMethod  (Handle, id_compareTo_Ljava_lang_Enum_, __args);
+				int __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_compareTo_Ljava_lang_Enum_, __args);
 				return __ret;
 			} finally {
 				JNIEnv.DeleteLocalRef (native_o);

--- a/tools/generator/Tests/expected/java.lang.Enum/Java.Lang.IComparable.cs
+++ b/tools/generator/Tests/expected/java.lang.Enum/Java.Lang.IComparable.cs
@@ -53,7 +53,7 @@ namespace Java.Lang {
 
 		public IComparableInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
 		{
-			IntPtr local_ref = JNIEnv.GetObjectClass (Handle);
+			IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
 			this.class_ref = JNIEnv.NewGlobalRef (local_ref);
 			JNIEnv.DeleteLocalRef (local_ref);
 		}
@@ -84,7 +84,7 @@ namespace Java.Lang {
 			IntPtr native_another = JNIEnv.ToLocalJniHandle (another);
 			JValue* __args = stackalloc JValue [1];
 			__args [0] = new JValue (native_another);
-			int __ret = JNIEnv.CallIntMethod (Handle, id_compareTo_Ljava_lang_Object_, __args);
+			int __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_compareTo_Ljava_lang_Object_, __args);
 			JNIEnv.DeleteLocalRef (native_another);
 			return __ret;
 		}

--- a/tools/generator/Tests/expected/java.util.List/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected/java.util.List/Xamarin.Test.SomeObject.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Test {
 			get {
 				if (myStrings_jfieldId == IntPtr.Zero)
 					myStrings_jfieldId = JNIEnv.GetFieldID (class_ref, "myStrings", "Ljava/util/List;");
-				IntPtr __ret = JNIEnv.GetObjectField (Handle, myStrings_jfieldId);
+				IntPtr __ret = JNIEnv.GetObjectField (((global::Java.Lang.Object) this).Handle, myStrings_jfieldId);
 				return global::Android.Runtime.JavaList<string>.FromJniHandle (__ret, JniHandleOwnership.TransferLocalRef);
 			}
 			set {
@@ -25,7 +25,7 @@ namespace Xamarin.Test {
 					myStrings_jfieldId = JNIEnv.GetFieldID (class_ref, "myStrings", "Ljava/util/List;");
 				IntPtr native_value = global::Android.Runtime.JavaList<string>.ToLocalJniHandle (value);
 				try {
-					JNIEnv.SetField (Handle, myStrings_jfieldId, native_value);
+					JNIEnv.SetField (((global::Java.Lang.Object) this).Handle, myStrings_jfieldId, native_value);
 				} finally {
 					JNIEnv.DeleteLocalRef (native_value);
 				}
@@ -40,7 +40,7 @@ namespace Xamarin.Test {
 			get {
 				if (myInts_jfieldId == IntPtr.Zero)
 					myInts_jfieldId = JNIEnv.GetFieldID (class_ref, "myInts", "Ljava/util/List;");
-				IntPtr __ret = JNIEnv.GetObjectField (Handle, myInts_jfieldId);
+				IntPtr __ret = JNIEnv.GetObjectField (((global::Java.Lang.Object) this).Handle, myInts_jfieldId);
 				return global::Android.Runtime.JavaList<int>.FromJniHandle (__ret, JniHandleOwnership.TransferLocalRef);
 			}
 			set {
@@ -48,7 +48,7 @@ namespace Xamarin.Test {
 					myInts_jfieldId = JNIEnv.GetFieldID (class_ref, "myInts", "Ljava/util/List;");
 				IntPtr native_value = global::Android.Runtime.JavaList<int>.ToLocalJniHandle (value);
 				try {
-					JNIEnv.SetField (Handle, myInts_jfieldId, native_value);
+					JNIEnv.SetField (((global::Java.Lang.Object) this).Handle, myInts_jfieldId, native_value);
 				} finally {
 					JNIEnv.DeleteLocalRef (native_value);
 				}
@@ -63,7 +63,7 @@ namespace Xamarin.Test {
 			get {
 				if (mybools_jfieldId == IntPtr.Zero)
 					mybools_jfieldId = JNIEnv.GetFieldID (class_ref, "mybools", "Ljava/util/List;");
-				IntPtr __ret = JNIEnv.GetObjectField (Handle, mybools_jfieldId);
+				IntPtr __ret = JNIEnv.GetObjectField (((global::Java.Lang.Object) this).Handle, mybools_jfieldId);
 				return global::Android.Runtime.JavaList<bool>.FromJniHandle (__ret, JniHandleOwnership.TransferLocalRef);
 			}
 			set {
@@ -71,7 +71,7 @@ namespace Xamarin.Test {
 					mybools_jfieldId = JNIEnv.GetFieldID (class_ref, "mybools", "Ljava/util/List;");
 				IntPtr native_value = global::Android.Runtime.JavaList<bool>.ToLocalJniHandle (value);
 				try {
-					JNIEnv.SetField (Handle, mybools_jfieldId, native_value);
+					JNIEnv.SetField (((global::Java.Lang.Object) this).Handle, mybools_jfieldId, native_value);
 				} finally {
 					JNIEnv.DeleteLocalRef (native_value);
 				}
@@ -86,7 +86,7 @@ namespace Xamarin.Test {
 			get {
 				if (myObjects_jfieldId == IntPtr.Zero)
 					myObjects_jfieldId = JNIEnv.GetFieldID (class_ref, "myObjects", "Ljava/util/List;");
-				IntPtr __ret = JNIEnv.GetObjectField (Handle, myObjects_jfieldId);
+				IntPtr __ret = JNIEnv.GetObjectField (((global::Java.Lang.Object) this).Handle, myObjects_jfieldId);
 				return global::Android.Runtime.JavaList<global::Java.Lang.Object>.FromJniHandle (__ret, JniHandleOwnership.TransferLocalRef);
 			}
 			set {
@@ -94,7 +94,7 @@ namespace Xamarin.Test {
 					myObjects_jfieldId = JNIEnv.GetFieldID (class_ref, "myObjects", "Ljava/util/List;");
 				IntPtr native_value = global::Android.Runtime.JavaList<global::Java.Lang.Object>.ToLocalJniHandle (value);
 				try {
-					JNIEnv.SetField (Handle, myObjects_jfieldId, native_value);
+					JNIEnv.SetField (((global::Java.Lang.Object) this).Handle, myObjects_jfieldId, native_value);
 				} finally {
 					JNIEnv.DeleteLocalRef (native_value);
 				}
@@ -109,7 +109,7 @@ namespace Xamarin.Test {
 			get {
 				if (myfloats_jfieldId == IntPtr.Zero)
 					myfloats_jfieldId = JNIEnv.GetFieldID (class_ref, "myfloats", "Ljava/util/List;");
-				IntPtr __ret = JNIEnv.GetObjectField (Handle, myfloats_jfieldId);
+				IntPtr __ret = JNIEnv.GetObjectField (((global::Java.Lang.Object) this).Handle, myfloats_jfieldId);
 				return global::Android.Runtime.JavaList<float>.FromJniHandle (__ret, JniHandleOwnership.TransferLocalRef);
 			}
 			set {
@@ -117,7 +117,7 @@ namespace Xamarin.Test {
 					myfloats_jfieldId = JNIEnv.GetFieldID (class_ref, "myfloats", "Ljava/util/List;");
 				IntPtr native_value = global::Android.Runtime.JavaList<float>.ToLocalJniHandle (value);
 				try {
-					JNIEnv.SetField (Handle, myfloats_jfieldId, native_value);
+					JNIEnv.SetField (((global::Java.Lang.Object) this).Handle, myfloats_jfieldId, native_value);
 				} finally {
 					JNIEnv.DeleteLocalRef (native_value);
 				}
@@ -132,7 +132,7 @@ namespace Xamarin.Test {
 			get {
 				if (mydoubles_jfieldId == IntPtr.Zero)
 					mydoubles_jfieldId = JNIEnv.GetFieldID (class_ref, "mydoubles", "Ljava/util/List;");
-				IntPtr __ret = JNIEnv.GetObjectField (Handle, mydoubles_jfieldId);
+				IntPtr __ret = JNIEnv.GetObjectField (((global::Java.Lang.Object) this).Handle, mydoubles_jfieldId);
 				return global::Android.Runtime.JavaList<double>.FromJniHandle (__ret, JniHandleOwnership.TransferLocalRef);
 			}
 			set {
@@ -140,7 +140,7 @@ namespace Xamarin.Test {
 					mydoubles_jfieldId = JNIEnv.GetFieldID (class_ref, "mydoubles", "Ljava/util/List;");
 				IntPtr native_value = global::Android.Runtime.JavaList<double>.ToLocalJniHandle (value);
 				try {
-					JNIEnv.SetField (Handle, mydoubles_jfieldId, native_value);
+					JNIEnv.SetField (((global::Java.Lang.Object) this).Handle, mydoubles_jfieldId, native_value);
 				} finally {
 					JNIEnv.DeleteLocalRef (native_value);
 				}
@@ -155,7 +155,7 @@ namespace Xamarin.Test {
 			get {
 				if (mylongs_jfieldId == IntPtr.Zero)
 					mylongs_jfieldId = JNIEnv.GetFieldID (class_ref, "mylongs", "Ljava/util/List;");
-				IntPtr __ret = JNIEnv.GetObjectField (Handle, mylongs_jfieldId);
+				IntPtr __ret = JNIEnv.GetObjectField (((global::Java.Lang.Object) this).Handle, mylongs_jfieldId);
 				return global::Android.Runtime.JavaList<long>.FromJniHandle (__ret, JniHandleOwnership.TransferLocalRef);
 			}
 			set {
@@ -163,7 +163,7 @@ namespace Xamarin.Test {
 					mylongs_jfieldId = JNIEnv.GetFieldID (class_ref, "mylongs", "Ljava/util/List;");
 				IntPtr native_value = global::Android.Runtime.JavaList<long>.ToLocalJniHandle (value);
 				try {
-					JNIEnv.SetField (Handle, mylongs_jfieldId, native_value);
+					JNIEnv.SetField (((global::Java.Lang.Object) this).Handle, mylongs_jfieldId, native_value);
 				} finally {
 					JNIEnv.DeleteLocalRef (native_value);
 				}

--- a/tools/generator/Tests/generator-Tests.csproj
+++ b/tools/generator/Tests/generator-Tests.csproj
@@ -90,6 +90,9 @@
     <Content Include="SupportFiles\Java_Lang_Object.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="SupportFiles\Java_Lang_Throwable.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="SupportFiles\GeneratedEnumAttribute.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/tools/generator/XmlPullParserSymbol.cs
+++ b/tools/generator/XmlPullParserSymbol.cs
@@ -41,6 +41,11 @@ namespace MonoDroid.Generation {
 			get { return null; }
 		}
 
+		public string GetObjectHandleProperty (string variable)
+		{
+			return $"((global::Java.Lang.Object) {variable}).Handle";
+		}
+
 		public string GetGenericType (Dictionary<string, string> mappings)
 		{
 			return null;

--- a/tools/generator/XmlResourceParserSymbol.cs
+++ b/tools/generator/XmlResourceParserSymbol.cs
@@ -41,6 +41,11 @@ namespace MonoDroid.Generation {
 			get { return null; }
 		}
 
+		public string GetObjectHandleProperty (string variable)
+		{
+			return $"((global::Java.Lang.Object) {variable}).Handle";
+		}
+
 		public string GetGenericType (Dictionary<string, string> mappings)
 		{
 			return null;


### PR DESCRIPTION
Android N Preview 2 adds some methods named `handle()`, such as
`java.util.concurrent.CompletableFuture.handle()`. This clashes with
the Java.Lang.Object.Handle property, resulting in C# compiler errors
within the generated binding code:

	if (Handle != IntPtr.Zero)
	// Java.Util.Concurrent.CompletableFuture.cs(101,8): error CS0019: Operator `!=' cannot be applied to operands of type `method group' and `System.IntPtr'

	__args [0] = new JniArgumentValue ((other == null) ? IntPtr.Zero : other.Handle);
	// Java.Util.Concurrent.CompletableFuture.cs(254,65): error CS0173: Type of conditional expression cannot be determined because there is no implicit conversion between `System.IntPtr' and `method group'

There are two possible fixes:

1. Forbid the name `Handle`, and *rename* any occurrences to something
    else, such as `InvokeHandle`.

2. *Qualify* the `Java.Lang.Object.Handle` property reference.

(1) is kinda ugly.

(2) is possible by using a cast: instead of `value.Handle`, use e.g.
`((Java.Lang.Object) value).Handle`, which causes the compiler to use
the intended member, and not whatever may be hiding it in the current
scope.

(2) results in an arguably nicer API -- maybe? -- as the bound API
more closely mirrors the Java API.

(2) also results in uglier binding code. However, who reads it?

Note: Why cast to e.g. Java.Lang.Object and not IJavaObject? To avoid
virtual calls. `((Java.Lang.Object)value).Handle` results in a direct
invocation of the Object.get_Handle() method, avoiding a virtual call.
Casting to IJavaObject would result in a virtual interface method
invocation, causing additional runtime overhead to lookup the value.