### PR TITLE
Make tests run on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,11 @@ CONFIGURATION = Debug
 
 ifeq ($(OS),Darwin)
 NATIVE_EXT = .dylib
+DLLMAP_OS_NAME = osx
 endif
 ifeq ($(OS),Linux)
 NATIVE_EXT = .so
+DLLMAP_OS_NAME = linux
 endif
 
 XA_CONFIGURATION  = XAIntegrationDebug
@@ -70,7 +72,7 @@ $(PACKAGES) $(NUNIT_CONSOLE):
 
 src/Java.Runtime.Environment/Java.Runtime.Environment.dll.config: src/Java.Runtime.Environment/Java.Runtime.Environment.dll.config.in \
 		bin/Build$(CONFIGURATION)/JdkInfo.props
-	sed 's#@JI_JVM_PATH@#$(JI_JVM_PATH)#g' < $< > $@
+	sed -e 's#@JI_JVM_PATH@#$(JI_JVM_PATH)#g' -e 's#@OS_NAME@#$(DLLMAP_OS_NAME)#g' < $< > $@
 
 xa-fxcop: lib/gendarme-2.10/gendarme.exe bin/$(XA_CONFIGURATION)/Java.Interop.dll
 	$(RUNTIME) $< --html xa-gendarme.html $(if @(GENDARME_XML),--xml xa-gendarme.xml) --ignore gendarme-ignore.txt bin/$(XA_CONFIGURATION)/Java.Interop.dll

--- a/src/Java.Runtime.Environment/Java.Runtime.Environment.dll.config.in
+++ b/src/Java.Runtime.Environment/Java.Runtime.Environment.dll.config.in
@@ -1,3 +1,3 @@
 <configuration>
-  <dllmap dll="jvm.dll" os="osx" target="@JI_JVM_PATH@"/>
+  <dllmap dll="jvm.dll" os="@OS_NAME@" target="@JI_JVM_PATH@"/>
 </configuration>


### PR DESCRIPTION
In order to do so we need to configure everything so that the
native libjvm is found by the runtime. This patch adds detection
logic as well as modifies the dllmap to work on Linux in addition
to OSX.