### PR TITLE
[generator] Qualify `object.GetType()` invocations

### DIFF
--- a/tools/generator/JavaInteropCodeGenerator.cs
+++ b/tools/generator/JavaInteropCodeGenerator.cs
@@ -124,7 +124,7 @@ namespace MonoDroid.Generation {
 			var oldindent = indent;
 			indent += "\t";
 			ctor.Parameters.WriteCallArgs (sw, indent, opt, invoker:false);
-			sw.WriteLine ("{0}var __r = _members.InstanceMethods.StartCreateInstance (__id, GetType (){1});", indent, ctor.Parameters.GetCallArgs (opt, invoker:false));
+			sw.WriteLine ("{0}var __r = _members.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (){1});", indent, ctor.Parameters.GetCallArgs (opt, invoker:false));
 			sw.WriteLine ("{0}SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);", indent);
 			sw.WriteLine ("{0}_members.InstanceMethods.FinishCreateInstance (__id, this{1});", indent, ctor.Parameters.GetCallArgs (opt, invoker:false));
 			indent = oldindent;

--- a/tools/generator/Tests-Core/expected.ji/Android.Text.SpannableString.cs
+++ b/tools/generator/Tests-Core/expected.ji/Android.Text.SpannableString.cs
@@ -44,7 +44,7 @@ namespace Android.Text {
 			try {
 				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
 				__args [0] = new JniArgumentValue (native_source);
-				var __r = _members.InstanceMethods.StartCreateInstance (__id, GetType (), __args);
+				var __r = _members.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), __args);
 				SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
 				_members.InstanceMethods.FinishCreateInstance (__id, this, __args);
 			} finally {
@@ -65,7 +65,7 @@ namespace Android.Text {
 			try {
 				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
 				__args [0] = new JniArgumentValue (native_source);
-				var __r = _members.InstanceMethods.StartCreateInstance (__id, GetType (), __args);
+				var __r = _members.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), __args);
 				SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
 				_members.InstanceMethods.FinishCreateInstance (__id, this, __args);
 			} finally {

--- a/tools/generator/Tests-Core/expected/Android.Text.SpannableString.cs
+++ b/tools/generator/Tests-Core/expected/Android.Text.SpannableString.cs
@@ -38,9 +38,9 @@ namespace Android.Text {
 			try {
 				JValue* __args = stackalloc JValue [1];
 				__args [0] = new JValue (native_source);
-				if (GetType () != typeof (SpannableString)) {
+				if (((object) this).GetType () != typeof (SpannableString)) {
 					SetHandle (
-							global::Android.Runtime.JNIEnv.StartCreateInstance (GetType (), "(Ljava/lang/CharSequence;)V", __args),
+							global::Android.Runtime.JNIEnv.StartCreateInstance (((object) this).GetType (), "(Ljava/lang/CharSequence;)V", __args),
 							JniHandleOwnership.TransferLocalRef);
 					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "(Ljava/lang/CharSequence;)V", __args);
 					return;
@@ -68,9 +68,9 @@ namespace Android.Text {
 			try {
 				JValue* __args = stackalloc JValue [1];
 				__args [0] = new JValue (native_source);
-				if (GetType () != typeof (SpannableString)) {
+				if (((object) this).GetType () != typeof (SpannableString)) {
 					SetHandle (
-							global::Android.Runtime.JNIEnv.StartCreateInstance (GetType (), "(Ljava/lang/CharSequence;)V", __args),
+							global::Android.Runtime.JNIEnv.StartCreateInstance (((object) this).GetType (), "(Ljava/lang/CharSequence;)V", __args),
 							JniHandleOwnership.TransferLocalRef);
 					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "(Ljava/lang/CharSequence;)V", __args);
 					return;
@@ -117,7 +117,7 @@ namespace Android.Text {
 				__args [0] = new JValue (what);
 
 				Android.Text.SpanTypes __ret;
-				if (GetType () == ThresholdType)
+				if (((object) this).GetType () == ThresholdType)
 					__ret = (Android.Text.SpanTypes) JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getSpanFlags_Ljava_lang_Object_, __args);
 				else
 					__ret = (Android.Text.SpanTypes) JNIEnv.CallNonvirtualIntMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "getSpanFlags", "(Ljava/lang/Object;)I"), __args);

--- a/tools/generator/Tests-Core/expected/Android.Text.SpannableStringInternal.cs
+++ b/tools/generator/Tests-Core/expected/Android.Text.SpannableStringInternal.cs
@@ -56,7 +56,7 @@ namespace Android.Text {
 				__args [0] = new JValue (p0);
 
 				Android.Text.SpanTypes __ret;
-				if (GetType () == ThresholdType)
+				if (((object) this).GetType () == ThresholdType)
 					__ret = (Android.Text.SpanTypes) JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getSpanFlags_Ljava_lang_Object_, __args);
 				else
 					__ret = (Android.Text.SpanTypes) JNIEnv.CallNonvirtualIntMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "getSpanFlags", "(Ljava/lang/Object;)I"), __args);

--- a/tools/generator/Tests-Core/expected/Android.Views.View.cs
+++ b/tools/generator/Tests-Core/expected/Android.Views.View.cs
@@ -164,7 +164,7 @@ namespace Android.Views {
 				JValue* __args = stackalloc JValue [1];
 				__args [0] = new JValue (l);
 
-				if (GetType () == ThresholdType)
+				if (((object) this).GetType () == ThresholdType)
 					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_setOnClickListener_Landroid_view_View_OnClickListener_, __args);
 				else
 					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "setOnClickListener", "(Landroid/view/View$OnClickListener;)V"), __args);
@@ -201,7 +201,7 @@ namespace Android.Views {
 				JValue* __args = stackalloc JValue [1];
 				__args [0] = new JValue (native_views);
 
-				if (GetType () == ThresholdType)
+				if (((object) this).GetType () == ThresholdType)
 					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_addTouchables_Ljava_util_ArrayList_, __args);
 				else
 					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "addTouchables", "(Ljava/util/ArrayList;)V"), __args);

--- a/tools/generator/Tests/expected.ji/Adapters/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/Adapters/Mono.Android.projitems
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);ANDROID_1;ANDROID_2;ANDROID_3;ANDROID_4</DefineConstants>
+  </PropertyGroup>
+  <!-- Classes -->
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.AbsSpinner.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.AdapterView.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.GenericReturnObject.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.IAdapter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.ISpinnerAdapter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+  </ItemGroup>
+  <!-- Enums -->
+  <ItemGroup />
+</Project>

--- a/tools/generator/Tests/expected.ji/Android.Graphics.Color/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/Android.Graphics.Color/Mono.Android.projitems
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);ANDROID_1;ANDROID_2;ANDROID_3;ANDROID_4</DefineConstants>
+  </PropertyGroup>
+  <!-- Classes -->
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.SomeObject.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+  </ItemGroup>
+  <!-- Enums -->
+  <ItemGroup />
+</Project>

--- a/tools/generator/Tests/expected.ji/Arrays/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/Arrays/Mono.Android.projitems
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);ANDROID_1;ANDROID_2;ANDROID_3;ANDROID_4</DefineConstants>
+  </PropertyGroup>
+  <!-- Classes -->
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.SomeObject.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+  </ItemGroup>
+  <!-- Enums -->
+  <ItemGroup />
+</Project>

