### PR TITLE
[api-xml-adjuster] further fix on generic nested type name parsing.

### DIFF
--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiTypeResolverExtensions.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiTypeResolverExtensions.cs
@@ -18,15 +18,15 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			var tn = JavaTypeName.Parse (name);
 			return JavaTypeNameToReference (api, tn, contextTypeParameters);
 		}
-		
+
 		static JavaTypeReference JavaTypeNameToReference (this JavaApi api, JavaTypeName tn, params JavaTypeParameters [] contextTypeParameters)
 		{
-			var tp = contextTypeParameters.Where (tps => tps != null).SelectMany (tps => tps.TypeParameters).FirstOrDefault (_ => _.Name == tn.FullNameNonGeneric);
+			var tp = contextTypeParameters.Where (tps => tps != null).SelectMany (tps => tps.TypeParameters).FirstOrDefault (_ => _.Name == tn.DottedName);
 			if (tp != null)
 				return new JavaTypeReference (tp, tn.ArrayPart);
-			if (tn.FullNameNonGeneric == JavaTypeReference.GenericWildcard.SpecialName)
+			if (tn.DottedName == JavaTypeReference.GenericWildcard.SpecialName)
 				return new JavaTypeReference (tn.BoundsType, tn.GenericConstraints?.Select (gc => JavaTypeNameToReference (api, gc, contextTypeParameters)), tn.ArrayPart);
-			var primitive = JavaTypeReference.GetSpecialType (tn.FullNameNonGeneric);
+			var primitive = JavaTypeReference.GetSpecialType (tn.DottedName);
 			if (primitive != null)
 				return tn.ArrayPart == null && tn.GenericConstraints == null ? primitive : new JavaTypeReference (primitive, tn.ArrayPart, tn.BoundsType, tn.GenericConstraints?.Select (gc => JavaTypeNameToReference (api, gc, contextTypeParameters)));
 			var type = api.FindNonGenericType (tn.FullNameNonGeneric);

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/Tests/JavaApiTest.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/Tests/JavaApiTest.cs
@@ -42,6 +42,22 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster.Tests
 			Assert.AreEqual (1, ga2.GenericConstraints.Count, "genarg#1 incorrect number of parsed generic constraints");
 			Assert.AreEqual ("U", ga2.GenericConstraints [0].FullNameNonGeneric, "genarg#1.1 constraint name mismatch");
 		}
+
+		[Test]
+		public void ParseName2 ()
+		{
+			string name = "com.good.gd.ndkproxy.auth.GDFingerprintAuthenticationManager.a<com.good.gd.ndkproxy.auth.c.a>.b<com.good.gd.ndkproxy.auth.d.a>";
+			var tn = JavaTypeName.Parse (name);
+			Assert.IsTrue (tn.GenericParent != null, "result has generic parent");
+			Assert.AreEqual ("b", tn.DottedName, "result name mismatch");
+			Assert.AreEqual ("com.good.gd.ndkproxy.auth.GDFingerprintAuthenticationManager.a.b", tn.FullNameNonGeneric, "failed to parse name");
+			Assert.AreEqual (1, tn.GenericArguments.Count, "result genparams count mismatch");
+			Assert.AreEqual ("com.good.gd.ndkproxy.auth.d.a", tn.GenericArguments [0].FullNameNonGeneric, "result genarg name mismatch");
+			var p = tn.GenericParent;
+			Assert.AreEqual (1, p.GenericArguments.Count, "top genparams count");
+			var ga1 = p.GenericArguments [0];
+			Assert.AreEqual ("com.good.gd.ndkproxy.auth.c.a", ga1.FullNameNonGeneric, "top genarg name mismatch");
+		}
 	}
 }
 


### PR DESCRIPTION
We have fixed nested generic type name crashes[*1] at 769f9444, but
that was only to fix the crash. The resulting type name was not parsed
correctly - namely, the resulting type name dropped the remainings after
the first generic arguments list i.e. in `A<b>.C<d>`, `.C<d>` part had
dropped.

The cause of the problem is somewhat deep, as JavaTypeName and
JavaTypeReference do not consider the possibility that both the nested
generic parent and child have generic arguments.

Anyhow in JavaTypeName now we store the expected information, by
having (hacky) `GenericParent` property to store the expected information.

Now it comes with a test so that it should prove the purpose of the change.

[*1] https://bugzilla.xamarin.com/show_bug.cgi?id=46344