### PR TITLE
[api-xml-adjuster] method overrides cannot expose non-public types.

### DIFF
--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApi.XmlModel.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApi.XmlModel.cs
@@ -253,6 +253,12 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 
 	public partial class JavaParameter
 	{
+		public JavaParameter (JavaMethodBase parent)
+		{
+			Parent = parent;
+		}
+
+		public JavaMethodBase Parent { get; private set; }
 		public string Name { get; set; }
 		public string Type { get; set; }
 		
@@ -309,7 +315,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		
 		public override string ToString ()
 		{
-			return Name + (GenericConstraints == null ? null : GenericConstraints.ToString ());
+			return Name;
 		}
 	}
 
@@ -326,7 +332,10 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		
 		public override string ToString ()
 		{
-			return " " + (BoundsType ?? "extends") + " " + string.Join (" & ", GenericConstraints);
+			string csts = string.Join (" & ", GenericConstraints);
+			if (csts == "java.lang.Object")
+				return string.Empty;
+			return " " + (BoundsType ?? "extends") + " " + csts;
 		}
 	}
 	

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiFixVisibilityExtensions.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiFixVisibilityExtensions.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Linq;
+
+namespace Xamarin.Android.Tools.ApiXmlAdjuster
+{
+	public static class JavaApiFixVisibilityExtensions
+	{
+		public static string GetVisibleTypeName (this JavaParameter parameter)
+		{
+			var r = GetVisibleNonSpecialType (parameter);
+			return r != null ? r.ToString () : parameter.Type;
+		}
+
+		public static string GetVisibleReturnTypeName (this JavaMethod method)
+		{
+			var r = GetVisibleNonSpecialReturnType (method);
+			return r != null ? r.ToString () : method.Return;
+		}
+
+		public static JavaTypeReference GetVisibleNonSpecialType (this JavaParameter parameter)
+		{
+			return GetVisibleNonSpecialType (parameter.Parent, parameter.ResolvedType);
+		}
+
+		public static JavaTypeReference GetVisibleNonSpecialReturnType (this JavaMethod method)
+		{
+			return GetVisibleNonSpecialType (method, method.ResolvedReturnType);
+		}
+
+		static JavaTypeReference GetVisibleNonSpecialType (this JavaMethodBase method, JavaTypeReference r)
+		{
+			if (r == null || r.SpecialName != null || r.ReferencedTypeParameter != null || r.ArrayPart != null)
+				return null;
+			var requiredVisibility = method.Visibility == "public" && method.Parent.Visibility == "public" ? "public" : method.Visibility;
+			for (var t = r; t != null; t = (t.ReferencedType as JavaClass)?.ResolvedExtends) {
+				if (t.ReferencedType == null)
+					break;
+				if (IsAcceptableVisibility (required: requiredVisibility, actual: t.ReferencedType.Visibility))
+					return t;
+			}
+			return null;
+		}
+
+		static bool IsAcceptableVisibility (string required, string actual)
+		{
+			if (required == "public")
+				return actual == "public";
+			else
+				return true;
+		}
+	}
+}

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiXmlGeneratorExtensions.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiXmlGeneratorExtensions.cs
@@ -176,7 +176,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			SaveCommon (method, writer, "method",
 				XmlConvert.ToString (method.Abstract),
 				XmlConvert.ToString (method.Native),
-				method.Return,
+				method.GetVisibleReturnTypeName (),
 				XmlConvert.ToString (method.Synchronized),
 				null,
 				null,
@@ -232,8 +232,8 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 				foreach (var p in parameters) {
 					writer.WriteStartElement ("parameter");
 					writer.WriteAttributeString ("name", p.Name);
-					writer.WriteAttributeString ("type", p.Type);
-					writer.WriteString ("\n        ");			
+					writer.WriteAttributeString ("type", p.GetVisibleTypeName ());
+					writer.WriteString ("\n        ");
 					writer.WriteFullEndElement ();
 				}
 			}

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiXmlLoaderExtensions.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiXmlLoaderExtensions.cs
@@ -242,7 +242,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 						tp.Load (reader);
 						method.TypeParameters = tp;
 					} else if (reader.LocalName == "parameter") {
-						var p = new JavaParameter ();
+						var p = new JavaParameter (methodBase);
 						p.Load (reader);
 						methodBase.Parameters.Add (p);
 					} else if (reader.LocalName == "exception") {

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/Tests/JavaApiTest.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/Tests/JavaApiTest.cs
@@ -24,6 +24,24 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster.Tests
 			var kls = pkg.Types.First (t => t.FullName == "android.database.ContentObservable");
 			Assert.AreEqual ("[Class] android.database.ContentObservable", kls.ToString ());
 		}
