### PR TITLE
[class-parse] fix class visibility XML output.

### DIFF
--- a/src/Xamarin.Android.Tools.Bytecode/XmlClassDeclarationBuilder.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/XmlClassDeclarationBuilder.cs
@@ -93,8 +93,6 @@ namespace Xamarin.Android.Tools.Bytecode {
 				return "public";
 			if ((accessFlags & ClassAccessFlags.Protected) != 0)
 				return "protected";
-			if ((accessFlags & ClassAccessFlags.Private) != 0)
-				return "private";
 			return "";
 		}
 


### PR DESCRIPTION
As part of fixing MSBuild test regression[*1], I noticed that class-parse
does not generate correct visibility for class/interface elements, which
could affect further API metadata processing. It should not generate
"private" for nested types when it should be "" (package private).

[*1] it should be ported to OSS...