### PR TITLE
[generator] Generate Threshold{Class,Type} all classes (#154)

### DIFF
--- a/tools/generator/ClassGen.cs
+++ b/tools/generator/ClassGen.cs
@@ -162,10 +162,6 @@ namespace MonoDroid.Generation {
 			get { return "IntPtr"; }
 		}
 
-		public bool HasClassHandle {
-			get { return ctors.Count > 0 || Fields.Count > 0 || Methods.Count > 0 || Properties.Count > 0 || IsAnnotation; }
-		}
-
 		public IList<Ctor> Ctors {
 			get { return ctors; }
 		}
@@ -451,17 +447,16 @@ namespace MonoDroid.Generation {
 				sw.WriteLine ();
 			}
 
-			if (HasClassHandle) {
-				bool requireNew = false;
+			bool requireNew = InheritsObject;
+			if (!requireNew) {
 				for (var bg = BaseGen; bg != null && bg is XmlClassGen; bg = bg.BaseGen) {
-					if (bg.HasClassHandle) {
+					if (bg.InheritsObject) {
 						requireNew = true;
 						break;
 					}
 				}
-
-				opt.CodeGenerator.WriteClassHandle (this, sw, indent, opt, requireNew);
 			}
+			opt.CodeGenerator.WriteClassHandle (this, sw, indent, opt, requireNew);
 
 			GenConstructors (sw, indent + "\t", opt);
 

--- a/tools/generator/Tests/expected.ji/Adapters/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/Adapters/Java.Lang.Object.cs
@@ -9,5 +9,12 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
+		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
 	}
 }

--- a/tools/generator/Tests/expected.ji/Adapters/Xamarin.Test.AdapterView.cs
+++ b/tools/generator/Tests/expected.ji/Adapters/Xamarin.Test.AdapterView.cs
@@ -10,8 +10,8 @@ namespace Xamarin.Test {
 	[global::Java.Interop.JavaTypeParameters (new string [] {"T extends xamarin.test.Adapter"})]
 	public abstract partial class AdapterView : global::Java.Lang.Object {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/AdapterView", typeof (AdapterView));
-		internal static IntPtr class_ref {
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/AdapterView", typeof (AdapterView));
+		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
 			}

--- a/tools/generator/Tests/expected.ji/Adapters/Xamarin.Test.GenericReturnObject.cs
+++ b/tools/generator/Tests/expected.ji/Adapters/Xamarin.Test.GenericReturnObject.cs
@@ -9,8 +9,8 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/GenericReturnObject", DoNotGenerateAcw=true)]
 	public partial class GenericReturnObject : global::Java.Lang.Object {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/GenericReturnObject", typeof (GenericReturnObject));
-		internal static IntPtr class_ref {
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/GenericReturnObject", typeof (GenericReturnObject));
+		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
 			}

--- a/tools/generator/Tests/expected.ji/Android.Graphics.Color/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/Android.Graphics.Color/Java.Lang.Object.cs
@@ -9,5 +9,12 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
+		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
 	}
 }

--- a/tools/generator/Tests/expected.ji/Android.Graphics.Color/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected.ji/Android.Graphics.Color/Xamarin.Test.SomeObject.cs
@@ -29,8 +29,8 @@ namespace Xamarin.Test {
 				}
 			}
 		}
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
-		internal static IntPtr class_ref {
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
 			}

--- a/tools/generator/Tests/expected.ji/Arrays/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/Arrays/Java.Lang.Object.cs
@@ -9,5 +9,12 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
+		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
 	}
 }

--- a/tools/generator/Tests/expected.ji/Arrays/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected.ji/Arrays/Xamarin.Test.SomeObject.cs
@@ -163,8 +163,8 @@ namespace Xamarin.Test {
 				}
 			}
 		}
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
-		internal static IntPtr class_ref {
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
 			}

--- a/tools/generator/Tests/expected.ji/CSharpKeywords/Xamarin.Test.CSharpKeywords.cs
+++ b/tools/generator/Tests/expected.ji/CSharpKeywords/Xamarin.Test.CSharpKeywords.cs
@@ -9,8 +9,8 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/CSharpKeywords", DoNotGenerateAcw=true)]
 	public partial class CSharpKeywords : global::Java.Lang.Object {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/CSharpKeywords", typeof (CSharpKeywords));
-		internal static IntPtr class_ref {
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/CSharpKeywords", typeof (CSharpKeywords));
+		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
 			}

--- a/tools/generator/Tests/expected.ji/Constructors/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/Constructors/Java.Lang.Object.cs
@@ -9,5 +9,12 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
+		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
 	}
 }

