### PR TITLE
[generator] fix generic parameter code generation for interface.

### DIFF
--- a/tools/generator/CollectionSymbol.cs
+++ b/tools/generator/CollectionSymbol.cs
@@ -52,6 +52,10 @@ namespace MonoDroid.Generation {
 			get { return null; }
 		}
 
+		public bool MayHaveManagedGenericArguments {
+			get { return true; }
+		}
+
 		public string GetObjectHandleProperty (string variable)
 		{
 			return $"((global::Java.Lang.Object) {variable}).Handle";

--- a/tools/generator/GenericSymbol.cs
+++ b/tools/generator/GenericSymbol.cs
@@ -91,7 +91,8 @@ namespace MonoDroid.Generation {
 
 		public string GetGenericType (Dictionary<string, string> mappings)
 		{
-			return gen.FullName + (mappings == null ? tps : MapTypeParams (mappings));
+			var rgm = gen as IRequireGenericMarshal;
+			return gen.FullName + (rgm != null && !rgm.MayHaveManagedGenericArguments ? null : mappings == null ? tps : MapTypeParams (mappings));
 		}
 
 		public string ToNative (CodeGenerationOptions opt, string varname)

--- a/tools/generator/IRequireGenericMarshal.cs
+++ b/tools/generator/IRequireGenericMarshal.cs
@@ -5,6 +5,7 @@ namespace MonoDroid.Generation
 {
 	public interface IRequireGenericMarshal
 	{
+		bool MayHaveManagedGenericArguments { get; }
 		string GetGenericJavaObjectTypeOverride ();
 		string ToInteroperableJavaObject (string varname);
 	}

--- a/tools/generator/InterfaceGen.cs
+++ b/tools/generator/InterfaceGen.cs
@@ -24,8 +24,13 @@ namespace MonoDroid.Generation {
 				AddMethod (new ManagedMethod (this, m));
 			}
 		}
+
 		public override string ArgsType {
 			get { throw new NotImplementedException (); }
+		}
+
+		public override bool MayHaveManagedGenericArguments {
+			get { return !this.IsAcw; }
 		}
 	}
 #endif
@@ -107,6 +112,10 @@ namespace MonoDroid.Generation {
 		public bool IsListener {
 			// If there is a property it cannot generate valid implementor, so reject this at least so far.
 			get { return Name.EndsWith ("Listener") && Properties.Count == 0 && Interfaces.Count == 0; }
+		}
+
+		public virtual bool MayHaveManagedGenericArguments {
+			get { return false; }
 		}
 
 		public override string NativeType {

--- a/tools/generator/Tests/GenericArguments.cs
+++ b/tools/generator/Tests/GenericArguments.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace generatortests
+{
+	[TestFixture]
+	public class GenericArguments : BaseGeneratorTest
+	{
+		[Test]
+		public void GeneratedOK ()
+		{
+			RunAllTargets (
+					outputRelativePath: "GenericArguments",
+					apiDescriptionFile: "expected/GenericArguments/GenericArguments.xml",
+					expectedRelativePath: "GenericArguments",
+					additionalSupportPaths: null);
+		}
+	}
+}
+

--- a/tools/generator/Tests/expected.ji/GenericArguments/Com.Google.Android.Exoplayer.Drm.FrameworkMediaDrm.cs
+++ b/tools/generator/Tests/expected.ji/GenericArguments/Com.Google.Android.Exoplayer.Drm.FrameworkMediaDrm.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Com.Google.Android.Exoplayer.Drm {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='com.google.android.exoplayer.drm']/class[@name='FrameworkMediaDrm']"
+	[global::Android.Runtime.Register ("com/google/android/exoplayer/drm/FrameworkMediaDrm", DoNotGenerateAcw=true)]
+	public sealed partial class FrameworkMediaDrm : global::Java.Lang.Object, global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm {
+
+		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("com/google/android/exoplayer/drm/FrameworkMediaDrm", typeof (FrameworkMediaDrm));
+		internal static IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+		internal FrameworkMediaDrm (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		// Metadata.xml XPath constructor reference: path="/api/package[@name='com.google.android.exoplayer.drm']/class[@name='FrameworkMediaDrm']/constructor[@name='FrameworkMediaDrm' and count(parameter)=0]"
+		[Register (".ctor", "()V", "")]
+		public unsafe FrameworkMediaDrm ()
+			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		{
+			const string __id = "()V";
+
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+				return;
+
+			try {
+				var __r = _members.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), null);
+				SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
+				_members.InstanceMethods.FinishCreateInstance (__id, this, null);
+			} finally {
+			}
+		}
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='com.google.android.exoplayer.drm']/class[@name='FrameworkMediaDrm']/method[@name='setOnEventListener' and count(parameter)=1 and parameter[1][@type='com.google.android.exoplayer.drm.ExoMediaDrm.OnEventListener&lt;com.google.android.exoplayer.drm.FrameworkMediaCrypto&gt;']]"
+		[Register ("setOnEventListener", "(Lcom/google/android/exoplayer/drm/ExoMediaDrm$OnEventListener;)V", "")]
+		public unsafe void SetOnEventListener (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener p0)
+		{
+			const string __id = "setOnEventListener.(Lcom/google/android/exoplayer/drm/ExoMediaDrm$OnEventListener;)V";
+			try {
+				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+				__args [0] = new JniArgumentValue ((p0 == null) ? IntPtr.Zero : ((global::Java.Lang.Object) p0).Handle);
+				_members.InstanceMethods.InvokeAbstractVoidMethod (__id, this, __args);
+			} finally {
+			}
+		}
+
+		// This method is explicitly implemented as a member of an instantiated Com.Google.Android.Exoplayer.Drm.IExoMediaDrm
+		void global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.SetOnEventListener (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener p0)
+		{
+			SetOnEventListener (global::Java.Interop.JavaObjectExtensions.JavaCast<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener>(p0));
+		}
+
+	}
+}

