### PR TITLE
api.xml doc parser

### DIFF
--- a/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
@@ -17,6 +17,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 		Java6,
 		Java7,
 		Java8,
+		ApiXml
 	}
 
 	public class ClassPath {
@@ -217,20 +218,21 @@ namespace Xamarin.Android.Tools.Bytecode {
 			if (DocumentationPaths == null)
 				return;
 			foreach (var path in DocumentationPaths) {
-				if (!Directory.Exists (path))
+				if (!Directory.Exists (path) && !File.Exists (path))
 					continue;
 				FixupParametersFromDocs (api, path);
 			}
 		}
 
-		AndroidDocScraper CreateDocScraper (string dir)
+		IAndroidDocScraper CreateDocScraper (string src)
 		{
 			switch (DocletType) {
-			default: return new DroidDoc2Scraper (dir);
-			case JavaDocletType.DroidDoc: return new DroidDocScraper (dir);
-			case JavaDocletType.Java6: return new JavaDocScraper (dir);
-			case JavaDocletType.Java7: return new Java7DocScraper (dir);
-			case JavaDocletType.Java8: return new Java8DocScraper (dir);
+			default: return new DroidDoc2Scraper (src);
+			case JavaDocletType.DroidDoc: return new DroidDocScraper (src);
+			case JavaDocletType.Java6: return new JavaDocScraper (src);
+			case JavaDocletType.Java7: return new Java7DocScraper (src);
+			case JavaDocletType.Java8: return new Java8DocScraper (src);
+			case JavaDocletType.ApiXml: return new ApiXmlDocScraper(src);
 			}
 		}
 

--- a/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 		Java6,
 		Java7,
 		Java8,
-		ApiXml
+		_ApiXml
 	}
 
 	public class ClassPath {
@@ -232,7 +232,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 			case JavaDocletType.Java6: return new JavaDocScraper (src);
 			case JavaDocletType.Java7: return new Java7DocScraper (src);
 			case JavaDocletType.Java8: return new Java8DocScraper (src);
-			case JavaDocletType.ApiXml: return new ApiXmlDocScraper(src);
+			case JavaDocletType._ApiXml: return new ApiXmlDocScraper (src);
 			}
 		}
 

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/ClassFileFixture.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/ClassFileFixture.cs
@@ -25,7 +25,7 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 				return r.ReadToEnd ();
 		}
 
-		protected static void AssertXmlDeclaration (string classResource, string xmlResource, string documentationPath = null)
+		protected static void AssertXmlDeclaration (string classResource, string xmlResource, string documentationPath = null, JavaDocletType? javaDocletType = null)
 		{
 			var classPathBuilder    = new ClassPath () {
 				ApiSource           = "class-parse",
@@ -33,10 +33,14 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 					documentationPath,
 				},
 			};
+			if (javaDocletType.HasValue)
+				classPathBuilder.DocletType = javaDocletType.Value;
 			classPathBuilder.Add (LoadClassFile (classResource));
 
 			var actual  = new StringWriter ();
 			classPathBuilder.ApiSource  = "class-parse";
+			if (javaDocletType.HasValue)
+				classPathBuilder.DocletType = javaDocletType.Value;
 			classPathBuilder.SaveXmlDescription (actual);
 
 			var expected    = LoadString (xmlResource);

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/ParameterFixupApiXmlDocs.xml
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/ParameterFixupApiXmlDocs.xml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<api>
+	<package name="java.util">
+		<class name="Collection">
+			<method name="add">
+				<parameter name="object" type="E" />
+			</method>
+		</class>
+	</package>
+</api>

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/ParameterFixupTests.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/ParameterFixupTests.cs
@@ -39,7 +39,7 @@ namespace Xamarin.Android.Tools.BytecodeTests
 				tempFile = Path.GetTempFileName();
 				File.WriteAllText(tempFile, LoadString("ParameterFixupApiXmlDocs.xml"));
 
-				AssertXmlDeclaration("Collection.class", "ParameterFixupFromDocs.xml", tempFile, Bytecode.JavaDocletType.ApiXml);
+				AssertXmlDeclaration("Collection.class", "ParameterFixupFromDocs.xml", tempFile, Bytecode.JavaDocletType._ApiXml);
 			}
 			catch (Exception ex)
 			{

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/ParameterFixupTests.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/ParameterFixupTests.cs
@@ -30,6 +30,31 @@ namespace Xamarin.Android.Tools.BytecodeTests
 		}
 
 		[Test]
+		public void XmlDeclaration_FixedUpFromApiXmlDocumentation()
+		{
+			string tempFile = null;
+
+			try
+			{
+				tempFile = Path.GetTempFileName();
+				File.WriteAllText(tempFile, LoadString("ParameterFixupApiXmlDocs.xml"));
+
+				AssertXmlDeclaration("Collection.class", "ParameterFixupFromDocs.xml", tempFile, Bytecode.JavaDocletType.ApiXml);
+			}
+			catch (Exception ex)
+			{
+				try
+				{
+					if (File.Exists(tempFile))
+						File.Delete(tempFile);
+				}
+				catch { }
+
+				Assert.Fail("An unexpected exception was thrown : {0}", ex);
+			}
+		}
+
+		[Test]
 		public void XmlDeclaration_DoesNotThrowAnExceptionIfDocumentationNotFound ()
 		{
 			try {

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj
@@ -151,6 +151,9 @@
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\java\util\Collection.class">
       <LogicalName>Collection.class</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="ParameterFixupApiXmlDocs.xml">
+      <LogicalName>ParameterFixupApiXmlDocs.xml</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/tools/class-parse/Program.cs
+++ b/tools/class-parse/Program.cs
@@ -94,6 +94,7 @@ namespace Xamarin.Android.Tools {
 			{ "java6",      JavaDocletType.Java6 },
 			{ "java7",      JavaDocletType.Java7 },
 			{ "java8",      JavaDocletType.Java8 },
+			{ "apixml",     JavaDocletType.ApiXml },
 		};
 
 		static JavaDocletType GetJavaDocletType (string value)


### PR DESCRIPTION
The existing doc parsers are great for when the documentation is available for download publicly, however we are facing a situation with Android Support libraries where documentation available online is either lagging behind releases or is simply not updated in the usual locations for consuming.

The documentation is available on the web server, however since we can't redistribute this content, we need to distribute the information (parameter names) in an intermediate format which the binding build process can use as a source for parameter name data.

For Android Support libraries, we are starting to produce parameter names in an intermediate format which mimics the existing `api.xml` structure (albeit with much less information in the attributes).

This PR creates a parameter name doc parser for the `api.xml` format.