### PR TITLE
[generator] do not generate identical methods to previously generated ones.

### DIFF
--- a/tools/generator/ClassGen.cs
+++ b/tools/generator/ClassGen.cs
@@ -313,9 +313,7 @@ namespace MonoDroid.Generation {
 		void GenerateAbstractMembers (StreamWriter sw, string indent, CodeGenerationOptions opt)
 		{
 			foreach (InterfaceGen gen in GetAllDerivedInterfaces ())
-				// FIXME: this is an ugly workaround for bug in generator that generates extraneous member.
-				if (FullName != "Android.Views.Animations.BaseInterpolator" || gen.FullName != "Android.Views.Animations.IInterpolator")
-					gen.GenerateAbstractMembers (this, sw, indent, opt);
+				gen.GenerateAbstractMembers (this, sw, indent, opt);
 		}
 
 		void GenMethods (StreamWriter sw, string indent, CodeGenerationOptions opt)
@@ -339,6 +337,7 @@ namespace MonoDroid.Generation {
 					m.GenerateAbstractDeclaration (sw, indent, opt, null, this);
 				else
 					m.Generate (sw, indent, opt, this, true);
+				opt.ContextGeneratedMethods.Add (m);
 				m.IsVirtual = virt;
 			}
 
@@ -371,6 +370,8 @@ namespace MonoDroid.Generation {
 		public override void Generate (StreamWriter sw, string indent, CodeGenerationOptions opt, GenerationInfo gen_info)
 		{
 			opt.ContextTypes.Push (this);
+			opt.ContextGeneratedMethods = new List<Method> ();
+
 			gen_info.TypeRegistrations.Add (new KeyValuePair<string, string>(RawJniName, AssemblyQualifiedName));
 			bool is_enum = base_symbol != null && base_symbol.FullName == "Java.Lang.Enum";
 			if (is_enum)
@@ -497,6 +498,9 @@ namespace MonoDroid.Generation {
 				sw.WriteLine ();
 				GenerateInvoker (sw, indent, opt);
 			}
+
+			opt.ContextGeneratedMethods.Clear ();
+
 			opt.ContextTypes.Pop ();
 		}
 

--- a/tools/generator/CodeGenerator.cs
+++ b/tools/generator/CodeGenerator.cs
@@ -560,6 +560,7 @@ namespace MonoDroid.Generation {
 		public Stack<GenBase> ContextTypes {
 			get { return context_types; }
 		}
+		public List<Method> ContextGeneratedMethods { get; set; } = new List<Method> ();
 		public GenBase ContextType {
 			get { return context_types.Any () ? context_types.Peek () : null; }
 		}

--- a/tools/generator/InterfaceGen.cs
+++ b/tools/generator/InterfaceGen.cs
@@ -620,6 +620,8 @@ namespace MonoDroid.Generation {
 			foreach (Method m in Methods.Where (m => !m.IsInterfaceDefaultMethod && !m.IsStatic)) {
 				bool mapped = false;
 				string sig = m.GetSignature ();
+				if (opt.ContextGeneratedMethods.Any (_ => _.Name == m.Name && _.JniSignature == m.JniSignature))
+					continue;
 				for (var cls = gen; cls != null; cls = cls.BaseGen)
 					if (cls.ContainsMethod (m, false) || cls != gen && gen.ExplicitlyImplementedInterfaceMethods.Contains (sig)) {
 						mapped = true;
@@ -631,6 +633,7 @@ namespace MonoDroid.Generation {
 					m.GenerateExplicitInterfaceImplementation (sw, indent, opt, this);
 				else
 					m.GenerateAbstractDeclaration (sw, indent, opt, this, gen);
+				opt.ContextGeneratedMethods.Add (m); 
 			}
 			foreach (Property prop in Properties) {
 				if (gen.ContainsProperty (prop.Name, false))

--- a/tools/generator/Tests/InterfaceMethodsConflict.cs
+++ b/tools/generator/Tests/InterfaceMethodsConflict.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace generatortests
+{
+	[TestFixture]
+	public class InterfaceMethodsConflict : BaseGeneratorTest
+	{
+		[Test]
+		public void GeneratedOK ()
+		{
+			RunAllTargets (
+					outputRelativePath:     "InterfaceMethodsConflict",
+					apiDescriptionFile:     "expected/InterfaceMethodsConflict/InterfaceMethodsConflict.xml",
+					expectedRelativePath:   "InterfaceMethodsConflict");
+		}
+	}
+}
+

--- a/tools/generator/Tests/expected.ji/InterfaceMethodsConflict/InterfaceMethodsConflict.xml
+++ b/tools/generator/Tests/expected.ji/InterfaceMethodsConflict/InterfaceMethodsConflict.xml
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<api>
+	<package name="xamarin.test">
+	    <class abstract="false" deprecated="not deprecated" final="false" name="Object" static="false" visibility="public">
+	    </class>
+	  </package>
+	<package name="xamarin.test">
+	  <interface abstract="true" deprecated="not deprecated" final="false" name="I1" static="false" visibility="public">
+		<method abstract="true" deprecated="not deprecated" final="false" name="close" native="false" return="void" static="false" synchronized="false" visibility="public">
+		</method>
+	  </interface>
+	  <interface abstract="true" deprecated="not deprecated" final="false" name="I2" static="false" visibility="public">
+		<method abstract="true" deprecated="not deprecated" final="false" name="close" native="false" return="void" static="false" synchronized="false" visibility="public">
+		</method>
+	  </interface>
+	  <class abstract="true" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" 
+	  		final="false" name="SomeObject" static="false" visibility="public">
+		<implements name="xamarin.test.I1" name-generic-aware="xamarin.test.I1" />
+		<implements name="xamarin.test.I2" name-generic-aware="xamarin.test.I2" />
+	  </class>
+	</package>
+</api>
+
+
+

--- a/tools/generator/Tests/expected.ji/InterfaceMethodsConflict/Java.Interop.__TypeRegistrations.cs
+++ b/tools/generator/Tests/expected.ji/InterfaceMethodsConflict/Java.Interop.__TypeRegistrations.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Java.Interop {
+
+	partial class __TypeRegistrations {
+
+		public static void RegisterPackages ()
+		{
+#if MONODROID_TIMING
+			var start = DateTime.Now;
+			Android.Util.Log.Info ("MonoDroid-Timing", "RegisterPackages start: " + (start - new DateTime (1970, 1, 1)).TotalMilliseconds);
+#endif // def MONODROID_TIMING
+			Java.Interop.TypeManager.RegisterPackages (
+					new string[]{
+					},
+					new Converter<string, Type>[]{
+					});
+#if MONODROID_TIMING
+			var end = DateTime.Now;
+			Android.Util.Log.Info ("MonoDroid-Timing", "RegisterPackages time: " + (end - new DateTime (1970, 1, 1)).TotalMilliseconds + " [elapsed: " + (end - start).TotalMilliseconds + " ms]");
+#endif // def MONODROID_TIMING
+		}
+
+		static Type Lookup (string[] mappings, string javaType)
+		{
+			string managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
+			if (managedType == null)
+				return null;
+			return Type.GetType (managedType);
+		}
+	}
+}

--- a/tools/generator/Tests/expected.ji/InterfaceMethodsConflict/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/InterfaceMethodsConflict/Java.Lang.Object.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Java.Lang {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
+	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
+	public partial class Object  {
+
+	}
+}

--- a/tools/generator/Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.II1.cs
+++ b/tools/generator/Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.II1.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Xamarin.Test {
+
+	// Metadata.xml XPath interface reference: path="/api/package[@name='xamarin.test']/interface[@name='I1']"
+	[Register ("xamarin/test/I1", "", "Xamarin.Test.II1Invoker")]
+	public partial interface II1 : IJavaObject {
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/interface[@name='I1']/method[@name='close' and count(parameter)=0]"
+		[Register ("close", "()V", "GetCloseHandler:Xamarin.Test.II1Invoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
+		void Close ();
+
+	}
+
+	[global::Android.Runtime.Register ("xamarin/test/I1", DoNotGenerateAcw=true)]
+	internal class II1Invoker : global::Java.Lang.Object, II1 {
+
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/I1", typeof (II1Invoker));
+
+		static IntPtr java_class_ref {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+		IntPtr class_ref;
+
+		public static II1 GetObject (IntPtr handle, JniHandleOwnership transfer)
+		{
+			return global::Java.Lang.Object.GetObject<II1> (handle, transfer);
+		}
+
+		static IntPtr Validate (IntPtr handle)
+		{
+			if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
+				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
+							JNIEnv.GetClassNameFromInstance (handle), "xamarin.test.I1"));
+			return handle;
+		}
+
+		protected override void Dispose (bool disposing)
+		{
+			if (this.class_ref != IntPtr.Zero)
+				JNIEnv.DeleteGlobalRef (this.class_ref);
+			this.class_ref = IntPtr.Zero;
+			base.Dispose (disposing);
+		}
+
+		public II1Invoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
+		{
+			IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
+			this.class_ref = JNIEnv.NewGlobalRef (local_ref);
+			JNIEnv.DeleteLocalRef (local_ref);
+		}
+
+		static Delegate cb_close;
+#pragma warning disable 0169
+		static Delegate GetCloseHandler ()
+		{
+			if (cb_close == null)
+				cb_close = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr>) n_Close);
+			return cb_close;
+		}
+
+		static void n_Close (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Xamarin.Test.II1 __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.II1> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			__this.Close ();
+		}
+#pragma warning restore 0169
+
+		IntPtr id_close;
+		public unsafe void Close ()
+		{
+			if (id_close == IntPtr.Zero)
+				id_close = JNIEnv.GetMethodID (class_ref, "close", "()V");
+			JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_close);
+		}
+
+	}
+
+}

--- a/tools/generator/Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.II2.cs
+++ b/tools/generator/Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.II2.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Xamarin.Test {
+
+	// Metadata.xml XPath interface reference: path="/api/package[@name='xamarin.test']/interface[@name='I2']"
+	[Register ("xamarin/test/I2", "", "Xamarin.Test.II2Invoker")]
+	public partial interface II2 : IJavaObject {
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/interface[@name='I2']/method[@name='close' and count(parameter)=0]"
+		[Register ("close", "()V", "GetCloseHandler:Xamarin.Test.II2Invoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
+		void Close ();
+
+	}
+
+	[global::Android.Runtime.Register ("xamarin/test/I2", DoNotGenerateAcw=true)]
+	internal class II2Invoker : global::Java.Lang.Object, II2 {
+
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/I2", typeof (II2Invoker));
+
+		static IntPtr java_class_ref {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+		IntPtr class_ref;
+
+		public static II2 GetObject (IntPtr handle, JniHandleOwnership transfer)
+		{
+			return global::Java.Lang.Object.GetObject<II2> (handle, transfer);
+		}
+
+		static IntPtr Validate (IntPtr handle)
+		{
+			if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
+				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
+							JNIEnv.GetClassNameFromInstance (handle), "xamarin.test.I2"));
+			return handle;
+		}
+
+		protected override void Dispose (bool disposing)
+		{
+			if (this.class_ref != IntPtr.Zero)
+				JNIEnv.DeleteGlobalRef (this.class_ref);
+			this.class_ref = IntPtr.Zero;
+			base.Dispose (disposing);
+		}
+
+		public II2Invoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
+		{
+			IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
+			this.class_ref = JNIEnv.NewGlobalRef (local_ref);
+			JNIEnv.DeleteLocalRef (local_ref);
+		}
+
+		static Delegate cb_close;
+#pragma warning disable 0169
+		static Delegate GetCloseHandler ()
+		{
+			if (cb_close == null)
+				cb_close = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr>) n_Close);
+			return cb_close;
+		}
+
+		static void n_Close (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Xamarin.Test.II2 __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.II2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			__this.Close ();
+		}
+#pragma warning restore 0169
+
+		IntPtr id_close;
+		public unsafe void Close ()
+		{
+			if (id_close == IntPtr.Zero)
+				id_close = JNIEnv.GetMethodID (class_ref, "close", "()V");
+			JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_close);
+		}
+
+	}
+
+}

--- a/tools/generator/Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.SomeObject.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Xamarin.Test {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']"
+	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
+	public partial class SomeObject : global::Java.Lang.Object, global::Xamarin.Test.II1, global::Xamarin.Test.II2 {
+
+		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+		internal static IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+		protected SomeObject (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		static Delegate cb_close;
+#pragma warning disable 0169
+		static Delegate GetCloseHandler ()
+		{
+			if (cb_close == null)
+				cb_close = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr>) n_Close);
+			return cb_close;
+		}
+
+		static void n_Close (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			__this.Close ();
+		}
+#pragma warning restore 0169
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/method[@name='close' and count(parameter)=0]"
+		[Register ("close", "()V", "GetCloseHandler")]
+		public virtual unsafe void Close ()
+		{
+			const string __id = "close.()V";
+			try {
+				_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, null);
+			} finally {
+			}
+		}
+
+	}
+}

--- a/tools/generator/Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.SomeObject2.cs
+++ b/tools/generator/Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.SomeObject2.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Xamarin.Test {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject2']"
+	[global::Android.Runtime.Register ("xamarin/test/SomeObject2", DoNotGenerateAcw=true)]
+	public abstract partial class SomeObject2 : global::Java.Lang.Object, global::Xamarin.Test.II1, global::Xamarin.Test.II2 {
+
+		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject2", typeof (SomeObject2));
+		internal static IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+		protected SomeObject2 (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		static Delegate cb_irrelevant;
+#pragma warning disable 0169
+		static Delegate GetIrrelevantHandler ()
+		{
+			if (cb_irrelevant == null)
+				cb_irrelevant = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr>) n_Irrelevant);
+			return cb_irrelevant;
+		}
+
+		static void n_Irrelevant (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Xamarin.Test.SomeObject2 __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			__this.Irrelevant ();
+		}
+#pragma warning restore 0169
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject2']/method[@name='irrelevant' and count(parameter)=0]"
+		[Register ("irrelevant", "()V", "GetIrrelevantHandler")]
+		public virtual unsafe void Irrelevant ()
+		{
+			const string __id = "irrelevant.()V";
+			try {
+				_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, null);
+			} finally {
+			}
+		}
+
+		static Delegate cb_close;
+#pragma warning disable 0169
+		static Delegate GetCloseHandler ()
+		{
+			if (cb_close == null)
+				cb_close = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr>) n_Close);
+			return cb_close;
+		}
+
+		static void n_Close (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Xamarin.Test.SomeObject2 __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			__this.Close ();
+		}
+#pragma warning restore 0169
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/interface[@name='I1']/method[@name='close' and count(parameter)=0]"
+		[Register ("close", "()V", "GetCloseHandler")]
+		public abstract void Close ();
+
+	}
+
+	[global::Android.Runtime.Register ("xamarin/test/SomeObject2", DoNotGenerateAcw=true)]
+	internal partial class SomeObject2Invoker : SomeObject2 {
+
+		public SomeObject2Invoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
+
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject2", typeof (SomeObject2Invoker));
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/interface[@name='I1']/method[@name='close' and count(parameter)=0]"
+		[Register ("close", "()V", "GetCloseHandler")]
+		public override unsafe void Close ()
+		{
+			const string __id = "close.()V";
+			try {
+				_members.InstanceMethods.InvokeAbstractVoidMethod (__id, this, null);
+			} finally {
+			}
+		}
+
+	}
+
+}