--- a/tools/generator/Tests/expected.ji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
+++ b/tools/generator/Tests/expected.ji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
@@ -1,0 +1,279 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Com.Google.Android.Exoplayer.Drm {
+
+	// Metadata.xml XPath interface reference: path="/api/package[@name='com.google.android.exoplayer.drm']/interface[@name='ExoMediaDrm.OnEventListener']"
+	[Register ("com/google/android/exoplayer/drm/ExoMediaDrm$OnEventListener", "", "Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListenerInvoker")]
+	[global::Java.Interop.JavaTypeParameters (new string [] {"T extends com.google.android.exoplayer.drm.ExoMediaCrypto"})]
+	public partial interface IExoMediaDrmOnEventListener : IJavaObject {
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='com.google.android.exoplayer.drm']/interface[@name='ExoMediaDrm.OnEventListener']/method[@name='onEvent' and count(parameter)=5 and parameter[1][@type='com.google.android.exoplayer.drm.ExoMediaDrm&lt;T&gt;'] and parameter[2][@type='byte[]'] and parameter[3][@type='int'] and parameter[4][@type='int'] and parameter[5][@type='byte[]']]"
+		[Register ("onEvent", "(Lcom/google/android/exoplayer/drm/ExoMediaDrm;[BII[B)V", "GetOnEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayBHandler:Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListenerInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
+		void OnEvent (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm p0, byte[] p1, int p2, int p3, byte[] p4);
+
+	}
+
+	[global::Android.Runtime.Register ("com/google/android/exoplayer/drm/ExoMediaDrm$OnEventListener", DoNotGenerateAcw=true)]
+	internal class IExoMediaDrmOnEventListenerInvoker : global::Java.Lang.Object, IExoMediaDrmOnEventListener {
+
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("com/google/android/exoplayer/drm/ExoMediaDrm$OnEventListener", typeof (IExoMediaDrmOnEventListenerInvoker));
+
+		static IntPtr java_class_ref {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+		IntPtr class_ref;
+
+		public static IExoMediaDrmOnEventListener GetObject (IntPtr handle, JniHandleOwnership transfer)
+		{
+			return global::Java.Lang.Object.GetObject<IExoMediaDrmOnEventListener> (handle, transfer);
+		}
+
+		static IntPtr Validate (IntPtr handle)
+		{
+			if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
+				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
+							JNIEnv.GetClassNameFromInstance (handle), "com.google.android.exoplayer.drm.ExoMediaDrm.OnEventListener"));
+			return handle;
+		}
+
+		protected override void Dispose (bool disposing)
+		{
+			if (this.class_ref != IntPtr.Zero)
+				JNIEnv.DeleteGlobalRef (this.class_ref);
+			this.class_ref = IntPtr.Zero;
+			base.Dispose (disposing);
+		}
+
+		public IExoMediaDrmOnEventListenerInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
+		{
+			IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
+			this.class_ref = JNIEnv.NewGlobalRef (local_ref);
+			JNIEnv.DeleteLocalRef (local_ref);
+		}
+
+		static Delegate cb_onEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB;
+#pragma warning disable 0169
+		static Delegate GetOnEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayBHandler ()
+		{
+			if (cb_onEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB == null)
+				cb_onEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr, IntPtr, IntPtr, int, int, IntPtr>) n_OnEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB);
+			return cb_onEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB;
+		}
+
+		static void n_OnEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB (IntPtr jnienv, IntPtr native__this, IntPtr native_p0, IntPtr native_p1, int p2, int p3, IntPtr native_p4)
+		{
+			global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener __this = global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm p0 = (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm)global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm> (native_p0, JniHandleOwnership.DoNotTransfer);
+			byte[] p1 = (byte[]) JNIEnv.GetArray (native_p1, JniHandleOwnership.DoNotTransfer, typeof (byte));
+			byte[] p4 = (byte[]) JNIEnv.GetArray (native_p4, JniHandleOwnership.DoNotTransfer, typeof (byte));
+			__this.OnEvent (p0, p1, p2, p3, p4);
+			if (p1 != null)
+				JNIEnv.CopyArray (p1, native_p1);
+			if (p4 != null)
+				JNIEnv.CopyArray (p4, native_p4);
+		}
+#pragma warning restore 0169
+
+		IntPtr id_onEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB;
+		public unsafe void OnEvent (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm p0, byte[] p1, int p2, int p3, byte[] p4)
+		{
+			if (id_onEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB == IntPtr.Zero)
+				id_onEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB = JNIEnv.GetMethodID (class_ref, "onEvent", "(Lcom/google/android/exoplayer/drm/ExoMediaDrm;[BII[B)V");
+			IntPtr native_p1 = JNIEnv.NewArray (p1);
+			IntPtr native_p4 = JNIEnv.NewArray (p4);
+			JValue* __args = stackalloc JValue [5];
+			__args [0] = new JValue ((p0 == null) ? IntPtr.Zero : ((global::Java.Lang.Object) p0).Handle);
+			__args [1] = new JValue (native_p1);
+			__args [2] = new JValue (p2);
+			__args [3] = new JValue (p3);
+			__args [4] = new JValue (native_p4);
+			JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_onEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB, __args);
+			if (p1 != null) {
+				JNIEnv.CopyArray (native_p1, p1);
+				JNIEnv.DeleteLocalRef (native_p1);
+			}
+			if (p4 != null) {
+				JNIEnv.CopyArray (native_p4, p4);
+				JNIEnv.DeleteLocalRef (native_p4);
+			}
+		}
+
+	}
+
+	public partial class ExoMediaDrmOnEventEventArgs : global::System.EventArgs {
+
+		public ExoMediaDrmOnEventEventArgs (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm p0, byte[] p1, int p2, int p3, byte[] p4)
+		{
+			this.p0 = p0;
+			this.p1 = p1;
+			this.p2 = p2;
+			this.p3 = p3;
+			this.p4 = p4;
+		}
+
+		global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm p0;
+		public global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm P0 {
+			get { return p0; }
+		}
+
+		byte[] p1;
+		public byte[] P1 {
+			get { return p1; }
+		}
+
+		int p2;
+		public int P2 {
+			get { return p2; }
+		}
+
+		int p3;
+		public int P3 {
+			get { return p3; }
+		}
+
+		byte[] p4;
+		public byte[] P4 {
+			get { return p4; }
+		}
+	}
+
+	[global::Android.Runtime.Register ("mono/com/google/android/exoplayer/drm/ExoMediaDrm_OnEventListenerImplementor")]
+	internal sealed partial class IExoMediaDrmOnEventListenerImplementor : global::Java.Lang.Object, IExoMediaDrmOnEventListener {
+
+		object sender;
+
+		public IExoMediaDrmOnEventListenerImplementor (object sender)
+			: base (
+				global::Android.Runtime.JNIEnv.StartCreateInstance ("mono/com/google/android/exoplayer/drm/ExoMediaDrm_OnEventListenerImplementor", "()V"),
+				JniHandleOwnership.TransferLocalRef)
+		{
+			global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "()V");
+			this.sender = sender;
+		}
+
+#pragma warning disable 0649
+		public EventHandler<ExoMediaDrmOnEventEventArgs> Handler;
+#pragma warning restore 0649
+
+		public void OnEvent (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm p0, byte[] p1, int p2, int p3, byte[] p4)
+		{
+			var __h = Handler;
+			if (__h != null)
+				__h (sender, new ExoMediaDrmOnEventEventArgs (p0, p1, p2, p3, p4));
+		}
+
+		internal static bool __IsEmpty (IExoMediaDrmOnEventListenerImplementor value)
+		{
+			return value.Handler == null;
+		}
+	}
+
+
+	// Metadata.xml XPath interface reference: path="/api/package[@name='com.google.android.exoplayer.drm']/interface[@name='ExoMediaDrm']"
+	[Register ("com/google/android/exoplayer/drm/ExoMediaDrm", "", "Com.Google.Android.Exoplayer.Drm.IExoMediaDrmInvoker")]
+	[global::Java.Interop.JavaTypeParameters (new string [] {"T extends com.google.android.exoplayer.drm.ExoMediaCrypto"})]
+	public partial interface IExoMediaDrm : IJavaObject {
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='com.google.android.exoplayer.drm']/interface[@name='ExoMediaDrm']/method[@name='setOnEventListener' and count(parameter)=1 and parameter[1][@type='com.google.android.exoplayer.drm.ExoMediaDrm.OnEventListener&lt;T&gt;']]"
+		[Register ("setOnEventListener", "(Lcom/google/android/exoplayer/drm/ExoMediaDrm$OnEventListener;)V", "GetSetOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_Handler:Com.Google.Android.Exoplayer.Drm.IExoMediaDrmInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
+		void SetOnEventListener (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener p0);
+
+	}
+
+	[global::Android.Runtime.Register ("com/google/android/exoplayer/drm/ExoMediaDrm", DoNotGenerateAcw=true)]
+	internal class IExoMediaDrmInvoker : global::Java.Lang.Object, IExoMediaDrm {
+
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("com/google/android/exoplayer/drm/ExoMediaDrm", typeof (IExoMediaDrmInvoker));
+
+		static IntPtr java_class_ref {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+		IntPtr class_ref;
+
+		public static IExoMediaDrm GetObject (IntPtr handle, JniHandleOwnership transfer)
+		{
+			return global::Java.Lang.Object.GetObject<IExoMediaDrm> (handle, transfer);
+		}
+
+		static IntPtr Validate (IntPtr handle)
+		{
+			if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
+				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
+							JNIEnv.GetClassNameFromInstance (handle), "com.google.android.exoplayer.drm.ExoMediaDrm"));
+			return handle;
+		}
+
+		protected override void Dispose (bool disposing)
+		{
+			if (this.class_ref != IntPtr.Zero)
+				JNIEnv.DeleteGlobalRef (this.class_ref);
+			this.class_ref = IntPtr.Zero;
+			base.Dispose (disposing);
+		}
+
+		public IExoMediaDrmInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
+		{
+			IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
+			this.class_ref = JNIEnv.NewGlobalRef (local_ref);
+			JNIEnv.DeleteLocalRef (local_ref);
+		}
+
+		static Delegate cb_setOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_;
+#pragma warning disable 0169
+		static Delegate GetSetOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_Handler ()
+		{
+			if (cb_setOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_ == null)
+				cb_setOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_ = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr, IntPtr>) n_SetOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_);
+			return cb_setOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_;
+		}
+
+		static void n_SetOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
+		{
+			global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm __this = global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener p0 = (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener)global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener> (native_p0, JniHandleOwnership.DoNotTransfer);
+			__this.SetOnEventListener (p0);
+		}
+#pragma warning restore 0169
+
+		IntPtr id_setOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_;
+		public unsafe void SetOnEventListener (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener p0)
+		{
+			if (id_setOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_ == IntPtr.Zero)
+				id_setOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_ = JNIEnv.GetMethodID (class_ref, "setOnEventListener", "(Lcom/google/android/exoplayer/drm/ExoMediaDrm$OnEventListener;)V");
+			JValue* __args = stackalloc JValue [1];
+			__args [0] = new JValue ((p0 == null) ? IntPtr.Zero : ((global::Java.Lang.Object) p0).Handle);
+			JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_setOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_, __args);
+		}
+
+	}
+
+}

