### PR TITLE
[api-xml-adjuster] constructors could reference generic type parameters.

### DIFF
--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiTypeResolverExtensions.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiTypeResolverExtensions.cs
@@ -104,23 +104,23 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			f.ResolvedType = f.GetApi ().Parse (f.TypeGeneric, f.Parent.TypeParameters);
 		}
 		
-		static void ResolveMethodBase (this JavaMethodBase m, JavaTypeParameters methodTypeParameters)
+		static void ResolveMethodBase (this JavaMethodBase m)
 		{
+			if (m.TypeParameters != null)
+				m.TypeParameters.Resolve (m.GetApi (), m.TypeParameters);
 			foreach (var p in m.Parameters)
-				p.ResolvedType = m.GetApi ().Parse (p.Type, m.Parent.TypeParameters, methodTypeParameters);
+				p.ResolvedType = m.GetApi ().Parse (p.Type, m.Parent.TypeParameters, m.TypeParameters);
 		}
 		
 		public static void Resolve (this JavaMethod m)
 		{
-			if (m.TypeParameters != null)
-				m.TypeParameters.Resolve (m.GetApi (), m.TypeParameters);
-			m.ResolveMethodBase (m.TypeParameters);
+			m.ResolveMethodBase ();
 			m.ResolvedReturnType = m.GetApi ().Parse (m.Return, m.Parent.TypeParameters, m.TypeParameters);
 		}
 		
 		public static void Resolve (this JavaConstructor c)
 		{
-			c.ResolveMethodBase (null);
+			c.ResolveMethodBase ();
 		}
 		
 		static void Resolve (this JavaTypeParameters tp, JavaApi api, params JavaTypeParameters [] additionalTypeParameters)


### PR DESCRIPTION
Constructors had been considered to NOT reference generic type parameters
because Java syntax does not allow them. However, its argument types could
be java.lang.Class<T> in class-parse output XML (which I guess is because
class-parse tries to be as simple-and-stupid as it can be?) and every
difficulty is thrown toward api-xml-adjuster. Hence it is corrected here.

Note that it was not the first time that generic constructor arguments
have been taken care as a valid input (0ec431e).