--- a/tools/generator/Tests/expected.ji/Constructors/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected.ji/Constructors/Xamarin.Test.SomeObject.cs
@@ -9,8 +9,8 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public partial class SomeObject : global::Java.Lang.Object {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
-		internal static IntPtr class_ref {
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
 			}

--- a/tools/generator/Tests/expected.ji/GenericArguments/Com.Google.Android.Exoplayer.Drm.FrameworkMediaDrm.cs
+++ b/tools/generator/Tests/expected.ji/GenericArguments/Com.Google.Android.Exoplayer.Drm.FrameworkMediaDrm.cs
@@ -9,8 +9,8 @@ namespace Com.Google.Android.Exoplayer.Drm {
 	[global::Android.Runtime.Register ("com/google/android/exoplayer/drm/FrameworkMediaDrm", DoNotGenerateAcw=true)]
 	public sealed partial class FrameworkMediaDrm : global::Java.Lang.Object, global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("com/google/android/exoplayer/drm/FrameworkMediaDrm", typeof (FrameworkMediaDrm));
-		internal static IntPtr class_ref {
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("com/google/android/exoplayer/drm/FrameworkMediaDrm", typeof (FrameworkMediaDrm));
+		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
 			}

--- a/tools/generator/Tests/expected.ji/GenericArguments/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/GenericArguments/Java.Lang.Object.cs
@@ -9,5 +9,12 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
+		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
 	}
 }

--- a/tools/generator/Tests/expected.ji/NestedTypes/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/NestedTypes/Java.Lang.Object.cs
@@ -9,5 +9,12 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
+		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
 	}
 }

--- a/tools/generator/Tests/expected.ji/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
+++ b/tools/generator/Tests/expected.ji/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
@@ -103,6 +103,25 @@ namespace Xamarin.Test {
 			}
 
 
+			internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/NotificationCompatBase$Action", typeof (Action));
+			internal static new IntPtr class_ref {
+				get {
+					return _members.JniPeerType.PeerReference.Handle;
+				}
+			}
+
+			public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+				get { return _members; }
+			}
+
+			protected override IntPtr ThresholdClass {
+				get { return _members.JniPeerType.PeerReference.Handle; }
+			}
+
+			protected override global::System.Type ThresholdType {
+				get { return _members.ManagedPeerType; }
+			}
+
 			protected Action (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
 
 		}