--- a/tools/generator/Tests/expected.ji/Constructors/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/Constructors/Mono.Android.projitems
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);ANDROID_1;ANDROID_2;ANDROID_3;ANDROID_4</DefineConstants>
+  </PropertyGroup>
+  <!-- Classes -->
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.SomeObject.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+  </ItemGroup>
+  <!-- Enums -->
+  <ItemGroup />
+</Project>

--- a/tools/generator/Tests/expected.ji/Constructors/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected.ji/Constructors/Xamarin.Test.SomeObject.cs
@@ -41,7 +41,7 @@ namespace Xamarin.Test {
 				return;
 
 			try {
-				var __r = _members.InstanceMethods.StartCreateInstance (__id, GetType (), null);
+				var __r = _members.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), null);
 				SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
 				_members.InstanceMethods.FinishCreateInstance (__id, this, null);
 			} finally {
@@ -61,7 +61,7 @@ namespace Xamarin.Test {
 			try {
 				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
 				__args [0] = new JniArgumentValue (aint);
-				var __r = _members.InstanceMethods.StartCreateInstance (__id, GetType (), __args);
+				var __r = _members.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), __args);
 				SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
 				_members.InstanceMethods.FinishCreateInstance (__id, this, __args);
 			} finally {

--- a/tools/generator/Tests/expected.ji/NestedTypes/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/NestedTypes/Mono.Android.projitems
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);ANDROID_1;ANDROID_2;ANDROID_3;ANDROID_4</DefineConstants>
+  </PropertyGroup>
+  <!-- Classes -->
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.NotificationCompatBase.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+  </ItemGroup>
+  <!-- Enums -->
+  <ItemGroup />
+</Project>

--- a/tools/generator/Tests/expected.ji/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
+++ b/tools/generator/Tests/expected.ji/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
@@ -163,7 +163,7 @@ namespace Xamarin.Test {
 				try {
 					JniArgumentValue* __args = stackalloc JniArgumentValue [1];
 					__args [0] = new JniArgumentValue ((__self == null) ? IntPtr.Zero : ((global::Java.Lang.Object) __self).Handle);
-					var __r = _members.InstanceMethods.StartCreateInstance (__id, GetType (), __args);
+					var __r = _members.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), __args);
 					SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
 					_members.InstanceMethods.FinishCreateInstance (__id, this, __args);
 				} finally {

--- a/tools/generator/Tests/expected.ji/NonStaticFields/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/NonStaticFields/Mono.Android.projitems
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);ANDROID_1;ANDROID_2;ANDROID_3;ANDROID_4</DefineConstants>
+  </PropertyGroup>
+  <!-- Classes -->
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.SomeObject.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+  </ItemGroup>
+  <!-- Enums -->
+  <ItemGroup />
+</Project>

--- a/tools/generator/Tests/expected.ji/NormalMethods/Java.Lang.Class.cs
+++ b/tools/generator/Tests/expected.ji/NormalMethods/Java.Lang.Class.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Java.Lang {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Class']"
+	[global::Android.Runtime.Register ("java/lang/Class", DoNotGenerateAcw=true)]
+	[global::Java.Interop.JavaTypeParameters (new string [] {"T"})]
+	public partial class Class : global::Java.Lang.Object {
+
+		protected Class (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+	}
+}

--- a/tools/generator/Tests/expected.ji/NormalMethods/Java.Lang.Throwable.cs
+++ b/tools/generator/Tests/expected.ji/NormalMethods/Java.Lang.Throwable.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Java.Lang {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Throwable']"
+	[global::Android.Runtime.Register ("java/lang/Throwable", DoNotGenerateAcw=true)]
+	public partial class Throwable  {
+
+	}
+}

--- a/tools/generator/Tests/expected.ji/NormalMethods/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/NormalMethods/Mono.Android.projitems
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);ANDROID_1;ANDROID_2;ANDROID_3;ANDROID_4</DefineConstants>
+  </PropertyGroup>
+  <!-- Classes -->
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Class.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Integer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Throwable.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.A.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.C.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.SomeObject.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+  </ItemGroup>
+  <!-- Enums -->
+  <ItemGroup />
+</Project>

--- a/tools/generator/Tests/expected.ji/NormalMethods/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected.ji/NormalMethods/Xamarin.Test.SomeObject.cs
@@ -43,9 +43,37 @@ namespace Xamarin.Test {
 			try {
 				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
 				__args [0] = new JniArgumentValue ((c == null) ? IntPtr.Zero : ((global::Java.Lang.Object) c).Handle);
-				var __r = _members.InstanceMethods.StartCreateInstance (__id, GetType (), __args);
+				var __r = _members.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), __args);
 				SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
 				_members.InstanceMethods.FinishCreateInstance (__id, this, __args);
+			} finally {
+			}
+		}
+
+		static Delegate cb_getType;
+#pragma warning disable 0169
+		static Delegate GetGetTypeHandler ()
+		{
+			if (cb_getType == null)
+				cb_getType = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_GetType);
+			return cb_getType;
+		}
+
+		static IntPtr n_GetType (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.NewArray (__this.GetType ());
+		}
+#pragma warning restore 0169
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/method[@name='getType' and count(parameter)=0]"
+		[Register ("getType", "()[I", "GetGetTypeHandler")]
+		public virtual unsafe int[] GetType ()
+		{
+			const string __id = "getType.()[I";
+			try {
+				var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, null);
+				return (int[]) JNIEnv.GetArray (__rm.Handle, JniHandleOwnership.TransferLocalRef, typeof (int));
 			} finally {
 			}
 		}

--- a/tools/generator/Tests/expected.ji/NormalProperties/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/NormalProperties/Mono.Android.projitems
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);ANDROID_1;ANDROID_2;ANDROID_3;ANDROID_4</DefineConstants>
+  </PropertyGroup>
+  <!-- Classes -->
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.SomeObject.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+  </ItemGroup>
+  <!-- Enums -->
+  <ItemGroup />
+</Project>

--- a/tools/generator/Tests/expected.ji/ParameterXPath/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/ParameterXPath/Mono.Android.projitems
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);ANDROID_1;ANDROID_2;ANDROID_3;ANDROID_4</DefineConstants>
+  </PropertyGroup>
+  <!-- Classes -->
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Integer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.A.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+  </ItemGroup>
+  <!-- Enums -->
+  <ItemGroup />
+</Project>

--- a/tools/generator/Tests/expected.ji/StaticFields/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/StaticFields/Mono.Android.projitems
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);ANDROID_1;ANDROID_2;ANDROID_3;ANDROID_4</DefineConstants>
+  </PropertyGroup>
+  <!-- Classes -->
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.SomeObject.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+  </ItemGroup>
+  <!-- Enums -->
+  <ItemGroup />
+</Project>

--- a/tools/generator/Tests/expected.ji/StaticMethods/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/StaticMethods/Mono.Android.projitems
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);ANDROID_1;ANDROID_2;ANDROID_3;ANDROID_4</DefineConstants>
+  </PropertyGroup>
+  <!-- Classes -->
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.SomeObject.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+  </ItemGroup>
+  <!-- Enums -->
+  <ItemGroup />
+</Project>

--- a/tools/generator/Tests/expected.ji/StaticProperties/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/StaticProperties/Mono.Android.projitems
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);ANDROID_1;ANDROID_2;ANDROID_3;ANDROID_4</DefineConstants>
+  </PropertyGroup>
+  <!-- Classes -->
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.SomeObject.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+  </ItemGroup>
+  <!-- Enums -->
+  <ItemGroup />
+</Project>

