### PR TITLE
[Java.Interop.Tools.JavaCallableWrappers] Fix tests

### DIFF
--- a/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers/SupportDeclarations.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers/SupportDeclarations.cs
@@ -143,7 +143,7 @@ namespace Xamarin.Android.ToolsTests {
 	{
 	}
 
-	[ContentProvider (new [] { "ignore.authority" }, Name = "provider.Name")]
+	[ContentProvider (Name = "provider.Name")]
 	class ProviderName : Java.Lang.Object
 	{
 	}


### PR DESCRIPTION
Commit b58416a5 broke compilation of
`tests/Java.Interop-Tests/Java.Interop-Tests.csproj`:

	Java.Interop.Tools.JavaCallableWrappers/SupportDeclarations.cs(146,3):
	error CS1729: The type `Android.Content.ContentProviderAttribute' does not contain a constructor that takes `1' arguments

The cause of the breakage is that commit b58416a5 removed the
`ContentProviderAttribute(string[])` constructor, as it isn't entirely
relevant within Java.Interop.

Fix the compilation error by using the `ContentProviderAttribute`
default constructor within `SupportDeclarations.cs`.