--- a/tools/generator/Tests/expected.ji/InterfaceMethodsConflict/__NamespaceMapping__.cs
+++ b/tools/generator/Tests/expected.ji/InterfaceMethodsConflict/__NamespaceMapping__.cs
@@ -1,0 +1,2 @@
+[assembly:global::Android.Runtime.NamespaceMapping (Java = "java.lang", Managed="Java.Lang")]
+[assembly:global::Android.Runtime.NamespaceMapping (Java = "xamarin.test", Managed="Xamarin.Test")]

--- a/tools/generator/Tests/expected.targets
+++ b/tools/generator/Tests/expected.targets
@@ -495,6 +495,12 @@
     <Content Include='expected.ji\TestInterface\Test.ME.TestInterfaceImplementation.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include='expected.ji\InterfaceMethodsConflict\InterfaceMethodsConflict.xml'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected.ji\InterfaceMethodsConflict\Xamarin.Test.SomeObject.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include='expected\GenericArguments\GenericArguments.xml'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -613,6 +619,12 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include='expected\TestInterface\Test.ME.TestInterfaceImplementation.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected\InterfaceMethodsConflict\InterfaceMethodsConflict.xml'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected\InterfaceMethodsConflict\Xamarin.Test.SomeObject.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/tools/generator/Tests/expected/InterfaceMethodsConflict/InterfaceMethodsConflict.xml
