### PR TITLE
[jcw-gen] constructors need to respect ExportAttribute

### DIFF
--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
@@ -738,6 +738,10 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 				get { return retval; }
 			}
 
+			public string ThrowsDeclaration {
+				get { return ThrownTypeNames?.Length > 0 ? " throws " + String.Join (", ", ThrownTypeNames) : null; }
+			}
+
 			public readonly string JavaAccess;
 			public readonly string ManagedParameters;
 			public readonly string JniSignature;
@@ -757,7 +761,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 			sw.WriteLine ();
 			if (ctor.Annotations != null)
 				sw.WriteLine (ctor.Annotations);
-			sw.WriteLine ("\tpublic {0} ({1}) throws java.lang.Throwable", name, ctor.Params);
+			sw.WriteLine ("\tpublic {0} ({1}){2}", name, ctor.Params, ctor.ThrowsDeclaration);
 			sw.WriteLine ("\t{");
 			sw.WriteLine ("\t\tsuper ({0});", ctor.SuperCall);
 #if MONODROID_TIMING
@@ -796,7 +800,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 			sw.WriteLine ();
 			if (method.Annotations != null)
 				sw.WriteLine (method.Annotations);
-			sw.WriteLine ("\t{0} {1}{2} {3} ({4}){5}", method.IsExport ? method.JavaAccess : "public", method.IsStatic ? "static " : null, method.Retval, method.JavaName, method.Params, method.ThrownTypeNames != null ? " throws " + String.Join (", ", method.ThrownTypeNames) : null);
+			sw.WriteLine ("\t{0} {1}{2} {3} ({4}){5}", method.IsExport ? method.JavaAccess : "public", method.IsStatic ? "static " : null, method.Retval, method.JavaName, method.Params, method.ThrowsDeclaration);
 			sw.WriteLine ("\t{");
 #if MONODROID_TIMING
 			sw.WriteLine ("\t\tandroid.util.Log.i(\"MonoDroid-Timing\", \"{0}.{1}: time: \"+java.lang.System.currentTimeMillis());", name, method.Name);

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGeneratorTests.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGeneratorTests.cs
@@ -160,6 +160,8 @@ public class ExportsMembers
 			""n_GetValue:()Ljava/lang/String;:__export__\n"" +
 			""n_methodNamesNotMangled:()V:__export__\n"" +
 			""n_CompletelyDifferentName:(Ljava/lang/String;I)Ljava/lang/String;:__export__\n"" +
+			""n_methodThatThrows:()V:__export__\n"" +
+			""n_methodThatThrowsEmptyArray:()V:__export__\n"" +
 			"""";
 		mono.android.Runtime.register (""Xamarin.Android.ToolsTests.ExportsMembers, Java.Interop.Tools.JavaCallableWrappers-Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"", ExportsMembers.class, __md_methods);
 	}
@@ -199,6 +201,22 @@ public class ExportsMembers
 	}
 
 	private native java.lang.String n_CompletelyDifferentName (java.lang.String p0, int p1);
+
+
+	public void methodThatThrows () throws java.lang.Throwable
+	{
+		n_methodThatThrows ();
+	}
+
+	private native void n_methodThatThrows ();
+
+
+	public void methodThatThrowsEmptyArray ()
+	{
+		n_methodThatThrowsEmptyArray ();
+	}
+
+	private native void n_methodThatThrowsEmptyArray ();
 
 	private java.util.ArrayList refList;
 	public void monodroidAddReference (java.lang.Object obj)
@@ -337,6 +355,122 @@ public class Name$Override
 		__md_methods = 
 			"""";
 		mono.android.Runtime.register (""Xamarin.Android.ToolsTests.RegisterName+OverrideNestedName, Java.Interop.Tools.JavaCallableWrappers-Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"", Name$Override.class, __md_methods);
