### PR TITLE
[api-xml-adjuster] fix predefined managed types.

### DIFF
--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApi.XmlModel.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApi.XmlModel.cs
@@ -111,8 +111,8 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 
 	class ManagedType : JavaType
 	{
-		static JavaPackage dummy_system_package, dummy_system_io_package;
-		static JavaType system_object, system_exception, system_io_stream;
+		static JavaPackage dummy_system_package, dummy_system_io_package, dummy_system_xml_package;
+		static JavaType system_object, system_exception, system_io_stream, system_xml_xmlreader;
 
 		static ManagedType ()
 		{
@@ -122,14 +122,18 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			dummy_system_package.Types.Add (system_object);
 			dummy_system_package.Types.Add (system_exception);
 			dummy_system_io_package = new JavaPackage (null) { Name = "System.IO" };
-			system_io_stream = new ManagedType (dummy_system_package) { Name = "Stream" };
+			system_io_stream = new ManagedType (dummy_system_io_package) { Name = "Stream" };
 			dummy_system_io_package.Types.Add (system_io_stream);
+			dummy_system_xml_package = new JavaPackage (null) { Name = "System.Xml" };
+			system_xml_xmlreader = new ManagedType (dummy_system_xml_package) { Name = "XmlReader" };
+			dummy_system_io_package.Types.Add (system_xml_xmlreader);
 		}
 
 		public static IEnumerable<JavaPackage> DummyManagedPackages {
 			get {
 				yield return dummy_system_package; 
 				yield return dummy_system_io_package;
+				yield return dummy_system_xml_package;
 			}
 		}
 


### PR DESCRIPTION
ApiXmlAdjuster had been emitting red-herring warning that it cannot find
System.IO.Stream. It is not a Java type so it is by nature that it is
not found, but we had predefined type definition for that.

Turned out that it was assigned a wrong "package" and therefore the
type was never resolved. This fixes it to the right package.

Also, XmlReader could be used as a predefined type because it is
mapped from XmlPullParser (and AndroidResourceParser). So add it too.