### PR TITLE
[generator] Fix Formatted() overloads & parameter aliases

### DIFF
--- a/tools/generator/Method.cs
+++ b/tools/generator/Method.cs
@@ -687,24 +687,27 @@ namespace MonoDroid.Generation {
 				call.Append (pname);
 			}
 			sw.WriteLine ("{0}{1}{2}{3} ({4});", indent, RetVal.IsVoid ? String.Empty : opt.GetOutputName (RetVal.FullName) + " __result = ", haveSelf ? "self." : "", AdjustedName, call.ToString ());
-			foreach (Parameter p in Parameters) {
-				if (p.Type == "Java.Lang.ICharSequence")
-					sw.WriteLine ("{0}if ({1} != null) {1}.Dispose ();", indent, p.GetName ("jls_"));
-				else if (p.Type == "Java.Lang.ICharSequence[]")
-					sw.WriteLine ("{0}if ({1} != null) foreach (global::Java.Lang.String s in {1}) if (s != null) s.Dispose ();", indent, p.GetName ("jlca_"));
-			}
 			switch (RetVal.FullName) {
 			case "void":
 				break;
 			case "Java.Lang.ICharSequence[]":
-				sw.WriteLine ("{0}return CharSequence.ArrayToStringArray (__result);", indent);
+				sw.WriteLine ("{0}var __rsval = CharSequence.ArrayToStringArray (__result);", indent);
 				break;
 			case "Java.Lang.ICharSequence":
-				sw.WriteLine ("{0}return __result == null ? null : __result.ToString ();", indent);
+				sw.WriteLine ("{0}var __rsval = __result?.ToString ();", indent);
 				break;
 			default:
-				sw.WriteLine ("{0}return __result;", indent);
+				sw.WriteLine ("{0}var __rsval = __result;", indent);
 				break;
+			}
+			foreach (Parameter p in Parameters) {
+				if (p.Type == "Java.Lang.ICharSequence")
+					sw.WriteLine ("{0}{1}?.Dispose ();", indent, p.GetName ("jls_"));
+				else if (p.Type == "Java.Lang.ICharSequence[]")
+					sw.WriteLine ("{0}if ({1} != null) foreach (global::Java.Lang.String s in {1}) s?.Dispose ();", indent, p.GetName ("jlca_"));
+			}
+			if (!RetVal.IsVoid) {
+				sw.WriteLine ($"{indent}return __rsval;");
 			}
 		}
 

--- a/tools/generator/Tests/SupportFiles/Android_Runtime_CharSequence.cs
+++ b/tools/generator/Tests/SupportFiles/Android_Runtime_CharSequence.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Android.Runtime {
+
+	public static class CharSequence
+	{
+		public static Java.Lang.ICharSequence [] ArrayFromStringArray (string [] val)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public static string [] ArrayToStringArray (Java.Lang.ICharSequence [] val)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public static IntPtr ToLocalJniHandle (string value)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public static IntPtr ToLocalJniHandle (Java.Lang.ICharSequence value)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public static IntPtr ToLocalJniHandle (IEnumerable<char> value)
+		{
+			throw new NotImplementedException ();
+		}
+	}
+}

--- a/tools/generator/Tests/SupportFiles/Java_Lang_ICharSequence.cs
+++ b/tools/generator/Tests/SupportFiles/Java_Lang_ICharSequence.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Android.Runtime;
+
+namespace Java.Lang {
+
+	public partial interface ICharSequence : IJavaObject
+	{
+		char CharAt (int index);
+		int Length ();
+		Java.Lang.ICharSequence SubSequenceFormatted (int start, int end);
+		string ToString ();
+	}
+}

--- a/tools/generator/Tests/SupportFiles/Java_Lang_String.cs
+++ b/tools/generator/Tests/SupportFiles/Java_Lang_String.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Java.Lang {
+
+	public sealed partial class String : global::Java.Lang.Object, Java.Lang.ICharSequence
+	{
+		public String (string value)
+		{
+		}
+
+		public char CharAt (int index)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public int Length ()
+		{
+			throw new NotImplementedException ();
+		}
+
+		public Java.Lang.ICharSequence SubSequenceFormatted (int start, int end)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public override string ToString ()
+		{
+			throw new NotImplementedException ();
+		}
+
+		public IEnumerator<char> GetEnumerator ()
+		{
+			throw new NotImplementedException ();
+		}
+
+		IEnumerator IEnumerable.GetEnumerator ()
+		{
+			throw new NotImplementedException ();
+		}
+	}
+}