--- a/tools/generator/Tests/expected.ji/Streams/Java.IO.FilterOutputStream.cs
+++ b/tools/generator/Tests/expected.ji/Streams/Java.IO.FilterOutputStream.cs
@@ -44,7 +44,7 @@ namespace Java.IO {
 			try {
 				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
 				__args [0] = new JniArgumentValue (native__out);
-				var __r = _members.InstanceMethods.StartCreateInstance (__id, GetType (), __args);
+				var __r = _members.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), __args);
 				SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
 				_members.InstanceMethods.FinishCreateInstance (__id, this, __args);
 			} finally {

--- a/tools/generator/Tests/expected.ji/Streams/Java.IO.InputStream.cs
+++ b/tools/generator/Tests/expected.ji/Streams/Java.IO.InputStream.cs
@@ -41,7 +41,7 @@ namespace Java.IO {
 				return;
 
 			try {
-				var __r = _members.InstanceMethods.StartCreateInstance (__id, GetType (), null);
+				var __r = _members.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), null);
 				SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
 				_members.InstanceMethods.FinishCreateInstance (__id, this, null);
 			} finally {

--- a/tools/generator/Tests/expected.ji/Streams/Java.IO.OutputStream.cs
+++ b/tools/generator/Tests/expected.ji/Streams/Java.IO.OutputStream.cs
@@ -41,7 +41,7 @@ namespace Java.IO {
 				return;
 
 			try {
-				var __r = _members.InstanceMethods.StartCreateInstance (__id, GetType (), null);
+				var __r = _members.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), null);
 				SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
 				_members.InstanceMethods.FinishCreateInstance (__id, this, null);
 			} finally {

--- a/tools/generator/Tests/expected.ji/Streams/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/Streams/Mono.Android.projitems
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);ANDROID_1;ANDROID_2;ANDROID_3;ANDROID_4</DefineConstants>
+  </PropertyGroup>
+  <!-- Classes -->
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.IO.FilterOutputStream.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.IO.InputStream.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.IO.IOException.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.IO.OutputStream.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Throwable.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+  </ItemGroup>
+  <!-- Enums -->
+  <ItemGroup />
+</Project>

--- a/tools/generator/Tests/expected.ji/TestInterface/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/TestInterface/Mono.Android.projitems
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);ANDROID_1;ANDROID_2;ANDROID_3;ANDROID_4</DefineConstants>
+  </PropertyGroup>
+  <!-- Classes -->
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.String.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Test.ME.GenericImplementation.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Test.ME.GenericStringImplementation.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Test.ME.IGenericInterface.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Test.ME.ITestInterface.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Test.ME.TestInterfaceImplementation.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+  </ItemGroup>
+  <!-- Enums -->
+  <ItemGroup />
+</Project>

--- a/tools/generator/Tests/expected.ji/TestInterface/Test.ME.GenericImplementation.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Test.ME.GenericImplementation.cs
@@ -41,7 +41,7 @@ namespace Test.ME {
 				return;
 
 			try {
-				var __r = _members.InstanceMethods.StartCreateInstance (__id, GetType (), null);
+				var __r = _members.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), null);
 				SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
 				_members.InstanceMethods.FinishCreateInstance (__id, this, null);
 			} finally {

--- a/tools/generator/Tests/expected.ji/TestInterface/Test.ME.GenericStringImplementation.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Test.ME.GenericStringImplementation.cs
@@ -41,7 +41,7 @@ namespace Test.ME {
 				return;
 
 			try {
-				var __r = _members.InstanceMethods.StartCreateInstance (__id, GetType (), null);
+				var __r = _members.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), null);
 				SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
 				_members.InstanceMethods.FinishCreateInstance (__id, this, null);
 			} finally {

--- a/tools/generator/Tests/expected.ji/TestInterface/Test.ME.TestInterfaceImplementation.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Test.ME.TestInterfaceImplementation.cs
@@ -63,7 +63,7 @@ namespace Test.ME {
 				return;
 
 			try {
-				var __r = _members.InstanceMethods.StartCreateInstance (__id, GetType (), null);
+				var __r = _members.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), null);
 				SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
 				_members.InstanceMethods.FinishCreateInstance (__id, this, null);
 			} finally {

--- a/tools/generator/Tests/expected.ji/java.lang.Enum/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/java.lang.Enum/Mono.Android.projitems
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);ANDROID_1;ANDROID_2;ANDROID_3;ANDROID_4</DefineConstants>
+  </PropertyGroup>
+  <!-- Classes -->
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Enum.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.IComparable.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.State.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+  </ItemGroup>
+  <!-- Enums -->
+  <ItemGroup />
+</Project>

--- a/tools/generator/Tests/expected.ji/java.lang.Object/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/java.lang.Object/Mono.Android.projitems
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);ANDROID_1;ANDROID_2;ANDROID_3;ANDROID_4</DefineConstants>
+  </PropertyGroup>
+  <!-- Classes -->
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+  </ItemGroup>
+  <!-- Enums -->
+  <ItemGroup />
+</Project>

--- a/tools/generator/Tests/expected.ji/java.util.List/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/java.util.List/Mono.Android.projitems
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);ANDROID_1;ANDROID_2;ANDROID_3;ANDROID_4</DefineConstants>
+  </PropertyGroup>
+  <!-- Classes -->
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.SomeObject.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+  </ItemGroup>
+  <!-- Enums -->
+  <ItemGroup />
+</Project>

--- a/tools/generator/Tests/expected.targets
+++ b/tools/generator/Tests/expected.targets
@@ -6,6 +6,9 @@
     <Content Include='expected.ji\Adapters\Java.Lang.Object.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include='expected.ji\Adapters\Mono.Android.projitems'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include='expected.ji\Adapters\Xamarin.Test.AbsSpinner.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -33,6 +36,9 @@
     <Content Include='expected.ji\Android.Graphics.Color\Java.Lang.Object.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include='expected.ji\Android.Graphics.Color\Mono.Android.projitems'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include='expected.ji\Android.Graphics.Color\Xamarin.Test.SomeObject.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -46,6 +52,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include='expected.ji\Arrays\Java.Lang.Object.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected.ji\Arrays\Mono.Android.projitems'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include='expected.ji\Arrays\Xamarin.Test.SomeObject.cs'>
@@ -63,6 +72,9 @@
     <Content Include='expected.ji\Constructors\Java.Lang.Object.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include='expected.ji\Constructors\Mono.Android.projitems'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include='expected.ji\Constructors\Xamarin.Test.SomeObject.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -76,6 +88,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include='expected.ji\NestedTypes\Java.Lang.Object.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected.ji\NestedTypes\Mono.Android.projitems'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include='expected.ji\NestedTypes\Xamarin.Test.NotificationCompatBase.cs'>
@@ -93,6 +108,9 @@
     <Content Include='expected.ji\NonStaticFields\Java.Lang.Object.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include='expected.ji\NonStaticFields\Mono.Android.projitems'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include='expected.ji\NonStaticFields\Xamarin.Test.SomeObject.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -105,10 +123,19 @@
     <Content Include='expected.ji\NormalMethods\Java.Interop.__TypeRegistrations.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include='expected.ji\NormalMethods\Java.Lang.Class.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include='expected.ji\NormalMethods\Java.Lang.Integer.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include='expected.ji\NormalMethods\Java.Lang.Object.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected.ji\NormalMethods\Java.Lang.Throwable.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected.ji\NormalMethods\Mono.Android.projitems'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include='expected.ji\NormalMethods\Xamarin.Test.A.cs'>
