### PR TITLE
[Java.Interop] Reduce string allocations from assertions

### DIFF
--- a/src/Java.Interop/Java.Interop/JniRuntime.JniObjectReferenceManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniObjectReferenceManager.cs
@@ -168,6 +168,9 @@ namespace Java.Interop {
 			[Conditional ("DEBUG")]
 			static void AssertReferenceType (ref JniObjectReference reference, JniObjectReferenceType type)
 			{
+				if (reference.Type == type)
+					return;
+
 				Debug.Assert (reference.Type == type,
 						string.Format ("Object reference {0} should be of type {1}, is instead {2}!",
 							reference.ToString (), type, reference.Type));
@@ -176,6 +179,9 @@ namespace Java.Interop {
 			[Conditional ("DEBUG")]
 			void AssertCount (int count, string type, string value)
 			{
+				if (count >= 0)
+					return;
+
 				Debug.Assert (count >= 0,
 						string.Format ("{0} count is {1}, expected to be >= 0 when dealing with handle {2} on thread '{3}'({4}).",
 							type, count, value, Runtime.GetCurrentManagedThreadName (), Environment.CurrentManagedThreadId));


### PR DESCRIPTION
Context: https://bugzilla.xamarin.com/show_bug.cgi?id=42476

Bug #42476 notes that the `string.Format()` within the JNI reference
count assertions contributes to process memory allocations which the
profiler reports, and those generated `strings` are pointless because
they're not used unless the assertion fails.

This is a fair point, outside of whether or not the assertions should
be present at all...

Improve the `JniRuntime.JniObjectReferenceManager` JNI reference
assertions so that they return early if the assertion wouldn't fire.
This avoids the unnecessary string allocation.