--- a/tools/generator/Tests/expected.ji/TestInterface/Test.ME.ITestInterface.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Test.ME.ITestInterface.cs
@@ -48,6 +48,33 @@ namespace Test.ME {
 		[Register ("getSpanFlags", "(Ljava/lang/Object;)I", "GetGetSpanFlags_Ljava_lang_Object_Handler:Test.ME.ITestInterfaceInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
 		int GetSpanFlags (global::Java.Lang.Object tag);
 
+		// Metadata.xml XPath method reference: path="/api/package[@name='test.me']/interface[@name='TestInterface']/method[@name='append' and count(parameter)=1 and parameter[1][@type='java.lang.CharSequence']]"
+		[Register ("append", "(Ljava/lang/CharSequence;)V", "GetAppend_Ljava_lang_CharSequence_Handler:Test.ME.ITestInterfaceInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
+		void Append (global::Java.Lang.ICharSequence value);
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='test.me']/interface[@name='TestInterface']/method[@name='identity' and count(parameter)=1 and parameter[1][@type='java.lang.CharSequence']]"
+		[Register ("identity", "(Ljava/lang/CharSequence;)Ljava/lang/CharSequence;", "GetIdentity_Ljava_lang_CharSequence_Handler:Test.ME.ITestInterfaceInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
+		global::Java.Lang.ICharSequence IdentityFormatted (global::Java.Lang.ICharSequence value);
+
+	}
+
+	public static partial class ITestInterfaceExtensions {
+
+		public static void Append (this Test.ME.ITestInterface self, string value)
+		{
+			global::Java.Lang.String jls_value = value == null ? null : new global::Java.Lang.String (value);
+			self.Append (jls_value);
+			jls_value?.Dispose ();
+		}
+
+		public static string Identity (this Test.ME.ITestInterface self, string value)
+		{
+			global::Java.Lang.String jls_value = value == null ? null : new global::Java.Lang.String (value);
+			global::Java.Lang.ICharSequence __result = self.IdentityFormatted (jls_value);
+			var __rsval = __result?.ToString ();
+			jls_value?.Dispose ();
+			return __rsval;
+		}
 	}
 
 	[global::Android.Runtime.Register ("test/me/TestInterface", DoNotGenerateAcw=true)]
@@ -127,6 +154,66 @@ namespace Test.ME {
 			JValue* __args = stackalloc JValue [1];
 			__args [0] = new JValue ((tag == null) ? IntPtr.Zero : ((global::Java.Lang.Object) tag).Handle);
 			int __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getSpanFlags_Ljava_lang_Object_, __args);
+			return __ret;
+		}
+
+		static Delegate cb_append_Ljava_lang_CharSequence_;
+#pragma warning disable 0169
+		static Delegate GetAppend_Ljava_lang_CharSequence_Handler ()
+		{
+			if (cb_append_Ljava_lang_CharSequence_ == null)
+				cb_append_Ljava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr, IntPtr>) n_Append_Ljava_lang_CharSequence_);
+			return cb_append_Ljava_lang_CharSequence_;
+		}
+
+		static void n_Append_Ljava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
+		{
+			global::Test.ME.ITestInterface __this = global::Java.Lang.Object.GetObject<global::Test.ME.ITestInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			global::Java.Lang.ICharSequence value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
+			__this.Append (value);
+		}
+#pragma warning restore 0169
+
+		IntPtr id_append_Ljava_lang_CharSequence_;
+		public unsafe void Append (global::Java.Lang.ICharSequence value)
+		{
+			if (id_append_Ljava_lang_CharSequence_ == IntPtr.Zero)
+				id_append_Ljava_lang_CharSequence_ = JNIEnv.GetMethodID (class_ref, "append", "(Ljava/lang/CharSequence;)V");
+			IntPtr native_value = CharSequence.ToLocalJniHandle (value);
+			JValue* __args = stackalloc JValue [1];
+			__args [0] = new JValue (native_value);
+			JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_append_Ljava_lang_CharSequence_, __args);
+			JNIEnv.DeleteLocalRef (native_value);
+		}
+
+		static Delegate cb_identity_Ljava_lang_CharSequence_;
+#pragma warning disable 0169
+		static Delegate GetIdentity_Ljava_lang_CharSequence_Handler ()
+		{
+			if (cb_identity_Ljava_lang_CharSequence_ == null)
+				cb_identity_Ljava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr, IntPtr>) n_Identity_Ljava_lang_CharSequence_);
+			return cb_identity_Ljava_lang_CharSequence_;
+		}
+
+		static IntPtr n_Identity_Ljava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
+		{
+			global::Test.ME.ITestInterface __this = global::Java.Lang.Object.GetObject<global::Test.ME.ITestInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			global::Java.Lang.ICharSequence value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
+			IntPtr __ret = CharSequence.ToLocalJniHandle (__this.IdentityFormatted (value));
+			return __ret;
+		}
+#pragma warning restore 0169
+
+		IntPtr id_identity_Ljava_lang_CharSequence_;
+		public unsafe global::Java.Lang.ICharSequence IdentityFormatted (global::Java.Lang.ICharSequence value)
+		{
+			if (id_identity_Ljava_lang_CharSequence_ == IntPtr.Zero)
+				id_identity_Ljava_lang_CharSequence_ = JNIEnv.GetMethodID (class_ref, "identity", "(Ljava/lang/CharSequence;)Ljava/lang/CharSequence;");
+			IntPtr native_value = CharSequence.ToLocalJniHandle (value);
+			JValue* __args = stackalloc JValue [1];
+			__args [0] = new JValue (native_value);
+			global::Java.Lang.ICharSequence __ret = global::Java.Lang.Object.GetObject<Java.Lang.ICharSequence> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_identity_Ljava_lang_CharSequence_, __args), JniHandleOwnership.TransferLocalRef);
+			JNIEnv.DeleteLocalRef (native_value);
 			return __ret;
 		}
 

