### PR TITLE
Make JavaProxyThrowable inherit Java.Lang.Error

### DIFF
--- a/src/Java.Interop/java/com/xamarin/java_interop/internal/JavaProxyThrowable.java
+++ b/src/Java.Interop/java/com/xamarin/java_interop/internal/JavaProxyThrowable.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import com.xamarin.java_interop.GCUserPeerable;
 
 /* package */ final class JavaProxyThrowable
-		extends java.lang.Throwable
+		extends java.lang.Error
 		implements GCUserPeerable
 {
 	static  final   String  assemblyQualifiedName   = "Java.Interop.JavaProxyThrowable, Java.Interop, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null";


### PR DESCRIPTION
Android's Zygote process, responsible for starting and initializing
of every app as well as catching any application crashes (exceptions
not handled by the app, most of the time), special-cases application
exceptions of types Java.Lang.Error and Java.Lang.Exception (and their
derivatives) and this may cause issues with automatic crash reporting
recently added to the Google's Developer Console. The automatically collected
reports do not contain the full trace of our exceptions.