### PR TITLE
[jcw-gen] Fix InvalidCastException from Cecil upgrade

### DIFF
--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
@@ -130,7 +130,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 				}
 			}
 
-			foreach (MethodDefinition imethod in type.Interfaces.Cast<TypeReference> ()
+			foreach (MethodDefinition imethod in type.Interfaces.Select (ifaceInfo => ifaceInfo.InterfaceType)
 					.Select (r => {
 						var d = r.Resolve ();
 						if (d == null)
@@ -141,7 +141,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 						return d;
 					})
 					.Where (d => GetRegisterAttributes (d).Any ())
-					.SelectMany (d => d.Methods.Cast<MethodDefinition>())) {
+					.SelectMany (d => d.Methods)) {
 				AddMethod (imethod, imethod);
 			}
 
@@ -538,7 +538,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 			sw.WriteLine ("\textends " + extendsType);
 			sw.WriteLine ("\timplements");
 			sw.Write ("\t\tmono.android.IGCUserPeer");
-			IEnumerable<TypeDefinition> ifaces = type.Interfaces.Cast<TypeReference>()
+			IEnumerable<TypeDefinition> ifaces = type.Interfaces.Select (ifaceInfo => ifaceInfo.InterfaceType)
 				.Select (r => r.Resolve ())
 				.Where (d => GetRegisterAttributes (d).Any ());
 			if (ifaces.Any ()) {

--- a/src/Java.Interop.Tools.TypeNameMappings/Java.Interop.Tools.TypeNameMappings/JniType.cs
+++ b/src/Java.Interop.Tools.TypeNameMappings/Java.Interop.Tools.TypeNameMappings/JniType.cs
@@ -612,14 +612,14 @@ namespace Java.Interop.Tools.TypeNameMappings {
 				return false;
 
 			return GetBaseConstructors (type)
-				.Any (ctor => ctor.Parameters.Cast<ParameterDefinition> ().Any (p => p.Name == "__self"));
+				.Any (ctor => ctor.Parameters.Any (p => p.Name == "__self"));
 		}
 
 		static IEnumerable<MethodDefinition> GetBaseConstructors (TypeDefinition type)
 		{
 			var baseType = type.GetBaseTypes ().FirstOrDefault (t => t.GetCustomAttributes (typeof (RegisterAttribute)).Any ());
 			if (baseType != null)
-				return baseType.Methods.Where (m => m.IsConstructor && !m.IsStatic).Cast<MethodDefinition> ();
+				return baseType.Methods.Where (m => m.IsConstructor && !m.IsStatic);
 			return Enumerable.Empty<MethodDefinition> ();
 		}
 #endif  // HAVE_CECIL


### PR DESCRIPTION
Commit dfed286d updated Cecil to Cecil 0.10.0-beta1-v2, which has
multiple API incompatibilities with Cecil 0.9.6.

Unfortunately, some of these incompatibilities were hidden by use of
the `.Cast<T>()` extension method, which was used because older
versions of Cecil didn't use generics at all, so the `.Cast<T>()` was
present to provide types.

Types which became wrong with Cecil 0.10.0.

The result is that when
[building xamarin-android with a newer Java.Interop][0],
[things broke][1]:

	jcw-gen: System.InvalidCastException: Unable to cast object of type 'Mono.Cecil.InterfaceImplementation' to type 'Mono.Cecil.TypeReference'.
	  at (wrapper castclass) System.Object:__castclass_with_cache (object,intptr,intptr)
	  at System.Linq.Enumerable+<CastIterator>c__Iterator17`1[TResult].MoveNext () [0x00059] in /private/tmp/source-mono-4.4.0-c7sr1/bockbuild-mono-4.4.0-branch-c7sr1/profiles/mono-mac-xamarin/build-root/mono-x86/external/referencesource/System.Core/System/Linq/Enumerable.cs:916
	  at System.Linq.Enumerable+WhereSelectEnumerableIterator`2[TSource,TResult].MoveNext () [0x00078] in /private/tmp/source-mono-4.4.0-c7sr1/bockbuild-mono-4.4.0-branch-c7sr1/profiles/mono-mac-xamarin/build-root/mono-x86/external/referencesource/System.Core/System/Linq/Enumerable.cs:282
	  at System.Linq.Enumerable+WhereEnumerableIterator`1[TSource].MoveNext () [0x00062] in /private/tmp/source-mono-4.4.0-c7sr1/bockbuild-mono-4.4.0-branch-c7sr1/profiles/mono-mac-xamarin/build-root/mono-x86/external/referencesource/System.Core/System/Linq/Enumerable.cs:147
	  at System.Linq.Enumerable+<SelectManyIterator>c__Iterator2`2[TSource,TResult].MoveNext () [0x0009a] in /private/tmp/source-mono-4.4.0-c7sr1/bockbuild-mono-4.4.0-branch-c7sr1/profiles/mono-mac-xamarin/build-root/mono-x86/external/referencesource/System.Core/System/Linq/Enumerable.cs:424
	  at Java.Interop.Tools.JavaCallableWrappers.JavaCallableWrapperGenerator..ctor (Mono.Cecil.TypeDefinition type, System.String outerType, System.Action`2 log) [0x00332] in /Users/builder/jenkins/workspace/xamarin-android-pr-builder/xamarin-android/external/Java.Interop/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs:144
	  at Java.Interop.Tools.JavaCallableWrappers.JavaCallableWrapperGenerator..ctor (Mono.Cecil.TypeDefinition type, System.Action`2 log) [0x00000] in /Users/builder/jenkins/workspace/xamarin-android-pr-builder/xamarin-android/external/Java.Interop/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs:60
	  at Java.Interop.Tools.App.GenerateJavaCallableWrapper (Mono.Cecil.TypeDefinition type, System.String outputPath) [0x0001f] in /Users/builder/jenkins/workspace/xamarin-android-pr-builder/xamarin-android/external/Java.Interop/tools/jcw-gen/App.cs:78
	  at Java.Interop.Tools.App.Main (System.String[] args) [0x00265] in /Users/builder/jenkins/workspace/xamarin-android-pr-builder/xamarin-android/external/Java.Interop/tools/jcw-gen/App.cs:66

Remove use of `.Cast<T>()`: it's superfluous now that Cecil uses
generics (and has for ages...), and it's use introduces bugs.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-pr-builder/164/
[1]: https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-pr-builder/162/consoleText