@@ -132,6 +159,9 @@
     <Content Include='expected.ji\NormalProperties\Java.Lang.Object.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include='expected.ji\NormalProperties\Mono.Android.projitems'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include='expected.ji\NormalProperties\Xamarin.Test.SomeObject.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -150,6 +180,9 @@
     <Content Include='expected.ji\ParameterXPath\Java.Lang.Object.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include='expected.ji\ParameterXPath\Mono.Android.projitems'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include='expected.ji\ParameterXPath\Xamarin.Test.A.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -163,6 +196,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include='expected.ji\StaticFields\Java.Lang.Object.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected.ji\StaticFields\Mono.Android.projitems'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include='expected.ji\StaticFields\Xamarin.Test.SomeObject.cs'>
@@ -180,6 +216,9 @@
     <Content Include='expected.ji\StaticMethods\Java.Lang.Object.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include='expected.ji\StaticMethods\Mono.Android.projitems'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include='expected.ji\StaticMethods\Xamarin.Test.SomeObject.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -195,6 +234,9 @@
     <Content Include='expected.ji\StaticProperties\Java.Lang.Object.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include='expected.ji\StaticProperties\Mono.Android.projitems'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include='expected.ji\StaticProperties\Xamarin.Test.SomeObject.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -207,6 +249,9 @@
     <Content Include='expected.ji\Streams\Java.IO.FilterOutputStream.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include='expected.ji\Streams\Java.IO.IOException.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include='expected.ji\Streams\Java.IO.InputStream.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -217,6 +262,12 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include='expected.ji\Streams\Java.Lang.Object.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected.ji\Streams\Java.Lang.Throwable.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected.ji\Streams\Mono.Android.projitems'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include='expected.ji\Streams\__NamespaceMapping__.cs'>
@@ -232,6 +283,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include='expected.ji\TestInterface\Java.Lang.String.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected.ji\TestInterface\Mono.Android.projitems'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include='expected.ji\TestInterface\Test.ME.GenericImplementation.cs'>
@@ -270,6 +324,9 @@
     <Content Include='expected.ji\java.lang.Enum\Java.Lang.State.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include='expected.ji\java.lang.Enum\Mono.Android.projitems'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include='expected.ji\java.lang.Enum\__NamespaceMapping__.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -282,6 +339,9 @@
     <Content Include='expected.ji\java.lang.Object\Java.Lang.Object.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include='expected.ji\java.lang.Object\Mono.Android.projitems'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include='expected.ji\java.lang.Object\__NamespaceMapping__.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -292,6 +352,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include='expected.ji\java.util.List\Java.Lang.Object.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected.ji\java.util.List\Mono.Android.projitems'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include='expected.ji\java.util.List\Xamarin.Test.SomeObject.cs'>
@@ -384,6 +447,9 @@
     <Content Include='expected\NonStaticFields\Xamarin.Test.SomeObject.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include='expected\NormalMethods\Java.Lang.Throwable.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include='expected\NormalMethods\NormalMethods.xml'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -429,10 +495,16 @@
     <Content Include='expected\Streams\Java.IO.FilterOutputStream.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include='expected\Streams\Java.IO.IOException.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include='expected\Streams\Java.IO.InputStream.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include='expected\Streams\Java.IO.OutputStream.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected\Streams\Java.Lang.Throwable.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include='expected\Streams\Streams.xml'>

--- a/tools/generator/Tests/expected/Adapters/Xamarin.Test.AbsSpinner.cs
+++ b/tools/generator/Tests/expected/Adapters/Xamarin.Test.AbsSpinner.cs
@@ -68,7 +68,7 @@ namespace Xamarin.Test {
 					id_getAdapter = JNIEnv.GetMethodID (class_ref, "getAdapter", "()Lxamarin/test/SpinnerAdapter;");
 				try {
 
-					if (GetType () == ThresholdType)
+					if (((object) this).GetType () == ThresholdType)
 						return global::Java.Lang.Object.GetObject<global::Xamarin.Test.ISpinnerAdapter> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_getAdapter), JniHandleOwnership.TransferLocalRef);
 					else
 						return global::Java.Lang.Object.GetObject<global::Xamarin.Test.ISpinnerAdapter> (JNIEnv.CallNonvirtualObjectMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "getAdapter", "()Lxamarin/test/SpinnerAdapter;")), JniHandleOwnership.TransferLocalRef);
@@ -84,7 +84,7 @@ namespace Xamarin.Test {
 					JValue* __args = stackalloc JValue [1];
 					__args [0] = new JValue (value);
 
-					if (GetType () == ThresholdType)
+					if (((object) this).GetType () == ThresholdType)
 						JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_setAdapter_Lxamarin_test_SpinnerAdapter_, __args);
 					else
 						JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "setAdapter", "(Lxamarin/test/SpinnerAdapter;)V"), __args);

--- a/tools/generator/Tests/expected/Adapters/Xamarin.Test.GenericReturnObject.cs
+++ b/tools/generator/Tests/expected/Adapters/Xamarin.Test.GenericReturnObject.cs
@@ -50,7 +50,7 @@ namespace Xamarin.Test {
 				id_GenericReturn = JNIEnv.GetMethodID (class_ref, "GenericReturn", "()Lxamarin/test/AdapterView;");
 			try {
 
-				if (GetType () == ThresholdType)
+				if (((object) this).GetType () == ThresholdType)
 					return global::Java.Lang.Object.GetObject<global::Xamarin.Test.AdapterView> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_GenericReturn), JniHandleOwnership.TransferLocalRef);
 				else
 					return global::Java.Lang.Object.GetObject<global::Xamarin.Test.AdapterView> (JNIEnv.CallNonvirtualObjectMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "GenericReturn", "()Lxamarin/test/AdapterView;")), JniHandleOwnership.TransferLocalRef);