--- a/tools/generator/Tests/expected.ji/GenericArguments/GenericArguments.xml
+++ b/tools/generator/Tests/expected.ji/GenericArguments/GenericArguments.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<api>
+  <package name="java.lang">
+    <class abstract="false" deprecated="not deprecated" final="false" name="Object" static="false" visibility="public">
+    </class>
+  </package>
+  <package name="com.google.android.exoplayer.drm">
+    <interface abstract="true" deprecated="not deprecated" final="false" name="ExoMediaCrypto" static="false" visibility="public">
+      <method abstract="true" deprecated="not deprecated" final="false" name="requiresSecureDecoderComponent" native="false" return="boolean" static="false" synchronized="false" visibility="public">
+        <parameter name="p0" type="java.lang.String">
+        </parameter>
+      </method>
+    </interface>
+    <interface abstract="true" deprecated="not deprecated" final="false" name="ExoMediaDrm" static="false" visibility="public">
+      <typeParameters>
+        <typeParameter name="T">
+          <genericConstraints>
+            <genericConstraint type="com.google.android.exoplayer.drm.ExoMediaCrypto" />
+          </genericConstraints>
+        </typeParameter>
+      </typeParameters>
+      <method abstract="true" deprecated="not deprecated" final="false" name="setOnEventListener" native="false" return="void" static="false" synchronized="false" visibility="public">
+        <parameter name="p0" type="com.google.android.exoplayer.drm.ExoMediaDrm.OnEventListener&lt;T&gt;">
+        </parameter>
+      </method>
+    </interface>
+    <interface abstract="true" deprecated="not deprecated" final="false" name="ExoMediaDrm.OnEventListener" static="true" visibility="public">
+      <typeParameters>
+        <typeParameter name="T">
+          <genericConstraints>
+            <genericConstraint type="com.google.android.exoplayer.drm.ExoMediaCrypto" />
+          </genericConstraints>
+        </typeParameter>
+      </typeParameters>
+      <method abstract="true" deprecated="not deprecated" final="false" name="onEvent" native="false" return="void" static="false" synchronized="false" visibility="public">
+        <parameter name="p0" type="com.google.android.exoplayer.drm.ExoMediaDrm&lt;T&gt;">
+        </parameter>
+        <parameter name="p1" type="byte[]">
+        </parameter>
+        <parameter name="p2" type="int">
+        </parameter>
+        <parameter name="p3" type="int">
+        </parameter>
+        <parameter name="p4" type="byte[]">
+        </parameter>
+      </method>
+    </interface>
+    <class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="true" name="FrameworkMediaCrypto" static="false" visibility="public">
+      <implements name="com.google.android.exoplayer.drm.ExoMediaCrypto" name-generic-aware="com.google.android.exoplayer.drm.ExoMediaCrypto">
+      </implements>
+      <constructor deprecated="not deprecated" final="false" name="FrameworkMediaCrypto" static="false" type="com.google.android.exoplayer.drm.FrameworkMediaCrypto" visibility="public">
+      </constructor>
+      <method abstract="false" deprecated="not deprecated" final="false" name="requiresSecureDecoderComponent" native="false" return="boolean" static="false" synchronized="false" visibility="public">
+        <parameter name="p0" type="java.lang.String">
+        </parameter>
+      </method>
+    </class>
+    <class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="true" name="FrameworkMediaDrm" static="false" visibility="public">
+      <implements name="com.google.android.exoplayer.drm.ExoMediaDrm" name-generic-aware="com.google.android.exoplayer.drm.ExoMediaDrm&lt;com.google.android.exoplayer.drm.FrameworkMediaCrypto&gt;">
+      </implements>
+      <constructor deprecated="not deprecated" final="false" name="FrameworkMediaDrm" static="false" type="com.google.android.exoplayer.drm.FrameworkMediaDrm" visibility="public">
+      </constructor>
+      <method abstract="false" deprecated="not deprecated" final="false" name="setOnEventListener" native="false" return="void" static="false" synchronized="false" visibility="public">
+        <parameter name="p0" type="com.google.android.exoplayer.drm.ExoMediaDrm.OnEventListener&lt;com.google.android.exoplayer.drm.FrameworkMediaCrypto&gt;">
+        </parameter>
+      </method>
+    </class>
+  </package>
+</api>

