### PR TITLE
[jcw-gen] Build `jcw-gen.exe` into `$(UtilityOutputFullPath)`

### DIFF
--- a/tools/jcw-gen/jcw-gen.csproj
+++ b/tools/jcw-gen/jcw-gen.csproj
@@ -11,11 +11,12 @@
     <AssemblyName>jcw-gen</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
+  <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\bin\Debug</OutputPath>
+    <OutputPath>$(UtilityOutputFullPath)</OutputPath>
     <DefineConstants>DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -24,7 +25,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>full</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\..\bin\Release</OutputPath>
+    <OutputPath>$(UtilityOutputFullPath)</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ExternalConsole>true</ExternalConsole>


### PR DESCRIPTION
Context: https://github.com/mono/Embeddinator-4000
Context: https://github.com/xamarin/Java.Interop/commit/b6431ac85042960ba28dfb19f0be19573745d968

Embeddinator-4000 is an in-progress utility to easily allow
Java/C/Objective-C/etc. to consume .NET CIL. For example, it would be
desirable to be able to "export" a `.dll` into an Android `.aar` file,
so that Java developers using Android Studio can consume and use
managed assemblies in a straightforward manner.

Part of making this work will be to generate Java "bindings" of an
assembly.

"Funny" thing: we already partially have that: `jcw-gen.exe` will take
an assembly and generate Java Callable Wrappers for `Java.Lang.Object`
subclasses from that assembly. Aside from the base class requirement,
this is (more or less) what Embeddinator-4000 requires...except that
Embeddinator-4000 wants to handle *all* managed types, not just
`Java.Lang.Object` subclasses.

That said, at some point it will be desirable for "transparent" use of
`Java.Lang.Object` subclasses; Embeddinator-4000 can't (reasonably or
sanely) use it's "normal" non-`Java.Lang.Object`-aware generator to
bind `Java.Lang.Object` subclasses; for starters, the base class will
be completely wrong (`Java.Lang.Object` instead of
`java.lang.Object`!).

Embeddinator-4000 *could* use the
`Java.Interop.Tools.JavaCallableWrappers` assembly in order to perform
this work, but that would require that Embeddinator-4000 reference
Java.Interop or otherwise "obtain" an assembly to build against,
complicating bootstrapping and ongoing maintenance.

Instead, Embeddinator-4000 can use our existing command-line code
generation interface, `jcw-gen.exe`. This simplifies the build --
at the expense of runtime, as now you need to specify where
`jcw-gen.exe` is -- and provides a "break" between repositories.

Update `jcw-gen.csproj` so that it's `$(OutputPath)` is
`$(UtilityOutputFullPath)`, as is the case for `class-parse`,
`generator`, and `logcat-parse`, so that `jcw-gen.exe` can be
distributed as part of Xamarin.Android.