### PR TITLE
Update more generator tests for the recent changes

### DIFF
--- a/tools/generator/Tests-Core/expected.cp/Java.Lang.Object.cs
+++ b/tools/generator/Tests-Core/expected.cp/Java.Lang.Object.cs
@@ -8,5 +8,12 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
+		internal static IntPtr java_class_handle;
+		internal static IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("java/lang/Object", ref java_class_handle);
+			}
+		}
+
 	}
 }

--- a/tools/generator/Tests-Core/expected.cp/Java.Lang.String.cs
+++ b/tools/generator/Tests-Core/expected.cp/Java.Lang.String.cs
@@ -8,6 +8,21 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/String", DoNotGenerateAcw=true)]
 	public partial class String : Java.Lang.Object {
 
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("java/lang/String", ref java_class_handle);
+			}
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (String); }
+		}
+
 		protected String (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
 
 	}

--- a/tools/generator/Tests-Core/expected.cp/Xamarin.Test.Invalidnames.In.cs
+++ b/tools/generator/Tests-Core/expected.cp/Xamarin.Test.Invalidnames.In.cs
@@ -8,6 +8,21 @@ namespace Xamarin.Test.Invalidnames {
 	[global::Android.Runtime.Register ("xamarin/test/invalidnames/in", DoNotGenerateAcw=true)]
 	public partial class In : Java.Lang.Object {
 
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("xamarin/test/invalidnames/in", ref java_class_handle);
+			}
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (In); }
+		}
+
 		protected In (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
 
 	}

--- a/tools/generator/Tests-Core/expected.cp/Xamarin.Test.Invalidnames.InvalidNameMembers.cs
+++ b/tools/generator/Tests-Core/expected.cp/Xamarin.Test.Invalidnames.InvalidNameMembers.cs
@@ -8,6 +8,21 @@ namespace Xamarin.Test.Invalidnames {
 	[global::Android.Runtime.Register ("xamarin/test/invalidnames/InvalidNameMembers", DoNotGenerateAcw=true)]
 	public partial class InvalidNameMembers : Java.Lang.Object {
 
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("xamarin/test/invalidnames/InvalidNameMembers", ref java_class_handle);
+			}
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (InvalidNameMembers); }
+		}
+
 		protected InvalidNameMembers (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
 
 	}

--- a/tools/generator/Tests-Core/expected.ji/Android.Text.SpannableStringInternal.cs
+++ b/tools/generator/Tests-Core/expected.ji/Android.Text.SpannableStringInternal.cs
@@ -9,8 +9,8 @@ namespace Android.Text {
 	[global::Android.Runtime.Register ("android/text/SpannableStringInternal", DoNotGenerateAcw=true)]
 	public abstract partial class SpannableStringInternal : Java.Lang.Object {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("android/text/SpannableStringInternal", typeof (SpannableStringInternal));
-		internal static IntPtr class_ref {
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("android/text/SpannableStringInternal", typeof (SpannableStringInternal));
+		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
 			}

--- a/tools/generator/Tests-Core/expected.ji/Android.Views.View.cs
+++ b/tools/generator/Tests-Core/expected.ji/Android.Views.View.cs
@@ -128,8 +128,8 @@ namespace Android.Views {
 		}
 
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("android/view/View", typeof (View));
-		internal static IntPtr class_ref {
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("android/view/View", typeof (View));
+		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
 			}

--- a/tools/generator/Tests-Core/expected.ji/Java.Lang.Object.cs
+++ b/tools/generator/Tests-Core/expected.ji/Java.Lang.Object.cs
@@ -9,5 +9,12 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
+		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
 	}
 }

--- a/tools/generator/Tests-Core/expected/Android.Text.SpannableStringInternal.cs
+++ b/tools/generator/Tests-Core/expected/Android.Text.SpannableStringInternal.cs
@@ -8,8 +8,8 @@ namespace Android.Text {
 	[global::Android.Runtime.Register ("android/text/SpannableStringInternal", DoNotGenerateAcw=true)]
 	public abstract partial class SpannableStringInternal : Java.Lang.Object {
 
-		internal static IntPtr java_class_handle;
-		internal static IntPtr class_ref {
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
 			get {
 				return JNIEnv.FindClass ("android/text/SpannableStringInternal", ref java_class_handle);
 			}

--- a/tools/generator/Tests-Core/expected/Android.Views.View.cs
+++ b/tools/generator/Tests-Core/expected/Android.Views.View.cs
@@ -119,8 +119,8 @@ namespace Android.Views {
 		}
 
 
-		internal static IntPtr java_class_handle;
-		internal static IntPtr class_ref {
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
 			get {
 				return JNIEnv.FindClass ("android/view/View", ref java_class_handle);
 			}

--- a/tools/generator/Tests-Core/expected/Java.Lang.Object.cs
+++ b/tools/generator/Tests-Core/expected/Java.Lang.Object.cs
@@ -8,5 +8,12 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
+		internal static IntPtr java_class_handle;
+		internal static IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("java/lang/Object", ref java_class_handle);
+			}
+		}
+
 	}
 }


### PR DESCRIPTION
Commit https://github.com/xamarin/java.interop/commit/b292931362fa0bfc90e3facf30bc767fe89a3dea
introduced changes that broke the generator core tests but, somehow,
the tests wouldn't fail neither on the local machine nor on Jenkis.
The breakage became apparent only on Wrench and this commit updates
the core template files to match the current generator behavior.