### PR TITLE
[generator] less aggressive obfuscation marking.

### DIFF
--- a/tools/generator/Tests-Core/api-cp.xml
+++ b/tools/generator/Tests-Core/api-cp.xml
@@ -3,6 +3,8 @@
   <package name="java.lang">
     <class abstract="false" deprecated="not deprecated" final="false" name="Object" static="false" visibility="public">
     </class>
+    <class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="false" name="String" static="false" visibility="public">
+    </class>
   </package>
   <package name="xamarin.test.invalidnames">
     <class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="false" name="InvalidNameMembers" static="false" visibility="public">
@@ -12,6 +14,12 @@
       </field>
       <method abstract="false" deprecated="not deprecated" final="false" name="invalid$name" native="false" return="int" static="false" synchronized="false" visibility="public">
       </method>
+    </class>
+    <class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="false" name="a" static="false" visibility="public">
+    </class>
+    <class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="false" name="in" static="false" visibility="public">
+    </class>
+    <class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="false" name="zzTop" static="false" visibility="public">
     </class>
   </package>
 </api>

--- a/tools/generator/Tests-Core/expected.cp/GeneratedFiles.projitems
+++ b/tools/generator/Tests-Core/expected.cp/GeneratedFiles.projitems
@@ -7,6 +7,8 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.String.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.Invalidnames.In.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.Invalidnames.InvalidNameMembers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
   </ItemGroup>

--- a/tools/generator/Tests-Core/expected.cp/Java.Interop.__TypeRegistrations.cs
+++ b/tools/generator/Tests-Core/expected.cp/Java.Interop.__TypeRegistrations.cs
@@ -14,8 +14,10 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 			Java.Interop.TypeManager.RegisterPackages (
 					new string[]{
+						"xamarin/test/invalidnames",
 					},
 					new Converter<string, Type>[]{
+						lookup_xamarin_test_invalidnames_package,
 					});
 #if MONODROID_TIMING
 			var end = DateTime.Now;
@@ -29,6 +31,18 @@ namespace Java.Interop {
 			if (managedType == null)
 				return null;
 			return Type.GetType (managedType);
+		}
+
+		static string[] package_xamarin_test_invalidnames_mappings;
+		static Type lookup_xamarin_test_invalidnames_package (string klass)
+		{
+			if (package_xamarin_test_invalidnames_mappings == null) {
+				package_xamarin_test_invalidnames_mappings = new string[]{
+					"xamarin/test/invalidnames/in:Xamarin.Test.Invalidnames.In",
+				};
+			}
+
+			return Lookup (package_xamarin_test_invalidnames_mappings, klass);
 		}
 	}
 }

--- a/tools/generator/Tests-Core/expected.cp/Java.Lang.String.cs
+++ b/tools/generator/Tests-Core/expected.cp/Java.Lang.String.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Java.Lang {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='String']"
+	[global::Android.Runtime.Register ("java/lang/String", DoNotGenerateAcw=true)]
+	public partial class String : Java.Lang.Object {
+
+		protected String (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+	}
+}

--- a/tools/generator/Tests-Core/expected.cp/Xamarin.Test.Invalidnames.In.cs
+++ b/tools/generator/Tests-Core/expected.cp/Xamarin.Test.Invalidnames.In.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Xamarin.Test.Invalidnames {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test.invalidnames']/class[@name='in']"
+	[global::Android.Runtime.Register ("xamarin/test/invalidnames/in", DoNotGenerateAcw=true)]
+	public partial class In : Java.Lang.Object {
+
+		protected In (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+	}
+}


### PR DESCRIPTION
This is a fixup for c51469e, as well as bugfix for:
https://bugzilla.xamarin.com/show_bug.cgi?id=51337

What's happening behind bug #51337 was this:

	BINDINGSGENERATOR:  warning BG8800: Unknown parameter
	type org.osmdroid.ResourceProxy.bitmap in method GetBitmap
	in managed type OsmDroid.DefaultResourceProxyImpl.

This was, because, "bitmap" is all lowercased and was marked as obfuscated
(because, WHY NAME A CLASS ALL IN LOWERCASE!?).

Such classes should not exist, or should be marked as "obfuscated='false'".

However what bug #51337 implies is that people are not going to make
this additional markup for generator improvements.

What this generator change does is then - a hack. A hack to mark "classes
with very short names" as obfuscated, instead of "all lowercase or number".

As commented on c51469e, there isn't good way to check API element
siblings (it can check sibling names every time at all expensive
calculation). So we just count the sibling nodes and if name length is
short enough to fit within the number of classes, we mark as obfucated.