+++ b/tools/generator/Tests/expected/InterfaceMethodsConflict/InterfaceMethodsConflict.xml
@@ -1,0 +1,35 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<api>
+	<package name="java.lang">
+	  <class abstract="false" deprecated="not deprecated" final="false" name="Object" static="false" visibility="public">
+	    </class>
+	</package>
+	<package name="xamarin.test">
+	  <interface abstract="true" deprecated="not deprecated" final="false" name="I1" static="false" visibility="public">
+		<method abstract="true" deprecated="not deprecated" final="false" name="close" native="false" return="void" static="false" synchronized="false" visibility="public">
+		</method>
+	  </interface>
+	  <interface abstract="true" deprecated="not deprecated" final="false" name="I2" static="false" visibility="public">
+		<method abstract="true" deprecated="not deprecated" final="false" name="close" native="false" return="void" static="false" synchronized="false" visibility="public">
+		</method>
+	  </interface>
+	  <class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" 
+	  		final="false" name="SomeObject" static="false" visibility="public">
+		<implements name="xamarin.test.I1" name-generic-aware="xamarin.test.I1" />
+		<implements name="xamarin.test.I2" name-generic-aware="xamarin.test.I2" />
+		<method abstract="false" deprecated="not deprecated" final="false" name="close" native="false" return="void" static="false" synchronized="false" visibility="public">
+		</method>
+	  </class>
+	  <class abstract="true" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" 
+	  		final="false" name="SomeObject2" static="false" visibility="public">
+		<implements name="xamarin.test.I1" name-generic-aware="xamarin.test.I1" />
+		<implements name="xamarin.test.I2" name-generic-aware="xamarin.test.I2" />
+		<!-- FIXME: this should not be required, but generator has an issue that when there is no member in the declaring class, "class_ref" is not generated and then the generated code does not compile because those invoker implementations depend on it. -->
+		<method abstract="false" deprecated="not deprecated" final="false" name="irrelevant" native="false" return="void" static="false" synchronized="false" visibility="public">
+		</method>
+	  </class>
+	</package>
+</api>
+
+
+

