### PR TITLE
[Xamarin.Android.Tools.Bytecode] MethodParameters Attribute parsing

### DIFF
--- a/src/Xamarin.Android.Tools.Bytecode/Tests/IJavaInterface.xml
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/IJavaInterface.xml
@@ -50,7 +50,7 @@
         synthetic="false"
         jni-signature="(Ljava/lang/CharSequence;)Ljava/lang/Object;">
         <parameter
-          name="p0"
+          name="value"
           type="TString"
           jni-type="TTString;" />
       </method>

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/IJavaInterfaceTests.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/IJavaInterfaceTests.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 			new ExpectedTypeDeclaration {
 				MajorVersion        = 0x32,
 				MinorVersion        = 0,
-				ConstantPoolCount   = 21,
+				ConstantPoolCount   = 23,
 				AccessFlags         = ClassAccessFlags.Interface | ClassAccessFlags.Abstract,
 				FullName            = "com/xamarin/IJavaInterface",
 				Superclass          = new TypeInfo ("java/lang/Object", "Ljava/lang/Object;"),
@@ -61,7 +61,7 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 						ReturnDescriptor        = "Ljava/lang/Object;",
 						ReturnGenericDescriptor = "TTReturn;",
 						Parameters = {
-							new ParameterInfo ("p0",    "Ljava/lang/CharSequence;", "TTString;"),
+							new ParameterInfo ("value",     "Ljava/lang/CharSequence;", "TTString;"),
 						},
 					},
 				}

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/JavaEnumTests.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/JavaEnumTests.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 			new ExpectedTypeDeclaration {
 				MajorVersion        = 0x32,
 				MinorVersion        = 0,
-				ConstantPoolCount   = 50,
+				ConstantPoolCount   = 53,
 				AccessFlags         = ClassAccessFlags.Final | ClassAccessFlags.Super | ClassAccessFlags.Enum,
 				FullName            = "com/xamarin/JavaEnum",
 				Superclass          = new TypeInfo ("java/lang/Enum",   "Ljava/lang/Enum<Lcom/xamarin/JavaEnum;>;"),
@@ -62,8 +62,8 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 						AccessFlags             = MethodAccessFlags.Private,
 						ReturnDescriptor        = "V",
 						Parameters = {
-							new ParameterInfo ("p0", "Ljava/lang/String;",  "Ljava/lang/String;"),
-							new ParameterInfo ("p1", "I",                   "I"),
+							new ParameterInfo ("$enum$name",    "Ljava/lang/String;",  "Ljava/lang/String;"),
+							new ParameterInfo ("$enum$ordinal", "I",                   "I"),
 						},
 					},
 					new ExpectedMethodDeclaration {

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/JavaType$RNC$RPNC.xml
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/JavaType$RNC$RPNC.xml
@@ -68,7 +68,7 @@
         synthetic="false"
         jni-signature="(Ljava/lang/Object;)Ljava/lang/Object;">
         <parameter
-          name="p0"
+          name="value"
           type="E2"
           jni-type="TE2;" />
       </method>

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/JavaType$RNC.xml
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/JavaType$RNC.xml
@@ -64,7 +64,7 @@
         synthetic="false"
         jni-signature="(Ljava/lang/Object;)Ljava/lang/Object;">
         <parameter
-          name="p0"
+          name="value"
           type="E"
           jni-type="TE;" />
       </method>

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/JavaType.RNC.RPNCTests.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/JavaType.RNC.RPNCTests.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 			new ExpectedTypeDeclaration {
 				MajorVersion        = 0x32,
 				MinorVersion        = 0,
-				ConstantPoolCount   = 44,
+				ConstantPoolCount   = 46,
 				AccessFlags         = ClassAccessFlags.Public | ClassAccessFlags.Super | ClassAccessFlags.Abstract,
 				FullName            = "com/xamarin/JavaType$RNC$RPNC",
 				Superclass          = new TypeInfo ("java/lang/Object", "Ljava/lang/Object;"),
@@ -71,7 +71,7 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 						ReturnDescriptor        = "Ljava/lang/Object;",
 						ReturnGenericDescriptor = "TE3;",
 						Parameters = {
-							new ParameterInfo ("p0",    "Ljava/lang/Object;", "TE2;"),
+							new ParameterInfo ("value",     "Ljava/lang/Object;", "TE2;"),
 						},
 					},
 				}

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/JavaType.RNCTests.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/JavaType.RNCTests.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 			new ExpectedTypeDeclaration {
 				MajorVersion        = 0x32,
 				MinorVersion        = 0,
-				ConstantPoolCount   = 42,
+				ConstantPoolCount   = 44,
 				AccessFlags         = ClassAccessFlags.Public | ClassAccessFlags.Super | ClassAccessFlags.Abstract,
 				FullName            = "com/xamarin/JavaType$RNC",
 				Superclass          = new TypeInfo ("java/lang/Object", "Ljava/lang/Object;"),
@@ -70,7 +70,7 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 						ReturnDescriptor        = "Ljava/lang/Object;",
 						ReturnGenericDescriptor = "TE2;",
 						Parameters = {
-							new ParameterInfo ("p0",        "Ljava/lang/Object;",   "TE;"),
+							new ParameterInfo ("value",     "Ljava/lang/Object;",   "TE;"),
 						},
 					},
 				}

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/JavaType.xml
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/JavaType.xml
@@ -110,7 +110,7 @@
         synthetic="true"
         jni-signature="(Ljava/lang/Object;)I">
         <parameter