--- a/tools/generator/Tests/expected/Constructors/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected/Constructors/Xamarin.Test.SomeObject.cs
@@ -35,9 +35,9 @@ namespace Xamarin.Test {
 				return;
 
 			try {
-				if (GetType () != typeof (SomeObject)) {
+				if (((object) this).GetType () != typeof (SomeObject)) {
 					SetHandle (
-							global::Android.Runtime.JNIEnv.StartCreateInstance (GetType (), "()V"),
+							global::Android.Runtime.JNIEnv.StartCreateInstance (((object) this).GetType (), "()V"),
 							JniHandleOwnership.TransferLocalRef);
 					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "()V");
 					return;
@@ -65,9 +65,9 @@ namespace Xamarin.Test {
 			try {
 				JValue* __args = stackalloc JValue [1];
 				__args [0] = new JValue (aint);
-				if (GetType () != typeof (SomeObject)) {
+				if (((object) this).GetType () != typeof (SomeObject)) {
 					SetHandle (
-							global::Android.Runtime.JNIEnv.StartCreateInstance (GetType (), "(I)V", __args),
+							global::Android.Runtime.JNIEnv.StartCreateInstance (((object) this).GetType (), "(I)V", __args),
 							JniHandleOwnership.TransferLocalRef);
 					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "(I)V", __args);
 					return;

--- a/tools/generator/Tests/expected/EnumerationFixup/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected/EnumerationFixup/Xamarin.Test.SomeObject.cs
@@ -68,7 +68,7 @@ namespace Xamarin.Test {
 					id_getSomeObjectProperty = JNIEnv.GetMethodID (class_ref, "getSomeObjectProperty", "()I");
 				try {
 
-					if (GetType () == ThresholdType)
+					if (((object) this).GetType () == ThresholdType)
 						return (global::Xamarin.Test.SomeValues) JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getSomeObjectProperty);
 					else
 						return (global::Xamarin.Test.SomeValues) JNIEnv.CallNonvirtualIntMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "getSomeObjectProperty", "()I"));
@@ -84,7 +84,7 @@ namespace Xamarin.Test {
 					JValue* __args = stackalloc JValue [1];
 					__args [0] = new JValue ((int) value);
 
-					if (GetType () == ThresholdType)
+					if (((object) this).GetType () == ThresholdType)
 						JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_setSomeObjectProperty_I, __args);
 					else
 						JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "setSomeObjectProperty", "(I)V"), __args);

--- a/tools/generator/Tests/expected/EnumerationFixup/Xamarin.Test.SomeObject2.cs
+++ b/tools/generator/Tests/expected/EnumerationFixup/Xamarin.Test.SomeObject2.cs
@@ -68,7 +68,7 @@ namespace Xamarin.Test {
 					id_getSomeObjectProperty = JNIEnv.GetMethodID (class_ref, "getSomeObjectProperty", "()I");
 				try {
 
-					if (GetType () == ThresholdType)
+					if (((object) this).GetType () == ThresholdType)
 						return (global::Xamarin.Test.SomeValues) JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getSomeObjectProperty);
 					else
 						return (global::Xamarin.Test.SomeValues) JNIEnv.CallNonvirtualIntMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "getSomeObjectProperty", "()I"));
@@ -84,7 +84,7 @@ namespace Xamarin.Test {
 					JValue* __args = stackalloc JValue [1];
 					__args [0] = new JValue ((int) value);
 
-					if (GetType () == ThresholdType)
+					if (((object) this).GetType () == ThresholdType)
 						JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_setSomeObjectProperty_I, __args);
 					else
 						JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "setSomeObjectProperty", "(I)V"), __args);
@@ -119,7 +119,7 @@ namespace Xamarin.Test {
 				id_getSomeObjectPropertyArray = JNIEnv.GetMethodID (class_ref, "getSomeObjectPropertyArray", "()[I");
 			try {
 
-				if (GetType () == ThresholdType)
+				if (((object) this).GetType () == ThresholdType)
 					return (global::Xamarin.Test.SomeValues[]) JNIEnv.GetArray (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_getSomeObjectPropertyArray), JniHandleOwnership.TransferLocalRef, typeof (global::Xamarin.Test.SomeValues));
 				else
 					return (global::Xamarin.Test.SomeValues[]) JNIEnv.GetArray (JNIEnv.CallNonvirtualObjectMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "getSomeObjectPropertyArray", "()[I")), JniHandleOwnership.TransferLocalRef, typeof (global::Xamarin.Test.SomeValues));
@@ -158,7 +158,7 @@ namespace Xamarin.Test {
 				JValue* __args = stackalloc JValue [1];
 				__args [0] = new JValue (native_newvalue);
 
-				if (GetType () == ThresholdType)
+				if (((object) this).GetType () == ThresholdType)
 					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_setSomeObjectPropertyArray_arrayI, __args);
 				else
 					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "setSomeObjectPropertyArray", "([I)V"), __args);

--- a/tools/generator/Tests/expected/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
+++ b/tools/generator/Tests/expected/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
@@ -143,9 +143,9 @@ namespace Xamarin.Test {
 				try {
 					JValue* __args = stackalloc JValue [1];
 					__args [0] = new JValue (__self);
-					if (GetType () != typeof (InstanceInner)) {
+					if (((object) this).GetType () != typeof (InstanceInner)) {
 						SetHandle (
-								global::Android.Runtime.JNIEnv.StartCreateInstance (GetType (), "(L" + global::Android.Runtime.JNIEnv.GetJniName (GetType ().DeclaringType) + ";)V", __args),
+								global::Android.Runtime.JNIEnv.StartCreateInstance (((object) this).GetType (), "(L" + global::Android.Runtime.JNIEnv.GetJniName (GetType ().DeclaringType) + ";)V", __args),
 								JniHandleOwnership.TransferLocalRef);
 						global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "(L" + global::Android.Runtime.JNIEnv.GetJniName (GetType ().DeclaringType) + ";)V", __args);
 						return;

--- a/tools/generator/Tests/expected/NormalMethods/NormalMethods.xml
+++ b/tools/generator/Tests/expected/NormalMethods/NormalMethods.xml
@@ -15,11 +15,28 @@
 	    </class>
 	  </package>
 	<package name="xamarin.test">
+    <!--
+      public class SomeObject {
+        // `int[]` to inhibit turning into a `Type` property.
+        public  int[]   getType();
+        public  int     handle(Object o, Throwable t);
+        public  int     IntegerMethod();
+        public  void    VoidMethod();
+        public  String  StringMethod();
+        public  Object  ObjectMethod();
+        public  void    VoidMethodWithParams(String astring, int anint, Object anObject);
+        @Deprecated
+        public  int     ObsoleteMethod();
+        public  void    ArrayListTest(ArrayList<Integer> p0);
+      }
+      -->
 	  <class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" 
 	  		final="false" name="SomeObject" static="false" visibility="public">
 			<constructor deprecated="not deprecated" final="false" name="SomeObject" native="false" return="int" static="false" synchronized="false" visibility="public">
 				<parameter name="c" type="java.lang.Class&lt;? extends xamarin.test.SomeObject&gt;" />
 			</constructor>
+			<method abstract="false" deprecated="not deprecated" final="false" name="getType" native="false" return="int[]" static="false" synchronized="false" visibility="public">
+			</method>
 			<method abstract="false" deprecated="not deprecated" final="false" name="handle" native="false" return="int" static="false" synchronized="false" visibility="public">
 				<parameter name="o" type="java.lang.Object" />
 				<parameter name="t" type="java.lang.Throwable" />

--- a/tools/generator/Tests/expected/NormalMethods/Xamarin.Test.A.cs
+++ b/tools/generator/Tests/expected/NormalMethods/Xamarin.Test.A.cs
@@ -57,7 +57,7 @@ namespace Xamarin.Test {
 					JValue* __args = stackalloc JValue [1];
 					__args [0] = new JValue (index);
 
-					if (GetType () == ThresholdType)
+					if (((object) this).GetType () == ThresholdType)
 						return (Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_setCustomDimension_I, __args), JniHandleOwnership.TransferLocalRef);
 					else
 						return (Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallNonvirtualObjectMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "setCustomDimension", "(I)Lxamarin/test/A$B;"), __args), JniHandleOwnership.TransferLocalRef);
@@ -109,7 +109,7 @@ namespace Xamarin.Test {
 				id_getHandle = JNIEnv.GetMethodID (class_ref, "getHandle", "()I");
 			try {
 
-				if (GetType () == ThresholdType)
+				if (((object) this).GetType () == ThresholdType)
 					return JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getHandle);
 				else
 					return JNIEnv.CallNonvirtualIntMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "getHandle", "()I"));

--- a/tools/generator/Tests/expected/NormalMethods/Xamarin.Test.C.cs
+++ b/tools/generator/Tests/expected/NormalMethods/Xamarin.Test.C.cs
@@ -53,7 +53,7 @@ namespace Xamarin.Test {
 				JValue* __args = stackalloc JValue [1];
 				__args [0] = new JValue (index);
 
-				if (GetType () == ThresholdType)
+				if (((object) this).GetType () == ThresholdType)
 					return (Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_setCustomDimension_I, __args), JniHandleOwnership.TransferLocalRef);
 				else
 					return (Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallNonvirtualObjectMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "setCustomDimension", "(I)Lxamarin/test/C;"), __args), JniHandleOwnership.TransferLocalRef);

