### PR TITLE
Support building with `msbuild`

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ on the command line or by specifying MSBuild properties to control behavior.
 The following **make**(1) variables may be specified:
 
 * `$(CONFIGURATION)`: The product configuration to build, and corresponds
-    to the `$(Configuration)` MSBuild property when running `$(XBUILD)`.
+    to the `$(Configuration)` MSBuild property when running `$(MSBUILD)`.
     Valid values are `Debug` and `Release`. Default value is `Debug`.
 * `$(RUNTIME)`: The managed runtime to use to execute utilities, tests.
     Default value is `mono64` if present in `$PATH`, otherwise `mono`.
@@ -85,9 +85,9 @@ The following **make**(1) variables may be specified:
 
         make run-tests TESTS=bin/Debug/Java.Interop.Dynamic-Tests.dll
 
-* `$(V)`: If set to a non-empty string, adds `/v:diag` to `$(XBUILD)`
+* `$(V)`: If set to a non-empty string, adds `/v:diag` to `$(MSBUILD_FLAGS)`
     invocations.
-* `$(XBUILD)`: The MSBuild build tool to execute for builds.
+* `$(MSBUILD)`: The MSBuild build tool to execute for builds.
     Default value is `xbuild`.
 
 

--- a/build-tools/scripts/mono.mk
+++ b/build-tools/scripts/mono.mk
@@ -5,6 +5,7 @@
 #
 #   $(OS): Optional; **uname**(1) value of the host operating system
 #   $(CONFIGURATION): Build configuration name, e.g. Debug or Release
+#   $(V): Output verbosity. If != 0, then `MONO_OPTIONS` is exported with --debug.
 #
 # Outputs:
 #
@@ -26,6 +27,14 @@
 
 OS            ?= $(shell uname)
 RUNTIME       := $(shell if [ -f "`which mono64`" ] ; then echo mono64 ; else echo mono; fi) --debug=casts
+
+ifneq ($(V),0)
+MONO_OPTIONS  += --debug
+endif   # $(V) != 0
+
+ifneq ($(MONO_OPTIONS),)
+export MONO_OPTIONS
+endif   # $(MONO_OPTIONS) != ''
 
 ifeq ($(OS),Darwin)
 JI_MONO_FRAMEWORK_PATH = /Library/Frameworks/Mono.framework/Libraries/libmonosgen-2.0.1.dylib

--- a/build-tools/scripts/msbuild.mk
+++ b/build-tools/scripts/msbuild.mk
@@ -1,0 +1,29 @@
+#
+# MSBuild Abstraction.
+#
+# Makefile targets which need to invoke MSBuild should use `$(MSBUILD)`,
+# not some specific MSBuild program such as `xbuild` or `msbuild`.
+#
+# Typical use will also include `$(MSBUILD_FLAGS)`, which provides the
+# Configuration and logging verbosity, as per $(CONFIGURATION) and $(V):
+#
+#   $(MSBUILD) $(MSBUILD_FLAGS) path/to/Project.csproj
+#
+# Inputs:
+#
+#   $(CONFIGURATION): Build configuration name, e.g. Debug or Release
+#   $(MSBUILD): The MSBuild program to use.
+#   $(MSBUILD_ARGS): Extra arguments to pass to $(MSBUILD); embedded into $(MSBUILD_FLAGS)
+#   $(V): Build verbosity
+#
+# Outputs:
+#
+#   $(MSBUILD): The MSBuild program to use. Defaults to `xbuild` unless overridden.
+#   $(MSBUILD_FLAGS): Additional MSBuild flags; contains $(CONFIGURATION), $(V), $(MSBUILD_ARGS).
+
+MSBUILD       = xbuild
+MSBUILD_FLAGS = /p:Configuration=$(CONFIGURATION) $(MSBUILD_ARGS)
+
+ifneq ($(V),0)
+MSBUILD_FLAGS += /v:d
+endif   # $(V) != 0

--- a/src/Xamarin.Android.Cecil/Xamarin.Android.Cecil.targets
+++ b/src/Xamarin.Android.Cecil/Xamarin.Android.Cecil.targets
@@ -3,8 +3,9 @@
   <PropertyGroup>
     <CecilDirectory>$(MSBuildThisFileDirectory)\..\..\external\cecil</CecilDirectory>
     <CecilPreparedFlag>prepared.flag</CecilPreparedFlag>
-    <OutputPath Condition=" '$(OutputPath)' == '' ">$(MSBuildThisFileDirectory)\..\..\bin\$(Configuration)</OutputPath>
-    <CecilOutputPath>$([System.IO.Path]::GetFullPath ('$(OutputPath)'))</CecilOutputPath>
+    <OutputPath Condition=" '$(OutputPath)' == '' ">..\..\bin\$(Configuration)</OutputPath>
+    <CecilOutputPath>$([System.IO.Path]::Combine ($(MSBuildThisFileDirectory), $(OutputPath)))</CecilOutputPath>
+    <CecilOutputPath>$([System.IO.Path]::GetFullPath ($(CecilOutputPath)))</CecilOutputPath>
     <CecilAssemblies>$(OutputPath)\Xamarin.Android.Cecil.dll;$(OutputPath)\Xamarin.Android.Cecil.Mdb.dll</CecilAssemblies>
   </PropertyGroup>
   <Target Name="PrepareCecil"

