### PR TITLE
[Xamarin.Android.Tools.Bytecode-Tests] Update for API-24 docs

### DIFF
--- a/src/Xamarin.Android.Tools.Bytecode/Tests/ParameterFixupApiXmlDocs.xml
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/ParameterFixupApiXmlDocs.xml
@@ -3,7 +3,7 @@
 	<package name="java.util">
 		<class name="Collection">
 			<method name="add">
-				<parameter name="object" type="E" />
+				<parameter name="e" type="E" />
 			</method>
 		</class>
 	</package>

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/ParameterFixupFromDocs.xml
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/ParameterFixupFromDocs.xml
@@ -38,7 +38,7 @@
         synthetic="false"
         jni-signature="(Ljava/lang/Object;)Z">
         <parameter
-          name="object"
+          name="e"
           type="E"
           jni-type="TE;" />
       </method>


### PR DESCRIPTION
The `ParameterFixupTests.XmlDeclaration_FixedUpFromDocumentation()` and
`ParameterFixupTests.XmlDeclaration_FixedUpFromApiXmlDocumentation()`
tests read a `java.util.Collection.class` file that contains no
parameter name information, and uses XML and/or "JavaDoc" HTML
documentation to ascertain the correct parameter names.

For better or worse, parameter names are *not* part of any Java ABI,
and thus can change over time.

Which is what happened here: these tests were originally written
against the Android documentation for API-18. Since then, the docs for
API-24 have *changed the parameter names* for the `Collection.add(E)`
method, changing the parameter name from `object` to `e`.

Update the expected paramater names when reading docs from
`$ANDROID_SDK_PATH` so that the API-24 names are expected.