### PR TITLE
[tests] various fixes for Windows

### DIFF
--- a/src/Java.Runtime.Environment/Java.Runtime.Environment.csproj
+++ b/src/Java.Runtime.Environment/Java.Runtime.Environment.csproj
@@ -48,7 +48,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="Java.Runtime.Environment.dll.config">
+    <Content Include="Java.Runtime.Environment.dll.config" Condition=" '$(OS)' != 'Windows_NT' ">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\Configuration.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -73,8 +74,8 @@
   </PropertyGroup>
   <Target Name="BuildClasses" Inputs="@(TestJar)" Outputs="@(TestJar-&gt;'$(IntermediateOutputPath)classes\%(RecursiveDir)%(Filename).class')">
     <MakeDir Directories="$(IntermediateOutputPath)classes" />
-    <Exec Command="&quot;javac&quot; -parameters -source 1.5 -target 1.6 -g -d &quot;$(IntermediateOutputPath)classes&quot; @(TestJar->'%(Identity)', ' ')" />
-    <Exec Command="&quot;javac&quot; -source 1.5 -target 1.6 -g -d &quot;$(IntermediateOutputPath)classes&quot; @(TestJarNoParameters->'%(Identity)', ' ')" />
+    <Exec Command="&quot;$(JavaCPath)&quot; -parameters -source 1.5 -target 1.6 -g -d &quot;$(IntermediateOutputPath)classes&quot; @(TestJar->'%(Identity)', ' ')" />
+    <Exec Command="&quot;$(JavaCPath)&quot; -source 1.5 -target 1.6 -g -d &quot;$(IntermediateOutputPath)classes&quot; @(TestJarNoParameters->'%(Identity)', ' ')" />
   </Target>
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Android.Tools.Bytecode.csproj">

--- a/tools/generator/Tests/BaseGeneratorTest.cs
+++ b/tools/generator/Tests/BaseGeneratorTest.cs
@@ -40,7 +40,7 @@ namespace generatortests
 			}
 			bool    hasErrors;
 			string  compilerOutput;
-			BuiltAssembly = Compiler.Compile (Options, "Mono.Andoroid", AdditionalSourceDirectories,
+			BuiltAssembly = Compiler.Compile (Options, "Mono.Android", AdditionalSourceDirectories,
 				out hasErrors, out compilerOutput);
 			Assert.AreEqual (false, hasErrors, compilerOutput);
 			Assert.IsNotNull (BuiltAssembly);
@@ -79,8 +79,8 @@ namespace generatortests
 			result = File.Exists (file1) && File.Exists (file2);
 
 			if (result) {
-				byte[] f1 = File.ReadAllBytes (file1);
-				byte[] f2 = File.ReadAllBytes (file2);
+				byte[] f1 = ReadAllBytesIgnoringLineEndings (file1);
+				byte[] f2 = ReadAllBytesIgnoringLineEndings (file2);
 
 				var hash = MD5.Create ();
 				var f1hash = Convert.ToBase64String (hash.ComputeHash (f1));
@@ -89,6 +89,22 @@ namespace generatortests
 			}
 
 			return result;
+		}
+
+		private byte[] ReadAllBytesIgnoringLineEndings (string path)
+		{
+			using (var memoryStream = new MemoryStream ()) {
+ 				using (var file = File.OpenRead (path)) {
+ 					int readByte;
+ 					while ((readByte = file.ReadByte()) != -1) {
+ 						byte b = (byte)readByte;
+ 						if (b != '\r' && b != '\n') {
+ 							memoryStream.WriteByte (b);
+ 						}
+ 					}
+ 				}
+				return memoryStream.ToArray ();
+			}
 		}
 
 		protected void RunAllTargets (string outputRelativePath, string apiDescriptionFile, string expectedRelativePath, string[] additionalSupportPaths = null)

--- a/tools/generator/Tests/Compiler.cs
+++ b/tools/generator/Tests/Compiler.cs
@@ -70,9 +70,13 @@ namespace generatortests
 			var env = Environment.GetEnvironmentVariable ("FACADES_PATH");
 			if (env != null)
 				return env;
-			return Path.Combine (
-					Path.GetDirectoryName (typeof (object).Assembly.Location),
-					"Facades");
+
+			var dir = Path.GetDirectoryName (typeof (object).Assembly.Location);
+			var facades = Path.Combine (dir, "Facades");
+			if (Directory.Exists (facades))
+				return facades;
+
+			return dir;
 		}
 	}
 }


### PR DESCRIPTION
`Java.Interop.sln` did not compile on Windows:
- `Java.Runtime.Environment.dll.config` can be conditional, I don't
think it is needed on Windows
- `Bytecode-Tests.csproj` needs to use `$(JavaCPath)` instead of `javac`

`generator-Tests` were not passing:
- `BaseGeneratorTest` needs to ignore line endings when comparing files
    - also fixed a typo
- `Compiler` was not able to locate `System.Runtime.dll` on Windows. It
turns out there is not a `Facades` directory on Windows (just a flat
directory), so added a `Directory.Exists` check