### PR TITLE
Bump to Mono.Cecil 0.10.0-beta1-v2

### DIFF
--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil.csproj
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil.csproj
@@ -31,16 +31,16 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="Mono.Cecil">
-      <HintPath>$(MSBuildThisFileDirectory)\..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.dll</HintPath>
+      <HintPath>$(MSBuildThisFileDirectory)\..\..\packages\Mono.Cecil.0.10.0-beta1-v2\lib\net40\Mono.Cecil.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Mdb">
-      <HintPath>$(MSBuildThisFileDirectory)\..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Mdb.dll</HintPath>
+      <HintPath>$(MSBuildThisFileDirectory)\..\..\packages\Mono.Cecil.0.10.0-beta1-v2\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Pdb">
-      <HintPath>..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Pdb.dll</HintPath>
+      <HintPath>$(MSBuildThisFileDirectory)\..\..\packages\Mono.Cecil.0.10.0-beta1-v2\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Rocks">
-      <HintPath>..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Rocks.dll</HintPath>
+      <HintPath>$(MSBuildThisFileDirectory)\..\..\packages\Mono.Cecil.0.10.0-beta1-v2\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/DirectoryAssemblyResolver.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/DirectoryAssemblyResolver.cs
@@ -74,6 +74,16 @@ namespace Java.Interop.Tools.Cecil {
 			SearchDirectories = new List<string> ();
 		}
 
+		public void Dispose ()
+		{
+			Dispose (disposing: false);
+			GC.SuppressFinalize (this);
+		}
+
+		protected virtual void Dispose (bool disposing)
+		{
+		}
+
 		public IDictionary ToResolverCache ()
 		{
 			var resolver_cache = new Hashtable ();

--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/TypeDefinitionRocks.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/TypeDefinitionRocks.cs
@@ -41,9 +41,11 @@ namespace Java.Interop.Tools.Cecil {
 					return true;
 				if (!t.HasInterfaces)
 					continue;
-				foreach (var i in t.Interfaces)
+				foreach (var ifaceImpl in t.Interfaces) {
+					var i   = ifaceImpl.InterfaceType;
 					if (IsAssignableFrom (type, i))
 						return true;
+				}
 			}
 			return false;
 		}
@@ -56,7 +58,7 @@ namespace Java.Interop.Tools.Cecil {
 		public static bool ImplementsInterface (this TypeDefinition type, string interfaceName)
 		{
 			return type.GetTypeAndBaseTypes ().Any (t => t.HasInterfaces &&
-					t.Interfaces.Any (i => i.FullName == interfaceName));
+					t.Interfaces.Any (i => i.InterfaceType.FullName == interfaceName));
 		}
 
 		public static string GetPartialAssemblyQualifiedName (this TypeReference type)

--- a/src/Java.Interop.Tools.Cecil/packages.config
+++ b/src/Java.Interop.Tools.Cecil/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Mono.Cecil" version="0.9.6.1" targetFramework="net45" />
+  <package id="Mono.Cecil" version="0.10.0-beta1-v2" targetFramework="net40" />
 </packages>

--- a/src/Java.Interop.Tools.Diagnostics/Java.Interop.Tools.Diagnostics.csproj
+++ b/src/Java.Interop.Tools.Diagnostics/Java.Interop.Tools.Diagnostics.csproj
@@ -31,16 +31,16 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="Mono.Cecil">
-      <HintPath>..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.dll</HintPath>
+      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta1-v2\lib\net40\Mono.Cecil.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Mdb">
-      <HintPath>..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Mdb.dll</HintPath>
+      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta1-v2\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Pdb">
-      <HintPath>..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Pdb.dll</HintPath>
+      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta1-v2\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Rocks">
-      <HintPath>..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Rocks.dll</HintPath>
+      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta1-v2\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Java.Interop.Tools.Diagnostics/packages.config
+++ b/src/Java.Interop.Tools.Diagnostics/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Mono.Cecil" version="0.9.6.1" targetFramework="net45" />
+  <package id="Mono.Cecil" version="0.10.0-beta1-v2" targetFramework="net40" />
 </packages>

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers.csproj
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers.csproj
@@ -32,16 +32,16 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="Mono.Cecil">
-      <HintPath>..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.dll</HintPath>
+      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta1-v2\lib\net40\Mono.Cecil.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Mdb">
-      <HintPath>..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Mdb.dll</HintPath>
+      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta1-v2\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Pdb">
-      <HintPath>..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Pdb.dll</HintPath>
+      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta1-v2\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Rocks">
-      <HintPath>..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Rocks.dll</HintPath>
+      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta1-v2\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
@@ -198,8 +198,9 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 				return null;
 
 			foreach (var ins in method.Body.Instructions) {
-				if (ins.SequencePoint != null)
-					return ins.SequencePoint;
+				var seqPoint = method.DebugInformation.GetSequencePoint (ins);
+				if (seqPoint != null)
+					return seqPoint;
 			}
 
 			return null;