--- a/tools/generator/Tests/expected.ji/TestInterface/Test.ME.TestInterfaceImplementation.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Test.ME.TestInterfaceImplementation.cs
@@ -92,6 +92,65 @@ namespace Test.ME {
 		[Register ("getSpanFlags", "(Ljava/lang/Object;)I", "GetGetSpanFlags_Ljava_lang_Object_Handler")]
 		public abstract int GetSpanFlags (global::Java.Lang.Object tag);
 
+		static Delegate cb_append_Ljava_lang_CharSequence_;
+#pragma warning disable 0169
+		static Delegate GetAppend_Ljava_lang_CharSequence_Handler ()
+		{
+			if (cb_append_Ljava_lang_CharSequence_ == null)
+				cb_append_Ljava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr, IntPtr>) n_Append_Ljava_lang_CharSequence_);
+			return cb_append_Ljava_lang_CharSequence_;
+		}
+
+		static void n_Append_Ljava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
+		{
+			global::Test.ME.TestInterfaceImplementation __this = global::Java.Lang.Object.GetObject<global::Test.ME.TestInterfaceImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			global::Java.Lang.ICharSequence value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
+			__this.Append (value);
+		}
+#pragma warning restore 0169
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='test.me']/interface[@name='TestInterface']/method[@name='append' and count(parameter)=1 and parameter[1][@type='java.lang.CharSequence']]"
+		[Register ("append", "(Ljava/lang/CharSequence;)V", "GetAppend_Ljava_lang_CharSequence_Handler")]
+		public abstract void Append (global::Java.Lang.ICharSequence value);
+
+		public void Append (string value)
+		{
+			global::Java.Lang.String jls_value = value == null ? null : new global::Java.Lang.String (value);
+			Append (jls_value);
+			jls_value?.Dispose ();
+		}
+
+		static Delegate cb_identity_Ljava_lang_CharSequence_;
+#pragma warning disable 0169
+		static Delegate GetIdentity_Ljava_lang_CharSequence_Handler ()
+		{
+			if (cb_identity_Ljava_lang_CharSequence_ == null)
+				cb_identity_Ljava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr, IntPtr>) n_Identity_Ljava_lang_CharSequence_);
+			return cb_identity_Ljava_lang_CharSequence_;
+		}
+
+		static IntPtr n_Identity_Ljava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
+		{
+			global::Test.ME.TestInterfaceImplementation __this = global::Java.Lang.Object.GetObject<global::Test.ME.TestInterfaceImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			global::Java.Lang.ICharSequence value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
+			IntPtr __ret = CharSequence.ToLocalJniHandle (__this.IdentityFormatted (value));
+			return __ret;
+		}
+#pragma warning restore 0169
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='test.me']/interface[@name='TestInterface']/method[@name='identity' and count(parameter)=1 and parameter[1][@type='java.lang.CharSequence']]"
+		[Register ("identity", "(Ljava/lang/CharSequence;)Ljava/lang/CharSequence;", "GetIdentity_Ljava_lang_CharSequence_Handler")]
+		public abstract global::Java.Lang.ICharSequence IdentityFormatted (global::Java.Lang.ICharSequence value);
+
+		public string Identity (string value)
+		{
+			global::Java.Lang.String jls_value = value == null ? null : new global::Java.Lang.String (value);
+			global::Java.Lang.ICharSequence __result = IdentityFormatted (jls_value);
+			var __rsval = __result?.ToString ();
+			jls_value?.Dispose ();
+			return __rsval;
+		}
+
 	}
 
 	[global::Android.Runtime.Register ("test/me/TestInterfaceImplementation", DoNotGenerateAcw=true)]
