### PR TITLE
[tests] Log NUnit XML output into TestResult-*.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ obj
 JavaDeveloper-2013005_dp__11m4609.pkg
 LocalJDK
 TestResult.xml
+TestResult-*.xml
 xa-gendarme.html
 packages

--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,7 @@ define RUN_TEST
 	$(RUNTIME) $$MONO_OPTIONS --runtime=v4.0.0 \
 		$(NUNIT_CONSOLE) $(NUNIT_EXTRA) $(1) \
 		$(if $(RUN),-run:$(RUN)) \
+		-xml=TestResult-$(basename $(notdir $(1))).xml \
 		-output=bin/Test$(CONFIGURATION)/TestOutput-$(basename $(notdir $(1))).txt ;
 endef
 


### PR DESCRIPTION
We're running on Jenkins!

	https://jenkins.mono-project.com/view/Xamarin.Android/job/java-interop

Jenkins allows processing NUnit test output!

	https://wiki.jenkins-ci.org/display/JENKINS/xUnit+Plugin

Update `make run-test` so that it logs `nunit-console` XML output into
`TestResult-*.xml` files, which embeds the unit test filename, e.g.
`TestResult-Java.Interop-Tests.xml`. This will allow the xUnit plugin
to nicely render that output.