### PR TITLE
[generator] .projitems shouldn't contain duplicate filenames

### DIFF
--- a/tools/generator/ClassGen.cs
+++ b/tools/generator/ClassGen.cs
@@ -625,8 +625,6 @@ namespace MonoDroid.Generation {
 			sw.WriteLine ("}");
 			sw.Close ();
 			gen_info.Writer = null;
-
-			GenerateAnnotationAttribute (opt, gen_info);
 		}
 
 		public static void GenerateTypeRegistrations (CodeGenerationOptions opt, GenerationInfo gen_info)


### PR DESCRIPTION
Building [Mono.Android][0] with `msbuild` results in error MSB3105:

	error MSB3105: The item
	".../xamarin-android/src/Mono.Android/obj/Debug/android-23/Android.Annotation.SuppressLintAttribute.cs"
	was specified more than once in the "Sources" parameter.  Duplicate
	items are not supported by the "Sources" parameter.

`Android.Annotation.SuppressLintAttribute.cs` is in the `Sources`
paameter twice becuase it's listed twice within
`Mono.Android.projitems`:

	<Compile Include="$(MSBuildThisFileDirectory)\Android.Annotation.SuppressLintAttribute.cs" />
	<Compile Include="$(MSBuildThisFileDirectory)\Android.Annotation.SuppressLintAttribute.cs" />

The question is *why* is this file -- and other files! -- repeated?

The answer is twofold:

1. Because `android.annotation.SuppressLint` is present *twice* within
    the API XML description, once as the "real" `<interface/>`, and
    once [manually added via `metadata`][1].

2. Because `ClassGen.cs` emits annotations.

(1) is done for backward compatibility reasons: long back in the mists
of time, Annotations were originally bound as "normal" classes instead
of as interface+custom attribute pairs, so if there are any ancient
binary assemblies referencing the class, that class needs to remain.

Consequently, removing (1) isn't an option.

That leaves (2): *both* `InterfaceGen.cs` and `ClassGen.cs` call
`GenerateAnnotationAttribute()`. `InterfaceGen.cs` -- respopnsible for
emitting `Android.Annotation.ISuppressLint.cs` in this example -- will
also emit `Android.Annotation.SuppressLintAttribute.cs`.
`ClassGen.cs` *also* emits
`Android.Annotation.SuppressLintAttribute.cs`.

The overall goal is to stop emitting duplicate files, as that will
allow `msbuild` to work properly. There are two plausible fixes:

1. `GenerationInfo.GenerateLibraryProjectFile()` could write out all
    unique filenames, thus "ignoring" the duplicate file generation.

2. Fix `ClassGen.cs` to *not emit annotations*.

(1) is a hack. It works, but I consider it a hack.

I assert that (2) is the proper fix. Java annotations are interfaces,
so I see no plausible reason for `ClassGen.cs` to be calling
`GenerateAnnotationAttribute()` in the first place.

[0]: https://github.com/xamarin/xamarin-android/tree/b89dc15/src/Mono.Android
[1]: https://github.com/xamarin/xamarin-android/blob/b89dc15d/src/Mono.Android/metadata#L583-L588