### PR TITLE
[windows] preparation for not requiring java in PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ Overridable MSBuild properties include:
     [`java-interop`](src/java-interop) against. By default this is
     probed for from numerious locations within
     [`build-tools/scripts/jdk.mk`](build-tools/scripts/jdk.mk).
+* `$(JavaCPath)`: Path to the `javac` command-line tool, by default set to `javac`.
+* `$(JarPath)`: Path to the `jar` command-line tool, by default set to `jar`.
+  * It may be desirable to override these on Windows, depending on your `PATH`.
 * `$(UtilityOutputFullPath)`: Directory to place various utilities such as
     [`class-parse`](tools/class-parse), [`generator`](tools/generator),
     and [`logcat-parse`](tools/logcat-parse). This value should be a full path.

--- a/build-tools/scripts/jdk.mk
+++ b/build-tools/scripts/jdk.mk
@@ -147,4 +147,8 @@ bin/Build$(CONFIGURATION)/JdkInfo.props: $(JI_JDK_INCLUDE_PATHS) $(JI_JVM_PATH)
 	echo '      </ItemGroup>' >> "$@"
 	echo '    </When>' >> "$@"
 	echo '  </Choose>' >> "$@"
+	echo '  <PropertyGroup>' >> "$@"
+	echo "    <JavaCPath Condition=\" '\$$(JavaCPath)' == '' \">javac</JavaCPath>" >> "$@"
+	echo "    <JarPath Condition=\" '\$$(JarPath)' == '' \">jar</JarPath>" >> "$@"
+	echo '  </PropertyGroup>' >> "$@"
 	echo '</Project>' >> "$@"

--- a/src/Java.Interop.Export/Tests/Export-Tests.projitems
+++ b/src/Java.Interop.Export/Tests/Export-Tests.projitems
@@ -8,6 +8,7 @@
   <PropertyGroup Label="Configuration">
     <Import_RootNamespace>Java.Interop.ExportTests</Import_RootNamespace>
   </PropertyGroup>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\..\bin\Build$(Configuration)\JdkInfo.props" />
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Java.Interop\ExportTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Java.Interop\MarshalMemberBuilderTest.cs" />
@@ -17,7 +18,7 @@
   </ItemGroup>
   <Target Name="BuildExportTestJar" Inputs="@(JavaExportTestJar)" Outputs="$(OutputPath)export-test.jar">
     <MakeDir Directories="$(IntermediateOutputPath)et-classes" />
-    <Exec Command="javac -classpath &quot;$(OutputPath)..\$(Configuration)\java-interop.jar&quot; -source 1.5 -target 1.6 -d &quot;$(IntermediateOutputPath)et-classes&quot; @(JavaExportTestJar -&gt; '%(Identity)', ' ')" />
-    <Exec Command="jar cf &quot;$(OutputPath)export-test.jar&quot; -C &quot;$(IntermediateOutputPath)et-classes&quot; ." />
+    <Exec Command="&quot;$(JavaCPath)&quot; -classpath &quot;$(OutputPath)..\$(Configuration)\java-interop.jar&quot; -source 1.5 -target 1.6 -d &quot;$(IntermediateOutputPath)et-classes&quot; @(JavaExportTestJar -&gt; '%(Identity)', ' ')" />
+    <Exec Command="&quot;$(JarPath)&quot; cf &quot;$(OutputPath)export-test.jar&quot; -C &quot;$(IntermediateOutputPath)et-classes&quot; ." />
   </Target>
 </Project>

--- a/src/Java.Interop/Java.Interop.csproj
+++ b/src/Java.Interop/Java.Interop.csproj
@@ -27,6 +27,7 @@
     <ConsolePause>false</ConsolePause>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DocumentationFile>..\..\bin\Debug\Java.Interop.xml</DocumentationFile>
+    <JNIEnvGenPath>..\..\bin\BuildDebug</JNIEnvGenPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>full</DebugType>
@@ -38,6 +39,7 @@
     <DefineConstants>INTEROP;FEATURE_JNIENVIRONMENT_JI_PINVOKES;FEATURE_JNIOBJECTREFERENCE_INTPTRS</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DocumentationFile>..\..\bin\Release\Java.Interop.xml</DocumentationFile>
