### PR TITLE
[api-xml-adjuster] api-O.xml.in will have <typeParameters> in <constructor>

### DIFF
--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApi.XmlModel.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApi.XmlModel.cs
@@ -198,6 +198,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 
 		public IList<JavaParameter> Parameters { get; set; }
 		public IList<JavaException> Exceptions { get; set; }
+		public JavaTypeParameters TypeParameters { get; set; }
 		
 		public bool ExtendedBridge { get; set; }
 		public string ExtendedJniReturn { get; set; }
@@ -246,8 +247,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		public bool Native { get; set; }
 		public string Return { get; set; }
 		public bool Synchronized { get; set; }
-		public JavaTypeParameters TypeParameters { get; set; }
-		
+
 		// Content of this value is not stable.
 		public override string ToString ()
 		{
@@ -287,14 +287,14 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			TypeParameters = new List<JavaTypeParameter> ();
 		}
 		
-		public JavaTypeParameters (JavaMethod parent)
+		public JavaTypeParameters (JavaMethodBase parent)
 		{
 			ParentMethod = parent;
 			TypeParameters = new List<JavaTypeParameter> ();
 		}
 		
 		public JavaType ParentType { get; set; }
-		public JavaMethod ParentMethod { get; set; }
+		public JavaMethodBase ParentMethod { get; set; }
 		
 		public IList<JavaTypeParameter> TypeParameters { get; set; }
 	}

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiXmlLoaderExtensions.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiXmlLoaderExtensions.cs
@@ -237,10 +237,10 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 						break;
 					if (reader.NodeType != XmlNodeType.Element)
 						throw XmlUtil.UnexpectedElementOrContent (elementName, reader, "parameter");
-					if (method != null && reader.LocalName == "typeParameters") {
-						var tp = new JavaTypeParameters (method);
+					if (reader.LocalName == "typeParameters") {
+						var tp = new JavaTypeParameters (methodBase);
 						tp.Load (reader);
-						method.TypeParameters = tp;
+						methodBase.TypeParameters = tp;
 					} else if (reader.LocalName == "parameter") {
 						var p = new JavaParameter (methodBase);
 						p.Load (reader);


### PR DESCRIPTION
It is because some types have Class<T> as some arguments to the contructor
and to resolve that T the API describes it.