--- a/tools/generator/Tests/expected.ji/GenericArguments/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/GenericArguments/Java.Lang.Object.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Java.Lang {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
+	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
+	public partial class Object  {
+
+	}
+}

--- a/tools/generator/Tests/expected.targets
+++ b/tools/generator/Tests/expected.targets
@@ -84,7 +84,19 @@
     <Content Include='expected\java.lang.Enum\Java.Lang.Object.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include='expected\java.lang.Enum\Java.Lang.State.cs'>
+    <Content Include='expected.ji\GenericArguments\GenericArguments.xml'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected.ji\GenericArguments\Java.Lang.Object.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected.ji\GenericArguments\Com.Google.Android.Exoplayer.Drm.FrameworkMediaDrm.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected.ji\GenericArguments\Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected.ji\NestedTypes\Java.Interop.__TypeRegistrations.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include='expected\java.lang.Object\enumlist'>
@@ -481,6 +493,18 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include='expected.ji\TestInterface\Test.ME.TestInterfaceImplementation.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected\GenericArguments\GenericArguments.xml'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected\GenericArguments\Java.Lang.Object.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected\GenericArguments\Com.Google.Android.Exoplayer.Drm.FrameworkMediaDrm.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected\GenericArguments\Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include='expected\NestedTypes\NestedTypes.xml'>

