### PR TITLE
[Java.Interop.Tools.JavaCallableWrappers] Use ReadingMode.Deferred

### DIFF
--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/TypeNameMapGenerator.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/TypeNameMapGenerator.cs
@@ -69,7 +69,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 
 			Log             = logMessage;
 			var Assemblies  = assemblies.ToList ();
-			var rp          = new ReaderParameters (ReadingMode.Immediate);
+			var rp          = new ReaderParameters ();
 
 			Resolver = new DirectoryAssemblyResolver (Log, loadDebugSymbols: true, loadReaderParameters: rp);
 			foreach (var assembly in Assemblies) {


### PR DESCRIPTION
A "funny" [^0] thing happened when trying to
[update xamarin-android to use a newer Java.Interop][0]: while all the
tests passed, the macOS+xbuild PR builder -- which actually runs the
unit tests -- was *really slow*: [2 hr 26 minutes to run][1], vs. a
more [normal 53 minutes][2].

Ouch.

@radekdoulik tried to verify that it wasn't
c794fabb; *that* build took [1 hr 42 min][3].

*Something* between cecil/d0cb2b7 and cecil/0d05ab1 caused this, but
we don't know what, and even if we knew, that might not matter.

That said, we have found two apparent factors in the slowdown:

1. Using `ReaderParameters.ReadingMode` to `ReadingMode.Immediate`
    (084e9f7f), and
2. Setting `ReaderParameters.ReadSymbols` to `true`.

There also appears to be something "wrong" with the `.pdb` files that
Roslyn on macOS is generating, in that the `.pdb` file appears to be
invalid; no real details at this time.

To verify:

	$ csharp -r:bin/Debug/Xamarin.Android.Cecil.dll
	csharp> using Mono.Cecil;
	csharp> var rp = new ReaderParameters (ReadingMode.Immediate) { ReadSymbols = true };
	csharp> var ad = AssemblyDefinition.ReadAssembly ("path/to/Mono.Android.dll", rp);

This "hangs", taking roughly 2 minutes to complete. (Oof.)

Change things to *remove* `ReadingMode.Immediate`, e.g.

	csharp> var rp = new ReaderParameters () { ReadSymbols = true };

and `AssemblyDefinition.ReadAssembly()` is instantaneous.

So...why are we using `ReadingMode.Immediate`?

Hysterical raisens, mostly: as commit 084e9f7f noted, in the "previous
world order" Cecil loaded everything in memory, so it seemed perfectly
reasonable that to fix various file sharing bugs we could/should
continue doing the same thing.

That turned out to be...not quite right; see 40b75e9c, in which the
`DirectoryAssemblyResolver` instance had to be turned into a member
instead of a constructor local parameter, because code "down the call
stack" was implicitly using the `DirectoryAssemblyResolver` instance.
This means we don't *really* need `ReadingMode.Immediate` *at all*,
and thus removing it should (1) not break anything, and (2) provide us
with a very nice performance improvement.

[0]: https://github.com/xamarin/xamarin-android/pull/532
[1]: https://jenkins.mono-project.com/job/xamarin-android-pr-builder/775/
[2]: https://jenkins.mono-project.com/job/xamarin-android-pr-builder/769/
[3]: https://jenkins.mono-project.com/job/xamarin-android-pr-builder/776/

[^0]: Everything is always "funny"...