### PR TITLE
[class-parse] support updated DroidDoc.

### DIFF
--- a/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
@@ -13,6 +13,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 
 	public enum JavaDocletType {
 		DroidDoc,
+		DroidDoc2,
 		Java6,
 		Java7,
 		Java8,
@@ -225,7 +226,8 @@ namespace Xamarin.Android.Tools.Bytecode {
 		AndroidDocScraper CreateDocScraper (string dir)
 		{
 			switch (DocletType) {
-			default: return new DroidDocScraper (dir);
+			default: return new DroidDoc2Scraper (dir);
+			case JavaDocletType.DroidDoc: return new DroidDocScraper (dir);
 			case JavaDocletType.Java6: return new JavaDocScraper (dir);
 			case JavaDocletType.Java7: return new Java7DocScraper (dir);
 			case JavaDocletType.Java8: return new Java8DocScraper (dir);

--- a/tools/class-parse/Program.cs
+++ b/tools/class-parse/Program.cs
@@ -90,6 +90,7 @@ namespace Xamarin.Android.Tools {
 
 		static  Dictionary<string, JavaDocletType>  JavaDocletTypeMapping   = new Dictionary<string, JavaDocletType> {
 			{ "droiddoc",   JavaDocletType.DroidDoc },
+			{ "droiddoc2",   JavaDocletType.DroidDoc2 },
 			{ "java6",      JavaDocletType.Java6 },
 			{ "java7",      JavaDocletType.Java7 },
 			{ "java8",      JavaDocletType.Java8 },


### PR DESCRIPTION
With the latest Android N, Google has (again) changed API documentation
format (i.e. doclet) and that broke API XML documentation parser.

Unlike previous ones or Oracle Javadoc doclets, it is not easily matcheable
with existing regex structure. So I made not a small set of changes
to make it working.

Unlike previous ones it takes a lot more time to process (e.g. more than
minutes to process all API Level 24 docs), but better than broken.

This is required to suppport any further API Levels (like 25).

(ClassParse task has an issue that it never supported correct Javadoc
processing as it ignores doclet differences. This only changes the
default to droiddoc2 just to be able to process the latest doc.
It needs different fix.)