+
+		[Test]
+		public void ParseName ()
+		{
+			var tn = JavaTypeName.Parse ("java.util.Function<java.util.Map.Entry<K, V>, ? extends U>");
+			Assert.AreEqual ("java.util.Function", tn.FullNameNonGeneric, "top failed to parse name");
+			Assert.AreEqual (2, tn.GenericArguments.Count, "top incorrect number of parsed generic arguments");
+			var ga1 = tn.GenericArguments [0];
+			Assert.AreEqual ("java.util.Map.Entry", ga1.FullNameNonGeneric, "genarg#0 name mismatch");
+			Assert.AreEqual (2, ga1.GenericArguments.Count, "genarg#0 incorrect number of parsed generic arguments");
+			Assert.AreEqual ("K", ga1.GenericArguments [0].FullNameNonGeneric, "genarg#0.1 name mismatch");
+			Assert.AreEqual ("V", ga1.GenericArguments [1].FullNameNonGeneric, "genarg#0.2 name mismatch");
+			var ga2 = tn.GenericArguments [1];
+			Assert.AreEqual ("?", ga2.FullNameNonGeneric, "genarg#1 name mismatch");
+			Assert.AreEqual (" extends ", ga2.BoundsType, "genarg#1 incorrect bounds type");
+			Assert.AreEqual (1, ga2.GenericConstraints.Count, "genarg#1 incorrect number of parsed generic constraints");
+			Assert.AreEqual ("U", ga2.GenericConstraints [0].FullNameNonGeneric, "genarg#1.1 constraint name mismatch");
+		}
 	}
 }
 

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/Tests/JavaApiTestHelper.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/Tests/JavaApiTestHelper.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster.Tests
 				"src",
 				"Xamarin.Android.Tools.ApiXmlAdjuster",
 				"Tests",
-				"api-10.xml.in");
+				"api-24.xml.in");
 
 		public static JavaApi GetLoadedApi ()
 		{

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/Tests/Xamarin.Android.Tools.ApiXmlAdjuster-Tests.csproj
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/Tests/Xamarin.Android.Tools.ApiXmlAdjuster-Tests.csproj
@@ -32,6 +32,7 @@
     <Reference Include="System" />
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+      <Package>nunit</Package>
     </Reference>
     <Reference Include="System.Xml" />
   </ItemGroup>
@@ -44,7 +45,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-    <None Include="api-10.xml.in" />
+    <None Include="api-24.xml.in" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Android.Tools.ApiXmlAdjuster.csproj">

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/Xamarin.Android.Tools.ApiXmlAdjuster.csproj
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/Xamarin.Android.Tools.ApiXmlAdjuster.csproj
@@ -48,6 +48,7 @@
     <Compile Include="JavaApiXmlGeneratorExtensions.cs" />
     <Compile Include="JavaApiDefectFinderExtensions.cs" />
     <Compile Include="JavaTypeResolutionUtil.cs" />
+    <Compile Include="JavaApiFixVisibilityExtensions.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/tools/generator/JavaApiDllLoaderExtensions.cs
+++ b/tools/generator/JavaApiDllLoaderExtensions.cs
@@ -119,7 +119,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		{
 			method.Deprecated = gm.Deprecated;
 			method.Visibility = gm.Visibility;
-			method.Parameters = gm.Parameters.Select (_ => new JavaParameter () {
+			method.Parameters = gm.Parameters.Select (_ => new JavaParameter (method) {
 				Name = _.JavaName,
 				Type = _.RawNativeType,
 				}).ToArray ();


### PR DESCRIPTION
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=44531

When a Java method is overriden, its parameter type or return type can be
variant, which possibly result in exposure of non-public types (returning
private class object which is derived from public type is totally valid).

It is because we blindly emit the parsed type from class-parse output
as the API XML adjuster output. It needs to be examined and adjusted to
be public (or protected) type.

jar2xml didn't have this problem because Java reflection API is clever
enough to cover that issue.

The fixes are... not cosmetic.

Basically now we use TypeReference.ToString() which used to not be
precise and ready for API XML output. So there are couple of fixes
for that. (We also want to track from which method base a parameter
or return type is bound, so we pass that to the .ctor now).

We hide extraneous public TypeParameter.ctor() now to reduce chances
for bugs. Tests need to be modified to reflect the changes.

Lastly, Mono.Android API XML will be updated to reflect this change.
There will be some removal of method overrides from api-*.xml.in but
there was no regression reported from api-diff.