### PR TITLE
[api-xml-adjuster] give chance to set logging verbosity in ApiXmlAdju…

### DIFF
--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiDefectFinderExtensions.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiDefectFinderExtensions.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			int dummy;
 			foreach (var p in methodBase.Parameters) {
 				if (p.Name.StartsWith ("p", StringComparison.Ordinal) && int.TryParse (p.Name.Substring (1), out dummy)) {
-					Console.Error.WriteLine ("Warning: {0} in {1} has 'unnamed' parameters", methodBase.Parent, methodBase);
+					Log.LogWarning ("Warning: {0} in {1} has 'unnamed' parameters", methodBase.Parent, methodBase);
 					break; // reporting once is enough.
 				}
 			}

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiGenericInheritanceMapperExtensions.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiGenericInheritanceMapperExtensions.cs
@@ -30,7 +30,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 					cls.GenericInheritanceMapping = empty;
 				else if (cls.ResolvedExtends.ReferencedType.TypeParameters == null) {
 					// FIXME: I guess this should not happen. But this still happens.
-					Console.WriteLine ("Warning: '{0}' is referenced as base type of '{1}' and expected to have generic type parameters, but it does not.", cls.ExtendsGeneric, cls.FullName);
+					Log.LogWarning ("Warning: '{0}' is referenced as base type of '{1}' and expected to have generic type parameters, but it does not.", cls.ExtendsGeneric, cls.FullName);
 					cls.GenericInheritanceMapping = empty;
 				} else {
 					if (cls.ResolvedExtends.ReferencedType.TypeParameters.TypeParameters.Count != cls.ResolvedExtends.TypeParameters.Count)
@@ -44,8 +44,6 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 						dic.Add (new JavaTypeReference (kvp.Key, null), kvp.Value);
 					if (dic.Any ()) {
 						cls.GenericInheritanceMapping = dic;
-//Console.WriteLine ("in {0}.{1}: {2}", cls.Parent.Name, cls.Name,
-//	string.Join (", ", dic.Select (p => string.Format ("base {0} becomes {1}", p.Key.ReferencedTypeParameter.Name, p.Value.ToString ()))));
 					}
 					else
 						cls.GenericInheritanceMapping = empty;

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiTypeResolverExtensions.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiTypeResolverExtensions.cs
@@ -54,9 +54,9 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			while (true) {
 				bool errors = false;
 				foreach (var t in api.Packages.SelectMany (p => p.Types).OfType<JavaClass> ().ToArray ())
-					try { t.Resolve (); } catch (JavaTypeResolutionException ex) { Console.Error.WriteLine (string.Format ("Error while processing type '{0}': {1}", t, ex.Message)); errors = true; t.Parent.Types.Remove (t); }
+					try { t.Resolve (); } catch (JavaTypeResolutionException ex) { Log.LogError ("Error while processing type '{0}': {1}", t, ex.Message); errors = true; t.Parent.Types.Remove (t); }
 				foreach (var t in api.Packages.SelectMany (p => p.Types).OfType<JavaInterface> ().ToArray ())
-					try { t.Resolve (); } catch (JavaTypeResolutionException ex) { Console.Error.WriteLine (string.Format ("Error while processing type '{0}': {1}", t, ex.Message)); errors = true; t.Parent.Types.Remove (t); }
+					try { t.Resolve (); } catch (JavaTypeResolutionException ex) { Log.LogError ("Error while processing type '{0}': {1}", t, ex.Message); errors = true; t.Parent.Types.Remove (t); }
 				if (!errors)
 					break;
 			}
@@ -89,7 +89,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			try {
 				resolve ();
 			} catch (JavaTypeResolutionException ex) {
-				Console.Error.WriteLine (string.Format ("Error while processing '{0}' in '{1}': {2}", m, m.Parent, ex.Message));
+				Log.LogError ("Error while processing '{0}' in '{1}': {2}", m, m.Parent, ex.Message);
 				m.Parent.Members.Remove (m);
 			}
 		}
@@ -128,7 +128,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			foreach (var t in tp.TypeParameters)
 				if (t.GenericConstraints != null)
 					foreach (var g in t.GenericConstraints.GenericConstraints)
-						try { g.ResolvedType = api.Parse (g.Type, additionalTypeParameters); } catch (JavaTypeResolutionException ex) { Console.Error.WriteLine (string.Format ("Warning: failed to resolve generic constraint: '{0}': {1}", g.Type, ex.Message)); }
+						try { g.ResolvedType = api.Parse (g.Type, additionalTypeParameters); } catch (JavaTypeResolutionException ex) { Log.LogWarning ("Warning: failed to resolve generic constraint: '{0}': {1}", g.Type, ex.Message); }
 		}
 	}
 }

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaTypeResolutionUtil.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaTypeResolutionUtil.cs
@@ -85,8 +85,8 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			if (typeParameter.GenericConstraints == null)
 				return true;
 			// FIXME: implement correct generic constraint conformance check.
