### PR TITLE
[build] Build `libNativeTiming.dylib` as a 32+64 native library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,15 @@ NATIVE_TIMING_LIB   = libNativeTiming$(NATIVE_EXT)
 
 bin/Test$(CONFIGURATION)/$(NATIVE_TIMING_LIB): tests/NativeTiming/timing.c $(wildcard $(JI_JDK_INCLUDE_PATHS)/jni.h)
 	mkdir -p `dirname "$@"`
+ifeq ($(OS),Darwin)
+	gcc -g -shared -m32 -o bin/Test$(CONFIGURATION)/libNativeTiming-m32.dylib $< $(JI_JDK_INCLUDE_PATHS:%=-I%)
+	gcc -g -shared -m64 -o bin/Test$(CONFIGURATION)/libNativeTiming-m64.dylib $< $(JI_JDK_INCLUDE_PATHS:%=-I%)
+	lipo bin/Test$(CONFIGURATION)/libNativeTiming-m32.dylib bin/Test$(CONFIGURATION)/libNativeTiming-m64.dylib -create \
+		-output "$@"
+endif
+ifeq ($(OS),Linux)
 	gcc -g -shared -o $@ $< -m32 $(JI_JDK_INCLUDE_PATHS:%=-I%)
+endif
 
 # Usage: $(call TestAssemblyTemplate,assembly-basename)
 define TestAssemblyTemplate


### PR DESCRIPTION
The [unit tests are failing][0]. In particular, `make run-ptests` is
failing:

	Test Error : Java.Interop.PerformanceTests.JniMethodInvocationOverheadTiming.MethodInvocationTiming
	System.DllNotFoundException : NativeTiming

Fortunately, it repro's locally, and with `MONO_LOG_LEVEL=debug` set,
we see:

	Mono: DllImport error loading library '.../Java.Interop/bin/TestDebug/libNativeTiming.dylib':
	'dlopen(.../Java.Interop/bin/TestDebug/libNativeTiming.dylib, 9): no suitable image found.  Did find:
		.../Java.Interop/bin/TestDebug/libNativeTiming.dylib: mach-o, but wrong architecture'.

Rephrasing: the unit tests are running in a 64-bit process, but
`libNativeTiming.dylib` is a *32-bit* binary, and can't be loaded.

The fix? Use [**lipo**(1)][1] to create a "fat binary", a
`libNativeTiming.dylib` that contains *both* 32-bit *and* 64-bit
architectures. This will allow `libNativeTiming.dylib` to be loaded
into both 32-bit and 64-bit processes, allowing `make run-ptests` to
work with e.g. both Apple JDK 6 (32-bit) and Oracle JDK (64-bit).

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/Java.Interop/69/console
[1]: http://www.manpages.info/macosx/lipo.1.html