### PR TITLE
[generator-Tests] Ignore `.fixed` files

### DIFF
--- a/tools/generator/Tests/BaseGeneratorTest.cs
+++ b/tools/generator/Tests/BaseGeneratorTest.cs
@@ -50,7 +50,8 @@ namespace generatortests
 		{
 			var files = Directory.GetFiles (sourceDir);
 			foreach (var file in files) {
-				if (Path.GetExtension (file) == ".xml")
+				var extension   = Path.GetExtension (file);
+				if (extension == ".xml" || extension == ".fixed")
 					continue;
 				var filename = Path.GetFileName (file);
 				var dest = Path.Combine (destinationDir, filename);


### PR DESCRIPTION
Commit 3b038a87 broke `make run-tests` because starting with 3b038a87
`generator` would emit an `api.xml.fixed` file into the output
directory, which wasn't present in the source directory. This resulted
in a unit test execution failures when running `generator-Tests.dll`:

	generatortests.Adapters.GeneratedOK : Expected out/Adapters/Adapters.xml.fixed but it was not generated.
	  at generatortests.BaseGeneratorTest.CompareOutputs (System.String sourceDir, System.String destinationDir) [0x0004f] in .../Java.Interop/tools/generator/Tests/BaseGeneratorTest.cs:57
	  at generatortests.BaseGeneratorTest.Run (CodeGenerationTarget target, System.String outputPath, System.String apiDescriptionFile, System.String expectedPath, System.String[] additionalSupportPaths) [0x0004a] in .../Java.Interop/tools/generator/Tests/BaseGeneratorTest.cs:112
	  at generatortests.BaseGeneratorTest.RunAllTargets (System.String outputRelativePath, System.String apiDescriptionFile, System.String expectedRelativePath, System.String[] additionalSupportPaths) [0x0001c] in .../Java.Interop/tools/generator/Tests/BaseGeneratorTest.cs:95
	  at generatortests.Adapters.GeneratedOK () [0x0001f] in .../Java.Interop/tools/generator/Tests/Adapters.cs:12
	  at (wrapper managed-to-native) System.Reflection.MonoMethod:InternalInvoke (System.Reflection.MonoMethod,object,object[],System.Exception&)
	  at System.Reflection.MonoMethod.Invoke (System.Object obj, BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00038] in /private/tmp/source-mono-4.4.0-c7sr0/bockbuild-mono-4.4.0-branch-c7sr0/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/corlib/System.Reflection/MonoMethod.cs:295

Fix this error by ignoring the `api.xml.fixed` files.