--- a/tools/generator/Tests/expected/NormalMethods/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected/NormalMethods/Xamarin.Test.SomeObject.cs
@@ -37,9 +37,9 @@ namespace Xamarin.Test {
 			try {
 				JValue* __args = stackalloc JValue [1];
 				__args [0] = new JValue (c);
-				if (GetType () != typeof (SomeObject)) {
+				if (((object) this).GetType () != typeof (SomeObject)) {
 					SetHandle (
-							global::Android.Runtime.JNIEnv.StartCreateInstance (GetType (), "(Ljava/lang/Class;)V", __args),
+							global::Android.Runtime.JNIEnv.StartCreateInstance (((object) this).GetType (), "(Ljava/lang/Class;)V", __args),
 							JniHandleOwnership.TransferLocalRef);
 					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "(Ljava/lang/Class;)V", __args);
 					return;
@@ -51,6 +51,39 @@ namespace Xamarin.Test {
 						global::Android.Runtime.JNIEnv.StartCreateInstance (class_ref, id_ctor_Ljava_lang_Class_, __args),
 						JniHandleOwnership.TransferLocalRef);
 				JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, class_ref, id_ctor_Ljava_lang_Class_, __args);
+			} finally {
+			}
+		}
+
+		static Delegate cb_getType;
+#pragma warning disable 0169
+		static Delegate GetGetTypeHandler ()
+		{
+			if (cb_getType == null)
+				cb_getType = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_GetType);
+			return cb_getType;
+		}
+
+		static IntPtr n_GetType (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.NewArray (__this.GetType ());
+		}
+#pragma warning restore 0169
+
+		static IntPtr id_getType;
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/method[@name='getType' and count(parameter)=0]"
+		[Register ("getType", "()[I", "GetGetTypeHandler")]
+		public virtual unsafe int[] GetType ()
+		{
+			if (id_getType == IntPtr.Zero)
+				id_getType = JNIEnv.GetMethodID (class_ref, "getType", "()[I");
+			try {
+
+				if (((object) this).GetType () == ThresholdType)
+					return (int[]) JNIEnv.GetArray (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_getType), JniHandleOwnership.TransferLocalRef, typeof (int));
+				else
+					return (int[]) JNIEnv.GetArray (JNIEnv.CallNonvirtualObjectMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "getType", "()[I")), JniHandleOwnership.TransferLocalRef, typeof (int));
 			} finally {
 			}
 		}
@@ -87,7 +120,7 @@ namespace Xamarin.Test {
 				__args [1] = new JValue (t);
 
 				int __ret;
-				if (GetType () == ThresholdType)
+				if (((object) this).GetType () == ThresholdType)
 					__ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_handle_Ljava_lang_Object_Ljava_lang_Throwable_, __args);
 				else
 					__ret = JNIEnv.CallNonvirtualIntMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "handle", "(Ljava/lang/Object;Ljava/lang/Throwable;)I"), __args);
@@ -121,7 +154,7 @@ namespace Xamarin.Test {
 				id_IntegerMethod = JNIEnv.GetMethodID (class_ref, "IntegerMethod", "()I");
 			try {
 
-				if (GetType () == ThresholdType)
+				if (((object) this).GetType () == ThresholdType)
 					return JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_IntegerMethod);
 				else
 					return JNIEnv.CallNonvirtualIntMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "IntegerMethod", "()I"));
@@ -154,7 +187,7 @@ namespace Xamarin.Test {
 				id_VoidMethod = JNIEnv.GetMethodID (class_ref, "VoidMethod", "()V");
 			try {
 
-				if (GetType () == ThresholdType)
+				if (((object) this).GetType () == ThresholdType)
 					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_VoidMethod);
 				else
 					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "VoidMethod", "()V"));
@@ -187,7 +220,7 @@ namespace Xamarin.Test {
 				id_StringMethod = JNIEnv.GetMethodID (class_ref, "StringMethod", "()Ljava/lang/String;");
 			try {
 
-				if (GetType () == ThresholdType)
+				if (((object) this).GetType () == ThresholdType)
 					return JNIEnv.GetString (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_StringMethod), JniHandleOwnership.TransferLocalRef);
 				else
 					return JNIEnv.GetString (JNIEnv.CallNonvirtualObjectMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "StringMethod", "()Ljava/lang/String;")), JniHandleOwnership.TransferLocalRef);
@@ -220,7 +253,7 @@ namespace Xamarin.Test {
 				id_ObjectMethod = JNIEnv.GetMethodID (class_ref, "ObjectMethod", "()Ljava/lang/Object;");
 			try {
 
-				if (GetType () == ThresholdType)
+				if (((object) this).GetType () == ThresholdType)
 					return global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_ObjectMethod), JniHandleOwnership.TransferLocalRef);
 				else
 					return global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallNonvirtualObjectMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "ObjectMethod", "()Ljava/lang/Object;")), JniHandleOwnership.TransferLocalRef);
@@ -260,7 +293,7 @@ namespace Xamarin.Test {
 				__args [1] = new JValue (anint);
 				__args [2] = new JValue (anObject);
 
-				if (GetType () == ThresholdType)
+				if (((object) this).GetType () == ThresholdType)
 					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_VoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object_, __args);
 				else
 					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "VoidMethodWithParams", "(Ljava/lang/String;ILjava/lang/Object;)V"), __args);
@@ -295,7 +328,7 @@ namespace Xamarin.Test {
 				id_ObsoleteMethod = JNIEnv.GetMethodID (class_ref, "ObsoleteMethod", "()I");
 			try {
 
-				if (GetType () == ThresholdType)
+				if (((object) this).GetType () == ThresholdType)
 					return JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_ObsoleteMethod);
 				else
 					return JNIEnv.CallNonvirtualIntMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "ObsoleteMethod", "()I"));
@@ -332,7 +365,7 @@ namespace Xamarin.Test {
 				JValue* __args = stackalloc JValue [1];
 				__args [0] = new JValue (native_p0);
 
-				if (GetType () == ThresholdType)
+				if (((object) this).GetType () == ThresholdType)
 					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_ArrayListTest_Ljava_util_ArrayList_, __args);
 				else
 					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "ArrayListTest", "(Ljava/util/ArrayList;)V"), __args);

--- a/tools/generator/Tests/expected/ParameterXPath/Xamarin.Test.A.cs
+++ b/tools/generator/Tests/expected/ParameterXPath/Xamarin.Test.A.cs
@@ -55,7 +55,7 @@ namespace Xamarin.Test {
 				JValue* __args = stackalloc JValue [1];
 				__args [0] = new JValue (native_adapter);
 
-				if (GetType () == ThresholdType)
+				if (((object) this).GetType () == ThresholdType)
 					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_setA_Ljava_lang_Object_, __args);
 				else
 					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "setA", "(Ljava/lang/Object;)V"), __args);
@@ -93,7 +93,7 @@ namespace Xamarin.Test {
 				JValue* __args = stackalloc JValue [1];
 				__args [0] = new JValue (native_p0);
 
-				if (GetType () == ThresholdType)
+				if (((object) this).GetType () == ThresholdType)
 					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_listTest_Ljava_util_List_, __args);
 				else
 					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "listTest", "(Ljava/util/List;)V"), __args);