--- a/tools/generator/Tests/expected/InterfaceMethodsConflict/Java.Interop.__TypeRegistrations.cs
+++ b/tools/generator/Tests/expected/InterfaceMethodsConflict/Java.Interop.__TypeRegistrations.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Java.Interop {
+
+	partial class __TypeRegistrations {
+
+		public static void RegisterPackages ()
+		{
+#if MONODROID_TIMING
+			var start = DateTime.Now;
+			Android.Util.Log.Info ("MonoDroid-Timing", "RegisterPackages start: " + (start - new DateTime (1970, 1, 1)).TotalMilliseconds);
+#endif // def MONODROID_TIMING
+			Java.Interop.TypeManager.RegisterPackages (
+					new string[]{
+					},
+					new Converter<string, Type>[]{
+					});
+#if MONODROID_TIMING
+			var end = DateTime.Now;
+			Android.Util.Log.Info ("MonoDroid-Timing", "RegisterPackages time: " + (end - new DateTime (1970, 1, 1)).TotalMilliseconds + " [elapsed: " + (end - start).TotalMilliseconds + " ms]");
+#endif // def MONODROID_TIMING
+		}
+
+		static Type Lookup (string[] mappings, string javaType)
+		{
+			string managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
+			if (managedType == null)
+				return null;
+			return Type.GetType (managedType);
+		}
+	}
+}

