### PR TITLE
[generator] Only skip generic "overloads" of bound types

### DIFF
--- a/src/Java.Interop.Tools.TypeNameMappings/Java.Interop.Tools.TypeNameMappings/JniType.cs
+++ b/src/Java.Interop.Tools.TypeNameMappings/Java.Interop.Tools.TypeNameMappings/JniType.cs
@@ -9,8 +9,8 @@ using Java.Interop;
 #if HAVE_CECIL
 using Mono.Cecil;
 using Java.Interop.Tools.Cecil;
-#if !GENERATOR
 using Android.Runtime;
+#if !GENERATOR
 using Java.Interop.Tools.JavaCallableWrappers;
 #endif  // !GENERATOR
 #endif  // HAVE_CECIL
@@ -252,7 +252,7 @@ namespace Java.Interop.Tools.TypeNameMappings {
 			return null;
 		}
 
-#if !GEN_JAVA_STUBS && !GENERATOR && !JAVADOC_TO_MDOC
+#if !GEN_JAVA_STUBS && !JAVADOC_TO_MDOC
 		// Keep in sync with ToJniNameFromAttributes(TypeDefinition)
 		public static string ToJniNameFromAttributes (Type type)
 		{
@@ -384,7 +384,7 @@ namespace Java.Interop.Tools.TypeNameMappings {
 		}
 #endif
 
-#if HAVE_CECIL && !GENERATOR
+#if HAVE_CECIL
 
 		internal static ExportParameterKind GetExportKind (Mono.Cecil.ICustomAttributeProvider p)
 		{

--- a/tools/generator/ClassGen.cs
+++ b/tools/generator/ClassGen.cs
@@ -15,7 +15,7 @@ using MonoDroid.Utils;
 using System.Xml.Linq;
 
 namespace MonoDroid.Generation {
-#if USE_CECIL
+#if HAVE_CECIL
 	static class ManagedExtensions
 	{
 		public static string FullNameCorrected (this TypeReference t)
@@ -69,7 +69,7 @@ namespace MonoDroid.Generation {
 			get { return t.IsSealed; }
 		}
 	}
-#endif
+#endif  // HAVE_CECIL
 	
 	public class XmlClassGen : ClassGen {
 		bool is_abstract;

--- a/tools/generator/Ctor.cs
+++ b/tools/generator/Ctor.cs
@@ -8,7 +8,7 @@ using Mono.Cecil;
 using Xamarin.Android.Tools;
 
 namespace MonoDroid.Generation {
-#if USE_CECIL
+#if HAVE_CECIL
 	public class ManagedCtor : Ctor {
 		MethodDefinition m;
 		string name;
@@ -53,7 +53,7 @@ namespace MonoDroid.Generation {
 			get { return null; }
 		}
 	}
-#endif
+#endif  // HAVE_CECIL
 
 	public class XmlCtor : Ctor {
 		string name;

--- a/tools/generator/Field.cs
+++ b/tools/generator/Field.cs
@@ -11,7 +11,7 @@ using MonoDroid.Utils;
 using System.Xml.Linq;
 
 namespace MonoDroid.Generation {
-#if USE_CECIL
+#if HAVE_CECIL
 	public class ManagedField : Field {
 		FieldDefinition f;
 		string java_name;
@@ -83,7 +83,7 @@ namespace MonoDroid.Generation {
 			}
 		}
 	}
-#endif
+#endif	// HAVE_CECIL
 
 	public class XmlField : Field {
 

--- a/tools/generator/GenBaseSupport.cs
+++ b/tools/generator/GenBaseSupport.cs
@@ -50,7 +50,7 @@ namespace MonoDroid.Generation
 		}
 	}
 	
-#if USE_CECIL
+#if HAVE_CECIL
 	public class ManagedGenBaseSupport : GenBaseSupport
 	{
 		TypeDefinition t;
@@ -152,7 +152,7 @@ namespace MonoDroid.Generation
 			get { return t.IsPublic || t.IsNestedPublic ? "public" : "protected internal"; }
 		}
 	}
-#endif
+#endif	// HAVE_CECIL
 
 	public class XmlGenBaseSupport : GenBaseSupport
 	{

--- a/tools/generator/InterfaceGen.cs
+++ b/tools/generator/InterfaceGen.cs
@@ -11,7 +11,7 @@ using Xamarin.Android.Binder;
 using Xamarin.Android.Tools;
 
 namespace MonoDroid.Generation {
-#if USE_CECIL
+#if HAVE_CECIL
 	public class ManagedInterfaceGen : InterfaceGen {
 		public ManagedInterfaceGen (TypeDefinition t)
 			: base (new ManagedGenBaseSupport (t))
@@ -34,7 +34,7 @@ namespace MonoDroid.Generation {
 			get { return !this.IsAcw; }
 		}
 	}
-#endif
+#endif	// HAVE_CECIL
 	
 	public class XmlInterfaceGen : InterfaceGen {
 

--- a/tools/generator/Method.cs
+++ b/tools/generator/Method.cs
@@ -12,7 +12,7 @@ using MonoDroid.Utils;
 using System.Xml.Linq;
 
 namespace MonoDroid.Generation {
-#if USE_CECIL
+#if HAVE_CECIL
 	public class ManagedMethod : Method {
 		MethodDefinition m;
 		string java_name;
@@ -121,7 +121,7 @@ namespace MonoDroid.Generation {
 			get { return null; }
 		}
 	}
-#endif
+#endif	// HAVE_CECIL
 
 	public class XmlMethod : Method {
 

--- a/tools/generator/MethodBase.cs
+++ b/tools/generator/MethodBase.cs
@@ -20,7 +20,7 @@ namespace MonoDroid.Generation {
 		string Visibility { get; }
 	}
 
-#if USE_CECIL
+#if HAVE_CECIL
 	public class ManagedMethodBaseSupport : IMethodBaseSupport {
 		MethodDefinition m;
 		public ManagedMethodBaseSupport (MethodDefinition m)
@@ -79,7 +79,7 @@ namespace MonoDroid.Generation {
 			}
 		}
 	}
-#endif
+#endif	// HAVE_CECIL
 	
 	public class XmlMethodBaseSupport : IMethodBaseSupport {
 

--- a/tools/generator/Parameter.cs
+++ b/tools/generator/Parameter.cs
@@ -284,7 +284,7 @@ namespace MonoDroid.Generation {
 			return new Parameter (name, java_package + "." + java_type, null, false);
 		}
 		
-#if USE_CECIL
+#if HAVE_CECIL
 		public static Parameter FromManagedParameter (ParameterDefinition p, string jnitype, string rawtype)
 		{
 			// FIXME: safe to use CLR type name? assuming yes as we often use it in metadatamap.
@@ -297,6 +297,6 @@ namespace MonoDroid.Generation {
 		{
 			return new Parameter ("__self", javaType ?? t.FullName, t.FullName, false);
 		}
-#endif
+#endif	// HAVE_CECIL
 	}
 }

--- a/tools/generator/generator.csproj
+++ b/tools/generator/generator.csproj
@@ -23,10 +23,11 @@
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>$(UtilityOutputFullPath)</OutputPath>
-    <DefineConstants>DEBUG;GENERATOR;USE_CECIL;JCW_ONLY_TYPE_NAMES</DefineConstants>
+    <DefineConstants>DEBUG;GENERATOR;HAVE_CECIL;JCW_ONLY_TYPE_NAMES</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
+    <PlatformTarget>anycpu</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>full</DebugType>
@@ -35,7 +36,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Externalconsole>True</Externalconsole>
-    <DefineConstants>GENERATOR;USE_CECIL;JCW_ONLY_TYPE_NAMES</DefineConstants>
+    <DefineConstants>GENERATOR;HAVE_CECIL;JCW_ONLY_TYPE_NAMES</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=57828

The #runtime team is attempting to update xamarin-android to use the
[mono/2017-06][0] and [mono/2017-08][1] (and...) branches, and when
doing so they are seeing a unit test fail in
`Xamarin.Android.Build.Tests.BuildTest.GeneratorValidateMultiMethodEventName()`:
no `BG850*` warnings are expected but they are produced.

After much analysis, the cause of ght `BG850*` warnings is that
the mono/2017-06 branch introduces a non-generic "overload" of
`System.Collections.Generic.KeyValuePair`:

	namespace System.Collections.Generic {
		// New with mono/2017-06
		partial class KeyValuePair {
			public static KeyValuePair<TKey, TValue> Create<TKey, TValue>(TKey key, TValue value);
		}

		// Existing since forever
		partial struct KeyValuePair<TKey, TValue> {
		}
	}

Specifically, the above "`KeyValuePair` overload" type runs into a
FIXME within `CodeGenerator.cs`:

	// FIXME: at some stage we want to import generic types.
	// For now generator fails to load generic types that have conflicting type e.g.
	// AdapterView`1 and AdapterView cannot co-exist.
	// It is mostly because generator primarily targets jar (no real generics land).

The *intent* of the check that is that, given a type `AdapterView<T>`,
we only check to see if `AdapterView` exists as well. If it does exist,
then we *ignore* the `AdapterView<T>` type, and only use the
`AdapterView` type for code generation.

In the case of `KeyValuePair`, the same "check" is done, which cause
us to *skip* type registration for `KeyValuePair<TKey, TValue>`, which
in turn causes us to invalidate e.g. `IDictionary<TKey, TValue>` -- as
it implements `ICollection<KeyValuePair<TKey, TValue>>` -- and
everything promply falls apart from there:

	warning BG8C00: For type System.Collections.Generic.IDictionary`2, base interface System.Collections.Generic.ICollection`1<System.Collections.Generic.KeyValuePair`2<TKey,TValue>> is invalid.
	warning BG8C00: For type System.Collections.Generic.IDictionary`2, base interface System.Collections.Generic.IEnumerable`1<System.Collections.Generic.KeyValuePair`2<TKey,TValue>> is invalid.
	warning BG8502: Invalidating System.Collections.Generic.IDictionary`2 and all nested types because some of its interfaces were invalid.
	warning BG8801: Invalid parameter type System.Collections.Generic.IDictionary`2<System.String,System.Collections.Generic.IList`1<System.String>> in method MapEquivalents in managed type Java.Util.Locale.LanguageRange.
	warning BG8801: Invalid parameter type System.Collections.Generic.IDictionary`2<System.String,System.Collections.Generic.IList`1<System.String>> in method Parse in managed type Java.Util.Locale.LanguageRange.
	warning BG8801: Invalid parameter type System.Collections.Generic.IDictionary`2<System.String,System.Object> in method NewFileSystem in managed type Java.Nio.FileNio.Spi.FileSystemProvider.
	warning BG8801: Invalid parameter type System.Collections.Generic.IDictionary`2<System.String,System.Object> in method NewFileSystem in managed type Java.Nio.FileNio.Spi.FileSystemProvider.
	warning BG8801: Invalid parameter type System.Collections.Generic.IDictionary`2<System.String,System.String> in method .ctor in managed type Java.Security.Provider.Service.
	warning BG8801: Invalid parameter type System.Collections.Generic.IDictionary`2<System.Object,System.Object> in method PutAll in managed type Java.Security.Provider.

I still don't fully understand the scenario that the check was
attempting to solve, so in lieu of actually fixing the FIXME, make the
check *stricter* so that we only ignore "generically overloaded" types
if they bind the *same* Java type. Since `KeyValuePair<TKey, TValue>`
binds *no* Java type, it will no longer be skipped, thus removing the
BG8502 and related warnings.

Additionally, a bit of code cleanup for consistency: some parts of the
code use `HAVE_CECIL`, and others use `USE_CECIL`. Standardize on
`HAVE_CECIL` for consistency and sanity.

[0]: https://github.com/xamarin/xamarin-android/pull/631
[1]: https://github.com/xamarin/xamarin-android/pull/723