@@ -121,6 +180,46 @@ namespace Test.ME {
 				return __rm;
 			} finally {
 			}
+		}
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='test.me']/interface[@name='TestInterface']/method[@name='append' and count(parameter)=1 and parameter[1][@type='java.lang.CharSequence']]"
+		[Register ("append", "(Ljava/lang/CharSequence;)V", "GetAppend_Ljava_lang_CharSequence_Handler")]
+		public override unsafe void Append (global::Java.Lang.ICharSequence value)
+		{
+			const string __id = "append.(Ljava/lang/CharSequence;)V";
+			IntPtr native_value = CharSequence.ToLocalJniHandle (value);
+			try {
+				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+				__args [0] = new JniArgumentValue (native_value);
+				_members.InstanceMethods.InvokeAbstractVoidMethod (__id, this, __args);
+			} finally {
+				JNIEnv.DeleteLocalRef (native_value);
+			}
+		}
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='test.me']/interface[@name='TestInterface']/method[@name='identity' and count(parameter)=1 and parameter[1][@type='java.lang.CharSequence']]"
+		[Register ("identity", "(Ljava/lang/CharSequence;)Ljava/lang/CharSequence;", "GetIdentity_Ljava_lang_CharSequence_Handler")]
+		public override unsafe global::Java.Lang.ICharSequence IdentityFormatted (global::Java.Lang.ICharSequence value)
+		{
+			const string __id = "identity.(Ljava/lang/CharSequence;)Ljava/lang/CharSequence;";
+			IntPtr native_value = CharSequence.ToLocalJniHandle (value);
+			try {
+				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+				__args [0] = new JniArgumentValue (native_value);
+				var __rm = _members.InstanceMethods.InvokeAbstractObjectMethod (__id, this, __args);
+				return global::Java.Lang.Object.GetObject<Java.Lang.ICharSequence> (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+			} finally {
+				JNIEnv.DeleteLocalRef (native_value);
+			}
+		}
+
+		public string Identity (string value)
+		{
+			global::Java.Lang.String jls_value = value == null ? null : new global::Java.Lang.String (value);
+			global::Java.Lang.ICharSequence __result = IdentityFormatted (jls_value);
+			var __rsval = __result?.ToString ();
+			jls_value?.Dispose ();
+			return __rsval;
 		}
 
 	}

