### PR TITLE
Bump to cecil/mono-2017-06/c0eb983d

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,4 +5,4 @@
 [submodule "external/cecil"]
 	path = external/cecil
 	url = https://github.com/mono/cecil.git
-	branch = master
+	branch = mono-2017-06


### PR DESCRIPTION
For consistency with mono/2017-06, which xamarin-android/d15-5 uses.