### PR TITLE
[Java.Interop.Tools.JavaCallableWrappers] Error on bad IJavaObject

### DIFF
--- a/src/Java.Interop.Tools.Diagnostics/Java.Interop.Tools.Diagnostics/Diagnostic.cs
+++ b/src/Java.Interop.Tools.Diagnostics/Java.Interop.Tools.Diagnostics/Diagnostic.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 using Mono.Cecil.Cil;
 
@@ -27,14 +28,14 @@ namespace Java.Interop.Tools.Diagnostics {
 	//					XA0013	Profiling support requires sgen to be enabled too
 	//					XA0014	iOS {0} does not support building applications targeting ARMv6
 	//					XA0020	Could not launch mandroid daemon.
-	
+
 	//					XA0100 EmbeddedNativeLibrary '{0}' is invalid in Android Application project. Please use AndroidNativeLibrary instead.
 	//					XA0101 @(Content) build action is not supported
 	//					XA0102 Lint Warning
 	//					XA0103 Lint Error
 	//					XA0104 Invalid Sequence Point mode
 	//					XA0105 The TargetFrameworkVersion for {0} (v{1}) is greater than the TargetFrameworkVersion for your project (v{2}). You need to increase the TargetFrameworkVersion for your project.
-	
+
 	// XA1xxx	file copy / symlinks (project related)
 	//			XA10xx	installer.cs / mtouch.cs
 	//					XA1001	Could not find an application at the specified directory
@@ -101,6 +102,7 @@ namespace Java.Interop.Tools.Diagnostics {
 	//					XA4209 Failed to create JavaTypeInfo for class: {0} due to {1}
 	//					XA4210 "You need to add a reference to Mono.Android.Export.dll when you use ExportAttribute or ExportFieldAttribute."
 	//					XA4211  AndroidManifest.xml //uses-sdk/@android:targetSdkVersion '{0}' is less than $(TargetFrameworkVersion) '{1}'. Using API-{1} for ACW compilation.
+	//					XA4212  Type `{0}` implements `Android.Runtime.IJavaObject` but does not inherit `Java.Lang.Object` or `Java.Lang.Throwable`. This is not supported.
 	// XA5xxx	GCC and toolchain
 	//			XA32xx	.apk generation
 	//					XA4300  Unsupported $(AndroidSupportedAbis) value '{0}'; ignoring.
@@ -175,6 +177,17 @@ namespace Java.Interop.Tools.Diagnostics {
 
 			destination.WriteLine ("monodroid: error XA0000: Unexpected error - Please file a bug report at http://bugzilla.xamarin.com. Reason: {0}",
 					verbose ? message.Message : message.ToString ());
+		}
+
+		public static Action<TraceLevel, string> CreateConsoleLogger ()
+		{
+			Action<TraceLevel, string> logger = (level, value) => {
+				if (level == TraceLevel.Error)
+					Console.Error.WriteLine (value);
+				else
+					Console.WriteLine (value);
+			};
+			return logger;
 		}
 	}
 }

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers/TypeNameMapGeneratorTests.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers/TypeNameMapGeneratorTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -9,6 +10,7 @@ using Mono.Cecil;
 using NUnit.Framework;
 
 using Java.Interop.Tools.Cecil;
+using Java.Interop.Tools.Diagnostics;
 using Java.Interop.Tools.JavaCallableWrappers;
 
 using Android.App;