--- a/tools/generator/Tests/expected/InterfaceMethodsConflict/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected/InterfaceMethodsConflict/Java.Lang.Object.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Java.Lang {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
+	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
+	public partial class Object  {
+
+	}
+}

--- a/tools/generator/Tests/expected/InterfaceMethodsConflict/Xamarin.Test.II1.cs
+++ b/tools/generator/Tests/expected/InterfaceMethodsConflict/Xamarin.Test.II1.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Xamarin.Test {
+
+	// Metadata.xml XPath interface reference: path="/api/package[@name='xamarin.test']/interface[@name='I1']"
+	[Register ("xamarin/test/I1", "", "Xamarin.Test.II1Invoker")]
+	public partial interface II1 : IJavaObject {
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/interface[@name='I1']/method[@name='close' and count(parameter)=0]"
+		[Register ("close", "()V", "GetCloseHandler:Xamarin.Test.II1Invoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
+		void Close ();
+
+	}
+
+	[global::Android.Runtime.Register ("xamarin/test/I1", DoNotGenerateAcw=true)]
+	internal class II1Invoker : global::Java.Lang.Object, II1 {
+
+		static IntPtr java_class_ref = JNIEnv.FindClass ("xamarin/test/I1");
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (II1Invoker); }
+		}
+
+		IntPtr class_ref;
+
+		public static II1 GetObject (IntPtr handle, JniHandleOwnership transfer)
+		{
+			return global::Java.Lang.Object.GetObject<II1> (handle, transfer);
+		}
+
+		static IntPtr Validate (IntPtr handle)
+		{
+			if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
+				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
+							JNIEnv.GetClassNameFromInstance (handle), "xamarin.test.I1"));
+			return handle;
+		}
+
+		protected override void Dispose (bool disposing)
+		{
+			if (this.class_ref != IntPtr.Zero)
+				JNIEnv.DeleteGlobalRef (this.class_ref);
+			this.class_ref = IntPtr.Zero;
+			base.Dispose (disposing);
+		}
+
+		public II1Invoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
+		{
+			IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
+			this.class_ref = JNIEnv.NewGlobalRef (local_ref);
+			JNIEnv.DeleteLocalRef (local_ref);
+		}
+
+		static Delegate cb_close;
+#pragma warning disable 0169
+		static Delegate GetCloseHandler ()
+		{
+			if (cb_close == null)
+				cb_close = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr>) n_Close);
+			return cb_close;
+		}
+
+		static void n_Close (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Xamarin.Test.II1 __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.II1> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			__this.Close ();
+		}
+#pragma warning restore 0169
+
+		IntPtr id_close;
+		public unsafe void Close ()
+		{
+			if (id_close == IntPtr.Zero)
+				id_close = JNIEnv.GetMethodID (class_ref, "close", "()V");
+			JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_close);
+		}
+
+	}
+
+}

