### PR TITLE
[build] Fix the `invocation-overhead` build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,6 @@ ifeq ($(OS),Linux)
 NATIVE_EXT = .so
 endif
 
-RUNTIME       := $(shell if [ -f "`which mono64`" ] ; then echo mono64 ; else echo mono; fi) --debug=casts
-
 XA_CONFIGURATION  = XAIntegrationDebug
 
 GENDARME_URL = https://cloud.github.com/downloads/spouliot/gendarme/gendarme-2.10-bin.zip
@@ -58,8 +56,8 @@ clean:
 	-rm -Rf bin/$(CONFIGURATION) bin/Build$(CONFIGURATION) bin/Test$(CONFIGURATION) bin/XAIntegration$(CONFIGURATION)
 	-rm src/Java.Runtime.Environment/Java.Runtime.Environment.dll.config
 
-include build-tools/scripts/jdk.mk
 include build-tools/scripts/mono.mk
+include build-tools/scripts/jdk.mk
 
 $(PACKAGES) $(NUNIT_CONSOLE):
 	nuget restore

--- a/build-tools/scripts/jdk.mk
+++ b/build-tools/scripts/jdk.mk
@@ -3,8 +3,9 @@
 #
 # Inputs:
 #
-#   $(OS): `uname` value of the host operating system
+#   $(OS): Optional; **uname**(1) value of the host operating system
 #   $(CONFIGURATION): Build configuration name, e.g. Debug or Release
+#   $(RUNTIME): `mono` executable for the host operating system
 #
 # Outputs:
 #
@@ -19,7 +20,7 @@
 #   $(JI_JVM_PATH):
 #       Location of the Java native library that contains e.g. JNI_CreateJavaVM().
 
-
+OS           ?= $(shell uname)
 
 ifeq ($(OS),Darwin)
 

--- a/build-tools/scripts/mono.mk
+++ b/build-tools/scripts/mono.mk
@@ -1,3 +1,31 @@
+#
+# Mono Path Probing
+#
+# Inputs:
+#
+#   $(OS): Optional; **uname**(1) value of the host operating system
+#   $(CONFIGURATION): Build configuration name, e.g. Debug or Release
+#
+# Outputs:
+#
+#   bin/Build$(CONFIGURATION)/MonoInfo.props:
+#       MSBuild property file which contains:
+#       * `$(MonoFrameworkPath)`: `$(JI_MONO_FRAMEWORK_PATH)` value.
+#       * `$(MonoLibs)`: `$(JI_MONO_LIBS)` value.
+#       * `@(MonoIncludePath)`: `$(JI_MONO_INCLUDE_PATHS)` values.
+#   $(JI_MONO_FRAMEWORK_PATH):
+#       Path to the `libmonosgen-2.0.1.dylib` file to link against.
+#   $(JI_MONO_INCLUDE_PATHS):
+#       One or more space separated paths containing Mono headers to pass as
+#       -Ipath values to the compiler.
+#       It DOES NOT contain the -I itself; use $(JI_MONO_INCLUDE_PATHS:%=-I%) for that.
+#   $(JI_MONO_LIBS)
+#       C compiler linker arguments to link against `$(JI_MONO_FRAMEWORK_PATH)`.
+#   $(RUNTIME):
+#       The **mono**(1) program to use to execute managed code.
+
+OS            ?= $(shell uname)
+RUNTIME       := $(shell if [ -f "`which mono64`" ] ; then echo mono64 ; else echo mono; fi) --debug=casts
 
 ifeq ($(OS),Darwin)
 JI_MONO_FRAMEWORK_PATH = /Library/Frameworks/Mono.framework/Libraries/libmonosgen-2.0.1.dylib

--- a/tests/invocation-overhead/Makefile
+++ b/tests/invocation-overhead/Makefile
@@ -1,11 +1,17 @@
-JNIENV_GEN        = ../../bin/Debug/jnienv-gen.exe
-LOCAL_JDK_HEADERS = ../../LocalJDK/System/Library/Frameworks/JavaVM.framework/Versions/A/Headers
+CONFIGURATION     = Debug
+JNIENV_GEN        = ../../bin/BuildDebug/jnienv-gen.exe
 
 all: test-overheads.exe libjava-interop.dylib
 
 clean:
 	-rm test-overheads.exe test-overheads.exe.mdb
 	-rm -Rf libJavaInterop.dylib*
+
+include ../../build-tools/scripts/mono.mk
+include ../../build-tools/scripts/jdk.mk
+
+$(JNIENV_GEN):
+	(cd ../../build-tools/jnienv-gen ; xbuild /p:Configuration=$(CONFIGURATION))
 
 HANDLE_FEATURES = \
 	-d:FEATURE_JNIENVIRONMENT_JI_INTPTRS \
@@ -17,10 +23,10 @@ test-overheads.exe: test-overheads.cs jni.cs
 	mcs -out:$@ -unsafe $(HANDLE_FEATURES) $^
 
 jni.c jni.cs: $(JNIENV_GEN)
-	mono $< jni.cs jni.c
+	$(RUNTIME) $< jni.cs jni.c
 
 libjava-interop.dylib: jni.c
-	gcc -g -shared -o $@ $< -m32 -DJI_DLL_EXPORT -fvisibility=hidden -I $(LOCAL_JDK_HEADERS)
+	gcc -g -shared -o $@ $< -m64 -DJI_DLL_EXPORT -fvisibility=hidden $(JI_JDK_INCLUDE_PATHS:%=-I%)
 
 run:
-	mono --debug test-overheads.exe
+	$(RUNTIME) test-overheads.exe


### PR DESCRIPTION
The `tests/invocation-overhead` build had regressed, largely becuase
it's rarely executed. Breakage was due to the fact that the JNI
headers could no longer be found, and that when running `make run`,
the "wrong" mono was being used wrt the JVM that was used (e.g. trying
to use a 32-bit mono with a 64-bit JVM).

Refactor some Makefile logic and cleanup for consistency.