### PR TITLE
[generator] add [IntDefinition (JniField = ...)] everywhere.

### DIFF
--- a/tools/generator/EnumMappings.cs
+++ b/tools/generator/EnumMappings.cs
@@ -152,8 +152,7 @@ namespace MonoDroid.Generation {
 
 					foreach (var member in enu.Value.Members) {
 						var managedMember = FindManagedMember (ns, enoom, enu.Value, member.Key, gens);
-						if (managedMember != null)
-							sw.WriteLine ("    [global::Android.Runtime.IntDefinition (\"" + managedMember + "\")]");
+						sw.WriteLine ("    [global::Android.Runtime.IntDefinition (" + (managedMember != null? "\"" + managedMember + "\"" : "null") + ", JniField = \"" + StripExtraInterfaceSpec (enu.Value.JniNames [member.Key]) + "\")]");
 						sw.WriteLine ("    {0} = {1},", member.Key.Trim (), member.Value.Trim ());
 					}
 					sw.WriteLine ("  }");
@@ -161,6 +160,11 @@ namespace MonoDroid.Generation {
 				}
 			}
 			return files;
+		}
+
+		string StripExtraInterfaceSpec (string jniFieldSpec)
+		{
+			return jniFieldSpec.StartsWith ("I:", StringComparison.Ordinal) ? jniFieldSpec.Substring (2) : jniFieldSpec;
 		}
 
 		string FindManagedMember (string ns, string enumName, EnumDescription desc, string enumFieldName, IEnumerable<GenBase> gens)

--- a/tools/generator/Tests-Core/expected.ji/Android.Text.SpanTypes.cs
+++ b/tools/generator/Tests-Core/expected.ji/Android.Text.SpanTypes.cs
@@ -1,5 +1,6 @@
 namespace Android.Text {
   public enum SpanTypes {
+    [global::Android.Runtime.IntDefinition (null, JniField = "android/text/Spanned.SPAN_COMPOSING")]
     Composing = 256,
   }
 }

--- a/tools/generator/Tests-Core/expected/Android.Text.SpanTypes.cs
+++ b/tools/generator/Tests-Core/expected/Android.Text.SpanTypes.cs
@@ -1,5 +1,6 @@
 namespace Android.Text {
   public enum SpanTypes {
+    [global::Android.Runtime.IntDefinition (null, JniField = "android/text/Spanned.SPAN_COMPOSING")]
     Composing = 256,
   }
 }

--- a/tools/generator/Tests/SupportFiles/IntDefinitionAttribute.cs
+++ b/tools/generator/Tests/SupportFiles/IntDefinitionAttribute.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Android.Runtime
+{
+	[AttributeUsage (AttributeTargets.Field)]
+	public class IntDefinitionAttribute : Attribute
+	{
+		public IntDefinitionAttribute (string constantMember)
+		{
+			ConstantMember = constantMember;
+		}
+
+		public string ConstantMember { get; set; }
+		public string JniField { get; set; }
+	}
+}
+

--- a/tools/generator/Tests/expected/EnumerationFixup/Xamarin.Test.SomeValues.cs
+++ b/tools/generator/Tests/expected/EnumerationFixup/Xamarin.Test.SomeValues.cs
@@ -1,6 +1,8 @@
 namespace Xamarin.Test {
   public enum SomeValues {
+    [global::Android.Runtime.IntDefinition (null, JniField = "xamarin/test/SomeObject.SOME_VALUE")]
     SomeValue = 0,
+    [global::Android.Runtime.IntDefinition (null, JniField = "xamarin/test/SomeObject.SOME_VALUE2")]
     SomeValue2 = 1,
   }
 }

--- a/tools/generator/Tests/generator-Tests.csproj
+++ b/tools/generator/Tests/generator-Tests.csproj
@@ -101,6 +101,9 @@
     <Content Include="SupportFiles\IJavaObject.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="SupportFiles\IntDefinitionAttribute.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="SupportFiles\JavaArray.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
DO NOT MERGE THIS WITHOUT MERGING https://github.com/xamarin/xamarin-android/pull/444, it depends on Mono.Android.dll updates.

It will be helpful when people read binding dlls and understand the enum
conversion, as well as tooling.