--- a/tools/generator/Tests/expected/InterfaceMethodsConflict/Xamarin.Test.II2.cs
+++ b/tools/generator/Tests/expected/InterfaceMethodsConflict/Xamarin.Test.II2.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Xamarin.Test {
+
+	// Metadata.xml XPath interface reference: path="/api/package[@name='xamarin.test']/interface[@name='I2']"
+	[Register ("xamarin/test/I2", "", "Xamarin.Test.II2Invoker")]
+	public partial interface II2 : IJavaObject {
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/interface[@name='I2']/method[@name='close' and count(parameter)=0]"
+		[Register ("close", "()V", "GetCloseHandler:Xamarin.Test.II2Invoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
+		void Close ();
+
+	}
+
+	[global::Android.Runtime.Register ("xamarin/test/I2", DoNotGenerateAcw=true)]
+	internal class II2Invoker : global::Java.Lang.Object, II2 {
+
+		static IntPtr java_class_ref = JNIEnv.FindClass ("xamarin/test/I2");
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (II2Invoker); }
+		}
+
+		IntPtr class_ref;
+
+		public static II2 GetObject (IntPtr handle, JniHandleOwnership transfer)
+		{
+			return global::Java.Lang.Object.GetObject<II2> (handle, transfer);
+		}
+
+		static IntPtr Validate (IntPtr handle)
+		{
+			if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
+				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
+							JNIEnv.GetClassNameFromInstance (handle), "xamarin.test.I2"));
+			return handle;
+		}
+
+		protected override void Dispose (bool disposing)
+		{
+			if (this.class_ref != IntPtr.Zero)
+				JNIEnv.DeleteGlobalRef (this.class_ref);
+			this.class_ref = IntPtr.Zero;
+			base.Dispose (disposing);
+		}
+
+		public II2Invoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
+		{
+			IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
+			this.class_ref = JNIEnv.NewGlobalRef (local_ref);
+			JNIEnv.DeleteLocalRef (local_ref);
+		}
+
+		static Delegate cb_close;
+#pragma warning disable 0169
+		static Delegate GetCloseHandler ()
+		{
+			if (cb_close == null)
+				cb_close = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr>) n_Close);
+			return cb_close;
+		}
+
+		static void n_Close (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Xamarin.Test.II2 __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.II2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			__this.Close ();
+		}
+#pragma warning restore 0169
+
+		IntPtr id_close;
+		public unsafe void Close ()
+		{
+			if (id_close == IntPtr.Zero)
+				id_close = JNIEnv.GetMethodID (class_ref, "close", "()V");
+			JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_close);
+		}
+
+	}
+
+}