@@ -129,8 +148,8 @@ namespace Xamarin.Test {
 		[global::Android.Runtime.Register ("xamarin/test/NotificationCompatBase$InstanceInner", DoNotGenerateAcw=true)]
 		public abstract partial class InstanceInner : global::Java.Lang.Object {
 
-			internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/NotificationCompatBase$InstanceInner", typeof (InstanceInner));
-			internal static IntPtr class_ref {
+			internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/NotificationCompatBase$InstanceInner", typeof (InstanceInner));
+			internal static new IntPtr class_ref {
 				get {
 					return _members.JniPeerType.PeerReference.Handle;
 				}
@@ -189,6 +208,25 @@ namespace Xamarin.Test {
 
 		}
 
+
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/NotificationCompatBase", typeof (NotificationCompatBase));
+		internal static new IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
 
 		protected NotificationCompatBase (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
 

--- a/tools/generator/Tests/expected.ji/NonStaticFields/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/NonStaticFields/Java.Lang.Object.cs
@@ -9,5 +9,12 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
+		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
 	}
 }

--- a/tools/generator/Tests/expected.ji/NonStaticFields/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected.ji/NonStaticFields/Xamarin.Test.SomeObject.cs
@@ -29,8 +29,8 @@ namespace Xamarin.Test {
 				}
 			}
 		}
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
-		internal static IntPtr class_ref {
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
 			}

--- a/tools/generator/Tests/expected.ji/NormalMethods/Java.Lang.Class.cs
+++ b/tools/generator/Tests/expected.ji/NormalMethods/Java.Lang.Class.cs
@@ -10,6 +10,25 @@ namespace Java.Lang {
 	[global::Java.Interop.JavaTypeParameters (new string [] {"T"})]
 	public partial class Class : global::Java.Lang.Object {
 
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Class", typeof (Class));
+		internal static new IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
 		protected Class (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
 
 	}

--- a/tools/generator/Tests/expected.ji/NormalMethods/Java.Lang.Integer.cs
+++ b/tools/generator/Tests/expected.ji/NormalMethods/Java.Lang.Integer.cs
@@ -9,6 +9,25 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Integer", DoNotGenerateAcw=true)]
 	public partial class Integer : global::Java.Lang.Object {
 
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Integer", typeof (Integer));
+		internal static new IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
 		protected Integer (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
 
 	}

--- a/tools/generator/Tests/expected.ji/NormalMethods/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/NormalMethods/Java.Lang.Object.cs
@@ -9,5 +9,12 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
+		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
 	}
 }

--- a/tools/generator/Tests/expected.ji/NormalMethods/Java.Lang.Throwable.cs
+++ b/tools/generator/Tests/expected.ji/NormalMethods/Java.Lang.Throwable.cs
@@ -9,5 +9,12 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Throwable", DoNotGenerateAcw=true)]
 	public partial class Throwable  {
 
+		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Throwable", typeof (Throwable));
+		internal static IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
 	}
 }

--- a/tools/generator/Tests/expected.ji/NormalMethods/Xamarin.Test.A.cs
+++ b/tools/generator/Tests/expected.ji/NormalMethods/Xamarin.Test.A.cs
@@ -14,8 +14,8 @@ namespace Xamarin.Test {
 		[global::Java.Interop.JavaTypeParameters (new string [] {"T extends xamarin.test.A.B"})]
 		public partial class B : global::Java.Lang.Object {
 
-			internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/A$B", typeof (B));
-			internal static IntPtr class_ref {
+			internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/A$B", typeof (B));
+			internal static new IntPtr class_ref {
 				get {
 					return _members.JniPeerType.PeerReference.Handle;
 				}
@@ -67,8 +67,8 @@ namespace Xamarin.Test {
 
 		}
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/A", typeof (A));
-		internal static IntPtr class_ref {
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/A", typeof (A));
+		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
 			}

--- a/tools/generator/Tests/expected.ji/NormalMethods/Xamarin.Test.C.cs
+++ b/tools/generator/Tests/expected.ji/NormalMethods/Xamarin.Test.C.cs
@@ -10,8 +10,8 @@ namespace Xamarin.Test {
 	[global::Java.Interop.JavaTypeParameters (new string [] {"T extends xamarin.test.C"})]
 	public partial class C : global::Java.Lang.Object {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/C", typeof (C));
-		internal static IntPtr class_ref {
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/C", typeof (C));
+		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
 			}

--- a/tools/generator/Tests/expected.ji/NormalMethods/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected.ji/NormalMethods/Xamarin.Test.SomeObject.cs
@@ -9,8 +9,8 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public partial class SomeObject : global::Java.Lang.Object {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
-		internal static IntPtr class_ref {
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
 			}

--- a/tools/generator/Tests/expected.ji/NormalProperties/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/NormalProperties/Java.Lang.Object.cs
@@ -9,5 +9,12 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
+		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
 	}
 }

--- a/tools/generator/Tests/expected.ji/NormalProperties/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected.ji/NormalProperties/Xamarin.Test.SomeObject.cs
@@ -9,8 +9,8 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public abstract partial class SomeObject : global::Java.Lang.Object {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
-		internal static IntPtr class_ref {
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
 			}

--- a/tools/generator/Tests/expected.ji/ParameterXPath/Java.Lang.Integer.cs
+++ b/tools/generator/Tests/expected.ji/ParameterXPath/Java.Lang.Integer.cs
@@ -9,6 +9,25 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Integer", DoNotGenerateAcw=true)]
 	public partial class Integer : global::Java.Lang.Object {
 
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Integer", typeof (Integer));
+		internal static new IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
 		protected Integer (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
 
 	}

--- a/tools/generator/Tests/expected.ji/ParameterXPath/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/ParameterXPath/Java.Lang.Object.cs
@@ -9,5 +9,12 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
+		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
 	}
 }

--- a/tools/generator/Tests/expected.ji/ParameterXPath/Xamarin.Test.A.cs
+++ b/tools/generator/Tests/expected.ji/ParameterXPath/Xamarin.Test.A.cs
@@ -10,8 +10,8 @@ namespace Xamarin.Test {
 	[global::Java.Interop.JavaTypeParameters (new string [] {"T extends java.lang.Object"})]
 	public partial class A : global::Java.Lang.Object {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/A", typeof (A));
-		internal static IntPtr class_ref {
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/A", typeof (A));
+		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
 			}

--- a/tools/generator/Tests/expected.ji/StaticFields/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/StaticFields/Java.Lang.Object.cs
@@ -9,5 +9,12 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
+		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
 	}
 }

--- a/tools/generator/Tests/expected.ji/StaticFields/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected.ji/StaticFields/Xamarin.Test.SomeObject.cs
@@ -41,8 +41,8 @@ namespace Xamarin.Test {
 				}
 			}
 		}
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
-		internal static IntPtr class_ref {
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
 			}

--- a/tools/generator/Tests/expected.ji/StaticMethods/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/StaticMethods/Java.Lang.Object.cs
@@ -9,5 +9,12 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
+		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
 	}
 }

--- a/tools/generator/Tests/expected.ji/StaticMethods/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected.ji/StaticMethods/Xamarin.Test.SomeObject.cs
@@ -9,8 +9,8 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public partial class SomeObject : global::Java.Lang.Object {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
-		internal static IntPtr class_ref {
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
 			}

--- a/tools/generator/Tests/expected.ji/StaticProperties/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/StaticProperties/Java.Lang.Object.cs
@@ -9,5 +9,12 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
+		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
 	}
 }

--- a/tools/generator/Tests/expected.ji/StaticProperties/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected.ji/StaticProperties/Xamarin.Test.SomeObject.cs
@@ -9,8 +9,8 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public partial class SomeObject : global::Java.Lang.Object {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
-		internal static IntPtr class_ref {
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
 			}

--- a/tools/generator/Tests/expected.ji/Streams/Java.IO.InputStream.cs
+++ b/tools/generator/Tests/expected.ji/Streams/Java.IO.InputStream.cs
@@ -9,8 +9,8 @@ namespace Java.IO {
 	[global::Android.Runtime.Register ("java/io/InputStream", DoNotGenerateAcw=true)]
 	public abstract partial class InputStream : global::Java.Lang.Object {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/io/InputStream", typeof (InputStream));
-		internal static IntPtr class_ref {
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/io/InputStream", typeof (InputStream));
+		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
 			}

--- a/tools/generator/Tests/expected.ji/Streams/Java.IO.OutputStream.cs
+++ b/tools/generator/Tests/expected.ji/Streams/Java.IO.OutputStream.cs
@@ -9,8 +9,8 @@ namespace Java.IO {
 	[global::Android.Runtime.Register ("java/io/OutputStream", DoNotGenerateAcw=true)]
 	public abstract partial class OutputStream : global::Java.Lang.Object {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/io/OutputStream", typeof (OutputStream));
-		internal static IntPtr class_ref {
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/io/OutputStream", typeof (OutputStream));
+		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
 			}

--- a/tools/generator/Tests/expected.ji/Streams/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/Streams/Java.Lang.Object.cs
@@ -9,5 +9,12 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
+		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
 	}
 }

--- a/tools/generator/Tests/expected.ji/TestInterface/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Java.Lang.Object.cs
@@ -9,5 +9,12 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
+		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
 	}
 }

--- a/tools/generator/Tests/expected.ji/TestInterface/Java.Lang.String.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Java.Lang.String.cs
@@ -9,6 +9,25 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/String", DoNotGenerateAcw=true)]
 	public partial class String : global::Java.Lang.Object {
 
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/String", typeof (String));
+		internal static new IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
 		protected String (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
 
 	}

--- a/tools/generator/Tests/expected.ji/TestInterface/Test.ME.GenericImplementation.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Test.ME.GenericImplementation.cs
@@ -9,8 +9,8 @@ namespace Test.ME {
 	[global::Android.Runtime.Register ("test/me/GenericImplementation", DoNotGenerateAcw=true)]
 	public partial class GenericImplementation : global::Java.Lang.Object, global::Test.ME.IGenericInterface {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("test/me/GenericImplementation", typeof (GenericImplementation));
-		internal static IntPtr class_ref {
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("test/me/GenericImplementation", typeof (GenericImplementation));
+		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
 			}

--- a/tools/generator/Tests/expected.ji/TestInterface/Test.ME.GenericStringImplementation.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Test.ME.GenericStringImplementation.cs
@@ -9,8 +9,8 @@ namespace Test.ME {
 	[global::Android.Runtime.Register ("test/me/GenericStringImplementation", DoNotGenerateAcw=true)]
 	public partial class GenericStringImplementation : global::Java.Lang.Object, global::Test.ME.IGenericInterface {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("test/me/GenericStringImplementation", typeof (GenericStringImplementation));
-		internal static IntPtr class_ref {
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("test/me/GenericStringImplementation", typeof (GenericStringImplementation));
+		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
 			}

--- a/tools/generator/Tests/expected.ji/TestInterface/Test.ME.TestInterfaceImplementation.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Test.ME.TestInterfaceImplementation.cs
@@ -31,8 +31,8 @@ namespace Test.ME {
 			}
 		}
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("test/me/TestInterfaceImplementation", typeof (TestInterfaceImplementation));
-		internal static IntPtr class_ref {
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("test/me/TestInterfaceImplementation", typeof (TestInterfaceImplementation));
+		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
 			}

--- a/tools/generator/Tests/expected.ji/java.lang.Enum/Java.Lang.Enum.cs
+++ b/tools/generator/Tests/expected.ji/java.lang.Enum/Java.Lang.Enum.cs
@@ -10,8 +10,8 @@ namespace Java.Lang {
 	[global::Java.Interop.JavaTypeParameters (new string [] {"E extends java.lang.Enum<E>"})]
 	public abstract partial class Enum : global::Java.Lang.Object, global::Java.Lang.IComparable {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Enum", typeof (Enum));
-		internal static IntPtr class_ref {
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Enum", typeof (Enum));
+		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
 			}

--- a/tools/generator/Tests/expected.ji/java.lang.Enum/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/java.lang.Enum/Java.Lang.Object.cs
@@ -9,5 +9,12 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
+		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
 	}
 }

--- a/tools/generator/Tests/expected.ji/java.lang.Object/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/java.lang.Object/Java.Lang.Object.cs
@@ -9,5 +9,12 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
+		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
 	}
 }

--- a/tools/generator/Tests/expected.ji/java.util.List/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/java.util.List/Java.Lang.Object.cs
@@ -9,5 +9,12 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
+		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
 	}
 }

--- a/tools/generator/Tests/expected.ji/java.util.List/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected.ji/java.util.List/Xamarin.Test.SomeObject.cs
@@ -163,8 +163,8 @@ namespace Xamarin.Test {
 				}
 			}
 		}
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
-		internal static IntPtr class_ref {
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
 			}