@@ -213,7 +214,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 					continue;
 
 				foreach (var ins in method.Body.Instructions) {
-					var seq = ins.SequencePoint;
+					var seq = method.DebugInformation.GetSequencePoint (ins);
 					if (seq == null)
 						continue;
 

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers-Tests.csproj
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers-Tests.csproj
@@ -35,16 +35,16 @@
       <HintPath>..\..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil">
-      <HintPath>..\..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.dll</HintPath>
+      <HintPath>..\..\..\packages\Mono.Cecil.0.10.0-beta1-v2\lib\net40\Mono.Cecil.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Mdb">
-      <HintPath>..\..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Mdb.dll</HintPath>
+      <HintPath>..\..\..\packages\Mono.Cecil.0.10.0-beta1-v2\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Pdb">
-      <HintPath>..\..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Pdb.dll</HintPath>
+      <HintPath>..\..\..\packages\Mono.Cecil.0.10.0-beta1-v2\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Rocks">
-      <HintPath>..\..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Rocks.dll</HintPath>
+      <HintPath>..\..\..\packages\Mono.Cecil.0.10.0-beta1-v2\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Test/packages.config
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Test/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Mono.Cecil" version="0.9.6.1" targetFramework="net45" />
+  <package id="Mono.Cecil" version="0.10.0-beta1-v2" targetFramework="net40" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
 </packages>

--- a/src/Java.Interop.Tools.JavaCallableWrappers/packages.config
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Mono.Cecil" version="0.9.6.1" targetFramework="net45" />
+  <package id="Mono.Cecil" version="0.10.0-beta1-v2" targetFramework="net40" />
 </packages>

--- a/src/Xamarin.Android.Tools.AnnotationSupport.Cecil/Xamarin.Android.Tools.AnnotationSupport.Cecil.csproj
+++ b/src/Xamarin.Android.Tools.AnnotationSupport.Cecil/Xamarin.Android.Tools.AnnotationSupport.Cecil.csproj
@@ -32,7 +32,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Mono.Cecil">
-      <HintPath>..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.dll</HintPath>
+      <HintPath>..\packages\Mono.Cecil.0.10.0-beta1-v2\lib\net40\Mono.Cecil.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Xamarin.Android.Tools.AnnotationSupport.Cecil/packages.config
+++ b/src/Xamarin.Android.Tools.AnnotationSupport.Cecil/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Mono.Cecil" version="0.9.6.1" targetFramework="net45" />
+  <package id="Mono.Cecil" version="0.10.0-beta1-v2" targetFramework="net40" />
 </packages>

--- a/tools/generator/ClassGen.cs
+++ b/tools/generator/ClassGen.cs
@@ -31,13 +31,14 @@ namespace MonoDroid.Generation {
 			: base (new ManagedGenBaseSupport (t))
 		{
 			this.t = t;
-			foreach (var itd in t.Interfaces) {
-				var def = itd.Resolve ();
+			foreach (var ifaceImpl in t.Interfaces) {
+				var iface   = ifaceImpl.InterfaceType;
+				var def     = ifaceImpl.InterfaceType.Resolve ();
 				if (def != null && def.IsNotPublic)
 					continue;
-				AddInterface (itd.FullNameCorrected ());
+				AddInterface (iface.FullNameCorrected ());
 			}
-			bool implements_charsequence = t.Interfaces.Any (it => it.FullName == "Java.Lang.CharSequence");
+			bool implements_charsequence = t.Interfaces.Any (it => it.InterfaceType.FullName == "Java.Lang.CharSequence");
 			foreach (var m in t.Methods) {
 				if (m.IsPrivate || m.IsAssembly || !m.CustomAttributes.Any (ca => ca.AttributeType.FullNameCorrected () == "Android.Runtime.RegisterAttribute"))
 					continue;

--- a/tools/generator/InterfaceGen.cs
+++ b/tools/generator/InterfaceGen.cs
@@ -15,8 +15,9 @@ namespace MonoDroid.Generation {
 		public ManagedInterfaceGen (TypeDefinition t)
 			: base (new ManagedGenBaseSupport (t))
 		{
-			foreach (var itd in t.Interfaces)
-				AddInterface (itd.FullNameCorrected ());
+			foreach (var ifaceImpl in t.Interfaces) {
+				AddInterface (ifaceImpl.InterfaceType.FullNameCorrected ());
+			}
 			foreach (var m in t.Methods) {
 				if (m.IsPrivate || m.IsAssembly || !m.CustomAttributes.Any (ca => ca.AttributeType.FullNameCorrected () == "Android.Runtime.RegisterAttribute"))
 					continue;

--- a/tools/generator/generator.csproj
+++ b/tools/generator/generator.csproj
@@ -43,16 +43,16 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Mono.Cecil">
-      <HintPath>..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.dll</HintPath>
+      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta1-v2\lib\net40\Mono.Cecil.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Mdb">
-      <HintPath>..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Mdb.dll</HintPath>
+      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta1-v2\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Pdb">
-      <HintPath>..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Pdb.dll</HintPath>
+      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta1-v2\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Rocks">
-      <HintPath>..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Rocks.dll</HintPath>
+      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta1-v2\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Options">
       <HintPath>..\..\packages\Mono.Options.4.4.0.0\lib\net4-client\Mono.Options.dll</HintPath>

--- a/tools/generator/packages.config
+++ b/tools/generator/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Mono.Cecil" version="0.9.6.1" targetFramework="net45" />
+  <package id="Mono.Cecil" version="0.10.0-beta1-v2" targetFramework="net40" />
   <package id="Mono.Options" version="4.4.0.0" targetFramework="net45" />
 </packages>

--- a/tools/jcw-gen/jcw-gen.csproj
+++ b/tools/jcw-gen/jcw-gen.csproj
@@ -31,16 +31,16 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="Mono.Cecil">
-      <HintPath>..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.dll</HintPath>
+      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta1-v2\lib\net40\Mono.Cecil.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Mdb">
-      <HintPath>..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Mdb.dll</HintPath>
+      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta1-v2\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Pdb">
-      <HintPath>..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Pdb.dll</HintPath>
+      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta1-v2\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Rocks">
-      <HintPath>..\..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Rocks.dll</HintPath>
+      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta1-v2\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Options">
       <HintPath>..\..\packages\Mono.Options.4.4.0.0\lib\net4-client\Mono.Options.dll</HintPath>

--- a/tools/jcw-gen/packages.config
+++ b/tools/jcw-gen/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Mono.Cecil" version="0.9.6.1" targetFramework="net45" />
+  <package id="Mono.Cecil" version="0.10.0-beta1-v2" targetFramework="net40" />
   <package id="Mono.Options" version="4.4.0.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Mono 4.8 has migrated to Mono.Cecil/master, based on 0.10.0, which is
API-incompatible with the previous Mono.Cecil 0.9.6.

In particular, `TypeDefinition.Interfaces` now returns a
`Collection<InterfaceImplementation>` instead of the previous
`Collection<TypeReference>`, which causes all manner of breakage.

Since the next version of Xamarin.Android will be based on Mono 4.8,
and Xamarin.Android needs Java.Interop, bump Java.Interop to use the
Mono.Cecil 0.10.x preview package, and fix the corresponding breakage.