--- a/tools/generator/Tests/expected/Streams/Java.IO.FilterOutputStream.cs
+++ b/tools/generator/Tests/expected/Streams/Java.IO.FilterOutputStream.cs
@@ -38,9 +38,9 @@ namespace Java.IO {
 			try {
 				JValue* __args = stackalloc JValue [1];
 				__args [0] = new JValue (native__out);
-				if (GetType () != typeof (FilterOutputStream)) {
+				if (((object) this).GetType () != typeof (FilterOutputStream)) {
 					SetHandle (
-							global::Android.Runtime.JNIEnv.StartCreateInstance (GetType (), "(Ljava/io/OutputStream;)V", __args),
+							global::Android.Runtime.JNIEnv.StartCreateInstance (((object) this).GetType (), "(Ljava/io/OutputStream;)V", __args),
 							JniHandleOwnership.TransferLocalRef);
 					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "(Ljava/io/OutputStream;)V", __args);
 					return;
@@ -84,7 +84,7 @@ namespace Java.IO {
 				JValue* __args = stackalloc JValue [1];
 				__args [0] = new JValue (oneByte);
 
-				if (GetType () == ThresholdType)
+				if (((object) this).GetType () == ThresholdType)
 					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_write_I, __args);
 				else
 					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "write", "(I)V"), __args);

--- a/tools/generator/Tests/expected/Streams/Java.IO.IOException.cs
+++ b/tools/generator/Tests/expected/Streams/Java.IO.IOException.cs
@@ -50,7 +50,7 @@ namespace Java.IO {
 				id_printStackTrace = JNIEnv.GetMethodID (class_ref, "printStackTrace", "()V");
 			try {
 
-				if (GetType () == ThresholdType)
+				if (((object) this).GetType () == ThresholdType)
 					JNIEnv.CallVoidMethod (((global::Java.Lang.Throwable) this).Handle, id_printStackTrace);
 				else
 					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Throwable) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "printStackTrace", "()V"));

--- a/tools/generator/Tests/expected/Streams/Java.IO.InputStream.cs
+++ b/tools/generator/Tests/expected/Streams/Java.IO.InputStream.cs
@@ -35,9 +35,9 @@ namespace Java.IO {
 				return;
 
 			try {
-				if (GetType () != typeof (InputStream)) {
+				if (((object) this).GetType () != typeof (InputStream)) {
 					SetHandle (
-							global::Android.Runtime.JNIEnv.StartCreateInstance (GetType (), "()V"),
+							global::Android.Runtime.JNIEnv.StartCreateInstance (((object) this).GetType (), "()V"),
 							JniHandleOwnership.TransferLocalRef);
 					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "()V");
 					return;
@@ -78,7 +78,7 @@ namespace Java.IO {
 				id_available = JNIEnv.GetMethodID (class_ref, "available", "()I");
 			try {
 
-				if (GetType () == ThresholdType)
+				if (((object) this).GetType () == ThresholdType)
 					return JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_available);
 				else
 					return JNIEnv.CallNonvirtualIntMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "available", "()I"));
@@ -111,7 +111,7 @@ namespace Java.IO {
 				id_close = JNIEnv.GetMethodID (class_ref, "close", "()V");
 			try {
 
-				if (GetType () == ThresholdType)
+				if (((object) this).GetType () == ThresholdType)
 					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_close);
 				else
 					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "close", "()V"));
@@ -146,7 +146,7 @@ namespace Java.IO {
 				JValue* __args = stackalloc JValue [1];
 				__args [0] = new JValue (readlimit);
 
-				if (GetType () == ThresholdType)
+				if (((object) this).GetType () == ThresholdType)
 					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_mark_I, __args);
 				else
 					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "mark", "(I)V"), __args);
@@ -179,7 +179,7 @@ namespace Java.IO {
 				id_markSupported = JNIEnv.GetMethodID (class_ref, "markSupported", "()Z");
 			try {
 
-				if (GetType () == ThresholdType)
+				if (((object) this).GetType () == ThresholdType)
 					return JNIEnv.CallBooleanMethod (((global::Java.Lang.Object) this).Handle, id_markSupported);
 				else
 					return JNIEnv.CallNonvirtualBooleanMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "markSupported", "()Z"));
@@ -240,7 +240,7 @@ namespace Java.IO {
 				__args [0] = new JValue (native_buffer);
 
 				int __ret;
-				if (GetType () == ThresholdType)
+				if (((object) this).GetType () == ThresholdType)
 					__ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_read_arrayB, __args);
 				else
 					__ret = JNIEnv.CallNonvirtualIntMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "read", "([B)I"), __args);
@@ -288,7 +288,7 @@ namespace Java.IO {
 				__args [2] = new JValue (byteCount);
 
 				int __ret;
-				if (GetType () == ThresholdType)
+				if (((object) this).GetType () == ThresholdType)
 					__ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_read_arrayBII, __args);
 				else
 					__ret = JNIEnv.CallNonvirtualIntMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "read", "([BII)I"), __args);
@@ -326,7 +326,7 @@ namespace Java.IO {
 				id_reset = JNIEnv.GetMethodID (class_ref, "reset", "()V");
 			try {
 
-				if (GetType () == ThresholdType)
+				if (((object) this).GetType () == ThresholdType)
 					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_reset);
 				else
 					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "reset", "()V"));
@@ -361,7 +361,7 @@ namespace Java.IO {
 				JValue* __args = stackalloc JValue [1];
 				__args [0] = new JValue (byteCount);
 
-				if (GetType () == ThresholdType)
+				if (((object) this).GetType () == ThresholdType)
 					return JNIEnv.CallLongMethod (((global::Java.Lang.Object) this).Handle, id_skip_J, __args);
 				else
 					return JNIEnv.CallNonvirtualLongMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "skip", "(J)J"), __args);

--- a/tools/generator/Tests/expected/Streams/Java.IO.OutputStream.cs
+++ b/tools/generator/Tests/expected/Streams/Java.IO.OutputStream.cs
@@ -35,9 +35,9 @@ namespace Java.IO {
 				return;
 
 			try {
-				if (GetType () != typeof (OutputStream)) {
+				if (((object) this).GetType () != typeof (OutputStream)) {
 					SetHandle (
-							global::Android.Runtime.JNIEnv.StartCreateInstance (GetType (), "()V"),
+							global::Android.Runtime.JNIEnv.StartCreateInstance (((object) this).GetType (), "()V"),
 							JniHandleOwnership.TransferLocalRef);
 					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "()V");
 					return;
@@ -78,7 +78,7 @@ namespace Java.IO {
 				id_close = JNIEnv.GetMethodID (class_ref, "close", "()V");
 			try {
 
-				if (GetType () == ThresholdType)
+				if (((object) this).GetType () == ThresholdType)
 					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_close);
 				else
 					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "close", "()V"));
@@ -111,7 +111,7 @@ namespace Java.IO {
 				id_flush = JNIEnv.GetMethodID (class_ref, "flush", "()V");
 			try {
 
-				if (GetType () == ThresholdType)
+				if (((object) this).GetType () == ThresholdType)
 					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_flush);
 				else
 					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "flush", "()V"));
@@ -150,7 +150,7 @@ namespace Java.IO {
 				JValue* __args = stackalloc JValue [1];
 				__args [0] = new JValue (native_buffer);
 
-				if (GetType () == ThresholdType)
+				if (((object) this).GetType () == ThresholdType)
 					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_write_arrayB, __args);
 				else
 					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "write", "([B)V"), __args);
