### PR TITLE
[build] Generate debug symbols in Release configuration

### DIFF
--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil.csproj
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil.csproj
@@ -22,6 +22,7 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>full</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>

--- a/src/Java.Interop.Tools.Diagnostics/Java.Interop.Tools.Diagnostics.csproj
+++ b/src/Java.Interop.Tools.Diagnostics/Java.Interop.Tools.Diagnostics.csproj
@@ -22,6 +22,7 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>full</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers.csproj
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers.csproj
@@ -22,6 +22,7 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>full</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release</OutputPath>
     <DefineConstants>JCW_ONLY_TYPE_NAMES;HAVE_CECIL</DefineConstants>

--- a/src/Java.Interop/Java.Interop.csproj
+++ b/src/Java.Interop/Java.Interop.csproj
@@ -29,6 +29,7 @@
     <DocumentationFile>..\..\bin\Debug\Java.Interop.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>full</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>

--- a/src/Xamarin.Android.Cecil/Xamarin.Android.Cecil.Mdb.csproj
+++ b/src/Xamarin.Android.Cecil/Xamarin.Android.Cecil.Mdb.csproj
@@ -22,6 +22,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>full</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>

--- a/src/Xamarin.Android.Cecil/Xamarin.Android.Cecil.csproj
+++ b/src/Xamarin.Android.Cecil/Xamarin.Android.Cecil.csproj
@@ -22,6 +22,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>full</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>

--- a/src/Xamarin.Android.Tools.AnnotationSupport.Cecil/Xamarin.Android.Tools.AnnotationSupport.Cecil.csproj
+++ b/src/Xamarin.Android.Tools.AnnotationSupport.Cecil/Xamarin.Android.Tools.AnnotationSupport.Cecil.csproj
@@ -22,6 +22,7 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>full</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>

--- a/src/Xamarin.Android.Tools.AnnotationSupport/Xamarin.Android.Tools.AnnotationSupport.csproj
+++ b/src/Xamarin.Android.Tools.AnnotationSupport/Xamarin.Android.Tools.AnnotationSupport.csproj
@@ -21,6 +21,7 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>full</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/Xamarin.Android.Tools.ApiXmlAdjuster.csproj
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/Xamarin.Android.Tools.ApiXmlAdjuster.csproj
@@ -22,6 +22,7 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>full</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>

--- a/tools/generator/generator.csproj
+++ b/tools/generator/generator.csproj
@@ -29,7 +29,7 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>none</DebugType>
+    <DebugType>full</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>$(UtilityOutputFullPath)</OutputPath>
     <ErrorReport>prompt</ErrorReport>

--- a/tools/jcw-gen/jcw-gen.csproj
+++ b/tools/jcw-gen/jcw-gen.csproj
@@ -22,6 +22,7 @@
     <ExternalConsole>true</ExternalConsole>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>full</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>


### PR DESCRIPTION
Debug symbols are needed to get line numbers in stack traces, which is
a handy feature even for Release binaries...