--- a/tools/generator/Tests/expected/TestInterface/Test.ME.ITestInterface.cs
+++ b/tools/generator/Tests/expected/TestInterface/Test.ME.ITestInterface.cs
@@ -48,6 +48,33 @@ namespace Test.ME {
 		[Register ("getSpanFlags", "(Ljava/lang/Object;)I", "GetGetSpanFlags_Ljava_lang_Object_Handler:Test.ME.ITestInterfaceInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
 		int GetSpanFlags (global::Java.Lang.Object tag);
 
+		// Metadata.xml XPath method reference: path="/api/package[@name='test.me']/interface[@name='TestInterface']/method[@name='append' and count(parameter)=1 and parameter[1][@type='java.lang.CharSequence']]"
+		[Register ("append", "(Ljava/lang/CharSequence;)V", "GetAppend_Ljava_lang_CharSequence_Handler:Test.ME.ITestInterfaceInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
+		void Append (global::Java.Lang.ICharSequence value);
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='test.me']/interface[@name='TestInterface']/method[@name='identity' and count(parameter)=1 and parameter[1][@type='java.lang.CharSequence']]"
+		[Register ("identity", "(Ljava/lang/CharSequence;)Ljava/lang/CharSequence;", "GetIdentity_Ljava_lang_CharSequence_Handler:Test.ME.ITestInterfaceInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
+		global::Java.Lang.ICharSequence IdentityFormatted (global::Java.Lang.ICharSequence value);
+
+	}
+
+	public static partial class ITestInterfaceExtensions {
+
+		public static void Append (this Test.ME.ITestInterface self, string value)
+		{
+			global::Java.Lang.String jls_value = value == null ? null : new global::Java.Lang.String (value);
+			self.Append (jls_value);
+			jls_value?.Dispose ();
+		}
+
+		public static string Identity (this Test.ME.ITestInterface self, string value)
+		{
+			global::Java.Lang.String jls_value = value == null ? null : new global::Java.Lang.String (value);
+			global::Java.Lang.ICharSequence __result = self.IdentityFormatted (jls_value);
+			var __rsval = __result?.ToString ();
+			jls_value?.Dispose ();
+			return __rsval;
+		}
 	}
 
 	[global::Android.Runtime.Register ("test/me/TestInterface", DoNotGenerateAcw=true)]
@@ -119,6 +146,66 @@ namespace Test.ME {
 			JValue* __args = stackalloc JValue [1];
 			__args [0] = new JValue (tag);
 			int __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getSpanFlags_Ljava_lang_Object_, __args);
+			return __ret;
+		}
+
+		static Delegate cb_append_Ljava_lang_CharSequence_;
+#pragma warning disable 0169
+		static Delegate GetAppend_Ljava_lang_CharSequence_Handler ()
+		{
+			if (cb_append_Ljava_lang_CharSequence_ == null)
+				cb_append_Ljava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr, IntPtr>) n_Append_Ljava_lang_CharSequence_);
+			return cb_append_Ljava_lang_CharSequence_;
+		}
+
+		static void n_Append_Ljava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
+		{
+			global::Test.ME.ITestInterface __this = global::Java.Lang.Object.GetObject<global::Test.ME.ITestInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			global::Java.Lang.ICharSequence value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
+			__this.Append (value);
+		}
+#pragma warning restore 0169
+
+		IntPtr id_append_Ljava_lang_CharSequence_;
+		public unsafe void Append (global::Java.Lang.ICharSequence value)
+		{
+			if (id_append_Ljava_lang_CharSequence_ == IntPtr.Zero)
+				id_append_Ljava_lang_CharSequence_ = JNIEnv.GetMethodID (class_ref, "append", "(Ljava/lang/CharSequence;)V");
+			IntPtr native_value = CharSequence.ToLocalJniHandle (value);
+			JValue* __args = stackalloc JValue [1];
+			__args [0] = new JValue (native_value);
+			JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_append_Ljava_lang_CharSequence_, __args);
+			JNIEnv.DeleteLocalRef (native_value);
+		}
+
+		static Delegate cb_identity_Ljava_lang_CharSequence_;
+#pragma warning disable 0169
+		static Delegate GetIdentity_Ljava_lang_CharSequence_Handler ()
+		{
+			if (cb_identity_Ljava_lang_CharSequence_ == null)
+				cb_identity_Ljava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr, IntPtr>) n_Identity_Ljava_lang_CharSequence_);
+			return cb_identity_Ljava_lang_CharSequence_;
+		}
+
+		static IntPtr n_Identity_Ljava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
+		{
+			global::Test.ME.ITestInterface __this = global::Java.Lang.Object.GetObject<global::Test.ME.ITestInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			global::Java.Lang.ICharSequence value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
+			IntPtr __ret = CharSequence.ToLocalJniHandle (__this.IdentityFormatted (value));
+			return __ret;
+		}
+#pragma warning restore 0169
+
+		IntPtr id_identity_Ljava_lang_CharSequence_;
+		public unsafe global::Java.Lang.ICharSequence IdentityFormatted (global::Java.Lang.ICharSequence value)
+		{
+			if (id_identity_Ljava_lang_CharSequence_ == IntPtr.Zero)
+				id_identity_Ljava_lang_CharSequence_ = JNIEnv.GetMethodID (class_ref, "identity", "(Ljava/lang/CharSequence;)Ljava/lang/CharSequence;");
+			IntPtr native_value = CharSequence.ToLocalJniHandle (value);
+			JValue* __args = stackalloc JValue [1];
+			__args [0] = new JValue (native_value);
+			global::Java.Lang.ICharSequence __ret = global::Java.Lang.Object.GetObject<Java.Lang.ICharSequence> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_identity_Ljava_lang_CharSequence_, __args), JniHandleOwnership.TransferLocalRef);
+			JNIEnv.DeleteLocalRef (native_value);
 			return __ret;
 		}
 