+    <JNIEnvGenPath>..\..\bin\BuildRelease</JNIEnvGenPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'XAIntegrationDebug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -59,7 +61,7 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <JNIEnvGenPath>..\..\bin\BuildDebug</JNIEnvGenPath>
+    <JNIEnvGenPath>..\..\bin\BuildRelease</JNIEnvGenPath>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Java.Interop/Java.Interop.targets
+++ b/src/Java.Interop/Java.Interop.targets
@@ -3,12 +3,13 @@
   <PropertyGroup>
     <Runtime Condition="'$(OS)' != 'Windows_NT'">mono</Runtime>
   </PropertyGroup>
+  <Import Project="$(JNIEnvGenPath)\JdkInfo.props" />
   <Target Name="BuildJnienvGen"
       Inputs="..\..\build-tools\jnienv-gen\jnienv-gen.csproj"
-      Outputs="..\..\bin\BuildDebug\jnienv-gen.exe">
+      Outputs="$(JNIEnvGenPath)\jnienv-gen.exe">
     <MSBuild
         Projects="..\..\build-tools\jnienv-gen\jnienv-gen.csproj"
-        Properties="Configuration=Debug"
+        Properties="Configuration=$(Configuration.Replace('XAIntegration', ''))"
     />
   </Target>
   <Target Name="BuildJniEnvironment_g_cs"
@@ -16,14 +17,14 @@
       Outputs="Java.Interop\JniEnvironment.g.cs;$(IntermediateOutputPath)\jni.c">
     <MakeDir Directories="$(IntermediateOutputPath)" />
     <Exec
-        Command="$(Runtime) &quot;..\..\bin\BuildDebug\jnienv-gen.exe&quot; Java.Interop\JniEnvironment.g.cs $(IntermediateOutputPath)\jni.c"
+        Command="$(Runtime) &quot;$(JNIEnvGenPath)\jnienv-gen.exe&quot; Java.Interop\JniEnvironment.g.cs $(IntermediateOutputPath)\jni.c"
     />
   </Target>
   <Target Name="BuildInteropJar"
       Inputs="@(CompileJavaInteropJar)"
       Outputs="$(OutputPath)java-interop.jar">
     <MakeDir Directories="$(OutputPath);$(IntermediateOutputPath)ji-classes" />
-    <Exec Command="javac -source 1.5 -target 1.6 -d &quot;$(IntermediateOutputPath)ji-classes&quot; @(CompileJavaInteropJar -&gt; '%(Identity)', ' ')" />
-    <Exec Command="jar cf &quot;$(OutputPath)java-interop.jar&quot; -C &quot;$(IntermediateOutputPath)ji-classes&quot; ." />
+    <Exec Command="&quot;$(JavaCPath)&quot; -source 1.5 -target 1.6 -d &quot;$(IntermediateOutputPath)ji-classes&quot; @(CompileJavaInteropJar -&gt; '%(Identity)', ' ')" />
+    <Exec Command="&quot;$(JarPath)&quot; cf &quot;$(OutputPath)java-interop.jar&quot; -C &quot;$(IntermediateOutputPath)ji-classes&quot; ." />
   </Target>
 </Project>

--- a/src/Java.Interop/Tests/Interop-Tests.projitems
+++ b/src/Java.Interop/Tests/Interop-Tests.projitems
@@ -8,6 +8,7 @@
   <PropertyGroup Label="Configuration">
     <Import_RootNamespace>Java.InteropTests</Import_RootNamespace>
   </PropertyGroup>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\..\bin\Build$(Configuration)\JdkInfo.props" />
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Cadenza.Collections\CollectionContract.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Cadenza.Collections\EnumerableContract.cs" />
@@ -64,7 +65,7 @@
   </ItemGroup>
   <Target Name="BuildInteropTestJar" Inputs="@(JavaInteropTestJar)" Outputs="$(OutputPath)interop-test.jar">
     <MakeDir Directories="$(IntermediateOutputPath)it-classes" />
