### PR TITLE
[generator] strip fields and methods that have '$' in the name.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,21 +161,23 @@ run-test-jnimarshal: bin/Test$(CONFIGURATION)/Java.Interop.Export-Tests.dll bin/
 
 GENERATOR_EXPECTED_TARGETS  = tools/generator/Tests/expected.targets
 
-# $(call GEN_CORE_OUTPUT, outdir)
+# $(call GEN_CORE_OUTPUT, outdir, suffix, extra)
 define GEN_CORE_OUTPUT
 	-$(RM) -Rf $(1)
 	mkdir -p $(1)
-	$(RUNTIME) bin/Test$(CONFIGURATION)/generator.exe -o $(1) $(2) --api-level=20 tools/generator/Tests-Core/api.xml \
-		--enummethods=tools/generator/Tests-Core/methods.xml \
-		--enumfields=tools/generator/Tests-Core/fields.xml \
+	$(RUNTIME) bin/Test$(CONFIGURATION)/generator.exe -o $(1) $(3) --api-level=20 tools/generator/Tests-Core/api$(2).xml \
+		--enummethods=tools/generator/Tests-Core/methods$(2).xml \
+		--enumfields=tools/generator/Tests-Core/fields$(2).xml \
 		--enumdir=$(1)
 endef
 
 run-test-generator-core: bin/Test$(CONFIGURATION)/generator.exe
 	$(call GEN_CORE_OUTPUT,bin/Test$(CONFIGURATION)/generator-core)
 	diff -rup tools/generator/Tests-Core/expected bin/Test$(CONFIGURATION)/generator-core
-	$(call GEN_CORE_OUTPUT,bin/Test$(CONFIGURATION)/generator-core,--codegen-target=JavaInterop1)
+	$(call GEN_CORE_OUTPUT,bin/Test$(CONFIGURATION)/generator-core,,--codegen-target=JavaInterop1)
 	diff -rup tools/generator/Tests-Core/expected.ji bin/Test$(CONFIGURATION)/generator-core
+	$(call GEN_CORE_OUTPUT,bin/Test$(CONFIGURATION)/generator-core,-cp)
+	diff -rup tools/generator/Tests-Core/expected.cp bin/Test$(CONFIGURATION)/generator-core
 
 bin/Test$(CONFIGURATION)/generator.exe: bin/$(CONFIGURATION)/generator.exe
 	cp $<* `dirname "$@"`

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiNonBindableStripper.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiNonBindableStripper.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Xamarin.Android.Tools.ApiXmlAdjuster
+{
+	public static class JavaApiNonBindableStripper
+	{
+		public static void StripNonBindables (this JavaApi api)
+		{
+			var invalids = new List<JavaMember> ();
+			foreach (var member in api.Packages.SelectMany (p => p.Types)
+			         .SelectMany (t => t.Members).Where (m => m.Name != null && m.Name.Contains ('$')))
+				invalids.Add (member);
+			foreach (var invalid in invalids)
+				invalid.Parent.Members.Remove (invalid);
+		}
+	}
+}

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/Xamarin.Android.Tools.ApiXmlAdjuster.csproj
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/Xamarin.Android.Tools.ApiXmlAdjuster.csproj
@@ -42,6 +42,7 @@
     <Compile Include="JavaApiTypeResolverExtensions.cs" />
     <Compile Include="JavaApiOverrideMarkerExtensions.cs" />
     <Compile Include="JavaApiGeneralExtensions.cs" />
+    <Compile Include="JavaApiNonBindableStripper.cs" />
     <Compile Include="JavaApi.RelationAnalysisModel.cs" />
     <Compile Include="JavaTypeReference.cs" />
     <Compile Include="JavaApiGenericInheritanceMapperExtensions.cs" />

--- a/tools/generator/ApiXmlAdjuster.cs
+++ b/tools/generator/ApiXmlAdjuster.cs
@@ -23,6 +23,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			var api = new JavaApi ();
 			api.LoadReferences (gens);
 			api.Load (inputXmlFile);
+			api.StripNonBindables ();
 			api.Resolve ();
 			api.CreateGenericInheritanceMapping ();
 			api.MarkOverrides ();

--- a/tools/generator/Tests-Core/api-cp.xml
+++ b/tools/generator/Tests-Core/api-cp.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<api api-source="class-parse">
+  <package name="java.lang">
+    <class abstract="false" deprecated="not deprecated" final="false" name="Object" static="false" visibility="public">
+    </class>
+  </package>
+  <package name="xamarin.test.invalidnames">
+    <class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="false" name="InvalidNameMembers" static="false" visibility="public">
+      <field deprecated="not deprecated" final="true" name="INVALID_$CONSTANT" static="true" transient="false" type="int" type-generic-aware="int" value="1" visibility="public" volatile="false">
+      </field>
+      <field deprecated="not deprecated" final="true" name="INVALID_$FIELD" static="false" transient="false" type="int" type-generic-aware="int" visibility="public" volatile="false">
+      </field>
+      <method abstract="false" deprecated="not deprecated" final="false" name="invalid$name" native="false" return="int" static="false" synchronized="false" visibility="public">
+      </method>
+    </class>
+  </package>
+</api>
+

