### PR TITLE
[Xamarin.Android.Tools.Bytecode] Handle null InnerClassInfo values

### DIFF
--- a/src/Xamarin.Android.Tools.Bytecode/AttributeInfo.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/AttributeInfo.cs
@@ -322,7 +322,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 		public override string ToString ()
 		{
 			return string.Format ("InnerClass(InnerClass='{0}', OuterClass='{1}', InnerName='{2}', InnerClassAccessFlags={3})",
-				InnerClass.Name.Value, OuterClass.Name.Value, InnerName, InnerClassAccessFlags);
+				InnerClass?.Name?.Value, OuterClass?.Name?.Value, InnerName, InnerClassAccessFlags);
 		}
 	}
 


### PR DESCRIPTION
While processing a version of `cardview-v7.jar`,
`class-parse --dump` was throwing a `NullReferenceException`:

	$ mkdir cardview-v7
	$ cd cardview-v7
	$ unzip ../cardview-v7.jar
	$ mono …/class-parse.exe -v --dump android/support/v7/widget/CardView.class >/dev/null
	class-parse: Unable to read file 'android/support/v7/widget/CardView.class': System.NullReferenceException: Object reference not set to an instance of an object
	  at Xamarin.Android.Tools.Bytecode.InnerClassInfo.ToString ()
	  ...

The `NullReferenceException` is because one of the `InnerClassInfo`
values which `InnerClassInfo.ToString()` references is `null`.

After fixing, we see:

	Attributes Count: 2
		0: Unknown[SourceFile](2)
		1: InnerClasses(Count=7,
			InnerClass(InnerClass='android/support/v7/widget/CardView$1', OuterClass='', InnerName='', InnerClassAccessFlags=0),
			InnerClass(InnerClass='android/R$attr', OuterClass='android/R', InnerName='attr', InnerClassAccessFlags=Public, Static, Final),
			InnerClass(InnerClass='android/view/View$MeasureSpec', OuterClass='android/view/View', InnerName='MeasureSpec', InnerClassAccessFlags=Public, Static),
			InnerClass(InnerClass='android/support/v7/cardview/R$styleable', OuterClass='android/support/v7/cardview/R', InnerName='styleable', InnerClassAccessFlags=Public, Static, Final),
			InnerClass(InnerClass='android/support/v7/cardview/R$style', OuterClass='android/support/v7/cardview/R', InnerName='style', InnerClassAccessFlags=Public, Static, Final),
			InnerClass(InnerClass='android/support/v7/cardview/R$color', OuterClass='android/support/v7/cardview/R', InnerName='color', InnerClassAccessFlags=Public, Static, Final),
			InnerClass(InnerClass='android/os/Build$VERSION', OuterClass='android/os/Build', InnerName='VERSION', InnerClassAccessFlags=Public, Static))

I'm not sure why `CardView$1` has no `InnerClassInfo.OuterClass` value
-- shouldn't it be `android/support/v7/widget/CardView`? -- but that
doesn't really matter; `class-parse --dump` shouldn't fail here.