@@ -195,7 +195,7 @@ namespace Java.IO {
 				__args [1] = new JValue (offset);
 				__args [2] = new JValue (count);
 
-				if (GetType () == ThresholdType)
+				if (((object) this).GetType () == ThresholdType)
 					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_write_arrayBII, __args);
 				else
 					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "write", "([BII)V"), __args);

--- a/tools/generator/Tests/expected/Streams/Java.Lang.Throwable.cs
+++ b/tools/generator/Tests/expected/Streams/Java.Lang.Throwable.cs
@@ -40,7 +40,7 @@ namespace Java.Lang {
 					id_getMessage = JNIEnv.GetMethodID (class_ref, "getMessage", "()Ljava/lang/String;");
 				try {
 
-					if (GetType () == ThresholdType)
+					if (((object) this).GetType () == ThresholdType)
 						return JNIEnv.GetString (JNIEnv.CallObjectMethod (((global::Java.Lang.Throwable) this).Handle, id_getMessage), JniHandleOwnership.TransferLocalRef);
 					else
 						return JNIEnv.GetString (JNIEnv.CallNonvirtualObjectMethod (((global::Java.Lang.Throwable) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "getMessage", "()Ljava/lang/String;")), JniHandleOwnership.TransferLocalRef);

--- a/tools/generator/Tests/expected/TestInterface/Test.ME.GenericImplementation.cs
+++ b/tools/generator/Tests/expected/TestInterface/Test.ME.GenericImplementation.cs
@@ -35,9 +35,9 @@ namespace Test.ME {
 				return;
 
 			try {
-				if (GetType () != typeof (GenericImplementation)) {
+				if (((object) this).GetType () != typeof (GenericImplementation)) {
 					SetHandle (
-							global::Android.Runtime.JNIEnv.StartCreateInstance (GetType (), "()V"),
+							global::Android.Runtime.JNIEnv.StartCreateInstance (((object) this).GetType (), "()V"),
 							JniHandleOwnership.TransferLocalRef);
 					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "()V");
 					return;
@@ -84,7 +84,7 @@ namespace Test.ME {
 				JValue* __args = stackalloc JValue [1];
 				__args [0] = new JValue (native_value);
 
-				if (GetType () == ThresholdType)
+				if (((object) this).GetType () == ThresholdType)
 					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_SetObject_arrayB, __args);
 				else
 					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "SetObject", "([B)V"), __args);

--- a/tools/generator/Tests/expected/TestInterface/Test.ME.GenericStringImplementation.cs
+++ b/tools/generator/Tests/expected/TestInterface/Test.ME.GenericStringImplementation.cs
@@ -35,9 +35,9 @@ namespace Test.ME {
 				return;
 
 			try {
-				if (GetType () != typeof (GenericStringImplementation)) {
+				if (((object) this).GetType () != typeof (GenericStringImplementation)) {
 					SetHandle (
-							global::Android.Runtime.JNIEnv.StartCreateInstance (GetType (), "()V"),
+							global::Android.Runtime.JNIEnv.StartCreateInstance (((object) this).GetType (), "()V"),
 							JniHandleOwnership.TransferLocalRef);
 					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "()V");
 					return;
@@ -84,7 +84,7 @@ namespace Test.ME {
 				JValue* __args = stackalloc JValue [1];
 				__args [0] = new JValue (native_value);
 
-				if (GetType () == ThresholdType)
+				if (((object) this).GetType () == ThresholdType)
 					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_SetObject_arrayLjava_lang_String_, __args);
 				else
 					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "SetObject", "([Ljava/lang/String;)V"), __args);

--- a/tools/generator/Tests/expected/TestInterface/Test.ME.TestInterfaceImplementation.cs
+++ b/tools/generator/Tests/expected/TestInterface/Test.ME.TestInterfaceImplementation.cs
@@ -58,9 +58,9 @@ namespace Test.ME {
 				return;
 
 			try {
-				if (GetType () != typeof (TestInterfaceImplementation)) {
+				if (((object) this).GetType () != typeof (TestInterfaceImplementation)) {
 					SetHandle (
-							global::Android.Runtime.JNIEnv.StartCreateInstance (GetType (), "()V"),
+							global::Android.Runtime.JNIEnv.StartCreateInstance (((object) this).GetType (), "()V"),
 							JniHandleOwnership.TransferLocalRef);
 					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "()V");
 					return;

--- a/tools/generator/XamarinAndroidCodeGenerator.cs
+++ b/tools/generator/XamarinAndroidCodeGenerator.cs
@@ -70,9 +70,9 @@ namespace MonoDroid.Generation {
 			var oldindent = indent;
 			indent += "\t";
 			ctor.Parameters.WriteCallArgs (sw, indent, opt, invoker:false);
-			sw.WriteLine ("{0}if (GetType () != typeof ({1})) {{", indent, ctor.Name);
+			sw.WriteLine ("{0}if (((object) this).GetType () != typeof ({1})) {{", indent, ctor.Name);
 			sw.WriteLine ("{0}\tSetHandle (", indent);
-			sw.WriteLine ("{0}\t\t\tglobal::Android.Runtime.JNIEnv.StartCreateInstance (GetType (), \"{1}\"{2}),",
+			sw.WriteLine ("{0}\t\t\tglobal::Android.Runtime.JNIEnv.StartCreateInstance (((object) this).GetType (), \"{1}\"{2}),",
 					indent,
 					ctor.IsNonStaticNestedType ? "(" + ctor.Parameters.JniNestedDerivedSignature + ")V" : ctor.JniSignature,
 					ctor.Parameters.GetCallArgs (opt, invoker:false));
@@ -135,7 +135,7 @@ namespace MonoDroid.Generation {
 				sw.WriteLine ();
 				if (!method.IsVoid && method.Parameters.HasCleanup)
 					sw.WriteLine ("{0}{1} __ret;", indent, opt.GetOutputName (method.RetVal.FullName));
-				sw.WriteLine ("{0}if (GetType () == ThresholdType)", indent);
+				sw.WriteLine ("{0}if (((object) this).GetType () == ThresholdType)", indent);
 				GenerateJNICall (method, sw, indent + "\t", opt,
 						"JNIEnv.Call" + method.RetVal.CallMethodPrefix + "Method (" +
 						opt.ContextType.GetObjectHandleProperty ("this") +


### PR DESCRIPTION
Context: https://bugzilla.xamarin.com/show_bug.cgi?id=45203
Context: https://bugzilla.xamarin.com/show_bug.cgi?id=44263#c8

(Sorry; private bugs.)

The `getType()` method isn't special; any Java library could contain
such a method:

	// Java
	public class Example {
		public int[] getType() {return null;}
	}

(It's a wonder that we haven't hit such a thing before!)

Unfortunately, should such a method (1) exist, and (2) be bound as
`GetType()` instead of as a `Type` property -- in the above example,
we use an `int[]` return type because if a Java method has an array
return type, we won't turn it into a property -- the resulting code
wouldn't compile:

	// error CS0019: Operator `==' cannot be applied to operands of type `int[]' and `System.Type'
	if (GetType () == ThresholdType) ...

To fix this, *qualify* all use of the `GetType()` method so that we
explicitly use `System.Object.GetType()`:

	if ((object) this).GetType () == ThresholdType) ...

This has no performance-impact, IL-wise, as the C# compiler is able to
statically determine that we want non-virtual invocation of the
`System.Object.GetType()` method. No runtime cast is performed.