### PR TITLE
[generator] fix bug #58403 - do not trim 8 name chars on non-set-list…

### DIFF
--- a/tools/generator/Method.cs
+++ b/tools/generator/Method.cs
@@ -396,7 +396,8 @@ namespace MonoDroid.Generation {
 		{
 			string event_name = EventName;
 			if (event_name == null) {
-				event_name = Name.Substring (0, Name.Length - 8).Substring (3);
+				var trimSize = Name.EndsWith ("Listener", StringComparison.Ordinal) ? 8 : 0;
+				event_name = Name.Substring (0, Name.Length - trimSize).Substring (3);
 				if (event_name.StartsWith ("On"))
 					event_name = event_name.Substring (2);
 				if (checkNameDuplicate (event_name))


### PR DESCRIPTION
…eners.

An event names is generated from the method name which was supposed to be
setOnXxxListener. Though we had been generating events for methods that
do not end with "Listener", resulting in weird event names (e.g. it was
"VisibleWidt" for `setOnVisibleWidthChanged` method).

Trim 8 characters only on setOnXxx"Listener" methods.