### PR TITLE
[generator] do not try to "enumify" reflection-based types.

### DIFF
--- a/tools/generator/GenBase.cs
+++ b/tools/generator/GenBase.cs
@@ -813,11 +813,12 @@ namespace MonoDroid.Generation {
 
 		public virtual void UpdateEnums (CodeGenerationOptions opt)
 		{
-			if (enum_updated)
+			if (enum_updated || !IsGeneratable)
 				return;
 			enum_updated = true;
-			for (var b = GetBaseGen (); b != null; b = b.GetBaseGen ())
-				b.UpdateEnums (opt);
+			var baseGen = GetBaseGen ();
+			if (baseGen != null)
+				baseGen.UpdateEnums (opt);
 
 			foreach (Method m in methods) {
 				AutoDetectEnumifiedOverrideParameters (m, opt);


### PR DESCRIPTION
We update possibly-enumified members after loading XML metadata, but
currently we iterate everything we loaded including managed references.
That's waste of processing, so don't do that.

(Also reduced attempts to process base types, but they did not actually
happen anyways. The relevant code is slightly simplified.)