-          name="p0"
+          name="value"
           type="java.lang.Object"
           jni-type="Ljava/lang/Object;" />
       </method>
@@ -162,7 +162,7 @@
         synthetic="true"
         jni-signature="(Ljava/lang/CharSequence;)Ljava/lang/Object;">
         <parameter
-          name="p0"
+          name="value"
           type="java.lang.CharSequence"
           jni-type="Ljava/lang/CharSequence;" />
       </method>

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/JavaTypeTests.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/JavaTypeTests.cs
@@ -20,7 +20,7 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 			new ExpectedTypeDeclaration {
 				MajorVersion        = 0x32,
 				MinorVersion        = 0,
-				ConstantPoolCount   = 183,
+				ConstantPoolCount   = 184,
 				AccessFlags         = ClassAccessFlags.Public | ClassAccessFlags.Super,
 				FullName            = "com/xamarin/JavaType",
 				Superclass          = new TypeInfo ("java/lang/Object", "Ljava/lang/Object;"),
@@ -132,7 +132,7 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 						Name                = "STATIC_FINAL_STRING",
 						Descriptor          = "Ljava/lang/String;",
 						AccessFlags         = FieldAccessFlags.Public | FieldAccessFlags.Static | FieldAccessFlags.Final,
-						ConstantValue       = "String(stringIndex=175 Utf8=\"Hello, \\\"embedded\0Nulls\" and \ud83d\udca9!\")",
+						ConstantValue       = "String(stringIndex=176 Utf8=\"Hello, \\\"embedded\0Nulls\" and \ud83d\udca9!\")",
 					},
 					new ExpectedFieldDeclaration {
 						Name                = "STATIC_FINAL_BOOL_FALSE",
@@ -309,7 +309,7 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 						AccessFlags             = MethodAccessFlags.Public | MethodAccessFlags.Bridge | MethodAccessFlags.Synthetic,
 						ReturnDescriptor        = "I",
 						Parameters = {
-							new ParameterInfo ("p0", "Ljava/lang/Object;", "Ljava/lang/Object;"),
+							new ParameterInfo ("value", "Ljava/lang/Object;", "Ljava/lang/Object;"),
 						},
 					},
 					new ExpectedMethodDeclaration {
@@ -317,7 +317,7 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 						AccessFlags             = MethodAccessFlags.Public | MethodAccessFlags.Bridge | MethodAccessFlags.Synthetic,
 						ReturnDescriptor        = "Ljava/lang/Object;",
 						Parameters = {
-							new ParameterInfo ("p0", "Ljava/lang/CharSequence;",    "Ljava/lang/CharSequence;"),
+							new ParameterInfo ("value", "Ljava/lang/CharSequence;", "Ljava/lang/CharSequence;"),
 						},
 					},
 					new ExpectedMethodDeclaration {

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj
@@ -56,7 +56,13 @@
     <Compile Include="ParameterFixupTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <TestJar Include="java\**\*.java" />
+    <TestJar
+        Include="java\**\*.java"
+        Exclude="java\java\util\Collection.java"
+    />
+    <TestJarNoParameters
+        Include="java\java\util\Collection.java"
+    />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
@@ -67,7 +73,8 @@
   </PropertyGroup>
   <Target Name="BuildClasses" Inputs="@(TestJar)" Outputs="@(TestJar-&gt;'$(IntermediateOutputPath)classes\%(RecursiveDir)%(Filename).class')">
     <MakeDir Directories="$(IntermediateOutputPath)classes" />
-    <Exec Command="&quot;javac&quot; -source 1.5 -target 1.6 -g -d &quot;$(IntermediateOutputPath)classes&quot; @(TestJar -&gt; '%(Identity)', ' ')" />
+    <Exec Command="&quot;javac&quot; -parameters -source 1.5 -target 1.6 -g -d &quot;$(IntermediateOutputPath)classes&quot; @(TestJar->'%(Identity)', ' ')" />
+    <Exec Command="&quot;javac&quot; -source 1.5 -target 1.6 -g -d &quot;$(IntermediateOutputPath)classes&quot; @(TestJarNoParameters->'%(Identity)', ' ')" />
   </Target>
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Android.Tools.Bytecode.csproj">


### PR DESCRIPTION
Fixes: https://github.com/xamarin/java.interop/issues/106

Java 8 adds support for a `javac -parameters` option, which adds a
`MethodParameters` attribute to the `.class` file. The
`MethodParameters` attribute blob contains *reliable* parameter names,
including for abstract methods and interface methods, unlike existing
`LocalVariableTable`, which only exists for `javac -g` builds, and
only for methods with *bodies*, i.e. *not* abstract methods and
interface methods.

Add support for parsing the `MethodParameters` attribute blob.