@@ -24,16 +26,25 @@ namespace Xamarin.Android.ToolsTests
 		public void ConstructorExceptions ()
 		{
 			Action<string, object []> logger = (f, o) => { };
-			Assert.Throws<ArgumentNullException> (() => new TypeNameMapGenerator ((string [])null, logger));
-			Assert.Throws<ArgumentNullException> (() => new TypeNameMapGenerator ((TypeDefinition [])null, logger));
-			Assert.Throws<ArgumentNullException> (() => new TypeNameMapGenerator (new string [0], null));
-			Assert.Throws<ArgumentNullException> (() => new TypeNameMapGenerator (new TypeDefinition [0], null));
+			Action<string, object []> nullLogger = null;
+			Action<TraceLevel, string> levelLogger = (l, v) => { };
+			Action<TraceLevel, string> nullLevelLogger = null;
+			Assert.Throws<ArgumentNullException> (() => new TypeNameMapGenerator ((string []) null, levelLogger));
+			Assert.Throws<ArgumentNullException> (() => new TypeNameMapGenerator ((TypeDefinition []) null, levelLogger));
+			Assert.Throws<ArgumentNullException> (() => new TypeNameMapGenerator (new string [0], nullLevelLogger));
+			Assert.Throws<ArgumentNullException> (() => new TypeNameMapGenerator (new TypeDefinition [0], nullLevelLogger));
+#pragma warning disable 0618
+			Assert.Throws<ArgumentNullException> (() => new TypeNameMapGenerator ((string []) null, logger));
+			Assert.Throws<ArgumentNullException> (() => new TypeNameMapGenerator ((TypeDefinition []) null, logger));
+			Assert.Throws<ArgumentNullException> (() => new TypeNameMapGenerator (new string [0], nullLogger));
+			Assert.Throws<ArgumentNullException> (() => new TypeNameMapGenerator (new TypeDefinition [0], nullLogger));
+#pragma warning restore 0618
 		}
 
 		[Test]
 		public void WriteJavaToManaged ()
 		{
-			var v = new TypeNameMapGenerator (SupportDeclarations.GetTestTypeDefinitions (), logMessage: Console.WriteLine);
+			var v = new TypeNameMapGenerator (SupportDeclarations.GetTestTypeDefinitions (), logger: Diagnostic.CreateConsoleLogger ());
 			var o = new MemoryStream ();
 			v.WriteJavaToManaged (o);
 			var a = ToArray (o);
@@ -97,7 +108,7 @@ namespace Xamarin.Android.ToolsTests
 		[Test]
 		public void WriteManagedToJava ()
 		{
-			var v = new TypeNameMapGenerator (SupportDeclarations.GetTestTypeDefinitions (), logMessage: Console.WriteLine);
+			var v = new TypeNameMapGenerator (SupportDeclarations.GetTestTypeDefinitions (), logger: Diagnostic.CreateConsoleLogger ());
 			var o = new MemoryStream ();
 			v.WriteManagedToJava (o);
 			var a = ToArray (o);

--- a/src/Java.Interop/Documentation/Java.Interop/IJavaPeerable.xml
+++ b/src/Java.Interop/Documentation/Java.Interop/IJavaPeerable.xml
@@ -314,7 +314,7 @@ partial class ExampleBinding {
   </member>
   <member name="M:SetPeerReference">
     <summary>Set the value returned by <c>PeerReference</c>.</summary>
-    <param name="value">
+    <param name="reference">
       A <see cref="T:Java.Interop.JniObjectReference" /> which contains the
       value that future invocations of the
       <see cref="P:Java.Interop.IJavaPeerable.PeerReference" />

--- a/tools/jcw-gen/App.cs
+++ b/tools/jcw-gen/App.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Linq;
 using System.IO;
 using System.Threading.Tasks;
 
 using Java.Interop.Tools.Cecil;
+using Java.Interop.Tools.Diagnostics;
 using Java.Interop.Tools.JavaCallableWrappers;
 using Mono.Cecil;
 using Mono.Options;
@@ -41,6 +43,7 @@ namespace Java.Interop.Tools
 				  "Show this message and exit",
 				  v => help = v != null },
 			};
+			var scanner = new JavaTypeScanner (Diagnostic.CreateConsoleLogger ());
 			try {
 				var assemblies = options.Parse (args);
 				if (assemblies.Count == 0 || outputPath == null || help) {
@@ -60,7 +63,7 @@ namespace Java.Interop.Tools
 					resolver.SearchDirectories.Add (Path.GetDirectoryName (assembly));
 					resolver.Load (assembly);
 				}
-				var types = JavaTypeScanner.GetJavaTypes (assemblies, resolver, log: Console.WriteLine)
+				var types = scanner.GetJavaTypes (assemblies, resolver)
 					.Where (td => !JavaTypeScanner.ShouldSkipJavaCallableWrapperGeneration (td));
 				foreach (var type in types) {
 					GenerateJavaCallableWrapper (type, outputPath);


### PR DESCRIPTION
Context: https://bugzilla.xamarin.com/show_bug.cgi?id=56819

Nothing *prevents* "anybody" from custom implementing `IJavaObject`:

	class MyBadClass : Android.Runtime.IJavaObject {
		public IntPtr Handle {
			get {return IntPtr.Zero;}
		}

		public void Dispose () {}
	}

The problem is that the above doesn't actually work: the
`IJavaObject.Handle` value contains the JNI Object Reference to pass
into JNI. The above code will thus result in always passing `null`
into Java code, which could result in a `NullPointerException`, but
will always result in *not* doing what was intended.

While it is *theoretically* possible to manually implement
`IJavaObject`, it's not something *I* would want to contemplate, nor
is it for the faint of heart, so long ago we decided to emit a warning
if we encounter a type which:

 1. Implements `Android.Runtime.IJavaObject`, and
 2. Does *not* also inherit `Java.Lang.Object` or
    `Java.Lang.Throwable`.

As such, the above `MyBadClass` would elicit the warning:

	Type 'MyBadClass' implements Android.Runtime.IJavaObject but does not inherit from Java.Lang.Object. It is not supported.

This is all well and good, but (effectively) *nobody* reads warnings,
*especially* since our toolchain emits so many warnings that enabling
`/warnaserror` is for the truly foolhardy, so *lots* of warnings is,
unfortunately, normal.

Which brings us to Bug #56819: Could we make this an error?

Answer: Of course we can. That said, I have no idea how much existing
code this will *break* if we turned it into an error. That might be
good and useful, but if there's no way to *disable* the error,
existing apps which (appear to) work will no longer build.

That's not desirable.

Turn `JavaTypeScanner` from a `static` class into a normal class, and
add a new `JavaTypeScanner.ErrorOnCustomJavaObject` property which,
when true, will cause `JavaTypeScanner` to emit an error instead of
a warning when it encounters types such as `MyBadClass`. (I'm turning
it into a normal class instead of adding a new
`JavaTypeScanner.GetJavaTypes()` overload in case we need to add
additional such "control" parameters in the future. Method overloads
will otherwise get unwieldy.)

`JavaTypeScanner.ErrorOnCustomJavaObject` is all well and good, but
how do we *actually* emit a warning vs. an error? The previous
`Action<string, object[]> log` delegate doesn't allow distinguishing
between warnings and errors (and possible diagnostic messages), so how
would we eventually hook this up into xamarin-android's
`<GenerateJavaStubs/>` task?

Attempt to better handle that question by replacing
`Action<string, object[]>` delegates with `Action<TraceLevel, string>`
delegates. This allows messages to explicitly specify
TraceLevel.Error, TraceLevel.Warning, or TraceLevel.Info (or others!)
so that messages can be sanely processed by downstream users.
Additionally, add a new `Diagnostic.CreateConsoleLogger()` method
which creates an `Action<TraceLevel, string>` which forwards messages
to `Console.Error` or `Console.Out`, as appropriate.