+	}
+
+	private java.util.ArrayList refList;
+	public void monodroidAddReference (java.lang.Object obj)
+	{
+		if (refList == null)
+			refList = new java.util.ArrayList ();
+		refList.add (obj);
+	}
+
+	public void monodroidClearReferences ()
+	{
+		if (refList != null)
+			refList.clear ();
+	}
+}
+";
+			Assert.AreEqual (expected, actual);
+		}
+
+		[Test]
+		public void GenerateConstructors ()
+		{
+			var actual = Generate (typeof (ExportsConstructors));
+			var expected = @"package register;
+
+
+public class ExportsConstructors
+	extends java.lang.Object
+	implements
+		mono.android.IGCUserPeer
+{
+/** @hide */
+	public static final String __md_methods;
+	static {
+		__md_methods = 
+			"""";
+		mono.android.Runtime.register (""Xamarin.Android.ToolsTests.ExportsConstructors, Java.Interop.Tools.JavaCallableWrappers-Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"", ExportsConstructors.class, __md_methods);
+	}
+
+
+	public ExportsConstructors ()
+	{
+		super ();
+		if (getClass () == ExportsConstructors.class)
+			mono.android.TypeManager.Activate (""Xamarin.Android.ToolsTests.ExportsConstructors, Java.Interop.Tools.JavaCallableWrappers-Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"", """", this, new java.lang.Object[] {  });
+	}
+
+
+	public ExportsConstructors (int p0)
+	{
+		super (p0);
+		if (getClass () == ExportsConstructors.class)
+			mono.android.TypeManager.Activate (""Xamarin.Android.ToolsTests.ExportsConstructors, Java.Interop.Tools.JavaCallableWrappers-Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"", """", this, new java.lang.Object[] { p0 });
+	}
+
+	private java.util.ArrayList refList;
+	public void monodroidAddReference (java.lang.Object obj)
+	{
+		if (refList == null)
+			refList = new java.util.ArrayList ();
+		refList.add (obj);
+	}
+
+	public void monodroidClearReferences ()
+	{
+		if (refList != null)
+			refList.clear ();
+	}
+}
+";
+			Assert.AreEqual (expected, actual);
+		}
+
+		[Test]
+		public void GenerateConstructors_WithThrows ()
+		{
+			var actual = Generate (typeof (ExportsThrowsConstructors));
+			var expected = @"package register;
+
+
+public class ExportsThrowsConstructors
+	extends java.lang.Object
+	implements
+		mono.android.IGCUserPeer
+{
+/** @hide */
+	public static final String __md_methods;
+	static {
+		__md_methods = 
+			"""";
+		mono.android.Runtime.register (""Xamarin.Android.ToolsTests.ExportsThrowsConstructors, Java.Interop.Tools.JavaCallableWrappers-Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"", ExportsThrowsConstructors.class, __md_methods);
+	}
+
+
+	public ExportsThrowsConstructors () throws java.lang.Throwable
+	{
+		super ();
+		if (getClass () == ExportsThrowsConstructors.class)
+			mono.android.TypeManager.Activate (""Xamarin.Android.ToolsTests.ExportsThrowsConstructors, Java.Interop.Tools.JavaCallableWrappers-Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"", """", this, new java.lang.Object[] {  });
+	}
+
+
+	public ExportsThrowsConstructors (int p0) throws java.lang.Throwable
+	{
+		super (p0);
+		if (getClass () == ExportsThrowsConstructors.class)
+			mono.android.TypeManager.Activate (""Xamarin.Android.ToolsTests.ExportsThrowsConstructors, Java.Interop.Tools.JavaCallableWrappers-Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"", """", this, new java.lang.Object[] { p0 });
+	}
+
+
+	public ExportsThrowsConstructors (java.lang.String p0)
+	{
+		super (p0);
+		if (getClass () == ExportsThrowsConstructors.class)
+			mono.android.TypeManager.Activate (""Xamarin.Android.ToolsTests.ExportsThrowsConstructors, Java.Interop.Tools.JavaCallableWrappers-Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"", """", this, new java.lang.Object[] { p0 });
 	}
 
 	private java.util.ArrayList refList;

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers/SupportDeclarations.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers/SupportDeclarations.cs
@@ -36,6 +36,11 @@ namespace Java.Lang {
 	class Object : Android.Runtime.IJavaObject
 	{
 	}
+
+	[Register ("java/lang/Throwable", DoNotGenerateAcw = true)]
+	class Throwable : Exception, Android.Runtime.IJavaObject
+	{
+	}
 }
 
 namespace Xamarin.Android.ToolsTests {
@@ -219,5 +224,38 @@ namespace Xamarin.Android.ToolsTests {
 		{
 			return value;
 		}
+
+		[Export (Throws = new [] { typeof (Java.Lang.Throwable) })]
+		public void methodThatThrows() 
+		{
+		}
+
+		[Export (Throws = new Type [0])]
+		public void methodThatThrowsEmptyArray ()
+		{
+		}
+	}
+
+	[Register ("register.ExportsConstructors")]
+	class ExportsConstructors : Java.Lang.Object
+	{
+		[Export]
+		public ExportsConstructors () { }
+
+		[Export]
+		public ExportsConstructors (int value) { }
+	}
+
+	[Register ("register.ExportsThrowsConstructors")]
+	class ExportsThrowsConstructors : Java.Lang.Object
+	{
+		[Export (Throws = new [] { typeof (Java.Lang.Throwable) })]
+		public ExportsThrowsConstructors () { }
+
+		[Export (Throws = new [] { typeof (Java.Lang.Throwable) })]
+		public ExportsThrowsConstructors (int value) { }
+
+		[Export (Throws = new Type [0])]
+		public ExportsThrowsConstructors (string value) { }
 	}
 }


### PR DESCRIPTION
Context: https://github.com/mono/Embeddinator-4000

Embeddinator-4000 will bring a lot more developers to consume C#
objects from their Java code. One pain point here is that all
constructors are generating `throws java.lang.Throwable` regardless of
the `[Export]` declaration. Looking into it further, there was also the
issue if you declared an empty Type[], jcw-gen was not handling that
case.

Changes:
- Added `ThrowsDeclaration` property for reuse, which also handles the
case of empty `Type[]`
- Constructors now use `ThrowsDeclaration` along with methods
- New test cases: a class with constructors with plain `[Export]` and a
class with `[Export]` declaring `Throws`
- Expanded methods test case: method with `Throws` and method with
`Throws` and an empty `Type[]`