### PR TITLE
[tests] migrate nunit-console commands to MSBuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,11 +139,7 @@ shell:
 define RUN_TEST
 	MONO_TRACE_LISTENER=Console.Out \
 	JAVA_INTEROP_GREF_LOG=g-$(basename $(notdir $(1))).txt $(if $(2),JAVA_INTEROP_LREF_LOG=l-$(basename $(notdir $(1))).txt,) \
-	$(RUNTIME) $$MONO_OPTIONS --runtime=v4.0.0 \
-		$(NUNIT_CONSOLE) $(NUNIT_EXTRA) $(1) \
-		$(if $(RUN),-run:$(RUN)) \
-		-xml=TestResult-$(basename $(notdir $(1))).xml \
-		-output=bin/Test$(CONFIGURATION)/TestOutput-$(basename $(notdir $(1))).txt ;
+	$(MSBUILD) $(MSBUILD_FLAGS) build-tools/scripts/RunNUnitTests.targets /p:TestAssembly=$(1) ;
 endef
 
 run-tests: $(TESTS) bin/Test$(CONFIGURATION)/$(JAVA_INTEROP_LIB)

--- a/build-tools/scripts/RunNUnitTests.targets
+++ b/build-tools/scripts/RunNUnitTests.targets
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="RunTests" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <_TopDir>$(MSBuildThisFileDirectory)..\..</_TopDir>
+    <_Runtime Condition=" '$(RUNTIME)' != '' ">$(RUNTIME)</_Runtime>
+    <_Runtime Condition=" '$(RUNTIME)' == '' And '$(OS)' != 'Windows_NT' ">mono</_Runtime>
+    <_NUnit>$(_Runtime) packages\NUnit.Runners.2.6.3\tools\nunit-console.exe</_NUnit>
+    <_Run Condition=" '$(RUN)' != '' ">--run=&quot;$(RUN)&quot;</_Run>
+  </PropertyGroup>
+  <ItemGroup>
+    <_TestAssembly Include="$(_TopDir)\bin\Test$(Configuration)\*-*Tests.dll" Condition=" '$(TestAssembly)' == '' " />
+    <_TestAssembly Include="$(TestAssembly)" Condition=" '$(TestAssembly)' != '' " />
+  </ItemGroup>
+  <Target Name="RunTests">
+    <Exec
+        Command="$(_NUnit) $(NUNIT_EXTRA) %(_TestAssembly.Identity) $(_Run) --result=&quot;TestResult-%(Filename).xml&quot; --output=&quot;bin\Test$(Configuration)\TestOutput-%(Filename).txt&quot;"
+        WorkingDirectory="$(_TopDir)"
+        ContinueOnError="True"
+    />
+  </Target>
+</Project>


### PR DESCRIPTION
The end goal here is to easily enable running tests on Windows. To
enable this, a new `build-tools/scripts/RunNUnitTests.targets` file is
needed. The `Makefile` will invoke this file so we aren't duplicating
anything.

We will continue with this approach in xamarin/xamarin-android, so
running unit tests is simpler on Windows there, too.

## Usage (Windows):

Run all tests:
```
msbuild build-tools/scripts/RunNUnitTests.targets
```
Filter based on the `--run` switch:
```
msbuild build-tools/scripts/RunNUnitTests.targets /p:Run=Java.Interop
```
Run tests on specific assemblies:
```
msbuild build-tools\scripts\RunNUnitTests.targets /p:TestAssembly="bin\TestDebug\Java.Interop.Tools.JavaCallableWrappers-Tests.dll;bin\TestDebug\LogcatParse-Tests.dll"
```

## Usage (macOS/linux)

`make` commands should remain unchanged. Existing environment variables
should continue to work such as `RUNTIME`, `RUN`, `CONFIGURATION`, etc.