### PR TITLE
[generator-Tests] Provide more context when errors happen

### DIFF
--- a/tools/generator/Tests/BaseGeneratorTest.cs
+++ b/tools/generator/Tests/BaseGeneratorTest.cs
@@ -38,10 +38,11 @@ namespace generatortests
 			if (output.Contains ("error")) {
 				Assert.Fail (output);
 			}
-			string[] errors;
-			BuiltAssembly = Compiler.Compile (Options, "Mono.Andoroid",
-				AdditionalSourceDirectories, out errors);
-			Assert.AreEqual (0, errors.Length, string.Join (Environment.NewLine, errors));
+			bool    hasErrors;
+			string  compilerOutput;
+			BuiltAssembly = Compiler.Compile (Options, "Mono.Andoroid", AdditionalSourceDirectories,
+				out hasErrors, out compilerOutput);
+			Assert.AreEqual (false, hasErrors, compilerOutput);
 			Assert.IsNotNull (BuiltAssembly);
 		}
 

--- a/tools/generator/Tests/Compiler.cs
+++ b/tools/generator/Tests/Compiler.cs
@@ -17,7 +17,8 @@ namespace generatortests
 		private static string supportFilePath = typeof(Compiler).Assembly.Location;
 
 		public static Assembly Compile (Xamarin.Android.Binder.CodeGeneratorOptions options,
-			string assemblyFileName, IEnumerable<string> AdditionalSourceDirectories, out string[] errors)
+			string assemblyFileName, IEnumerable<string> AdditionalSourceDirectories,
+			out bool hasErrors, out string output)
 		{
 			var generatedCodePath = options.ManagedCallableWrapperSourceOutputDirectory;
 			var sourceFiles = Directory.EnumerateFiles (generatedCodePath, "*.cs",
@@ -53,14 +54,12 @@ namespace generatortests
 			CSharpCodeProvider codeProvider = new CSharpCodeProvider ();
 			CompilerResults results = codeProvider.CompileAssemblyFromFile (parameters,sourceFiles.ToArray ());
 
-			List<string> errs = new List<string> ();
-			foreach (CompilerError message in results.Errors) {
-				if (message.IsWarning)
-					continue;
-				errs.Add (message.ToString ());
-			}
+			hasErrors   = false;
 
-			errors = errs.ToArray ();
+			foreach (CompilerError message in results.Errors) {
+				hasErrors   = hasErrors || (!message.IsWarning);
+			}
+			output  = string.Join (Environment.NewLine, results.Output.Cast<string> ());
 
 			return results.CompiledAssembly;
 		}


### PR DESCRIPTION
A unit test failure is being reported, which unfortunately doesn't
contain enough useful context:

	1) generatortests.NormalMethods.GeneratedOK :   error : .../Java.Interop/bin/TestDebug/SupportFiles/JavaObject.cs(78,17): (Location of the symbol related to previous warning)
	Expected: 0
	But was:  1

It's a very odd "error", in that there's no error reported, just a
mention of a "previous warning", which isn't shown.

The *cause* of this useless output is that `Compiler` "trims out" all
the "non-error" output from the compilation. This *seems* good, except
in this case it's the "useless output" that we need to make sense of
anything at all!

Revise `Compiler.Compile()` so that instead of extracting "errors" it
instead provides *all* compiler output and an indicator of whether or
not errors occurred. (This still depends on `CompilerResults.Errors`
having correct output -- and I'm starting to wonder if I'm actually
dealing with a CodeDom bug here -- but at least with more output I can
better rationalize about what's going on.)