### PR TITLE
[generator] remove extra warnings on missing methods for api-versions check.

### DIFF
--- a/tools/generator/ApiVersionsSupport.cs
+++ b/tools/generator/ApiVersionsSupport.cs
@@ -38,9 +38,6 @@ namespace MonoDroid.Generation
 					// it might be moved to the corresponding class. 
 					if (genf != null)
 						genf.ApiAvailableSince = field.Since > 0 ? field.Since : type.Since;
-					// commenting out this, because there are too many enum-mapped fields (removed).
-					//else
-					//	Console.Error.WriteLine ("!!!!! In type {0}, field {1} not found.", type.Name, field.Name);
 				}
 				Func<Method,ApiVersionsProvider.Definition,bool> methodMatch =
 					(m, method) => m.JavaName == method.MethodName && m.JniSignature == method.Name.Substring (method.MethodName.Length);
@@ -52,9 +49,6 @@ namespace MonoDroid.Generation
 						matchedGens.SelectMany (g => GetAllMethods (g)).FirstOrDefault (m => methodMatch (m, method));
 					if (genm != null)
 						genm.ApiAvailableSince = method.Since > 0 ? method.Since : type.Since;
-					// there are several "missing" stuff from android.test packages (unbound yet).
-					else if (!type.Name.StartsWith ("android.test") && method.Since <= currentApiLevel)
-						Report.Warning (0, Report.WarningAnnotationsProvider, " api-versions.xml mensions type {0}, methodbase {1}, but not found.", type.Name, method.Name);
 				}
 			}
 		}

--- a/tools/generator/CodeGenerator.cs
+++ b/tools/generator/CodeGenerator.cs
@@ -318,7 +318,7 @@ namespace Xamarin.Android.Binder {
 			Validate (gens, opt);
 
 			if (api_versions_xml != null)
-				ApiVersionsSupport.AssignApiLevels (gens, api_versions_xml, api_level);
+				ApiVersionsSupport.AssignApiLevels (gens, api_versions_xml);
 
 			foreach (GenBase gen in gens)
 				gen.FillProperties ();


### PR DESCRIPTION
When we fill [Available (ApiSince = x)] we load api-versions.xml and
checks if the mentioned Java member exists. But there are cases that
those members should not really exist (e.g. we merge API while we don't
for api-versions - we simply can't, there is no per-level api-versions).

Missing members should be checked elsewhere, not here, so remove those
extraneous (and mostly spurious) warnings.