### PR TITLE
Bump to cecil/cycle9/2b39856e

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,4 @@
 [submodule "external/cecil"]
 	path = external/cecil
 	url = https://github.com/mono/cecil.git
+	branch = cycle9


### PR DESCRIPTION
Xamarin.Android 7.1 ("Cycle 9") needs to use cecil/cycle9 for
consistency with other products (e.g. Mono).

Bump the commit refs accordingly.