-    <Exec Command="javac -source 1.5 -target 1.6 -d &quot;$(IntermediateOutputPath)it-classes&quot; -classpath &quot;$(OutputPath)..\$(Configuration)\java-interop.jar&quot; @(JavaInteropTestJar -&gt; '%(Identity)', ' ')" />
-    <Exec Command="jar cf &quot;$(OutputPath)interop-test.jar&quot; -C &quot;$(IntermediateOutputPath)it-classes&quot; ." />
+    <Exec Command="&quot;$(JavaCPath)&quot; -source 1.5 -target 1.6 -d &quot;$(IntermediateOutputPath)it-classes&quot; -classpath &quot;$(OutputPath)..\$(Configuration)\java-interop.jar&quot; @(JavaInteropTestJar -&gt; '%(Identity)', ' ')" />
+    <Exec Command="&quot;$(JarPath)&quot; cf &quot;$(OutputPath)interop-test.jar&quot; -C &quot;$(IntermediateOutputPath)it-classes&quot; ." />
   </Target>
 </Project>

--- a/src/java-interop/java-interop.mdproj
+++ b/src/java-interop/java-interop.mdproj
@@ -26,7 +26,7 @@
     <DefineSymbols>JI_DLL_EXPORT MONODEVELOP MONO_DLL_EXPORT</DefineSymbols>
     <SourceDirectory>.</SourceDirectory>
   </PropertyGroup>
-  <Import Project="$(JNIEnvGenPath)\JdkInfo.props" Condition="Exists('$(JNIEnvGenPath)\JdkInfo.props')" />
+  <Import Project="$(JNIEnvGenPath)\JdkInfo.props" />
   <Import Project="$(JNIEnvGenPath)\MonoInfo.props" Condition="Exists('$(JNIEnvGenPath)\MonoInfo.props')" />
   <ItemGroup>
     <None Include="java-interop.h" />

--- a/tests/PerformanceTests/PerformanceTests.projitems
+++ b/tests/PerformanceTests/PerformanceTests.projitems
@@ -5,6 +5,7 @@
     <HasSharedItems>true</HasSharedItems>
     <SharedGUID>{0FBECD2A-7C91-41AB-A4B4-B781E8EC8479}</SharedGUID>
   </PropertyGroup>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\JdkInfo.props" />
   <PropertyGroup Label="Configuration">
     <Import_RootNamespace>Java.Interop.PerformanceTests</Import_RootNamespace>
   </PropertyGroup>
@@ -17,7 +18,7 @@
   </ItemGroup>
   <Target Name="BuildPerformanceTestJar" Inputs="@(JavaPerformanceTestJar)" Outputs="$(OutputPath)performance-test.jar">
     <MakeDir Directories="$(IntermediateOutputPath)pt-classes" />
-    <Exec Command="javac -source 1.5 -target 1.6 -d &quot;$(IntermediateOutputPath)pt-classes&quot; @(JavaPerformanceTestJar -&gt; '%(Identity)', ' ')" />
-    <Exec Command="jar cf &quot;$(OutputPath)performance-test.jar&quot; -C &quot;$(IntermediateOutputPath)pt-classes&quot; ." />
+    <Exec Command="&quot;$(JavaCPath)&quot; -source 1.5 -target 1.6 -d &quot;$(IntermediateOutputPath)pt-classes&quot; @(JavaPerformanceTestJar -&gt; '%(Identity)', ' ')" />
+    <Exec Command="&quot;$(JarPath)&quot; cf &quot;$(OutputPath)performance-test.jar&quot; -C &quot;$(IntermediateOutputPath)pt-classes&quot; ." />
   </Target>
 </Project>


### PR DESCRIPTION
Windows machines do not include Java in their path by default, so it is
a better experience to not require it for the build.

Changes:
- `JdkInfo.props` will include `JavaCPath` and `JarPath`
- We can customize `JavaCPath` and `JarPath` as needed on Windows
- `jdk.mk` generates these values as `javac` and `jar` for existing
platforms
- Cleaned up `JNIEnvGenPath` and places that hardcoded `Configuration`

What will need to happen downstream in Xamarin.Android:
- `Configuration.OperatingSystem.props` and `JdkInfo.props` will set
`JavaCPath` and `JarPath` for Windows
- Changes to `PrepareWindows.targets` will be needed