### PR TITLE
Fix build when Java.Interop.Tools.Cecil is built outside the tree.

### DIFF
--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil.csproj
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil.csproj
@@ -31,10 +31,10 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="Mono.Cecil">
-      <HintPath>..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.dll</HintPath>
+      <HintPath>$(MSBuildThisFileDirectory)\..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Mdb">
-      <HintPath>..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Mdb.dll</HintPath>
+      <HintPath>$(MSBuildThisFileDirectory)\..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Mdb.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Pdb">
       <HintPath>..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Pdb.dll</HintPath>


### PR DESCRIPTION
Before this fix, it failed to build due to bogus reference resolution in
nuget somehow:

```
Java.Interop.Tools.Cecil/DirectoryAssemblyResolver.cs(99,16): error CS0012: The type `Mono.Cecil.Cil.SequencePoint' is defined in an assembly that is not referenced. Consider adding a reference to assembly `Xamarin.Android.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756'
				/sources/monodroid/monodroid/out/lib/mandroid//Java.Interop.Tools.Diagnostics.dll (Location of the symbol related to previous error)
			Task "Csc" execution -- FAILED
			Done building target "CoreCompile" in project "/sources/monodroid/Java.Interop/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil.csproj".-- FAILED
		Done building project "/sources/monodroid/Java.Interop/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil.csproj".-- FAILED
	Task "MSBuild" execution -- FAILED
	Done building target "ResolveProjectReferences" in project "/sources/monodroid/Java.Interop/tools/generator/generator.csproj".-- FAILED
Done building project "/sources/monodroid/Java.Interop/tools/generator/generator.csproj".-- FAILED
```

I have added explicit $(MSBuildThisFileDirectory) to fix the issue.