### PR TITLE
[build] Use `https://` urls for GIT submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "lib/mono.linq.expressions"]
 	path = lib/mono.linq.expressions
-	url = ../../jonpryor/mono.linq.expressions.git
+	url = https://github.com/jonpryor/mono.linq.expressions.git
+	branch = master


### PR DESCRIPTION
Relative paths -- used previously -- have some pros, but one large
con: it complicates submodule checkout.

For example (I assume?), [on Jenkins][0]:

	FATAL: Command "git submodule update --init --recursive" returned status code 128:
	stdout:
	stderr: Cloning into 'lib/mono.linq.expressions'...
	Permission denied (publickey).
	fatal: Could not read from remote repository.

	Please make sure you have the correct access rights
	and the repository exists.
	fatal: clone of 'git@github.com:jonpryor/mono.linq.expressions.git' into submodule path 'lib/mono.linq.expressions' failed

	hudson.plugins.git.GitException: Command "git submodule update --init --recursive" returned status code 128:

Use `https://` submodule urls.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/java-interop/62/console