### PR TITLE
ToResolverCache should return a Dictionary

### DIFF
--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/DirectoryAssemblyResolver.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/DirectoryAssemblyResolver.cs
@@ -96,14 +96,9 @@ namespace Java.Interop.Tools.Cecil {
 			cache = null;
 		}
 
-		[Obsolete ("Should not be used; was required with previous Cecil versions.")]
-		public IDictionary ToResolverCache ()
+		public Dictionary<string, AssemblyDefinition> ToResolverCache ()
 		{
-			var resolver_cache = new Hashtable ();
-			foreach (var pair in cache)
-				resolver_cache.Add (pair.Key, pair.Value);
-
-			return resolver_cache;
+			return new Dictionary<string, AssemblyDefinition>(cache);
 		}
 
 		public virtual AssemblyDefinition Load (string fileName)


### PR DESCRIPTION
fixes

```
        Tasks/LinkAssemblies.cs(103,41): error CS1503: Argument 1: cannot convert from 'System.Collections.IDictionary' to 'System.Collections.Generic.Dictionary<string, Mono.Cecil.AssemblyDefinition>'
```

in xamarin-android