--- a/tools/generator/Tests/expected/TestInterface/Test.ME.TestInterfaceImplementation.cs
+++ b/tools/generator/Tests/expected/TestInterface/Test.ME.TestInterfaceImplementation.cs
@@ -98,6 +98,65 @@ namespace Test.ME {
 		[Register ("getSpanFlags", "(Ljava/lang/Object;)I", "GetGetSpanFlags_Ljava_lang_Object_Handler")]
 		public abstract int GetSpanFlags (global::Java.Lang.Object tag);
 
+		static Delegate cb_append_Ljava_lang_CharSequence_;
+#pragma warning disable 0169
+		static Delegate GetAppend_Ljava_lang_CharSequence_Handler ()
+		{
+			if (cb_append_Ljava_lang_CharSequence_ == null)
+				cb_append_Ljava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr, IntPtr>) n_Append_Ljava_lang_CharSequence_);
+			return cb_append_Ljava_lang_CharSequence_;
+		}
+
+		static void n_Append_Ljava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
+		{
+			global::Test.ME.TestInterfaceImplementation __this = global::Java.Lang.Object.GetObject<global::Test.ME.TestInterfaceImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			global::Java.Lang.ICharSequence value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
+			__this.Append (value);
+		}
+#pragma warning restore 0169
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='test.me']/interface[@name='TestInterface']/method[@name='append' and count(parameter)=1 and parameter[1][@type='java.lang.CharSequence']]"
+		[Register ("append", "(Ljava/lang/CharSequence;)V", "GetAppend_Ljava_lang_CharSequence_Handler")]
+		public abstract void Append (global::Java.Lang.ICharSequence value);
+
+		public void Append (string value)
+		{
+			global::Java.Lang.String jls_value = value == null ? null : new global::Java.Lang.String (value);
+			Append (jls_value);
+			jls_value?.Dispose ();
+		}
+
+		static Delegate cb_identity_Ljava_lang_CharSequence_;
+#pragma warning disable 0169
+		static Delegate GetIdentity_Ljava_lang_CharSequence_Handler ()
+		{
+			if (cb_identity_Ljava_lang_CharSequence_ == null)
+				cb_identity_Ljava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr, IntPtr>) n_Identity_Ljava_lang_CharSequence_);
+			return cb_identity_Ljava_lang_CharSequence_;
+		}
+
+		static IntPtr n_Identity_Ljava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
+		{
+			global::Test.ME.TestInterfaceImplementation __this = global::Java.Lang.Object.GetObject<global::Test.ME.TestInterfaceImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			global::Java.Lang.ICharSequence value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
+			IntPtr __ret = CharSequence.ToLocalJniHandle (__this.IdentityFormatted (value));
+			return __ret;
+		}
+#pragma warning restore 0169
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='test.me']/interface[@name='TestInterface']/method[@name='identity' and count(parameter)=1 and parameter[1][@type='java.lang.CharSequence']]"
+		[Register ("identity", "(Ljava/lang/CharSequence;)Ljava/lang/CharSequence;", "GetIdentity_Ljava_lang_CharSequence_Handler")]
+		public abstract global::Java.Lang.ICharSequence IdentityFormatted (global::Java.Lang.ICharSequence value);
+
+		public string Identity (string value)
+		{
+			global::Java.Lang.String jls_value = value == null ? null : new global::Java.Lang.String (value);
+			global::Java.Lang.ICharSequence __result = IdentityFormatted (jls_value);
+			var __rsval = __result?.ToString ();
+			jls_value?.Dispose ();
+			return __rsval;
+		}
+
 	}
 
 	[global::Android.Runtime.Register ("test/me/TestInterfaceImplementation", DoNotGenerateAcw=true)]
