### PR TITLE
[Java.Interop.Tools.Cecil] Fix DirectoryAssemblyResolver.Dispose()

### DIFF
--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/TypeNameMapGenerator.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/TypeNameMapGenerator.cs
@@ -68,13 +68,15 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 
 			Log             = logMessage;
 			var Assemblies  = assemblies.ToList ();
-			var resolver    = new DirectoryAssemblyResolver (Log, loadDebugSymbols: true);
+			var rp          = new ReaderParameters (ReadingMode.Immediate);
 
-			foreach (var assembly in Assemblies) {
-				resolver.Load (Path.GetFullPath (assembly));
+			using (var resolver = new DirectoryAssemblyResolver (Log, loadDebugSymbols: true, loadReaderParameters: rp)) {
+				foreach (var assembly in Assemblies) {
+					resolver.Load (Path.GetFullPath (assembly));
+				}
+
+				Types       = JavaTypeScanner.GetJavaTypes (Assemblies, resolver, logMessage);
 			}
-
-			Types       = JavaTypeScanner.GetJavaTypes (Assemblies, resolver, logMessage);
 		}
 
 		public TypeNameMapGenerator (IEnumerable<TypeDefinition> types, Action<string, object[]> logMessage)

--- a/tools/generator/CodeGenerator.cs
+++ b/tools/generator/CodeGenerator.cs
@@ -209,6 +209,13 @@ namespace Xamarin.Android.Binder {
 			if (options == null)
 				throw new ArgumentNullException ("options");
 
+			using (var resolver = new DirectoryAssemblyResolver (Console.WriteLine, loadDebugSymbols: false)) {
+				Run (options, resolver);
+			}
+		}
+
+		static void Run (CodeGeneratorOptions options, DirectoryAssemblyResolver resolver)
+		{
 			string assemblyQN       = options.AssemblyQualifiedName;
 			string api_level        = options.ApiLevel;
 			int product_version     = options.ProductVersion;
@@ -239,7 +246,6 @@ namespace Xamarin.Android.Binder {
 
 			// Load reference libraries
 
-			var resolver = new DirectoryAssemblyResolver (Console.WriteLine, loadDebugSymbols: false);
 			foreach (var lib in options.LibraryPaths) {
 				resolver.SearchDirectories.Add (lib);
 			}

--- a/tools/jcw-gen/App.cs
+++ b/tools/jcw-gen/App.cs
@@ -71,6 +71,9 @@ namespace Java.Interop.Tools
 				Console.Error.Write ("jcw-gen: {0}", verbosity > 0 ? e.ToString () : e.Message);
 				return 1;
 			}
+			finally {
+				resolver.Dispose ();
+			}
 		}
 
 		static void GenerateJavaCallableWrapper (TypeDefinition type, string outputPath)


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/pull/87#issuecomment-249227731
Context: https://bugzilla.xamarin.com/show_bug.cgi?id=44529

(Private) Bug #44529 is an `IOException` on `xamarin-android/master`
due to file sharing:

	Error executing task StripEmbeddedLibraries: System.IO.IOException: Sharing violation on path .../obj/Release/linksrc/Xamarin.Android.NUnitLite.dll
	  at System.IO.FileStream..ctor (System.String path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, System.Int32 bufferSize, System.Boolean anonymous, System.IO.FileOptions options) [0x0025f] in <253a3790b2c44512bbca8669ecfc1822>:0
	  at System.IO.FileStream..ctor (System.String path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share) [0x00000] in <253a3790b2c44512bbca8669ecfc1822>:0
	  at (wrapper remoting-invoke-with-check) System.IO.FileStream:.ctor (string,System.IO.FileMode,System.IO.FileAccess,System.IO.FileShare)
	  at Mono.Cecil.ModuleDefinition.GetFileStream (System.String fileName, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share) [0x00007] in :0
	  at Mono.Cecil.ModuleDefinition.Write (System.String fileName, Mono.Cecil.WriterParameters parameters) [0x00007] in :0
	  at Mono.Cecil.AssemblyDefinition.Write (System.String fileName, Mono.Cecil.WriterParameters parameters) [0x00001] in :0
	  at Xamarin.Android.Tasks.StripEmbeddedLibraries.Execute () [0x0034a] in <3d5202a5d4874a76a99388021bf1ab1a>:0

The underlying cause of this change is the migration to
Cecil 0.10.0-beta1-v2 (dfed286d), which -- along with API changes --
has some *semantic* changes [^0].

In particular, within Cecil <= 0.9.x, `AssemblyDefinition` was
entirely in-memory. Starting with Cecil 0.10.x, `AssemblyDefinition`
isn't; it is backed by a `System.IO.Stream`, which can be in-memory
(if `ReaderParameters.InMemory` is `true`), or a `FileStream`
(the default).

This normally might not be bad, except we also have
`Java.Interop.Tools.Cecil.DirectoryAssemblyResolver`, which *caches*
all created `AssemblyDefinition` instances.

Thus, "normal" *correct* Cecil use would be fine, so long as you know
all assemblies which have been loaded, load them with the correct
`ReaderParameters`, and promptly `Dispose()` of the
`AssemblyDefinition` when done.

`DirectoryAssemblyResolver` throws a wrench in that, because
(1) commit dfed286d incorrectly implemented
`DirectoryAssemblyResolver.Dispose()`, leaving all of the cached
`AssemblyDefinition` instances still "live", which means
(2) The lifetime of the `Stream` underlying the `AssemblyDefinition`
is controlled by the GC, which can mean nearly anything.

This is all a *huge* recipe for confusion.

Fix `DirectoryAssemblyResolver.Dispose()` so that the cached
`AssemblyDefinition` instances are `Dispose()`d of, and review all use
of `DirectoryAssemblyResolver` within Java.Interop to ensure that any
created instances are appropriate `Dispose()`d of.

Additionally, add a new `DirectoryAssemblyResolver` constructor to
allow controlling the `ReaderParameters` that
`DirectoryAssemblyResolver.Load()` uses when loading an assembly:

	partial class DirectoryAssemblyResolver {
		public DirectoryAssemblyResolver (
			Action<string, object[]>  logWarnings,
			bool                      loadDebugSymbols,
			ReaderParameters          loadReaderParameters = null);
	}

The new `loadReaderParameters` allows specifying the default
`ReaderParameters` values to use when
`DirectoryAssemblyResolver.Load()` is invoked. This ensures that all
assemblies loaded by `DirectoryAssemblyResolver` are loaded in a
consistent fashion (e.g. readonly, read+write, in-memory), which will
hopefully allow code to be sanely reasoned about.

[^0]: The best kind of changes!