--- a/tools/generator/Tests/expected/GenericArguments/Com.Google.Android.Exoplayer.Drm.FrameworkMediaDrm.cs
+++ b/tools/generator/Tests/expected/GenericArguments/Com.Google.Android.Exoplayer.Drm.FrameworkMediaDrm.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Com.Google.Android.Exoplayer.Drm {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='com.google.android.exoplayer.drm']/class[@name='FrameworkMediaDrm']"
+	[global::Android.Runtime.Register ("com/google/android/exoplayer/drm/FrameworkMediaDrm", DoNotGenerateAcw=true)]
+	public sealed partial class FrameworkMediaDrm : global::Java.Lang.Object, global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm {
+
+		internal static IntPtr java_class_handle;
+		internal static IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("com/google/android/exoplayer/drm/FrameworkMediaDrm", ref java_class_handle);
+			}
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (FrameworkMediaDrm); }
+		}
+
+		internal FrameworkMediaDrm (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		static IntPtr id_ctor;
+		// Metadata.xml XPath constructor reference: path="/api/package[@name='com.google.android.exoplayer.drm']/class[@name='FrameworkMediaDrm']/constructor[@name='FrameworkMediaDrm' and count(parameter)=0]"
+		[Register (".ctor", "()V", "")]
+		public unsafe FrameworkMediaDrm ()
+			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		{
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+				return;
+
+			try {
+				if (((object) this).GetType () != typeof (FrameworkMediaDrm)) {
+					SetHandle (
+							global::Android.Runtime.JNIEnv.StartCreateInstance (((object) this).GetType (), "()V"),
+							JniHandleOwnership.TransferLocalRef);
+					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "()V");
+					return;
+				}
+
+				if (id_ctor == IntPtr.Zero)
+					id_ctor = JNIEnv.GetMethodID (class_ref, "<init>", "()V");
+				SetHandle (
+						global::Android.Runtime.JNIEnv.StartCreateInstance (class_ref, id_ctor),
+						JniHandleOwnership.TransferLocalRef);
+				JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, class_ref, id_ctor);
+			} finally {
+			}
+		}
+
+		static IntPtr id_setOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_;
+		// Metadata.xml XPath method reference: path="/api/package[@name='com.google.android.exoplayer.drm']/class[@name='FrameworkMediaDrm']/method[@name='setOnEventListener' and count(parameter)=1 and parameter[1][@type='com.google.android.exoplayer.drm.ExoMediaDrm.OnEventListener&lt;com.google.android.exoplayer.drm.FrameworkMediaCrypto&gt;']]"
+		[Register ("setOnEventListener", "(Lcom/google/android/exoplayer/drm/ExoMediaDrm$OnEventListener;)V", "")]
+		public unsafe void SetOnEventListener (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener p0)
+		{
+			if (id_setOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_ == IntPtr.Zero)
+				id_setOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_ = JNIEnv.GetMethodID (class_ref, "setOnEventListener", "(Lcom/google/android/exoplayer/drm/ExoMediaDrm$OnEventListener;)V");
+			try {
+				JValue* __args = stackalloc JValue [1];
+				__args [0] = new JValue (p0);
+				JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_setOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_, __args);
+			} finally {
+			}
+		}
+
+		// This method is explicitly implemented as a member of an instantiated Com.Google.Android.Exoplayer.Drm.IExoMediaDrm
+		void global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.SetOnEventListener (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener p0)
+		{
+			SetOnEventListener (global::Java.Interop.JavaObjectExtensions.JavaCast<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener>(p0));
+		}
+
+	}
+}

