### PR TITLE
[jcw-gen] DON'T generate Java Callable Wrappers in parallel

### DIFF
--- a/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGeneratorTests.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGeneratorTests.cs
@@ -31,69 +31,6 @@ namespace Java.Interop.Tools.JavaCallableWrappersTests
 		}
 
 		[Test]
-		public void GenerateInParallel ()
-		{
-			var assemblyDef = AssemblyDefinition.ReadAssembly (typeof (DefaultName).Assembly.Location);
-			var types       = new []{
-				typeof (AbstractClassInvoker),
-				typeof (AbstractClass),
-				typeof (ActivityName),
-				typeof (ApplicationName),
-				typeof (DefaultName),
-				typeof (DefaultName.A),
-				typeof (DefaultName.A.B),
-				typeof (DefaultName.C.D),
-				// Skip because this will produce nested types
-				// typeof (ExampleOuterClass),
-				// typeof (ExampleOuterClass.ExampleInnerClass),
-				typeof (InstrumentationName),
-				// Skip because this will produce nested types
-				// typeof (NonStaticOuterClass),
-				// typeof (NonStaticOuterClass.NonStaticInnerClass),
-				typeof (ProviderName),
-				typeof (ReceiverName),
-				typeof (RegisterName),
-				typeof (RegisterName.DefaultNestedName),
-				typeof (RegisterName.OverrideNestedName),
-				typeof (ServiceName),
-			};
-			var typeDefs    = types.Select (t => SupportDeclarations.GetTypeDefinition (t, assemblyDef))
-				.ToList ();
-
-			var tasks       = typeDefs.Select (type => Task.Run (() => {
-					var g = new JavaCallableWrapperGenerator (type, log: Console.WriteLine);
-					var o = new StringWriter ();
-					g.Generate (o);
-					var r = new StringReader (o.ToString ());
-					var l = r.ReadLine ();
-					if (!l.StartsWith ("package ", StringComparison.Ordinal))
-						throw new InvalidOperationException ($"Invalid JCW for {type.FullName}!");
-					var p = l.Substring ("package ".Length);
-					p = p.Substring (0, p.Length - 1);
-					l = r.ReadLine ();
-					if (l.Length != 0)
-						throw new InvalidOperationException ($"Invalid JCW for {type.FullName}! (Missing newline)");
-					l = r.ReadLine ();
-					if (l.Length != 0)
-						throw new InvalidOperationException ($"Invalid JCW for {type.FullName}! (Missing 2nd newline)");
-					l = r.ReadLine ();
-					string c = null;
-					if (l.StartsWith ("public class ", StringComparison.Ordinal))
-						c = l.Substring ("public class ".Length);
-					else if (l.StartsWith ("public abstract class ", StringComparison.Ordinal))
-						c = l.Substring ("public abstract class ".Length);
-					else
-						throw new InvalidOperationException ($"Invalid JCW for {type.FullName}! (Missing class)");
-					return p + "/" + c;
-			})).ToArray ();
-			Task.WaitAll (tasks);
-			for (int i = 0; i < types.Length; ++i) {
-				Assert.AreEqual (JniType.ToJniName (typeDefs [i]),  tasks [i].Result);
-				Assert.AreEqual (JniType.ToJniName (types [i]),     tasks [i].Result);
-			}
-		}
-
-		[Test]
 		public void GenerateApplication (
 				[Values (null, "android.app.Application", "android.support.multidex.MultiDexApplication")] string applicationJavaClass
 		)

--- a/tools/jcw-gen/App.cs
+++ b/tools/jcw-gen/App.cs
@@ -60,10 +60,11 @@ namespace Java.Interop.Tools
 					resolver.SearchDirectories.Add (Path.GetDirectoryName (assembly));
 					resolver.Load (assembly);
 				}
-				var tasks = JavaTypeScanner.GetJavaTypes (assemblies, resolver, log: Console.WriteLine)
-					.Where (td => !JavaTypeScanner.ShouldSkipJavaCallableWrapperGeneration (td))
-					.Select (td => Task.Run (() => GenerateJavaCallableWrapper (td, outputPath)));
-				Task.WaitAll (tasks.ToArray ());
+				var types = JavaTypeScanner.GetJavaTypes (assemblies, resolver, log: Console.WriteLine)
+					.Where (td => !JavaTypeScanner.ShouldSkipJavaCallableWrapperGeneration (td));
+				foreach (var type in types) {
+					GenerateJavaCallableWrapper (type, outputPath);
+				}
 				return 0;
 			}
 			catch (Exception e) {


### PR DESCRIPTION
Partially reverst commit f0fa3c34.

The problem with f0fa3c34 is that Mono.Cecil follows the normal .NET
guidelines with respect to thread safety: static members are
thread-safe, but *instance members are not thread safe*.

Meaning accessing e.g. `TypeDefinition.Methods` isn't thread-safe.

Attempting to generate Java Callable Wrappers in parallel can result
in "bizarre" Javav code wherein not all Java members which should be
overridden are actually overidden, presumably because the
TypeDefinition of the type, some base type, or some implemented
interface, is being used concurrently from multiple threads.

Revert the Task use from commit f0fa3c34 and generate
Java Callable Wrappers sequentially, so that they're valid.