### PR TITLE
[generator-Tests] Reference System.Core.dll

### DIFF
--- a/tools/generator/Tests/Compiler.cs
+++ b/tools/generator/Tests/Compiler.cs
@@ -40,6 +40,7 @@ namespace generatortests
 			parameters.CompilerOptions = "/unsafe";
 			parameters.OutputAssembly = assemblyFileName;
 			parameters.ReferencedAssemblies.Add (unitTestFrameworkAssemblyPath);
+			parameters.ReferencedAssemblies.Add (typeof (Enumerable).Assembly.Location);
 
 			var binDir  = Path.GetDirectoryName (typeof (BaseGeneratorTest).Assembly.Location);
 			var facDir  = GetFacadesPath ();


### PR DESCRIPTION
After upgrading to Mono 4.6, the `generator-Tests.dll` unit tests are
failing:

	18) Test Failure : generatortests.Streams.GeneratedOK
	     /Library/Frameworks/Mono.framework/Versions/4.6.0/bin/mcs /target:library /debug+ /optimize- /out:"Mono.Andoroid"
	     /r:"/Users/jon/Dropbox/Developer/Java.Interop/bin/TestDebug/nunit.framework.dll"
	     /r:"/Users/jon/Dropbox/Developer/Java.Interop/bin/TestDebug/Java.Interop.dll"
	     /r:"/Library/Frameworks/Mono.framework/Versions/4.6.0/lib/mono/4.5/Facades/System.Runtime.dll"
	     /unsafe /noconfig  --
	     ...
	.../Java.Interop/bin/TestDebug/SupportFiles/JNIEnv.cs(6,14): error CS0234: The type or namespace name `Linq' does not exist in the namespace `System'. Are you missing `System.Core' assembly reference?
	.../Java.Interop/bin/TestDebug/SupportFiles/JNIEnv.cs(7,14): error CS0234: The type or namespace name `Linq' does not exist in the namespace `System'. Are you missing `System.Core' assembly reference?
	.../Java.Interop/bin/TestDebug/SupportFiles/JavaArray.cs(4,14): error CS0234: The type or namespace name `Linq' does not exist in the namespace `System'. Are you missing `System.Core' assembly reference?
	.../Java.Interop/bin/TestDebug/SupportFiles/JavaCollection.cs(4,14): error CS0234: The type or namespace name `Linq' does not exist in the namespace `System'. Are you missing `System.Core' assembly reference?
	.../Java.Interop/bin/TestDebug/SupportFiles/TypeManager.cs(5,14): error CS0234: The type or namespace name `Linq' does not exist in the namespace `System'. Are you missing `System.Core' assembly reference?
	  Expected: False
	  But was:  True

I don't know *why*, but Mono 4.6's `CSharpCodeProvider` is providing
`/noconfig`, which prevents the default assemblies from being
referenced, including `System.Core.dll`. This in turn is responsible
for the CS0234 errors when trying to compile the support files.

Fix the CS0234 errors by explicitly referencing `System.Core.dll`.