### PR TITLE
[Xamarin.Android.Cecil] Fixups for chained MSBuild invocation

### DIFF
--- a/src/Xamarin.Android.Cecil/Xamarin.Android.Cecil.Mdb.csproj
+++ b/src/Xamarin.Android.Cecil/Xamarin.Android.Cecil.Mdb.csproj
@@ -11,18 +11,19 @@
     <AssemblyName>Xamarin.Android.Cecil.Mdb</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
   </PropertyGroup>
+  <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
+    <OutputPath>..\..\bin\Debug</OutputPath>
     <DefineConstants>DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release</OutputPath>
+    <OutputPath>..\..\bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/src/Xamarin.Android.Cecil/Xamarin.Android.Cecil.csproj
+++ b/src/Xamarin.Android.Cecil/Xamarin.Android.Cecil.csproj
@@ -11,18 +11,19 @@
     <AssemblyName>Xamarin.Android.Cecil</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
   </PropertyGroup>
+  <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
+    <OutputPath>..\..\bin\Debug</OutputPath>
     <DefineConstants>DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release</OutputPath>
+    <OutputPath>..\..\bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/src/Xamarin.Android.Cecil/Xamarin.Android.Cecil.targets
+++ b/src/Xamarin.Android.Cecil/Xamarin.Android.Cecil.targets
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <CecilDirectory>$(MSBuildThisFileDirectory)\..\..\external\cecil</CecilDirectory>
     <CecilPreparedFlag>prepared.flag</CecilPreparedFlag>
-    <OutputPath Condition="'$(OutputPath)' == ''">bin\$(Configuration)</OutputPath>
+    <OutputPath Condition=" '$(OutputPath)' == '' ">..\..\bin\$(Configuration)</OutputPath>
     <CecilOutputPath>$([System.IO.Path]::GetFullPath ('$(OutputPath)'))</CecilOutputPath>
     <CecilAssemblies>$(OutputPath)\Xamarin.Android.Cecil.dll;$(OutputPath)\Xamarin.Android.Cecil.Mdb.dll</CecilAssemblies>
   </PropertyGroup>
@@ -17,13 +17,19 @@
   <Target Name="BuildCecil"
       Inputs="$(CecilPreparedFlag)"
       Outputs="$(CecilAssemblies)" DependsOnTargets="PrepareCecil">
-    <Exec Command="cd $(CecilDirectory); patch -Ep1 &lt; $(MSBuildThisFileDirectory)\assembly-rename.patch" />
+    <Exec
+        Command="patch -Ep1 &lt; &quot;$(MSBuildThisFileDirectory)\assembly-rename.patch&quot;"
+        WorkingDirectory="$(CecilDirectory)"
+    />
     <MSBuild
-	Projects="$(CecilDirectory)\Mono.Cecil.csproj;$(CecilDirectory)\symbols\mdb\Mono.Cecil.Mdb.csproj"
-	Targets="Clean;Build"
-	StopOnFirstFailure="true"
-	Properties="Configuration=net_4_0_Debug;OutputPath=$(CecilOutputPath);BuildingSolutionFile=false" />
-    <Exec Command="cd $(CecilDirectory); patch -REp1 &lt; $(MSBuildThisFileDirectory)\assembly-rename.patch" />
+        Projects="$(CecilDirectory)\Mono.Cecil.csproj;$(CecilDirectory)\symbols\mdb\Mono.Cecil.Mdb.csproj"
+        Targets="Clean;Build"
+        StopOnFirstFailure="True"
+        Properties="Configuration=net_4_0_Debug;OutputPath=$(CecilOutputPath);BuildingSolutionFile=false" />
+    <Exec
+        Command="patch -REp1 &lt; &quot;$(MSBuildThisFileDirectory)\assembly-rename.patch&quot;"
+        WorkingDirectory="$(CecilDirectory)"
+    />
     <Touch Files="$(CecilAssemblies)" />
   </Target>
   <Target Name="Build" DependsOnTargets="BuildCecil" Returns="$(CecilOutputPath)\$(AssemblyName).dll">
@@ -31,6 +37,5 @@
   </Target>
   <Target Name="AfterClean">
     <Delete Files="$(CecilPreparedFlag)" />
-    <RemoveDir Directories="bin" />
   </Target>
 </Project>


### PR DESCRIPTION
Eventually -- sooner rather than later? -- we'd like to support
building xamarin-android using `msbuild` instead of `xbuild`.

Unfortunately, that doesn't work, for a variety of reasons.

Appropos to `Xamarin.Android.Cecil` is that if we, from a *clean*
state, build *just*
`xamarin-android/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj`
without a solution, the build fails because
`Xamarin.Android.Cecil.dll` and `Xamarin.Android.Cecil.Mdb.dll` cannot
be resolved or found, because they're copied into the wrong
directories.

Cleanup the `Xamarin.Android.Cecil` project files so that they
increase consistency with the other project files, e.g.
`$(OutputPath)` is `..\..\bin\$(Configuration)`, not
`bin\$(Configuration)`, which also allows a from-clean `msbuild`-based
build of `Xamarin.Android.Build.Tasks.csproj` to not be stopped when
attempting to build `Xamarin.Android.Cecil.dll`.