### PR TITLE
bump cecil and switch to mono-2017-04 to get mdb reading fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,4 +5,4 @@
 [submodule "external/cecil"]
 	path = external/cecil
 	url = https://github.com/mono/cecil.git
-	branch = master
+	branch = mono-2017-04


### PR DESCRIPTION
 - fixes #58511, #58173

 - the fix in cecil:

    commit 362e2bb00fa693d04c2d140a4cd313eb82c78d95
    Author: Radek Doulik <rodo@xamarin.com>
    Date:   Thu Jun 22 21:53:55 2017 +0200

        fix reading scope start

         - in case when the mdb file is out of sync, we might endup with
           start_instruction being null

         - it is regression introduced by
           7c8e0f767d7b2f652a430e4e26f1d98a20f9e125