### PR TITLE
[generator] fix bug #43883: generate only generatable code.

### DIFF
--- a/tools/generator/ClassGen.cs
+++ b/tools/generator/ClassGen.cs
@@ -333,7 +333,7 @@ namespace MonoDroid.Generation {
 			var overridens = defaultMethods.Where (m => overrides.Where (_ => _.Name == m.Name && _.JniSignature == m.JniSignature)
 				.Any (mm => mm.DeclaringType.GetAllDerivedInterfaces ().Contains (m.DeclaringType)));
 
-			foreach (Method m in Methods.Concat (defaultMethods.Except (overridens))) {
+			foreach (Method m in Methods.Concat (defaultMethods.Except (overridens)).Where (m => m.DeclaringType.IsGeneratable)) {
 				bool virt = m.IsVirtual;
 				m.IsVirtual = !IsFinal && virt;
 				if (m.IsAbstract && !m.IsInterfaceDefaultMethodOverride && !m.IsInterfaceDefaultMethod)

--- a/tools/generator/CodeGenerator.cs
+++ b/tools/generator/CodeGenerator.cs
@@ -323,7 +323,8 @@ namespace Xamarin.Android.Binder {
 			new NamespaceMapping (gens).Generate (opt, gen_info);
 
 			foreach (IGeneratable gen in gens)
-				gen.Generate (opt, gen_info);
+				if (gen.IsGeneratable)
+					gen.Generate (opt, gen_info);
 
 			ClassGen.GenerateTypeRegistrations (opt, gen_info);
 			ClassGen.GenerateEnumList (gen_info);


### PR DESCRIPTION
The bug describes the situation where generator attempts to generate code
for non-generatable referenced types from assemblies.