@@ -123,6 +182,50 @@ namespace Test.ME {
 				return __ret;
 			} finally {
 			}
+		}
+
+		static IntPtr id_append_Ljava_lang_CharSequence_;
+		// Metadata.xml XPath method reference: path="/api/package[@name='test.me']/interface[@name='TestInterface']/method[@name='append' and count(parameter)=1 and parameter[1][@type='java.lang.CharSequence']]"
+		[Register ("append", "(Ljava/lang/CharSequence;)V", "GetAppend_Ljava_lang_CharSequence_Handler")]
+		public override unsafe void Append (global::Java.Lang.ICharSequence value)
+		{
+			if (id_append_Ljava_lang_CharSequence_ == IntPtr.Zero)
+				id_append_Ljava_lang_CharSequence_ = JNIEnv.GetMethodID (class_ref, "append", "(Ljava/lang/CharSequence;)V");
+			IntPtr native_value = CharSequence.ToLocalJniHandle (value);
+			try {
+				JValue* __args = stackalloc JValue [1];
+				__args [0] = new JValue (native_value);
+				JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_append_Ljava_lang_CharSequence_, __args);
+			} finally {
+				JNIEnv.DeleteLocalRef (native_value);
+			}
+		}
+
+		static IntPtr id_identity_Ljava_lang_CharSequence_;
+		// Metadata.xml XPath method reference: path="/api/package[@name='test.me']/interface[@name='TestInterface']/method[@name='identity' and count(parameter)=1 and parameter[1][@type='java.lang.CharSequence']]"
+		[Register ("identity", "(Ljava/lang/CharSequence;)Ljava/lang/CharSequence;", "GetIdentity_Ljava_lang_CharSequence_Handler")]
+		public override unsafe global::Java.Lang.ICharSequence IdentityFormatted (global::Java.Lang.ICharSequence value)
+		{
+			if (id_identity_Ljava_lang_CharSequence_ == IntPtr.Zero)
+				id_identity_Ljava_lang_CharSequence_ = JNIEnv.GetMethodID (class_ref, "identity", "(Ljava/lang/CharSequence;)Ljava/lang/CharSequence;");
+			IntPtr native_value = CharSequence.ToLocalJniHandle (value);
+			try {
+				JValue* __args = stackalloc JValue [1];
+				__args [0] = new JValue (native_value);
+				global::Java.Lang.ICharSequence __ret = global::Java.Lang.Object.GetObject<Java.Lang.ICharSequence> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_identity_Ljava_lang_CharSequence_, __args), JniHandleOwnership.TransferLocalRef);
+				return __ret;
+			} finally {
+				JNIEnv.DeleteLocalRef (native_value);
+			}
+		}
+
+		public string Identity (string value)
+		{
+			global::Java.Lang.String jls_value = value == null ? null : new global::Java.Lang.String (value);
+			global::Java.Lang.ICharSequence __result = IdentityFormatted (jls_value);
+			var __rsval = __result?.ToString ();
+			jls_value?.Dispose ();
+			return __rsval;
 		}
 
 	}