--- a/tools/generator/Tests/expected/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
+++ b/tools/generator/Tests/expected/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
@@ -1,0 +1,262 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Com.Google.Android.Exoplayer.Drm {
+
+	// Metadata.xml XPath interface reference: path="/api/package[@name='com.google.android.exoplayer.drm']/interface[@name='ExoMediaDrm.OnEventListener']"
+	[Register ("com/google/android/exoplayer/drm/ExoMediaDrm$OnEventListener", "", "Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListenerInvoker")]
+	[global::Java.Interop.JavaTypeParameters (new string [] {"T extends com.google.android.exoplayer.drm.ExoMediaCrypto"})]
+	public partial interface IExoMediaDrmOnEventListener : IJavaObject {
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='com.google.android.exoplayer.drm']/interface[@name='ExoMediaDrm.OnEventListener']/method[@name='onEvent' and count(parameter)=5 and parameter[1][@type='com.google.android.exoplayer.drm.ExoMediaDrm&lt;T&gt;'] and parameter[2][@type='byte[]'] and parameter[3][@type='int'] and parameter[4][@type='int'] and parameter[5][@type='byte[]']]"
+		[Register ("onEvent", "(Lcom/google/android/exoplayer/drm/ExoMediaDrm;[BII[B)V", "GetOnEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayBHandler:Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListenerInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
+		void OnEvent (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm p0, byte[] p1, int p2, int p3, byte[] p4);
+
+	}
+
+	[global::Android.Runtime.Register ("com/google/android/exoplayer/drm/ExoMediaDrm$OnEventListener", DoNotGenerateAcw=true)]
+	internal class IExoMediaDrmOnEventListenerInvoker : global::Java.Lang.Object, IExoMediaDrmOnEventListener {
+
+		static IntPtr java_class_ref = JNIEnv.FindClass ("com/google/android/exoplayer/drm/ExoMediaDrm$OnEventListener");
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (IExoMediaDrmOnEventListenerInvoker); }
+		}
+
+		IntPtr class_ref;
+
+		public static IExoMediaDrmOnEventListener GetObject (IntPtr handle, JniHandleOwnership transfer)
+		{
+			return global::Java.Lang.Object.GetObject<IExoMediaDrmOnEventListener> (handle, transfer);
+		}
+
+		static IntPtr Validate (IntPtr handle)
+		{
+			if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
+				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
+							JNIEnv.GetClassNameFromInstance (handle), "com.google.android.exoplayer.drm.ExoMediaDrm.OnEventListener"));
+			return handle;
+		}
+
+		protected override void Dispose (bool disposing)
+		{
+			if (this.class_ref != IntPtr.Zero)
+				JNIEnv.DeleteGlobalRef (this.class_ref);
+			this.class_ref = IntPtr.Zero;
+			base.Dispose (disposing);
+		}
+
+		public IExoMediaDrmOnEventListenerInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
+		{
+			IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
+			this.class_ref = JNIEnv.NewGlobalRef (local_ref);
+			JNIEnv.DeleteLocalRef (local_ref);
+		}
+
+		static Delegate cb_onEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB;
+#pragma warning disable 0169
+		static Delegate GetOnEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayBHandler ()
+		{
+			if (cb_onEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB == null)
+				cb_onEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr, IntPtr, IntPtr, int, int, IntPtr>) n_OnEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB);
+			return cb_onEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB;
+		}
+
+		static void n_OnEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB (IntPtr jnienv, IntPtr native__this, IntPtr native_p0, IntPtr native_p1, int p2, int p3, IntPtr native_p4)
+		{
+			global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener __this = global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm p0 = (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm)global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm> (native_p0, JniHandleOwnership.DoNotTransfer);
+			byte[] p1 = (byte[]) JNIEnv.GetArray (native_p1, JniHandleOwnership.DoNotTransfer, typeof (byte));
+			byte[] p4 = (byte[]) JNIEnv.GetArray (native_p4, JniHandleOwnership.DoNotTransfer, typeof (byte));
+			__this.OnEvent (p0, p1, p2, p3, p4);
+			if (p1 != null)
+				JNIEnv.CopyArray (p1, native_p1);
+			if (p4 != null)
+				JNIEnv.CopyArray (p4, native_p4);
+		}
+#pragma warning restore 0169
+
+		IntPtr id_onEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB;
+		public unsafe void OnEvent (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm p0, byte[] p1, int p2, int p3, byte[] p4)
+		{
+			if (id_onEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB == IntPtr.Zero)
+				id_onEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB = JNIEnv.GetMethodID (class_ref, "onEvent", "(Lcom/google/android/exoplayer/drm/ExoMediaDrm;[BII[B)V");
+			IntPtr native_p1 = JNIEnv.NewArray (p1);
+			IntPtr native_p4 = JNIEnv.NewArray (p4);
+			JValue* __args = stackalloc JValue [5];
+			__args [0] = new JValue (p0);
+			__args [1] = new JValue (native_p1);
+			__args [2] = new JValue (p2);
+			__args [3] = new JValue (p3);
+			__args [4] = new JValue (native_p4);
+			JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_onEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB, __args);
+			if (p1 != null) {
+				JNIEnv.CopyArray (native_p1, p1);
+				JNIEnv.DeleteLocalRef (native_p1);
+			}
+			if (p4 != null) {
+				JNIEnv.CopyArray (native_p4, p4);
+				JNIEnv.DeleteLocalRef (native_p4);
+			}
+		}
+
+	}
+
+	public partial class ExoMediaDrmOnEventEventArgs : global::System.EventArgs {
+
+		public ExoMediaDrmOnEventEventArgs (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm p0, byte[] p1, int p2, int p3, byte[] p4)
+		{
+			this.p0 = p0;
+			this.p1 = p1;
+			this.p2 = p2;
+			this.p3 = p3;
+			this.p4 = p4;
+		}
+
+		global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm p0;
+		public global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm P0 {
+			get { return p0; }
+		}
+
+		byte[] p1;
+		public byte[] P1 {
+			get { return p1; }
+		}
+
+		int p2;
+		public int P2 {
+			get { return p2; }
+		}
+
+		int p3;
+		public int P3 {
+			get { return p3; }
+		}
+
+		byte[] p4;
+		public byte[] P4 {
+			get { return p4; }
+		}
+	}
+
+	[global::Android.Runtime.Register ("mono/com/google/android/exoplayer/drm/ExoMediaDrm_OnEventListenerImplementor")]
+	internal sealed partial class IExoMediaDrmOnEventListenerImplementor : global::Java.Lang.Object, IExoMediaDrmOnEventListener {
+
+		object sender;
+
+		public IExoMediaDrmOnEventListenerImplementor (object sender)
+			: base (
+				global::Android.Runtime.JNIEnv.StartCreateInstance ("mono/com/google/android/exoplayer/drm/ExoMediaDrm_OnEventListenerImplementor", "()V"),
+				JniHandleOwnership.TransferLocalRef)
+		{
+			global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "()V");
+			this.sender = sender;
+		}
+
+#pragma warning disable 0649
+		public EventHandler<ExoMediaDrmOnEventEventArgs> Handler;
+#pragma warning restore 0649
+
+		public void OnEvent (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm p0, byte[] p1, int p2, int p3, byte[] p4)
+		{
+			var __h = Handler;
+			if (__h != null)
+				__h (sender, new ExoMediaDrmOnEventEventArgs (p0, p1, p2, p3, p4));
+		}
+
+		internal static bool __IsEmpty (IExoMediaDrmOnEventListenerImplementor value)
+		{
+			return value.Handler == null;
+		}
+	}
+
+
+	// Metadata.xml XPath interface reference: path="/api/package[@name='com.google.android.exoplayer.drm']/interface[@name='ExoMediaDrm']"
+	[Register ("com/google/android/exoplayer/drm/ExoMediaDrm", "", "Com.Google.Android.Exoplayer.Drm.IExoMediaDrmInvoker")]
+	[global::Java.Interop.JavaTypeParameters (new string [] {"T extends com.google.android.exoplayer.drm.ExoMediaCrypto"})]
+	public partial interface IExoMediaDrm : IJavaObject {
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='com.google.android.exoplayer.drm']/interface[@name='ExoMediaDrm']/method[@name='setOnEventListener' and count(parameter)=1 and parameter[1][@type='com.google.android.exoplayer.drm.ExoMediaDrm.OnEventListener&lt;T&gt;']]"
+		[Register ("setOnEventListener", "(Lcom/google/android/exoplayer/drm/ExoMediaDrm$OnEventListener;)V", "GetSetOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_Handler:Com.Google.Android.Exoplayer.Drm.IExoMediaDrmInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
+		void SetOnEventListener (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener p0);
+
+	}
+
+	[global::Android.Runtime.Register ("com/google/android/exoplayer/drm/ExoMediaDrm", DoNotGenerateAcw=true)]
+	internal class IExoMediaDrmInvoker : global::Java.Lang.Object, IExoMediaDrm {
+
+		static IntPtr java_class_ref = JNIEnv.FindClass ("com/google/android/exoplayer/drm/ExoMediaDrm");
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (IExoMediaDrmInvoker); }
+		}
+
+		IntPtr class_ref;
+
+		public static IExoMediaDrm GetObject (IntPtr handle, JniHandleOwnership transfer)
+		{
+			return global::Java.Lang.Object.GetObject<IExoMediaDrm> (handle, transfer);
+		}
+
+		static IntPtr Validate (IntPtr handle)
+		{
+			if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
+				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
+							JNIEnv.GetClassNameFromInstance (handle), "com.google.android.exoplayer.drm.ExoMediaDrm"));
+			return handle;
+		}
+
+		protected override void Dispose (bool disposing)
+		{
+			if (this.class_ref != IntPtr.Zero)
+				JNIEnv.DeleteGlobalRef (this.class_ref);
+			this.class_ref = IntPtr.Zero;
+			base.Dispose (disposing);
+		}
+
+		public IExoMediaDrmInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
+		{
+			IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
+			this.class_ref = JNIEnv.NewGlobalRef (local_ref);
+			JNIEnv.DeleteLocalRef (local_ref);
+		}
+
+		static Delegate cb_setOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_;
+#pragma warning disable 0169
+		static Delegate GetSetOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_Handler ()
+		{
+			if (cb_setOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_ == null)
+				cb_setOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_ = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr, IntPtr>) n_SetOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_);
+			return cb_setOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_;
+		}
+
+		static void n_SetOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
+		{
+			global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm __this = global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener p0 = (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener)global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener> (native_p0, JniHandleOwnership.DoNotTransfer);
+			__this.SetOnEventListener (p0);
+		}
+#pragma warning restore 0169
+
+		IntPtr id_setOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_;
+		public unsafe void SetOnEventListener (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener p0)
+		{
+			if (id_setOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_ == IntPtr.Zero)
+				id_setOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_ = JNIEnv.GetMethodID (class_ref, "setOnEventListener", "(Lcom/google/android/exoplayer/drm/ExoMediaDrm$OnEventListener;)V");
+			JValue* __args = stackalloc JValue [1];
+			__args [0] = new JValue (p0);
+			JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_setOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_, __args);
+		}
+
+	}
+
+}