--- a/src/java-interop/java-interop.mdproj
+++ b/src/java-interop/java-interop.mdproj
@@ -81,7 +81,7 @@
       Inputs="@(Compile)"
       Outputs="@(MacLibLipo)">
     <PropertyGroup>
-      <_FixedDefines>$(DefineSymbols.Replace(' ', ';'))</_FixedDefines>
+      <_FixedDefines>$(DefineSymbols.Split(' '))</_FixedDefines>
     </PropertyGroup>
     <ItemGroup>
       <_Defines Include="$(_FixedDefines)" />

--- a/tests/invocation-overhead/Makefile
+++ b/tests/invocation-overhead/Makefile
@@ -9,9 +9,10 @@ clean:
 
 include ../../build-tools/scripts/mono.mk
 include ../../build-tools/scripts/jdk.mk
+include ../../build-tools/scripts/msbuild.mk
 
 $(JNIENV_GEN):
-	(cd ../../build-tools/jnienv-gen ; xbuild /p:Configuration=$(CONFIGURATION))
+	(cd ../../build-tools/jnienv-gen ; $(MSBUILD) $(MSBUILD_FLAGS) )
 
 HANDLE_FEATURES = \
 	-d:FEATURE_JNIENVIRONMENT_JI_INTPTRS \


### PR DESCRIPTION
MSBuild is open source -- has been for ages -- and we'd *really* like
to migrate all things Mono to MSBuild and deprecate/remove `xbuild`.

Which means we need to ensure that all of our products build with
`msbuild`. [Which unfortunately isn't the case in `Java.Interop`][0]:

	MSB3375: The file "../../bin/Release/Xamarin.Android.Cecil.dll" does not exist.
	...
	Java.Interop/MarshalMemberBuilder.cs(9,20): error CS0234:
	The type or namespace name `Expressions' does not exist in the namespace `Java.Interop'. Are you missing an assembly reference?
	...
	    36 Warning(s)
	    69 Error(s)

For starters, bring Java.Interop into aligntment/convention with the
[`xamarin-android` repo][1], so that `$(MSBUILD)` is the Make variable
to specify the MSBuild engine to use, not `$(XBUILD)`, and allow
`$(V)` to set `$MONO_OPTIONS` so that line numbers are included in
stack traces from mono.

Which brings us to the build errors. The MSB3375 error happens when
building e.g. `Xamarin.Android.Cecil.csproj` from another directory:

	$ msbuild src/Xamarin.Android.Cecil/Xamarin.Android.Cecil.csproj
	...
	.../src/Xamarin.Android.Cecil/Xamarin.Android.Cecil.targets(33,5):
	error MSB3375: The file "../../bin/Debug/Xamarin.Android.Cecil.dll" does not exist.
	...

The cause, in turn, is because the nested `<MSBuild/>` invocation
overrides `$(OutputPath)` when building
`external/Cecil/Mono.Cecil.csproj` to be
*`Xamarin.Android.Cecil.csproj`'s* `$(OutputPath)`:

	<PropertyGroup>
	  <CecilOutputPath>$([System.IO.Path]::GetFullPath ('$(OutputPath)'))</CecilOutputPath>
	</PropertyGroup>
	<MSBuild
	    Properties="OutputPath=$(CecilOutputPath)"
	    ...
	/>

Or rather, it *tries* to. It uses `Path.GetFullPath()` on
`$(OutputPath)` so that `Mono.Cecil.csproj` writes the assembly into
the expected `Xamarin.Android.Cecil.csproj`-specified directory. The
problem is that the `Path.GetFullPath()` call is relative to the
*current working directory*, so when:

1. The current working directory isn't the same directory as the
    directory containing `Xamarin.Android.Cecil.csproj`, and
2. We're building `Xamarin.Android.Cecil.csproj`, which defines
    `$(OutputPath)` as e.g. `..\..\Debug`

(1) and (2) interplay so that `$(CecilOutputPath)` becomes e.g.
`$CWD/../../bin/Debug`, which is *not* the correct directory, and may
(will!) be outside of the repo checkout directory.

Modify the `$(CecilOutputPath)` definition so that it instead assumes
that `$(OutputPath)` is a directory *relative to*
`$(MSBuildThisFileDirectory)`, equivalent to C#:

	var OutputPath                = ...
	var MSBuildThisFileDirectory  = ...

	var CecilOutputPath = Path.Combine (MSBuildThisFileDirectory, OutputPath);
	CecilOutputPath     = Path.GetFullPath (CecilOutputPath);

This fixes the above interplay by "inserting" use of
`$(MSBuildThisFileDirectory)` into the "normal"
`msbuild Xamarin.Android.Cecil.csproj` invocation path, ensuring that
output paths behave as expected.

This in turn allows `Xamarin.Android.Cecil.dll` to be placed into the
correct directory, which in turn fixes all of the other C# errors
(present apparently because `Xamarin.Android.Cecil.dll` couldn't be
resolved).

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/Java.Interop-msbuild/5/consoleText
[1]: https://github.com/xamarin/xamarin-android