--- a/tools/generator/Tests-Core/expected.cp/GeneratedFiles.projitems
+++ b/tools/generator/Tests-Core/expected.cp/GeneratedFiles.projitems
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);ANDROID_1;ANDROID_2;ANDROID_3;ANDROID_4;ANDROID_5;ANDROID_6;ANDROID_7;ANDROID_8;ANDROID_9;ANDROID_10;ANDROID_11;ANDROID_12;ANDROID_13;ANDROID_14;ANDROID_15;ANDROID_16;ANDROID_17;ANDROID_18;ANDROID_19;ANDROID_20</DefineConstants>
+  </PropertyGroup>
+  <!-- Classes -->
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.Invalidnames.InvalidNameMembers.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+  </ItemGroup>
+  <!-- Enums -->
+  <ItemGroup />
+</Project>

--- a/tools/generator/Tests-Core/expected.cp/Java.Interop.__TypeRegistrations.cs
+++ b/tools/generator/Tests-Core/expected.cp/Java.Interop.__TypeRegistrations.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Java.Interop {
+
+	partial class __TypeRegistrations {
+
+		public static void RegisterPackages ()
+		{
+#if MONODROID_TIMING
+			var start = DateTime.Now;
+			Android.Util.Log.Info ("MonoDroid-Timing", "RegisterPackages start: " + (start - new DateTime (1970, 1, 1)).TotalMilliseconds);
+#endif // def MONODROID_TIMING
+			Java.Interop.TypeManager.RegisterPackages (
+					new string[]{
+					},
+					new Converter<string, Type>[]{
+					});
+#if MONODROID_TIMING
+			var end = DateTime.Now;
+			Android.Util.Log.Info ("MonoDroid-Timing", "RegisterPackages time: " + (end - new DateTime (1970, 1, 1)).TotalMilliseconds + " [elapsed: " + (end - start).TotalMilliseconds + " ms]");
+#endif // def MONODROID_TIMING
+		}
+
+		static Type Lookup (string[] mappings, string javaType)
+		{
+			string managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
+			if (managedType == null)
+				return null;
+			return Type.GetType (managedType);
+		}
+	}
+}

--- a/tools/generator/Tests-Core/expected.cp/Java.Lang.Object.cs
+++ b/tools/generator/Tests-Core/expected.cp/Java.Lang.Object.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Java.Lang {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
+	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
+	public partial class Object  {
+
+	}
+}

--- a/tools/generator/Tests-Core/expected.cp/Xamarin.Test.Invalidnames.InvalidNameMembers.cs
+++ b/tools/generator/Tests-Core/expected.cp/Xamarin.Test.Invalidnames.InvalidNameMembers.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Xamarin.Test.Invalidnames {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test.invalidnames']/class[@name='InvalidNameMembers']"
+	[global::Android.Runtime.Register ("xamarin/test/invalidnames/InvalidNameMembers", DoNotGenerateAcw=true)]
+	public partial class InvalidNameMembers : Java.Lang.Object {
+
+		protected InvalidNameMembers (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+	}
+}

--- a/tools/generator/Tests-Core/expected.cp/__NamespaceMapping__.cs
+++ b/tools/generator/Tests-Core/expected.cp/__NamespaceMapping__.cs
@@ -1,0 +1,2 @@
+[assembly:global::Android.Runtime.NamespaceMapping (Java = "java.lang", Managed="Java.Lang")]
+[assembly:global::Android.Runtime.NamespaceMapping (Java = "xamarin.test.invalidnames", Managed="Xamarin.Test.Invalidnames")]

--- a/tools/generator/Tests-Core/fields-cp.xml
+++ b/tools/generator/Tests-Core/fields-cp.xml
@@ -1,0 +1,3 @@
+<enum-field-mappings>
+</enum-field-mappings>
+

--- a/tools/generator/Tests-Core/methods-cp.xml
+++ b/tools/generator/Tests-Core/methods-cp.xml
@@ -1,0 +1,3 @@
+<enum-method-mappings>
+</enum-method-mappings>
+


### PR DESCRIPTION
Related: https://bugzilla.xamarin.com/show_bug.cgi?id=46344#c12

class-parse has brought another problem; it generates fields and methods
that are compiler-generated and should not have been written to XML
in the first place.

class-parse has no idea on how to deal with them, so kill them in
api-xml-adjuster instead.