--- a/tools/generator/Tests/expected/GenericArguments/GenericArguments.xml
+++ b/tools/generator/Tests/expected/GenericArguments/GenericArguments.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<api>
+  <package name="java.lang">
+    <class abstract="false" deprecated="not deprecated" final="false" name="Object" static="false" visibility="public">
+    </class>
+  </package>
+  <package name="com.google.android.exoplayer.drm">
+    <interface abstract="true" deprecated="not deprecated" final="false" name="ExoMediaCrypto" static="false" visibility="public">
+      <method abstract="true" deprecated="not deprecated" final="false" name="requiresSecureDecoderComponent" native="false" return="boolean" static="false" synchronized="false" visibility="public">
+        <parameter name="p0" type="java.lang.String">
+        </parameter>
+      </method>
+    </interface>
+    <interface abstract="true" deprecated="not deprecated" final="false" name="ExoMediaDrm" static="false" visibility="public">
+      <typeParameters>
+        <typeParameter name="T">
+          <genericConstraints>
+            <genericConstraint type="com.google.android.exoplayer.drm.ExoMediaCrypto" />
+          </genericConstraints>
+        </typeParameter>
+      </typeParameters>
+      <method abstract="true" deprecated="not deprecated" final="false" name="setOnEventListener" native="false" return="void" static="false" synchronized="false" visibility="public">
+        <parameter name="p0" type="com.google.android.exoplayer.drm.ExoMediaDrm.OnEventListener&lt;T&gt;">
+        </parameter>
+      </method>
+    </interface>
+    <interface abstract="true" deprecated="not deprecated" final="false" name="ExoMediaDrm.OnEventListener" static="true" visibility="public">
+      <typeParameters>
+        <typeParameter name="T">
+          <genericConstraints>
+            <genericConstraint type="com.google.android.exoplayer.drm.ExoMediaCrypto" />
+          </genericConstraints>
+        </typeParameter>
+      </typeParameters>
+      <method abstract="true" deprecated="not deprecated" final="false" name="onEvent" native="false" return="void" static="false" synchronized="false" visibility="public">
+        <parameter name="p0" type="com.google.android.exoplayer.drm.ExoMediaDrm&lt;T&gt;">
+        </parameter>
+        <parameter name="p1" type="byte[]">
+        </parameter>
+        <parameter name="p2" type="int">
+        </parameter>
+        <parameter name="p3" type="int">
+        </parameter>
+        <parameter name="p4" type="byte[]">
+        </parameter>
+      </method>
+    </interface>
+    <class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="true" name="FrameworkMediaCrypto" static="false" visibility="public">
+      <implements name="com.google.android.exoplayer.drm.ExoMediaCrypto" name-generic-aware="com.google.android.exoplayer.drm.ExoMediaCrypto">
+      </implements>
+      <constructor deprecated="not deprecated" final="false" name="FrameworkMediaCrypto" static="false" type="com.google.android.exoplayer.drm.FrameworkMediaCrypto" visibility="public">
+      </constructor>
+      <method abstract="false" deprecated="not deprecated" final="false" name="requiresSecureDecoderComponent" native="false" return="boolean" static="false" synchronized="false" visibility="public">
+        <parameter name="p0" type="java.lang.String">
+        </parameter>
+      </method>
+    </class>
+    <class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="true" name="FrameworkMediaDrm" static="false" visibility="public">
+      <implements name="com.google.android.exoplayer.drm.ExoMediaDrm" name-generic-aware="com.google.android.exoplayer.drm.ExoMediaDrm&lt;com.google.android.exoplayer.drm.FrameworkMediaCrypto&gt;">
+      </implements>
+      <constructor deprecated="not deprecated" final="false" name="FrameworkMediaDrm" static="false" type="com.google.android.exoplayer.drm.FrameworkMediaDrm" visibility="public">
+      </constructor>
+      <method abstract="false" deprecated="not deprecated" final="false" name="setOnEventListener" native="false" return="void" static="false" synchronized="false" visibility="public">
+        <parameter name="p0" type="com.google.android.exoplayer.drm.ExoMediaDrm.OnEventListener&lt;com.google.android.exoplayer.drm.FrameworkMediaCrypto&gt;">
+        </parameter>
+      </method>
+    </class>
+  </package>
+</api>