--- a/tools/generator/Tests/expected/TestInterface/TestInterface.xml
+++ b/tools/generator/Tests/expected/TestInterface/TestInterface.xml
@@ -18,6 +18,9 @@
 				default void defaultInterfaceMethod()
 				{
 				}
+
+				void append(CharSequence value);
+				CharSequence identity(CharSequence value);
 			}
 		-->
 		<interface abstract="true" deprecated="not deprecated" final="false" name="TestInterface" static="false" visibility="public">
@@ -31,6 +34,12 @@
 			</field>
 			<field deprecated="not deprecated" final="true" name="DEFAULT_FOO" static="true" transient="false" type="java.lang.Object" type-generic-aware="java.lang.Object" visibility="public" volatile="false">
 			</field>
+			<method abstract="true" deprecated="not deprecated" final="false" name="append" native="false" return="void" static="false" synchronized="false" visibility="public">
+				<parameter name="value" type="java.lang.CharSequence" />
+			</method>
+			<method abstract="true" deprecated="not deprecated" final="false" name="identity" native="false" return="java.lang.CharSequence" static="false" synchronized="false" visibility="public">
+				<parameter name="value" type="java.lang.CharSequence" />
+			</method>
 		</interface>
 		<!--
 			public abstract class TestInterfaceImplementation implements TestInterface {

--- a/tools/generator/Tests/generator-Tests.csproj
+++ b/tools/generator/Tests/generator-Tests.csproj
@@ -90,7 +90,16 @@
     <Content Include="SupportFiles\JavaCollection.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="SupportFiles\Android_Runtime_CharSequence.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="SupportFiles\Java_Lang_ICharSequence.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="SupportFiles\Java_Lang_Object.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="SupportFiles\Java_Lang_String.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="SupportFiles\Java_Lang_Throwable.cs">


### PR DESCRIPTION
Fixes: https://bugzilla.xamarin.com/show_bug.cgi?id=59472

Assume you have the following Java method:

```java
	class Example {
		public static CharSequence identity(CharSequence value) {
			return value;
		}
	}
```

When binding `Example.identity()`, we will *rename* it to have a
`Formatted` suffix, and "overload" it with a `string` overload:

```csharp
	partial class Example {
		public static ICharSequence IdentityFormatted (ICharSequence value)
		{
			// ...
		}

		public static string Identity (string value)
		{
			// ...
		}
	}
```

The purpose of this overloading is to make it easier to call the
method from C# code. It's not currently possible for interfaces to
contain static methods, which in turn means it's not possible for
interfaces to contain conversion operators. Thus, if a C# developer
wants to do:

	Example.Identity ("value");

there would be no way to have this Just Work™ while having only
`ICharSequence` running around.

(Additionally, we rename the method so that we don't need to worry
about return types. In the above example, the return type is
converted, so if we didn't rename to `IdentityFormatted()`, we
couldn't overload for many interesting use cases.)

This feature has existed for quite some time, but there's a bug:
`Example.Identity()` would do:

```csharp
	partial class Example {
		public static string Identity (string value)
		{
			var jls_value = value == null ? null : new Java.Lang.String (value)
			var __result  = IdentityFormatted (jls_value);
			jls_value?.Dispose ();
			return __result?.ToString ();
		}
	}
```

This seems acceptable, but this will break when
`Example.IdentityFormatted()` -- `Example.identity()` -- returns the
parameter. When that happens, `jls_value` and `__result` are
*the same instance*, and thus the `jls_value?.Dispose()` *also*
disposes of `__result`. In this case, `__result.ToString()` will be
`null`, which is *not* what is desired.

The fix is to grab `__result.ToString()` *before* disposing of the
temporary parameters:

```csharp
	partial class Example {
		public static string Identity (string value)
		{
			var jls_value = value == null ? null : new Java.Lang.String (value)
			var __result  = IdentityFormatted (jls_value);
			var __rsval   = __result?.ToString ();
			jls_value?.Dispose ();
			return __rsval;
		}
	}
```

This way we ensure that we get a copy before the source is disposed.