### PR TITLE
[generator] Java RawJavaType (return type) should return int, not enu…

### DIFF
--- a/tools/generator/Method.cs
+++ b/tools/generator/Method.cs
@@ -37,7 +37,7 @@ namespace MonoDroid.Generation {
 			foreach (var p in support.GetParameters (regatt))
 				Parameters.Add (p);
 			
-			if (regatt != null && !IsReturnEnumified) {
+			if (regatt != null) {
 				var rt = support.GetJniReturnType (regatt);
 				if (rt != null)
 					java_return = rt.Type;
@@ -271,7 +271,7 @@ namespace MonoDroid.Generation {
 		
 		internal void FillReturnType ()
 		{
-			retval = new ReturnValue (this, Return, ManagedReturn);
+			retval = new ReturnValue (this, Return, ManagedReturn, IsReturnEnumified);
 		}
 
 		public bool GenerateDispatchingSetter { get; protected set; }

--- a/tools/generator/ReturnValue.cs
+++ b/tools/generator/ReturnValue.cs
@@ -12,11 +12,14 @@ namespace MonoDroid.Generation {
 		ISymbol sym;
 		string java_type;
 		string managed_type;
+		string raw_type;
+		bool is_enumified;
 
-		public ReturnValue (Method owner, string java_type, string managed_type)
+		public ReturnValue (Method owner, string java_type, string managed_type, bool isEnumified)
 		{
-			this.java_type = java_type;
+			this.raw_type = this.java_type = java_type;
 			this.managed_type = managed_type;
+			this.is_enumified = isEnumified;
 		}
 
 		public string CallMethodPrefix {
@@ -44,6 +47,7 @@ namespace MonoDroid.Generation {
 		public void SetGeneratedEnumType (string enumType)
 		{
 			sym = new GeneratedEnumSymbol (enumType);
+			is_enumified = true;
 			managed_type = null;
 			java_type = sym.JavaName;
 		}
@@ -59,6 +63,10 @@ namespace MonoDroid.Generation {
 
 		public bool IsArray {
 			get { return sym.IsArray; }
+		}
+
+		public bool IsEnumified {
+			get { return is_enumified; }
 		}
 
 		public bool IsGeneric {
@@ -78,7 +86,7 @@ namespace MonoDroid.Generation {
 		}
 
 		public string RawJavaType {
-			get { return java_type; }
+			get { return raw_type; }
 		}
 
 		public string FromNative (CodeGenerationOptions opt, string var_name, bool owned)


### PR DESCRIPTION
…m for C#.

There was inconsistency between jar2xml and class-parse + api-xml-adjuster
where the latter failed to retrieve valid return type when it was enumified.

(Found during new api-merge support experiment.)