### PR TITLE
[generator] (class-parse regression) mark obfuscated types in generator.

### DIFF
--- a/tools/generator/CodeGenerator.cs
+++ b/tools/generator/CodeGenerator.cs
@@ -308,8 +308,12 @@ namespace Xamarin.Android.Binder {
 			opt.Gens = gens;
 
 			// disable interface default methods here, especially before validation.
-			foreach (var gen in gens)
+			gens = gens.Where (g => !g.IsObfuscated && g.Visibility != "private").ToList ();
+			foreach (var gen in gens) {
 				gen.StripNonBindables ();
+				if (gen.IsGeneratable)
+					AddTypeToTable (gen);
+			}
 
 			Validate (gens, opt);
 
@@ -353,6 +357,13 @@ namespace Xamarin.Android.Binder {
 				: enummap.WriteEnumerations (enumdir, enums, FlattenNestedTypes (gens).ToArray (), opt.UseShortFileNames);
 
 			gen_info.GenerateLibraryProjectFile (options, enumFiles);
+		}
+
+		static void AddTypeToTable (GenBase gb)
+		{
+			SymbolTable.AddType (gb);
+			foreach (var nt in gb.NestedTypes)
+				AddTypeToTable (nt);
 		}
 
 		static IEnumerable<GenBase> FlattenNestedTypes (IEnumerable<GenBase> gens)

--- a/tools/generator/GenBase.cs
+++ b/tools/generator/GenBase.cs
@@ -53,6 +53,10 @@ namespace MonoDroid.Generation {
 			get { return support.IsDeprecated; }
 		}
 		
+		public bool IsObfuscated {
+			get { return support.IsObfuscated; }
+		}
+
 		public string DeprecatedComment {
 			get { return support.DeprecatedComment; }
 		}
@@ -718,6 +722,9 @@ namespace MonoDroid.Generation {
 			// have to "implement" those methods because they are declared and you have to implement
 			// any declared methods in C#. That is going to be problematic a lot.
 			methods = methods.Where (m => !m.IsInterfaceDefaultMethod).ToList ();
+			nested_types = nested_types.Where (n => !n.IsObfuscated && n.Visibility != "private").ToList ();
+			foreach (var n in nested_types)
+				n.StripNonBindables ();
 		}
 
 		public void FillProperties ()

--- a/tools/generator/Parser.cs
+++ b/tools/generator/Parser.cs
@@ -129,7 +129,6 @@ namespace MonoDroid.Generation {
 					nested [name] = gen;
 				else
 					result.Add (gen);
-				SymbolTable.AddType (gen);
 			}
 
 			foreach (string name in nested.Keys) {


### PR DESCRIPTION
DO NOT MERGE THIS WITHOUT MERGING https://github.com/xamarin/xamarin-android/pull/249 first (yes, that PR can be merged without this)

Basically this is part of the problems reported at
https://bugzilla.xamarin.com/show_bug.cgi?id=44263

In good old jar2xml era, we marked "obfuscated" types at jar2xml so
that those types are not generated in the API XML.

class-parse is not that clever and generates everything as is.

We could make changes to api-xml-adjuster to bring back sanity, but
instead of doing it in jar2xml, we had better bring in flexibility
to obfuscation marking. That is -

- If there is obfuscated='false' attribute specification by API
  metadata fixup, then do not mark as obfuscated in any case.
- If not, process any lowercase-named types and nested types as
  obfuscated, such as 'a', 'SomeType$a', or 'SomeType$b$a'.

Due to code structures, we cannot take the same code path as jar2xml
(we don't hold list of sibling classes when processing an XML element).
https://github.com/xamarin/jar2xml/blob/master/JavaPackage.java#L78

Also, we had seen some obfuscated types like b$a as NOT marked as
obfuscated in the past, because we were checking only a,aa,aaa,aaaa and
aaaaa as the parent type for nested types. That should be fixed.

To fix this issue, we process marking as part of StripNonBindables().
Also, it was too early to register those types to SymbolTable before
stripping those types out, so changed relevant processing order.

Fixing bug #44263 then exposed another problem; StripNonBindables()
was not complete and it was not processing nested C# types at all.
Thus we had generated non-bindable code before. This change fixes this
issue at the same time, for fixing the bug.

Thus, this will result in "API breakage" looking changes in the end,
but the bindings were invalid and should be removed without
compatibility concern.