### PR TITLE
[class-parse] Fix build break from 806082f2

### DIFF
--- a/tools/class-parse/Program.cs
+++ b/tools/class-parse/Program.cs
@@ -94,7 +94,7 @@ namespace Xamarin.Android.Tools {
 			{ "java6",      JavaDocletType.Java6 },
 			{ "java7",      JavaDocletType.Java7 },
 			{ "java8",      JavaDocletType.Java8 },
-			{ "apixml",     JavaDocletType.ApiXml },
+			{ "apixml",     JavaDocletType._ApiXml },
 		};
 
 		static JavaDocletType GetJavaDocletType (string value)


### PR DESCRIPTION
Fix a [build][0] [break][1] from commit 806082f2:

	Program.cs(97,35): error CS0117: `Xamarin.Android.Tools.Bytecode.JavaDocletType' does not contain a definition for `ApiXml'

It should be referencing `_ApiXml`, not `ApiXml`.

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/Java.Interop/94/
[1]: https://jenkins.mono-project.com/view/Xamarin.Android/job/Java.Interop/94/console