### PR TITLE
[Java.Interop] Add JniEnvironment.References.CreatedReference()

### DIFF
--- a/src/Java.Interop/Documentation/Java.Interop/JniEnvironment.References.xml
+++ b/src/Java.Interop/Documentation/Java.Interop/JniEnvironment.References.xml
@@ -1,0 +1,62 @@
+﻿<?xml version="1.0"?>
+<docs>
+  <member name="T:JniEnvironment.References">
+    <summary>
+      JNI Reference-related functionality.
+    </summary>
+    <remarks>
+      <para>
+        The <c>JniEnvironment.References</c> class exposes JNI Global, Local,
+        Weak-Global-related functionality which is not exposed by the
+        <see cref="T:Java.Interop.JniObjectReference" /> class, particularly
+        JNI reference creation and destruction.
+      </para>
+    </remarks>
+  </member>
+  <member name="M:CreatedReference">
+    <summary>Account for the creation of a JNI Reference.</summary>
+    <param name="value">
+      A <see cref="T:Java.Interop.JniObjectReference" /> value containing
+      a JNI Reference that was created.
+    </param>
+    <exception cref="T:System.ArgumentException">
+      <paramref name="value" /> is not a JNI Local Reference.
+    </exception>
+    <remarks>
+      <para>
+        The <see cref="P:Java.Interop.JniEnvironment.LocalReferenceCount" />
+        property provides an advisory value of the number of
+        JNI Local References which Java.Interop has created. The
+        <see cref="P:Java.Interop.JniRuntime.JniObjectReferenceManager.GlobalReferenceCount" />
+        property provides an advisory value of the number of
+        JNI Global References which Java.Interop has created. The
+        <see cref="P:Java.Interop.JniRuntime.JniObjectReferenceManager.WeakGlobalReferenceCount" />
+        property contains an advisory value of the number of
+        JNI Weak Global References which Java.Interop has created.
+        These counts are incremented whenever a JNI reference is created,
+        e.g. from <see cref="M:Java.Interop.JniObjectReference.NewLocalRef" />
+        or <see cref="M:Java.Interop.JniObjectReference.NewGlobalRef" />,
+        and this count is decremented whenever a JNI Local Reference is
+        destroyed, e.g. from
+        <see cref="M:Java.Interop.JniObjectReference.Dispose" />.
+      </para>
+      <para>
+        This accounting assumes a worldview in which Java.Interop can intervene
+        wherever a JNI Local Reference can be created. This is not the case,
+        as there are some scenarios where JNI Local References can be created
+        without Java.Interop knowing about it. One such notable example is when
+        using Platform Invoke to invoke a native <c>Java_</c> C function
+        which returns a JNI Local Reference (<see cref="T:System.IntPtr" />).
+        When such untrackable JNI Local References are created, this may result
+        in future assertions failing within
+        <see cref="M:Java.Interop.JniRuntime.JniObjectReferenceManager.DeleteLocalReference" />
+        when the tracked JNI Local Reference count becomes negative.
+      </para>
+      <para>
+        Use the <c>CreatedLocalReference</c> to notify Java.Interop that a
+        JNI Local Reference has been created externally, so that the
+        JNI Local Reference accounting doesn't generate future assertions.
+      </para>
+    </remarks>
+  </member>
+</docs>

--- a/src/Java.Interop/Java.Interop.csproj
+++ b/src/Java.Interop/Java.Interop.csproj
@@ -174,5 +174,6 @@
     </None>
     <None Include="Documentation\Java.Interop\IJavaPeerable.xml" />
     <None Include="Documentation\Java.Interop\JniManagedPeerStates.xml" />
+    <None Include="Documentation\Java.Interop\JniEnvironment.References.xml" />
   </ItemGroup>
 </Project>

