### PR TITLE
[generator] Don't register invariant+excluded types

### DIFF
--- a/tools/generator/SymbolTable.cs
+++ b/tools/generator/SymbolTable.cs
@@ -135,6 +135,9 @@ namespace MonoDroid.Generation {
 
 		public static void AddType (string key, ISymbol symbol)
 		{
+			if (!ShouldAddType (key))
+				return;
+
 			List<ISymbol> values;
 			if (!symbols.TryGetValue (key, out values)) {
 				symbols.Add (key, new List<ISymbol> { symbol });


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/732

Commit d7dfa0bb [broke][1] the
`xamarin-android/tests/CodeGen-Binding/Xamarin.Android.McwGen-Tests`
build, as it started treating `Android.Graphics.Color` as a normal
type, instead of the special-cased behavior it should have:

[1]: https://jenkins.mono-project.com/job/xamarin-android-pr-builder/1324/

	error CS0452: The type 'Color' must be a reference type in order to use it as parameter 'T' in the generic type or method 'Object.GetObject<T>(IntPtr, JniHandleOwnership)'
	error CS1503: Argument 1: cannot convert from 'Android.Graphics.Color' to 'Android.Runtime.IJavaObject'

The problem is that this code pattern:

	static int n_UseColors_I (IntPtr jnienv, IntPtr native__this, int native_p0)
	{
		global::Com.Xamarin.Android.Bxc4288 __this = global::Java.Lang.Object.GetObject<global::Com.Xamarin.Android.Bxc4288> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
		global::Android.Graphics.Color p0 = new global::Android.Graphics.Color (native_p0);
		return __this.UseColors (p0).ToArgb ();
	}

became:

	static IntPtr n_UseColors_LAndroid_Graphics_Color_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
	{
		global::Com.Xamarin.Android.Bxc4288 __this = global::Java.Lang.Object.GetObject<global::Com.Xamarin.Android.Bxc4288> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
		global::Android.Graphics.Color p0 = global::Java.Lang.Object.GetObject<global::Android.Graphics.Color> (native_p0, JniHandleOwnership.DoNotTransfer);
		IntPtr __ret = JNIEnv.ToLocalJniHandle (__this.UseColors (p0));
		return __ret;
	}

The cause reason for this is that d7dfa0bb updated
`SymbolTable.AddType()` so that it no longer called
`SymbolTable.ShouldAddType()`, which is what would prevent
type registration of `Android.Graphics.Color`.

Reintroduce the call to `ShouldAddType()` so that
`Android.Graphics.Color` isn't registered.