--- a/tools/generator/Tests/expected/InterfaceMethodsConflict/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected/InterfaceMethodsConflict/Xamarin.Test.SomeObject.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Xamarin.Test {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']"
+	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
+	public partial class SomeObject : global::Java.Lang.Object, global::Xamarin.Test.II1, global::Xamarin.Test.II2 {
+
+		internal static IntPtr java_class_handle;
+		internal static IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("xamarin/test/SomeObject", ref java_class_handle);
+			}
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (SomeObject); }
+		}
+
+		protected SomeObject (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		static Delegate cb_close;
+#pragma warning disable 0169
+		static Delegate GetCloseHandler ()
+		{
+			if (cb_close == null)
+				cb_close = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr>) n_Close);
+			return cb_close;
+		}
+
+		static void n_Close (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			__this.Close ();
+		}
+#pragma warning restore 0169
+
+		static IntPtr id_close;
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/method[@name='close' and count(parameter)=0]"
+		[Register ("close", "()V", "GetCloseHandler")]
+		public virtual unsafe void Close ()
+		{
+			if (id_close == IntPtr.Zero)
+				id_close = JNIEnv.GetMethodID (class_ref, "close", "()V");
+			try {
+
+				if (((object) this).GetType () == ThresholdType)
+					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_close);
+				else
+					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "close", "()V"));
+			} finally {
+			}
+		}
+
+	}
+}