--- a/src/Java.Interop/Java.Interop/JniEnvironment.References.cs
+++ b/src/Java.Interop/Java.Interop/JniEnvironment.References.cs
@@ -5,8 +5,23 @@ namespace Java.Interop
 {
 	partial class JniEnvironment {
 
+		/// <include file="../Documentation/Java.Interop/JniEnvironment.References.xml" path="/docs/member[@name='T:JniEnvironment.References']/*" />
 		static partial class References
 		{
+			/// <include file="../Documentation/Java.Interop/JniEnvironment.References.xml" path="/docs/member[@name='M:CreatedReference']/*" />
+			public static void CreatedReference (JniObjectReference value)
+			{
+				if (!value.IsValid)
+					return;
+				switch (value.Type) {
+				case JniObjectReferenceType.Local:
+					Runtime.ObjectReferenceManager.CreatedLocalReference (CurrentInfo, value);
+					break;
+				default:
+					throw new ArgumentException ("Only JNI Local References are currently supported.", nameof (value));
+				}
+			}
+
 			public static void GetJavaVM (out IntPtr invocationPointer)
 			{
 				int r   = _GetJavaVM (out invocationPointer);

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniObjectReferenceManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniObjectReferenceManager.cs
@@ -179,6 +179,13 @@ namespace Java.Interop {
 				Debug.Assert (count >= 0,
 						string.Format ("{0} count is {1}, expected to be >= 0 when dealing with handle {2} on thread '{3}'({4}).",
 							type, count, value, Runtime.GetCurrentManagedThreadName (), Environment.CurrentManagedThreadId));
+				if (count < 0) {
+					Debug.WriteLine ("Perhaps `Java.Interop.JniEnvironment.References.{0}()` should be used to note the creation of handle {1} on thread '{2}'({3})?",
+							nameof (JniEnvironment.References.CreatedReference),
+							value,
+							Runtime.GetCurrentManagedThreadName (),
+							Environment.CurrentManagedThreadId);
+				}
 			}
 		}
 	}

--- a/src/Java.Interop/Tests/Java.Interop/JniEnvironmentTests.cs
+++ b/src/Java.Interop/Tests/Java.Interop/JniEnvironmentTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reflection;
+using System.Runtime.InteropServices;
 
 using Java.Interop;
 
@@ -51,6 +52,93 @@ namespace Java.InteropTests
 				} finally {
 					JniObjectReference.Dispose (ref o);
 				}
+			}
+		}
+
+		[Test]
+		public void References_CreatedReference_InvalidRef ()
+		{
+			var c = JniEnvironment.LocalReferenceCount;
+			var r = new JniObjectReference ();
+			JniEnvironment.References.CreatedReference (r);
+			Assert.AreEqual (c, JniEnvironment.LocalReferenceCount);
+		}
+
+		[Test]
+		public void References_CreatedReference_LocalRef ()
+		{
+			var NewLocalRef = GetNewRefFunc ("java_interop_jnienv_new_local_ref");
+			if (NewLocalRef == null) {
+				Assert.Ignore ("This version of Java.Interop.dll doesn't use P/Invoke-based JNI invokes.");
+				return;
+			}
+			using (var t = new JniType ("java/lang/Object")) {
+				var c = JniEnvironment.LocalReferenceCount;
+				var r = NewLocalRef (JniEnvironment.EnvironmentPointer, t.PeerReference.Handle);
+
+				// This is the "problem": direct use of JNI functions don't contribute to
+				// our reference count accounting
+				Assert.AreEqual (c, JniEnvironment.LocalReferenceCount);
+
+				var o = new JniObjectReference (r, JniObjectReferenceType.Local);
+				JniEnvironment.References.CreatedReference (o);
+
+				Assert.AreEqual (c + 1, JniEnvironment.LocalReferenceCount);
+				JniObjectReference.Dispose (ref o);
+				Assert.AreEqual (c, JniEnvironment.LocalReferenceCount);
+			}
+		}
+
+		static readonly Type NativeMethods_type =
+			typeof (JniEnvironment).Assembly.GetType ("Java.Interop.NativeMethods", throwOnError: false) ??
+			typeof (JniEnvironment).Assembly.GetType ("Java.Interop.JIPinvokes.NativeMethods", throwOnError: false);
+
+		static Func<IntPtr, IntPtr, IntPtr> GetNewRefFunc (string method)
+		{
+			if (NativeMethods_type == null)
+				return null;
+			return (Func<IntPtr, IntPtr, IntPtr>)Delegate.CreateDelegate (
+					typeof (Func<IntPtr, IntPtr, IntPtr>),
+					NativeMethods_type,
+					method,
+					ignoreCase: false,
+					throwOnBindFailure: true);
+		}
+
+		static Action<IntPtr, IntPtr> GetDeleteRefFunc (string method)
+		{
+			if (NativeMethods_type == null)
+				return null;
+			return (Action<IntPtr, IntPtr>)Delegate.CreateDelegate (
+					typeof (Action<IntPtr, IntPtr>),
+					NativeMethods_type,
+					method,
+					ignoreCase: false,
+					throwOnBindFailure: true);
+		}
+
+		[Test]
+		public void References_CreatedReference_GlobalRef ()
+		{
+			var NewGlobalRef = GetNewRefFunc ("java_interop_jnienv_new_global_ref");
+			if (NewGlobalRef == null) {
+				Assert.Ignore ("This version of Java.Interop.dll doesn't use P/Invoke-based JNI invokes.");
+				return;
+			}
+			using (var t = new JniType ("java/lang/Object")) {
+				var c = JniEnvironment.Runtime.GlobalReferenceCount;
+				var r = NewGlobalRef (JniEnvironment.EnvironmentPointer, t.PeerReference.Handle);
+
+				// This is the "problem": direct use of JNI functions don't contribute to
+				// our reference count accounting
+				Assert.AreEqual (c, JniEnvironment.Runtime.GlobalReferenceCount);
+
+				var o = new JniObjectReference (r, JniObjectReferenceType.Global);
+				Assert.Throws<ArgumentException> (() => JniEnvironment.References.CreatedReference (o));
+
+				Assert.AreEqual (c, JniEnvironment.Runtime.GlobalReferenceCount);
+
+				GetDeleteRefFunc ("java_interop_jnienv_delete_global_ref")?.Invoke (JniEnvironment.EnvironmentPointer, o.Handle);
 			}
 		}
 	}


