### PR TITLE
[xa-fx-cop] Properly ignore Java.Interop assembly errors

### DIFF
--- a/xa-gendarme-ignore.txt
+++ b/xa-gendarme-ignore.txt
@@ -120,12 +120,12 @@ T: Java.Interop.JniObjectReferenceOptions
 
 R: Gendarme.Rules.Design.MarkAssemblyWithCLSCompliantRule
 # CLSCompliantAttribute isn't in the PCL profile we're targeting, so we can't apply it.
-A: Java.Interop, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null
+A: Java.Interop, Version=0.1.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065
 
 
 R: Gendarme.Rules.Design.MarkAssemblyWithComVisibleRule
 # Ditto; ComVisibleAttribute isn't in our PCL profile.
-A: Java.Interop, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null
+A: Java.Interop, Version=0.1.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065
 
 
 R: Gendarme.Rules.Design.PreferEventsOverMethodsRule


### PR DESCRIPTION
Gendarme invocation ignores the
`Gendarme.Rules.Design.MarkAssemblyWithCLSCompliantRule` and
`Gendarme.Rules.Design.MarkAssemblyWithComVisibleRule` rules because
the PCL profile that `Java.Interop.dll` targets doesn't provide the
`CLSComplientAttribute` and `ComVislbleAttribute` custom attributes,
and so they can't be used.

Commit 782f34aa "broke" these ignores by signing `Java.Interop.dll`,
causing the PublicKeyToken to change. This in turn caused the ignores
to be ignored, which meant Gendarme now reported errors:

> This assembly is not decorated with the [CLSCompliant] attribute
> This assembly is not decorated with the [ComVisible] attribute.

Fix the PublicKeyToken in the assembly name so that the rules are
properly ignored.