### PR TITLE
Fix stack overflow when running on Linux

### DIFF
--- a/src/java-interop/java-interop-gc-bridge-mono.c
+++ b/src/java-interop/java-interop-gc-bridge-mono.c
@@ -9,6 +9,7 @@
 #include "java-interop-mono.h"
 
 #ifdef __linux__
+	#include <sys/syscall.h>
 	#include <unistd.h>
 #endif  /* !defined (__linux__) */
 
@@ -1178,7 +1179,7 @@ get_thread_id (void)
 		return _mono_thread_get_managed_id (thread);
 	}
 #if __linux__
-	int64_t tid = gettid ();
+	int64_t tid = (int64_t)((pid_t)syscall(SYS_gettid));
 #else
 	int64_t tid = (int64_t) pthread_self ();
 #endif

--- a/src/java-interop/java-interop.mdproj
+++ b/src/java-interop/java-interop.mdproj
@@ -116,7 +116,7 @@
       <_Files>@(Compile -&gt; '%(Identity)', ' ')</_Files>
     </PropertyGroup>
     <MakeDir Directories="obj" />
-    <Exec Command="gcc -g -shared -std=c99 -o $(OutputPath)\lib$(OutputName).so $(_CppFlags) $(_LinkFlags) $(_Libs) $(_Includes) $(_Files)" />
+    <Exec Command="gcc -g -shared -std=c99 -D_GNU_SOURCE -D_POSIX_C_SOURCE=200809L -o $(OutputPath)\lib$(OutputName).so $(_CppFlags) $(_LinkFlags) $(_Libs) $(_Includes) $(_Files)" />
   </Target>
   <Target Name="Clean">
     <RemoveDir Directories="obj" />


### PR DESCRIPTION
Java.Interop native code is built with `-std=c99` which, on Linux,
makes the `strdup(3)` and `realpath(3)` functions undeclared (they're not
part of the C99 standard). This posesa problem since both of them
return pointers and the assumed return value for an undeclared
function is an `int` - when running on a 64-bit system the "integer"
is cast to a pointer so that the high 32-bits of the resulting value
are set to 1 thus creating an invalid pointer.

This commit makes sure both functions are declared.

The commit also removes call to `gettid` which does not have a
wrapper in glibc and should be called directly using `syscall(2)`