--- a/tools/generator/Tests/expected/GenericArguments/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected/GenericArguments/Java.Lang.Object.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Java.Lang {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
+	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
+	public partial class Object  {
+
+	}
+}

--- a/tools/generator/Tests/generator-Tests.csproj
+++ b/tools/generator/Tests/generator-Tests.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Adapters.cs" />
     <Compile Include="PamareterXPath.cs" />
     <Compile Include="CSharpKeywords.cs" />
+    <Compile Include="GenericArguments.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
This fixes bug #43513.

The background for the fix is, well, complicated.

It was generating wrong code:

    // This method is explicitly implemented as a member of an instantiated Com.Google.Android.Exoplayer.Drm.IExoMediaDrm
    void global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.SetOnEventListener (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener p0)
    {
        SetOnEventListener (global::Java.Interop.JavaObjectExtensions.JavaCast<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener<Java.Lang.Object>>(p0));
    }

where IExoMediaDrmOnEventListener is a normally generated interface ACW
which does not have any generic parameter.

The problem is, the Java API has generic argument T.

Usually it does not matter in normal classes. But reference to an interface
type with generic arguments is treated special: `IRequireGenericMarshal`

It was introduced at old monodroid commit 443598f (which is not in this
Java.Interop repo) for fixing bug #5979 to handle IList and ICollection
for collection marshaling.

So... basically ACWs were not expected to behave as IRequireGenericMarshal.
And now that behavior bites us at bug #43513.

Now, how to fix this new bug? This change introduces another boolean flag
to determine if reference to this type should really output generic
arguments. If it is False, then do not output any further.

This is the best logical explanation I can make right now.
What I still wonder are 1) whether it is only about InterfaceGen, and
2) if we could rather simplify things and eliminate this
IRequireGenericMarshal thing. But so far I have no answer to those.