--- a/tools/generator/Tests/expected/InterfaceMethodsConflict/Xamarin.Test.SomeObject2.cs
+++ b/tools/generator/Tests/expected/InterfaceMethodsConflict/Xamarin.Test.SomeObject2.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Xamarin.Test {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject2']"
+	[global::Android.Runtime.Register ("xamarin/test/SomeObject2", DoNotGenerateAcw=true)]
+	public abstract partial class SomeObject2 : global::Java.Lang.Object, global::Xamarin.Test.II1, global::Xamarin.Test.II2 {
+
+		internal static IntPtr java_class_handle;
+		internal static IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("xamarin/test/SomeObject2", ref java_class_handle);
+			}
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (SomeObject2); }
+		}
+
+		protected SomeObject2 (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		static Delegate cb_irrelevant;
+#pragma warning disable 0169
+		static Delegate GetIrrelevantHandler ()
+		{
+			if (cb_irrelevant == null)
+				cb_irrelevant = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr>) n_Irrelevant);
+			return cb_irrelevant;
+		}
+
+		static void n_Irrelevant (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Xamarin.Test.SomeObject2 __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			__this.Irrelevant ();
+		}
+#pragma warning restore 0169
+
+		static IntPtr id_irrelevant;
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject2']/method[@name='irrelevant' and count(parameter)=0]"
+		[Register ("irrelevant", "()V", "GetIrrelevantHandler")]
+		public virtual unsafe void Irrelevant ()
+		{
+			if (id_irrelevant == IntPtr.Zero)
+				id_irrelevant = JNIEnv.GetMethodID (class_ref, "irrelevant", "()V");
+			try {
+
+				if (((object) this).GetType () == ThresholdType)
+					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_irrelevant);
+				else
+					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "irrelevant", "()V"));
+			} finally {
+			}
+		}
+
+		static Delegate cb_close;
+#pragma warning disable 0169
+		static Delegate GetCloseHandler ()
+		{
+			if (cb_close == null)
+				cb_close = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr>) n_Close);
+			return cb_close;
+		}
+
+		static void n_Close (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Xamarin.Test.SomeObject2 __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			__this.Close ();
+		}
+#pragma warning restore 0169
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/interface[@name='I1']/method[@name='close' and count(parameter)=0]"
+		[Register ("close", "()V", "GetCloseHandler")]
+		public abstract void Close ();
+
+	}
+
+	[global::Android.Runtime.Register ("xamarin/test/SomeObject2", DoNotGenerateAcw=true)]
+	internal partial class SomeObject2Invoker : SomeObject2 {
+
+		public SomeObject2Invoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (SomeObject2Invoker); }
+		}
+
+		static IntPtr id_close;
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/interface[@name='I1']/method[@name='close' and count(parameter)=0]"
+		[Register ("close", "()V", "GetCloseHandler")]
+		public override unsafe void Close ()
+		{
+			if (id_close == IntPtr.Zero)
+				id_close = JNIEnv.GetMethodID (class_ref, "close", "()V");
+			try {
+				JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_close);
+			} finally {
+			}
+		}
+
+	}
+
+}

--- a/tools/generator/Tests/expected/InterfaceMethodsConflict/__NamespaceMapping__.cs
+++ b/tools/generator/Tests/expected/InterfaceMethodsConflict/__NamespaceMapping__.cs
@@ -1,0 +1,2 @@
+[assembly:global::Android.Runtime.NamespaceMapping (Java = "java.lang", Managed="Java.Lang")]
+[assembly:global::Android.Runtime.NamespaceMapping (Java = "xamarin.test", Managed="Xamarin.Test")]

--- a/tools/generator/Tests/generator-Tests.csproj
+++ b/tools/generator/Tests/generator-Tests.csproj
@@ -61,6 +61,7 @@
     <Compile Include="PamareterXPath.cs" />
     <Compile Include="CSharpKeywords.cs" />
     <Compile Include="GenericArguments.cs" />
+    <Compile Include="InterfaceMethodsConflict.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
There are classes that implement more than one interfaces that share an
identical methods (which share the same name and the same JNI signature).
For example, java.nio.AsynchronousFileChannel implements Closeable and
AsynchronousChannel, both of which contain `close()` method.

Only one `Close()` should be generated for that class.