### PR TITLE
[generator] fix enum managed return type.

### DIFF
--- a/tools/generator/ReturnValue.cs
+++ b/tools/generator/ReturnValue.cs
@@ -118,7 +118,7 @@ namespace MonoDroid.Generation {
 
 		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params)
 		{
-			sym = SymbolTable.Lookup (java_type, type_params);
+			sym = (IsEnumified ? SymbolTable.Lookup (managed_type, type_params) : null) ?? SymbolTable.Lookup (java_type, type_params);
 			if (sym == null) {
 				Report.Warning (0, Report.WarningReturnValue + 0, "Unknown return type {0} {1}.", java_type, opt.ContextString);
 				return false;


### PR DESCRIPTION
6d161a2 caused (either regressed or exposed) another issue that generator
didn't resole the return values for enums to be EnumSymbol which gives
explicit cast from int to enum for the output expressions.

This returns managed_type (which should be enum name) for enumified return
value (IsEnumified = true).