### PR TITLE
ONGOING / [api-xml-adjuster] add external extensibility feature and "source identifier

### DIFF
--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApi.XmlModel.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApi.XmlModel.cs
@@ -12,6 +12,8 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			Packages = new List<JavaPackage> ();
 		}
 
+		partial void Initialize ();
+
 		public string ExtendedApiSource { get; set; }
 		public IList<JavaPackage> Packages { get; set; }
 	}
@@ -25,6 +27,8 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			Types = new List<JavaType> ();
 		}
 		
+		partial void Initialize ();
+
 		public JavaApi Parent { get; private set; }
 
 		public string Name { get; set; }
@@ -45,7 +49,11 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			
 			Implements = new List<JavaImplements> ();
 			Members = new List<JavaMember> ();
+
+			Initialize ();
 		}
+
+		partial void Initialize ();
 
 		public JavaPackage Parent { get; private set; }
 
@@ -81,8 +89,11 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		public JavaInterface (JavaPackage parent)
 			: base (parent)
 		{
+			Initialize ();
 		}
 		
+		partial void Initialize ();
+
 		// Content of this value is not stable.
 		public override string ToString ()
 		{
@@ -97,6 +108,8 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		{
 		}
 		
+		partial void Initialize ();
+
 		public string Extends { get; set; }
 		public string ExtendsGeneric { get; set; }
 		public string ExtendedJniExtends { get; set; }
@@ -109,7 +122,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 	}
 
 
-	class ManagedType : JavaType
+	partial class ManagedType : JavaType
 	{
 		static JavaPackage dummy_system_package, dummy_system_io_package, dummy_system_xml_package;
 		static JavaType system_object, system_exception, system_io_stream, system_xml_xmlreader;
@@ -139,7 +152,10 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 
 		public ManagedType (JavaPackage package) : base (package) 
 		{
+			Initialize ();
 		}
+
+		partial void Initialize ();
 	}
 
 
@@ -156,8 +172,11 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		protected JavaMember (JavaType parent)
 		{
 			Parent = parent;
+			Initialize ();
 		}
-		
+
+		partial void Initialize ();
+
 		public JavaType Parent { get; private set; }
 		
 		public string Deprecated { get; set; }
@@ -172,8 +191,11 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		public JavaField (JavaType parent)
 			: base (parent)
 		{
+			Initialize ();
 		}
 		
+		partial void Initialize ();
+
 		public bool Transient { get; set; }
 		public string Type { get; set; }
 		public string TypeGeneric { get; set; }
@@ -194,7 +216,10 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		{
 			Parameters = new List<JavaParameter> ();
 			Exceptions = new List<JavaException> ();
+			Initialize ();
 		}
+
+		partial void Initialize ();
 
 		public IList<JavaParameter> Parameters { get; set; }
 		public IList<JavaException> Exceptions { get; set; }
@@ -223,8 +248,11 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		public JavaConstructor (JavaType parent)
 			: base (parent)
 		{
+			Initialize ();
 		}
 		
+		partial void Initialize ();
+
 		// it was required in the original API XML, but removed in class-parsed...
 		public string Type { get; set; }
 		
@@ -242,6 +270,8 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		{
 		}
 		