-			Console.Error.WriteLine ("WARNING: generic constraint conformance check is not implemented, so the type might be actually compatible. Type parameter: {0}{1}, examined type: {2}",
-				typeParameter.Name, typeParameter.Parent.ParentMethod?.Name ?? typeParameter.Parent.ParentType?.Name, examinedType.ToString ());
+			Log.LogDebug ("NOTICE: generic constraint conformance check is not implemented, so the type might be actually compatible. Type parameter: {0}{1}, examined type: {2}",
+			                               typeParameter.Name, typeParameter.Parent.ParentMethod?.Name ?? typeParameter.Parent.ParentType?.Name, examinedType);
 			return false;
 		}
 	}

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/Log.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/Log.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.IO;
+
+namespace Xamarin.Android.Tools.ApiXmlAdjuster
+{
+	public static class Log
+	{
+		public enum LoggingLevel
+		{
+			None = 0,
+			Error = 1,
+			Warning = 2,
+			Debug = 3,
+		}
+
+		static Action<string> write_default = s => (DefaultWriter ?? Console.Out).WriteLine (s);
+
+		static Action<string> e, w, d;
+
+		public static TextWriter DefaultWriter { get; set; }
+
+		public static LoggingLevel Verbosity { get; set; } = LoggingLevel.Error;
+
+		public static Action<string> LogErrorAction {
+			get { return e ?? write_default; }
+			set { e = value; }
+		}
+		public static Action<string> LogWarningAction {
+			get { return w ?? write_default; }
+			set { w = value; }
+		}
+		public static Action<string> LogDebugAction {
+			get { return d ?? write_default; }
+			set { d = value; }
+		}
+
+		public static void LogError (string format, params object [] args)
+		{
+			if ((int) Verbosity >= (int) LoggingLevel.Error)
+				LogErrorAction (args.Length > 0 ? string.Format (format, args) : format);
+		}
+
+		public static void LogWarning (string format, params object [] args)
+		{
+			if ((int)Verbosity >= (int)LoggingLevel.Warning)
+				LogWarningAction (args.Length > 0 ? string.Format (format, args) : format);
+		}
+
+		public static void LogDebug (string format, params object [] args)
+		{
+			if ((int)Verbosity >= (int)LoggingLevel.Debug)
+				LogDebugAction (args.Length > 0 ? string.Format (format, args) : format);
+		}
+	}
+}

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/Xamarin.Android.Tools.ApiXmlAdjuster.csproj
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/Xamarin.Android.Tools.ApiXmlAdjuster.csproj
@@ -49,6 +49,7 @@
     <Compile Include="JavaApiDefectFinderExtensions.cs" />
     <Compile Include="JavaTypeResolutionUtil.cs" />
     <Compile Include="JavaApiFixVisibilityExtensions.cs" />
+    <Compile Include="Log.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/tools/generator/ApiXmlAdjuster.cs
+++ b/tools/generator/ApiXmlAdjuster.cs
@@ -5,8 +5,21 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 {
 	public class Adjuster
 	{
-		public void Process (string inputXmlFile, GenBase [] gens, string outputXmlFile)
+		public void Process (string inputXmlFile, GenBase [] gens, string outputXmlFile, int reportVerbosity)
 		{
+			switch (reportVerbosity) {
+			case 0:
+				break;
+			case 1:
+				Log.Verbosity = Log.LoggingLevel.Error;
+				break;
+			case 2:
+				Log.Verbosity = Log.LoggingLevel.Warning;
+				break;
+			default:
+				Log.Verbosity = Log.LoggingLevel.Debug;
+				break;
+			}
 			var api = new JavaApi ();
 			api.LoadReferences (gens);
 			api.Load (inputXmlFile);

--- a/tools/generator/CodeGenerator.cs
+++ b/tools/generator/CodeGenerator.cs
@@ -282,7 +282,7 @@ namespace Xamarin.Android.Binder {
 			}
 			if (apiSourceAttr == "class-parse") {
 				apiXmlFile = api_xml_adjuster_output ?? Path.Combine (Path.GetDirectoryName (filename), Path.GetFileName (filename) + ".adjusted");
-				new Adjuster ().Process (filename, SymbolTable.AllRegisteredSymbols ().OfType<GenBase> ().ToArray (), apiXmlFile);
+				new Adjuster ().Process (filename, SymbolTable.AllRegisteredSymbols ().OfType<GenBase> ().ToArray (), apiXmlFile, Report.Verbosity ?? 0);
 			}
 			if (only_xml_adjuster)
 				return;


### PR DESCRIPTION
…ster.

ApiXmlAdjuster had been ignoring logging verbosity, but now it is time
to respect that at least from generator.

(mono xbuild does not appropriately implement some MSBuild logging API so
it will not be usable very soon until we switch to Microsoft/msbuild...)