### PR TITLE
[generator] Fix nested type visibility and findability.

### DIFF
--- a/tools/generator/GenBaseSupport.cs
+++ b/tools/generator/GenBaseSupport.cs
@@ -148,7 +148,7 @@ namespace MonoDroid.Generation
 		}
 
 		public override string Visibility {
-			get { return t.IsPublic ? "public" : "protected internal"; }
+			get { return t.IsPublic || t.IsNestedPublic ? "public" : "protected internal"; }
 		}
 	}
 #endif

--- a/tools/generator/JavaApiDllLoaderExtensions.cs
+++ b/tools/generator/JavaApiDllLoaderExtensions.cs
@@ -1,5 +1,6 @@
 #if GENERATOR
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using MonoDroid.Generation;
 
@@ -7,7 +8,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 {
 	public static class JavaApiDllLoaderExtensions
 	{
-		public static void LoadReferences (this JavaApi api, GenBase [] gens)
+		public static void LoadReferences (this JavaApi api, IEnumerable<GenBase> gens)
 		{
 			JavaPackage pkg = null;
 			foreach (var gen in gens.Where (_ => _.IsAcw)) {
@@ -27,6 +28,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 				}
 				else
 					throw new InvalidOperationException ();
+				api.LoadReferences (gen.NestedTypes);
 			}
 		}
 


### PR DESCRIPTION
AndroidSupportComponents/percent/source has some build issues that
PercentFrameLayout.LayoutParams generates wrong constructors that take
java.lang.Object as an argument. For example, for this:
https://developer.android.com/reference/android/support/percent/PercentFrameLayout.LayoutParams.html#PercentFrameLayout.LayoutParams(android.view.ViewGroup.LayoutParams)

And they resulted in build errors (which was rather fortunate; it
could be worse that the method is successfully generated with
java.lang.Object while the actual type isn't...)

Where are those weird java.lang.Object from?

Surprisingly(?), it was not about failed type resolution, but this:
https://github.com/xamarin/java.interop/commit/8dac926e

It hides nonpublic types up to java.lang.Object.

Why does it happen? Isn't android.view.ViewGroup.LayoutParams public?

It is. However, it was not treated as "public" - when it was loaded
via managed ACWs(!). Why? We were checking:

	TypeDescription.IsPublic

whereas it should also check

	TypeDescription.IsNestedPublic

... that's why it blew up to java.lang.Object which is (non-nested type).

Type iteration should also check GenBase.NestedTypes to load types
from DLLs. Hence another loader change.