### PR TITLE
fix typo

### DIFF
--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/DirectoryAssemblyResolver.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/DirectoryAssemblyResolver.cs
@@ -82,7 +82,7 @@ namespace Java.Interop.Tools.Cecil {
 
 		public void Dispose ()
 		{
-			Dispose (disposing: false);
+			Dispose (disposing: true);
 			GC.SuppressFinalize (this);
 		}
 


### PR DESCRIPTION
 - we actually want the disposing to be set to true when called from
   IDisposing.Dispose method so that the resources are disposed
   (unlike when called from finalizer)

 - this fixes part of #44529