--- a/tools/generator/Tests/expected/Adapters/Xamarin.Test.AdapterView.cs
+++ b/tools/generator/Tests/expected/Adapters/Xamarin.Test.AdapterView.cs
@@ -9,8 +9,8 @@ namespace Xamarin.Test {
 	[global::Java.Interop.JavaTypeParameters (new string [] {"T extends xamarin.test.Adapter"})]
 	public abstract partial class AdapterView : global::Java.Lang.Object {
 
-		internal static IntPtr java_class_handle;
-		internal static IntPtr class_ref {
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
 			get {
 				return JNIEnv.FindClass ("xamarin/test/AdapterView", ref java_class_handle);
 			}

--- a/tools/generator/Tests/expected/Adapters/Xamarin.Test.GenericReturnObject.cs
+++ b/tools/generator/Tests/expected/Adapters/Xamarin.Test.GenericReturnObject.cs
@@ -8,8 +8,8 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/GenericReturnObject", DoNotGenerateAcw=true)]
 	public partial class GenericReturnObject : global::Java.Lang.Object {
 
-		internal static IntPtr java_class_handle;
-		internal static IntPtr class_ref {
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
 			get {
 				return JNIEnv.FindClass ("xamarin/test/GenericReturnObject", ref java_class_handle);
 			}

--- a/tools/generator/Tests/expected/Android.Graphics.Color/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected/Android.Graphics.Color/Xamarin.Test.SomeObject.cs
@@ -29,8 +29,8 @@ namespace Xamarin.Test {
 				}
 			}
 		}
-		internal static IntPtr java_class_handle;
-		internal static IntPtr class_ref {
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
 			get {
 				return JNIEnv.FindClass ("xamarin/test/SomeObject", ref java_class_handle);
 			}

--- a/tools/generator/Tests/expected/Arrays/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected/Arrays/Xamarin.Test.SomeObject.cs
@@ -162,8 +162,8 @@ namespace Xamarin.Test {
 				}
 			}
 		}
-		internal static IntPtr java_class_handle;
-		internal static IntPtr class_ref {
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
 			get {
 				return JNIEnv.FindClass ("xamarin/test/SomeObject", ref java_class_handle);
 			}

--- a/tools/generator/Tests/expected/CSharpKeywords/Xamarin.Test.CSharpKeywords.cs
+++ b/tools/generator/Tests/expected/CSharpKeywords/Xamarin.Test.CSharpKeywords.cs
@@ -8,8 +8,8 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/CSharpKeywords", DoNotGenerateAcw=true)]
 	public partial class CSharpKeywords : global::Java.Lang.Object {
 
-		internal static IntPtr java_class_handle;
-		internal static IntPtr class_ref {
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
 			get {
 				return JNIEnv.FindClass ("xamarin/test/CSharpKeywords", ref java_class_handle);
 			}

--- a/tools/generator/Tests/expected/Constructors/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected/Constructors/Xamarin.Test.SomeObject.cs
@@ -8,8 +8,8 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public partial class SomeObject : global::Java.Lang.Object {
 
-		internal static IntPtr java_class_handle;
-		internal static IntPtr class_ref {
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
 			get {
 				return JNIEnv.FindClass ("xamarin/test/SomeObject", ref java_class_handle);
 			}

--- a/tools/generator/Tests/expected/EnumerationFixup/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected/EnumerationFixup/Java.Lang.Object.cs
@@ -8,5 +8,12 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
+		internal static IntPtr java_class_handle;
+		internal static IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("java/lang/Object", ref java_class_handle);
+			}
+		}
+
 	}
 }

--- a/tools/generator/Tests/expected/EnumerationFixup/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected/EnumerationFixup/Xamarin.Test.SomeObject.cs
@@ -8,8 +8,8 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public partial class SomeObject : global::Java.Lang.Object {
 
-		internal static IntPtr java_class_handle;
-		internal static IntPtr class_ref {
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
 			get {
 				return JNIEnv.FindClass ("xamarin/test/SomeObject", ref java_class_handle);
 			}

--- a/tools/generator/Tests/expected/GenericArguments/Com.Google.Android.Exoplayer.Drm.FrameworkMediaDrm.cs
+++ b/tools/generator/Tests/expected/GenericArguments/Com.Google.Android.Exoplayer.Drm.FrameworkMediaDrm.cs
@@ -8,8 +8,8 @@ namespace Com.Google.Android.Exoplayer.Drm {
 	[global::Android.Runtime.Register ("com/google/android/exoplayer/drm/FrameworkMediaDrm", DoNotGenerateAcw=true)]
 	public sealed partial class FrameworkMediaDrm : global::Java.Lang.Object, global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm {
 
-		internal static IntPtr java_class_handle;
-		internal static IntPtr class_ref {
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
 			get {
 				return JNIEnv.FindClass ("com/google/android/exoplayer/drm/FrameworkMediaDrm", ref java_class_handle);
 			}

--- a/tools/generator/Tests/expected/GenericArguments/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected/GenericArguments/Java.Lang.Object.cs
@@ -8,5 +8,12 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
+		internal static IntPtr java_class_handle;
+		internal static IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("java/lang/Object", ref java_class_handle);
+			}
+		}
+
 	}
 }

--- a/tools/generator/Tests/expected/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
+++ b/tools/generator/Tests/expected/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
@@ -94,6 +94,21 @@ namespace Xamarin.Test {
 			}
 
 
+			internal static new IntPtr java_class_handle;
+			internal static new IntPtr class_ref {
+				get {
+					return JNIEnv.FindClass ("xamarin/test/NotificationCompatBase$Action", ref java_class_handle);
+				}
+			}
+
+			protected override IntPtr ThresholdClass {
+				get { return class_ref; }
+			}
+
+			protected override global::System.Type ThresholdType {
+				get { return typeof (Action); }
+			}
+
 			protected Action (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
 
 		}
@@ -114,8 +129,8 @@ namespace Xamarin.Test {
 		[global::Android.Runtime.Register ("xamarin/test/NotificationCompatBase$InstanceInner", DoNotGenerateAcw=true)]
 		public abstract partial class InstanceInner : global::Java.Lang.Object {
 
-			internal static IntPtr java_class_handle;
-			internal static IntPtr class_ref {
+			internal static new IntPtr java_class_handle;
+			internal static new IntPtr class_ref {
 				get {
 					return JNIEnv.FindClass ("xamarin/test/NotificationCompatBase$InstanceInner", ref java_class_handle);
 				}
@@ -174,6 +189,21 @@ namespace Xamarin.Test {
 
 		}
 
+
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("xamarin/test/NotificationCompatBase", ref java_class_handle);
+			}
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (NotificationCompatBase); }
+		}
 
 		protected NotificationCompatBase (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
 

--- a/tools/generator/Tests/expected/NonStaticFields/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected/NonStaticFields/Xamarin.Test.SomeObject.cs
@@ -28,8 +28,8 @@ namespace Xamarin.Test {
 				}
 			}
 		}
-		internal static IntPtr java_class_handle;
-		internal static IntPtr class_ref {
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
 			get {
 				return JNIEnv.FindClass ("xamarin/test/SomeObject", ref java_class_handle);
 			}

--- a/tools/generator/Tests/expected/NormalMethods/Java.Lang.Throwable.cs
+++ b/tools/generator/Tests/expected/NormalMethods/Java.Lang.Throwable.cs
@@ -8,5 +8,12 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Throwable", DoNotGenerateAcw=true)]
 	public partial class Throwable  {
 
+		internal static IntPtr java_class_handle;
+		internal static IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("java/lang/Throwable", ref java_class_handle);
+			}
+		}
+
 	}
 }

--- a/tools/generator/Tests/expected/NormalMethods/Xamarin.Test.A.cs
+++ b/tools/generator/Tests/expected/NormalMethods/Xamarin.Test.A.cs
@@ -13,8 +13,8 @@ namespace Xamarin.Test {
 		[global::Java.Interop.JavaTypeParameters (new string [] {"T extends xamarin.test.A.B"})]
 		public partial class B : global::Java.Lang.Object {
 
-			internal static IntPtr java_class_handle;
-			internal static IntPtr class_ref {
+			internal static new IntPtr java_class_handle;
+			internal static new IntPtr class_ref {
 				get {
 					return JNIEnv.FindClass ("xamarin/test/A$B", ref java_class_handle);
 				}
@@ -67,8 +67,8 @@ namespace Xamarin.Test {
 
 		}
 
-		internal static IntPtr java_class_handle;
-		internal static IntPtr class_ref {
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
 			get {
 				return JNIEnv.FindClass ("xamarin/test/A", ref java_class_handle);
 			}

--- a/tools/generator/Tests/expected/NormalMethods/Xamarin.Test.C.cs
+++ b/tools/generator/Tests/expected/NormalMethods/Xamarin.Test.C.cs
@@ -9,8 +9,8 @@ namespace Xamarin.Test {
 	[global::Java.Interop.JavaTypeParameters (new string [] {"T extends xamarin.test.C"})]
 	public partial class C : global::Java.Lang.Object {
 
-		internal static IntPtr java_class_handle;
-		internal static IntPtr class_ref {
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
 			get {
 				return JNIEnv.FindClass ("xamarin/test/C", ref java_class_handle);
 			}

--- a/tools/generator/Tests/expected/NormalMethods/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected/NormalMethods/Xamarin.Test.SomeObject.cs
@@ -8,8 +8,8 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public partial class SomeObject : global::Java.Lang.Object {
 
-		internal static IntPtr java_class_handle;
-		internal static IntPtr class_ref {
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
 			get {
 				return JNIEnv.FindClass ("xamarin/test/SomeObject", ref java_class_handle);
 			}

--- a/tools/generator/Tests/expected/NormalProperties/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected/NormalProperties/Xamarin.Test.SomeObject.cs
@@ -8,8 +8,8 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public abstract partial class SomeObject : global::Java.Lang.Object {
 
-		internal static IntPtr java_class_handle;
-		internal static IntPtr class_ref {
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
 			get {
 				return JNIEnv.FindClass ("xamarin/test/SomeObject", ref java_class_handle);
 			}

--- a/tools/generator/Tests/expected/ParameterXPath/Xamarin.Test.A.cs
+++ b/tools/generator/Tests/expected/ParameterXPath/Xamarin.Test.A.cs
@@ -9,8 +9,8 @@ namespace Xamarin.Test {
 	[global::Java.Interop.JavaTypeParameters (new string [] {"T extends java.lang.Object"})]
 	public partial class A : global::Java.Lang.Object {
 
-		internal static IntPtr java_class_handle;
-		internal static IntPtr class_ref {
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
 			get {
 				return JNIEnv.FindClass ("xamarin/test/A", ref java_class_handle);
 			}

--- a/tools/generator/Tests/expected/StaticFields/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected/StaticFields/Xamarin.Test.SomeObject.cs
@@ -40,8 +40,8 @@ namespace Xamarin.Test {
 				}
 			}
 		}
-		internal static IntPtr java_class_handle;
-		internal static IntPtr class_ref {
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
 			get {
 				return JNIEnv.FindClass ("xamarin/test/SomeObject", ref java_class_handle);
 			}

--- a/tools/generator/Tests/expected/StaticMethods/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected/StaticMethods/Xamarin.Test.SomeObject.cs
@@ -8,8 +8,8 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public partial class SomeObject : global::Java.Lang.Object {
 
-		internal static IntPtr java_class_handle;
-		internal static IntPtr class_ref {
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
 			get {
 				return JNIEnv.FindClass ("xamarin/test/SomeObject", ref java_class_handle);
 			}

--- a/tools/generator/Tests/expected/StaticProperties/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected/StaticProperties/Xamarin.Test.SomeObject.cs
@@ -8,8 +8,8 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public partial class SomeObject : global::Java.Lang.Object {
 
-		internal static IntPtr java_class_handle;
-		internal static IntPtr class_ref {
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
 			get {
 				return JNIEnv.FindClass ("xamarin/test/SomeObject", ref java_class_handle);
 			}

--- a/tools/generator/Tests/expected/Streams/Java.IO.InputStream.cs
+++ b/tools/generator/Tests/expected/Streams/Java.IO.InputStream.cs
@@ -8,8 +8,8 @@ namespace Java.IO {
 	[global::Android.Runtime.Register ("java/io/InputStream", DoNotGenerateAcw=true)]
 	public abstract partial class InputStream : global::Java.Lang.Object {
 
-		internal static IntPtr java_class_handle;
-		internal static IntPtr class_ref {
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
 			get {
 				return JNIEnv.FindClass ("java/io/InputStream", ref java_class_handle);
 			}

--- a/tools/generator/Tests/expected/Streams/Java.IO.OutputStream.cs
+++ b/tools/generator/Tests/expected/Streams/Java.IO.OutputStream.cs
@@ -8,8 +8,8 @@ namespace Java.IO {
 	[global::Android.Runtime.Register ("java/io/OutputStream", DoNotGenerateAcw=true)]
 	public abstract partial class OutputStream : global::Java.Lang.Object {
 
-		internal static IntPtr java_class_handle;
-		internal static IntPtr class_ref {
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
 			get {
 				return JNIEnv.FindClass ("java/io/OutputStream", ref java_class_handle);
 			}

--- a/tools/generator/Tests/expected/TestInterface/Test.ME.GenericImplementation.cs
+++ b/tools/generator/Tests/expected/TestInterface/Test.ME.GenericImplementation.cs
@@ -8,8 +8,8 @@ namespace Test.ME {
 	[global::Android.Runtime.Register ("test/me/GenericImplementation", DoNotGenerateAcw=true)]
 	public partial class GenericImplementation : global::Java.Lang.Object, global::Test.ME.IGenericInterface {
 
-		internal static IntPtr java_class_handle;
-		internal static IntPtr class_ref {
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
 			get {
 				return JNIEnv.FindClass ("test/me/GenericImplementation", ref java_class_handle);
 			}

--- a/tools/generator/Tests/expected/TestInterface/Test.ME.GenericStringImplementation.cs
+++ b/tools/generator/Tests/expected/TestInterface/Test.ME.GenericStringImplementation.cs
@@ -8,8 +8,8 @@ namespace Test.ME {
 	[global::Android.Runtime.Register ("test/me/GenericStringImplementation", DoNotGenerateAcw=true)]
 	public partial class GenericStringImplementation : global::Java.Lang.Object, global::Test.ME.IGenericInterface {
 
-		internal static IntPtr java_class_handle;
-		internal static IntPtr class_ref {
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
 			get {
 				return JNIEnv.FindClass ("test/me/GenericStringImplementation", ref java_class_handle);
 			}

--- a/tools/generator/Tests/expected/TestInterface/Test.ME.TestInterfaceImplementation.cs
+++ b/tools/generator/Tests/expected/TestInterface/Test.ME.TestInterfaceImplementation.cs
@@ -31,8 +31,8 @@ namespace Test.ME {
 			}
 		}
 
-		internal static IntPtr java_class_handle;
-		internal static IntPtr class_ref {
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
 			get {
 				return JNIEnv.FindClass ("test/me/TestInterfaceImplementation", ref java_class_handle);
 			}

--- a/tools/generator/Tests/expected/java.lang.Enum/Java.Lang.Enum.cs
+++ b/tools/generator/Tests/expected/java.lang.Enum/Java.Lang.Enum.cs
@@ -9,8 +9,8 @@ namespace Java.Lang {
 	[global::Java.Interop.JavaTypeParameters (new string [] {"E extends java.lang.Enum<E>"})]
 	public abstract partial class Enum : global::Java.Lang.Object, global::Java.Lang.IComparable {
 
-		internal static IntPtr java_class_handle;
-		internal static IntPtr class_ref {
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
 			get {
 				return JNIEnv.FindClass ("java/lang/Enum", ref java_class_handle);
 			}

--- a/tools/generator/Tests/expected/java.lang.Enum/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected/java.lang.Enum/Java.Lang.Object.cs
@@ -8,5 +8,12 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
+		internal static IntPtr java_class_handle;
+		internal static IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("java/lang/Object", ref java_class_handle);
+			}
+		}
+
 	}
 }

--- a/tools/generator/Tests/expected/java.lang.Object/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected/java.lang.Object/Java.Lang.Object.cs
@@ -8,5 +8,12 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
+		internal static IntPtr java_class_handle;
+		internal static IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("java/lang/Object", ref java_class_handle);
+			}
+		}
+
 	}
 }

--- a/tools/generator/Tests/expected/java.util.List/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected/java.util.List/Xamarin.Test.SomeObject.cs
@@ -169,8 +169,8 @@ namespace Xamarin.Test {
 				}
 			}
 		}
-		internal static IntPtr java_class_handle;
-		internal static IntPtr class_ref {
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
 			get {
 				return JNIEnv.FindClass ("xamarin/test/SomeObject", ref java_class_handle);
 			}


### PR DESCRIPTION
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=56537

If a class derives from `Java.Lang.Object` it should have the two properties
mentioned above generated, so that it is possible to find methods in the correct
instance of Java class instance that is wrapped by our managed class.

Generator used to decide whether or not to generate these properties based on
the presence of class members (fields, constructors, methods and properties) or
whether the class is an annotation in the API description file.

However there exist a number of classes (for instance `Inet4Address`) which don't
have any of the members present and yet they should have the Threshold*
properties generated for the reasons described above.

The `HasClassHandle` property which was used to determine whether the class should
get these properties (among a handful of other members) doesn't serve its
purpose correctly leading to corner cases when the `Threshold*` properties are
missing and causing runtime bugs (e.g. calling `GetAddress()` on an instance of
`Inet4Address` returns `null` even though the underlying Java class has the
information - the call never reaches `Inet4Address` instance and thus returns
nothing).

Replacing `HasClassHandle` with a simple check for whether the class in question
derives from `Java.Lang.Object` is the correct fix that ensures the missing
properties are generated.