### PR DESCRIPTION
Context: https://bugzilla.xamarin.com/show_bug.cgi?id=41733

Java.Interop, like Xamarin.Android before it, assumes that it's the
only managed code that is interoperating with JNI, and the JNI object
reference accounting follows suit: "only" Java.Interop can create JNI
object references and increment the associated counts, and "only"
Java.Interop can *destroy* JNI object references and decrement the
associated counts.

...except that's not entirely true.

Case in point, Bug #41733, which is a Xamarin.Android app which
P/Invokes into the native method of a Java class,
`DemoLibrary.Java_demo_DemoLibrary_test()`.

Since this is using P/Invoke and not e.g.
`Java.Interop.JniEnvironment.InstanceMethods.CallObjectMethod()`, this
*bypases* the JNI object reference accounting which would incremement
`JniEnvironment.LocalReferenceCount`.

However, once the sample obtains the JNI local reference, it then
invokes `Android.Runtime.JNIEnv.GetArray()`, which eventually hits
`JniObjectReference.Dispose()`, which *decrements*
`JniEnvironment.LocalReferenceCount`.

The result is a mismatch: the app generates constant asserts because
the JNI local reference count is negative, and it's negative because
JNI local reference creation is unaccounted for, while destruction is
accounted for.

We can't forbid P/Invokes; they're very useful. We also can't change
the P/Invoke return type. (I'd *like* to, but that would require
SafeHandles, and SafeHandles aren't tenable; see 9d2dfc5).

Thus, the only fix to this accounting conundrum is to allow developers
to tell Java.Interop "I created a JNI local reference!", manually
contributing to the JNI local reference accounting.

Add a new `JniEnvironment.References.CreatedReference()` method:

	partial class JniEnvironment {
		partial class References {
			public static void CreatedReference (JniObjectReference value);
		}
	}

This allows developers to contribute to the JNI local reference
account logic, calling `JniEnvironment.References.CreatedReference()`
after any P/Invokes/etc.. This in turn prevents the assert from
`JniObjectReference.Dispose()` from firing, and keeps things happy.