+		partial void Initialize ();
+
 		public bool Abstract { get; set; }
 		public bool Native { get; set; }
 		public string Return { get; set; }

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApi.XmlModelExtensionObjects.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApi.XmlModelExtensionObjects.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Xamarin.Android.Tools.ApiXmlAdjuster
+{
+	public partial class JavaApi
+	{
+		public event Action<IJavaInfoItem> NewExtensibleCreated;
+
+		public void OnNewExtensibleCreated (IJavaInfoItem item)
+		{
+			if (NewExtensibleCreated != null)
+				NewExtensibleCreated (item);
+		}
+
+		Dictionary<IJavaInfoItem, IList<object>> extensions = new Dictionary<IJavaInfoItem, IList<object>> ();
+
+		IList<object> EnsureExtensionsListFor (IJavaInfoItem item)
+		{
+			IList<object> l;
+			if (!extensions.TryGetValue (item, out l)) {
+				l = new List<object> ();
+				extensions.Add (item, l);
+			}
+			return l;
+		}
+
+		public T GetExtension<T> (IJavaInfoItem item)
+		{
+			return EnsureExtensionsListFor (item).OfType<T> ().FirstOrDefault ();
+		}
+
+		public void SetExtension<T> (IJavaInfoItem item, T value)
+		{
+			var l = EnsureExtensionsListFor (item);
+			var existing = l.OfType<T> ();
+			if (existing is T)
+				l.Remove (existing);
+			l.Add (value);
+		}
+	}
+
+	public partial interface IJavaInfoItem
+	{
+		JavaApi Api { get; }
+	}
+
+	public static class IJavaInfoItemExtensions
+	{
+		public static T GetExtension<T> (this IJavaInfoItem item)
+		{
+			return item.Api.GetExtension<T> (item);
+		}
+
+		public static IJavaInfoItem SetExtension<T> (this IJavaInfoItem item, T value)
+		{
+			item.Api.SetExtension (item, value);
+			return item;
+		}
+	}
+
+	public partial class JavaPackage : IJavaInfoItem
+	{
+		JavaApi IJavaInfoItem.Api {
+			get {
+				return Parent;
+			}
+		}
+
+		partial void Initialize ()
+		{
+			((IJavaInfoItem) this).Api.OnNewExtensibleCreated (this);
+		}
+	}
+
+	public abstract partial class JavaType : IJavaInfoItem
+	{
+		public JavaApi Api {
+			get { return Parent.Parent; }
+		}
+
+		partial void Initialize ()
+		{
+			((IJavaInfoItem)this).Api.OnNewExtensibleCreated (this);
+		}
+	}
+
+	public partial class JavaMember : IJavaInfoItem
+	{
+		public JavaApi Api {
+			get { return Parent.Parent.Parent; }
+		}
+
+		partial void Initialize ()
+		{
+			((IJavaInfoItem)this).Api.OnNewExtensibleCreated (this);
+		}
+	}
+
+	public class SourceIdentifier
+	{
+		public SourceIdentifier (string sourceUri)
+		{
+			SourceUri = sourceUri;
+		}
+
+		public string SourceUri { get; set; }
+	}
+}

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApi.XmlModelExtensionObjects.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApi.XmlModelExtensionObjects.cs
@@ -7,11 +7,18 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 	public partial class JavaApi
 	{
 		public event Action<IJavaInfoItem> NewExtensibleCreated;
+		public event Action<IJavaInfoItem> ExistingExtensibleFoundOnLoad;
 
 		public void OnNewExtensibleCreated (IJavaInfoItem item)
 		{
 			if (NewExtensibleCreated != null)
 				NewExtensibleCreated (item);
+		}
+
+		public void OnExistingExtensibleFoundOnLoad (IJavaInfoItem existingItem)
+		{
+			if (ExistingExtensibleFoundOnLoad != null)
+				ExistingExtensibleFoundOnLoad (existingItem);
 		}
 
 		Dictionary<IJavaInfoItem, IList<object>> extensions = new Dictionary<IJavaInfoItem, IList<object>> ();

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/Xamarin.Android.Tools.ApiXmlAdjuster.csproj
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/Xamarin.Android.Tools.ApiXmlAdjuster.csproj
@@ -50,6 +50,7 @@
     <Compile Include="JavaTypeResolutionUtil.cs" />
     <Compile Include="JavaApiFixVisibilityExtensions.cs" />
     <Compile Include="Log.cs" />
+    <Compile Include="JavaApi.XmlModelExtensionObjects.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/XmlUtil.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/XmlUtil.cs
@@ -11,7 +11,9 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		static string GetLocation (XmlReader reader)
 		{
 			var li = reader as IXmlLineInfo;
-			return string.Format ("{0} ({1},{2})", new Uri (reader.BaseURI).LocalPath, li.LineNumber, li.LinePosition);
+			Uri uri;
+			// Uri.TryCreate() with UriKind.RelativeOrAbsolute results in "relative Uri not supported" !?
+			return string.Format ("{0} ({1},{2})", Uri.TryCreate (reader.BaseURI, UriKind.Absolute, out uri) ? uri.LocalPath : string.Empty, li.LineNumber, li.LinePosition);
 		}
 		
 		public static Exception UnexpectedElementOrContent (string elementName, XmlReader reader, params string [] expected)


### PR DESCRIPTION
This extensibility and SourceIdentifier extension can be used by external
API toolchain later.

For source cleanliness, extensibility support is done in partial methods.