### PR TITLE
[Java.Interop.Tools.JavaCallableWrappers] Support MultiDexApplication

### DIFF
--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
@@ -65,6 +65,8 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 			}
 		}
 
+		public  string          ApplicationJavaClass            { get; set; }
+
 		public bool UseSharedRuntime;
 
 		public bool GenerateOnCreateOverrides { get; set; }
@@ -530,6 +532,8 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 			sw.WriteLine ("public " + (type.IsAbstract ? "abstract " : "") + "class " + name);
 
 			string extendsType = GetJavaTypeName (type.BaseType);
+			if (extendsType == "android.app.Application" && !string.IsNullOrEmpty (ApplicationJavaClass))
+				extendsType = ApplicationJavaClass;
 			sw.WriteLine ("\textends " + extendsType);
 			sw.WriteLine ("\timplements");
 			sw.Write ("\t\tmono.android.IGCUserPeer");

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGeneratorTests.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGeneratorTests.cs
@@ -94,51 +94,55 @@ namespace Java.Interop.Tools.JavaCallableWrappersTests
 		}
 
 		[Test]
-		public void GenerateApplication ()
+		public void GenerateApplication (
+				[Values (null, "android.app.Application", "android.support.multidex.MultiDexApplication")] string applicationJavaClass
+		)
 		{
-			var actual      = Generate (typeof (ApplicationName));
-			var expected    = @"package application;
+			var actual      = Generate (typeof (ApplicationName), applicationJavaClass);
+			var expected    = $@"package application;
 
 
 public class Name
-	extends android.app.Application
+	extends {applicationJavaClass ?? "android.app.Application"}
 	implements
 		mono.android.IGCUserPeer
-{
+{{
 /** @hide */
 	public static final String __md_methods;
-	static {
+	static {{
 		__md_methods = 
 			"""";
-	}
+	}}
 
 	public Name ()
-	{
+	{{
 		mono.MonoPackageManager.setContext (this);
-	}
+	}}
 
 	private java.util.ArrayList refList;
 	public void monodroidAddReference (java.lang.Object obj)
-	{
+	{{
 		if (refList == null)
 			refList = new java.util.ArrayList ();
 		refList.add (obj);
-	}
+	}}
 
 	public void monodroidClearReferences ()
-	{
+	{{
 		if (refList != null)
 			refList.clear ();
-	}
-}
+	}}
+}}
 ";
 			Assert.AreEqual (expected, actual);
 		}
 
-		static string Generate (Type type)
+		static string Generate (Type type, string applicationJavaClass = null)
 		{
 			var td  = SupportDeclarations.GetTypeDefinition (type);
-			var g   = new JavaCallableWrapperGenerator (td, null);
+			var g   = new JavaCallableWrapperGenerator (td, null) {
+				ApplicationJavaClass        = applicationJavaClass,
+			};
 			var o   = new StringWriter ();
 			g.Generate ("__o");
 			g.Generate (o);
@@ -147,9 +151,11 @@ public class Name
 
 
 		[Test]
-		public void GenerateIndirectApplication ()
+		public void GenerateIndirectApplication (
+				[Values (null, "android.app.Application", "android.support.multidex.MultiDexApplication")] string applicationJavaClass
+		)
 		{
-			var actual      = Generate (typeof (IndirectApplication));
+			var actual      = Generate (typeof (IndirectApplication), applicationJavaClass);
 			var expected    = @"package md5fef72cac46d04ae5bdc90af5bb6221ad;
 
 


### PR DESCRIPTION
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=40976
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=41342

There is a desire to *trivially* enable use of MultiDexApplication by
setting the $(AndroidEnableMultiDex) MSBuild property to True. When
False (the default), the normal Java Callable Wrapper (JCW) base class
naming logic would be used (e.g. use the `[Register]`ed type name of
the base class in the `extends` clause). This normal logic hinders
"trivial" use of MultiDexApplication, as it would require that any
custom `Android.App.Application` type be changed to instead inherit
`Android.Support.Multidex.MultiDexApplication`, and default
`MultiDexApplication` use is required to support other functionality
such as enhanced Fast Deployment.

The original fix for Bug #40976 altered JCW generation so that a new
`$(AndroidApplicationJavaClass)` MSBuild property -- controlled by
`$(AndroidEnableMultiDex)` -- would explicitly provide the base class
for all `Application` subclasses.

Unfortunately, the fix applied to *all* `Application` subclasses,
including "indirect" subclasses. This C# hierarchy:

	partial class BaseApp : Android.App.Application {
	}

	partial class App : BaseApp {
	}

would result in the Java Callable Wrappers for *both* `BaseApp` and
`App` inheriting from `android.app.Application`, which would cause
everything to break if `BaseApp` e.g. implemented a new interface.

This was bug #41342: indirect subclasses had the wrong base class.

For Java.Interop purposes, merge both fixes together so that
`JavaCallableWrapperGenerator.AndroidJavaClass` can be used to
override the default `android.app.Application` base class, but *only*
when the base class is `android.app.Application`. This allows "fixing"
the JCW for `BaseApp` to inherit from `MultiDexApplication` if desired
while `App` continues to inherit from `BaseApp`.