### PR TITLE
[Java.Interop.Tools.JavaCallableWrappers] TypeNameMapGenerator directories

### DIFF
--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/TypeNameMapGenerator.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/TypeNameMapGenerator.cs
@@ -72,6 +72,13 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 
 			using (var resolver = new DirectoryAssemblyResolver (Log, loadDebugSymbols: true, loadReaderParameters: rp)) {
 				foreach (var assembly in Assemblies) {
+					var directory   = Path.GetDirectoryName (assembly);
+					if (string.IsNullOrEmpty (directory))
+						continue;
+					if (!resolver.SearchDirectories.Contains (directory))
+						resolver.SearchDirectories.Add (directory);
+				}
+				foreach (var assembly in Assemblies) {
 					resolver.Load (Path.GetFullPath (assembly));
 				}
 


### PR DESCRIPTION
The `TypeNameMapGenerator(IEnumerable<string>, Action<string,object[]>)`
constructor attempted to use `DirectoryAssemblyResolver` to load each
assembly provided by the `IEnumerable<string>` parameter, in-order,
*without* updating `DirectoryAssemblyResolver.SearchDirectories`.

The result is that things would only work if the assemblies were
sorted in "dependency order", e.g. `mscorlib.dll` first, and any other
assembly dependency before it's used.

Should the order be otherwise, e.g. `{System.dll, mscorlib.dll}`, then
things would horrifically break:

	System.IO.FileNotFoundException: Could not load assembly 'mscorlib, Version=2.0.5.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e'. Perhaps it doesn't exist in the Mono for Android profile?
	File name: 'mscorlib.dll'
	  at Java.Interop.Tools.Cecil.DirectoryAssemblyResolver.Resolve (Mono.Cecil.AssemblyNameReference reference, Mono.Cecil.ReaderParameters parameters) [0x0015d] in <216e7ad0b70c419890a52554f287cdcd>:0
	  at Java.Interop.Tools.Cecil.DirectoryAssemblyResolver.Resolve (Mono.Cecil.AssemblyNameReference reference) [0x00001] in <216e7ad0b70c419890a52554f287cdcd>:0
	  at Mono.Cecil.MetadataResolver.Resolve (Mono.Cecil.TypeReference type) [0x0004e] in <4f9b8c8361824d0ca9025449919e12be>:0
	  at Mono.Cecil.ModuleDefinition.Resolve (Mono.Cecil.TypeReference type) [0x00007] in <4f9b8c8361824d0ca9025449919e12be>:0
	  at Mono.Cecil.TypeReference.Resolve () [0x00014] in <4f9b8c8361824d0ca9025449919e12be>:0

Improver the `TypeNameMapGenerator` constructor so that
`DirectoryAssemblyResolver.SearchDirectories` is set to contain all
directories for all assemblies provied, *before* attempting to load
any assemblies. This allows assemblies to be provided in an arbitrary
order, while still allowing assemblies to be found.