### PR TITLE
[tests] various fixes for Windows

### DIFF
--- a/build-tools/scripts/RunNUnitTests.targets
+++ b/build-tools/scripts/RunNUnitTests.targets
@@ -14,7 +14,7 @@
   </ItemGroup>
   <Target Name="RunTests">
     <Exec
-        Command="$(_NUnit) $(NUNIT_EXTRA) %(_TestAssembly.Identity) $(_Run) --result=&quot;TestResult-%(Filename).xml&quot; --output=&quot;bin\Test$(Configuration)\TestOutput-%(Filename).txt&quot;"
+        Command="$(_NUnit) $(NUNIT_EXTRA) %(_TestAssembly.Identity) $(_Run) --noshadow --result=&quot;TestResult-%(Filename).xml&quot; --output=&quot;bin\Test$(Configuration)\TestOutput-%(Filename).txt&quot;"
         WorkingDirectory="$(_TopDir)"
         ContinueOnError="True"
     />

--- a/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
@@ -334,7 +334,6 @@ namespace Xamarin.Android.Tools.Bytecode {
 			var settings = new XmlWriterSettings () {
 				Indent              = true,
 				OmitXmlDeclaration  = true,
-				NewLineChars        = "\n",
 				NewLineOnAttributes = true,
 			};
 			var contents    = ToXElement ();

--- a/src/Xamarin.Android.Tools.Bytecode/ConstantPool.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/ConstantPool.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -112,7 +113,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 
 		public override string ToString ()
 		{
-			return string.Format ("Class(nameIndex={0} Name=\"{1}\")", nameIndex, Name.Value);
+			return string.Format (CultureInfo.InvariantCulture, "Class(nameIndex={0} Name=\"{1}\")", nameIndex, Name.Value);
 		}
 	}
 
@@ -138,7 +139,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 
 		public override string ToString ()
 		{
-			return string.Format ("{0}(classIndex={1} nameAndTypeIndex={2} Class='{3}' Name='{4}' Descriptor='{5}')",
+			return string.Format (CultureInfo.InvariantCulture, "{0}(classIndex={1} nameAndTypeIndex={2} Class='{3}' Name='{4}' Descriptor='{5}')",
 					Type, classIndex, nameAndTypeIndex, Class.Name, NameAndType.Name.Value, NameAndType.Descriptor.Value);
 		}
 	}
@@ -201,7 +202,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 
 		public override string ToString ()
 		{
-			return string.Format ("String(stringIndex={0} Utf8=\"{1}\")",
+			return string.Format (CultureInfo.InvariantCulture, "String(stringIndex={0} Utf8=\"{1}\")",
 					stringIndex, StringData.Value);
 		}
 	}
@@ -227,7 +228,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 
 		public override string ToString ()
 		{
-			return string.Format ("Integer({0})", Value);
+			return string.Format (CultureInfo.InvariantCulture, "Integer({0})", Value);
 		}
 	}
 
@@ -259,7 +260,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 
 		public override string ToString ()
 		{
-			return string.Format ("Float({0})", Value);
+			return string.Format (CultureInfo.InvariantCulture, "Float({0})", Value);
 		}
 	}
 
@@ -288,7 +289,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 
 		public override string ToString ()
 		{
-			return string.Format ("Long({0})", Value);
+			return string.Format (CultureInfo.InvariantCulture, "Long({0})", Value);
 		}
 	}
 
@@ -328,7 +329,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 
 		public override string ToString ()
 		{
-			return string.Format ("Double({0})", Value);
+			return string.Format (CultureInfo.InvariantCulture, "Double({0})", Value);
 		}
 	}
 
@@ -359,7 +360,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 
 		public override string ToString ()
 		{
-			return string.Format ("NameAndType(nameIndex={0} descriptorIndex={1} Name=\"{2}\" Descriptor=\"{3}\")",
+			return string.Format (CultureInfo.InvariantCulture, "NameAndType(nameIndex={0} descriptorIndex={1} Name=\"{2}\" Descriptor=\"{3}\")",
 					nameIndex, descriptorIndex, Name.Value, Descriptor.Value);
 		}
 	}
@@ -414,7 +415,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 
 		public override string ToString ()
 		{
-			return string.Format ("Utf8(\"{0}\")", Value);
+			return string.Format (CultureInfo.InvariantCulture, "Utf8(\"{0}\")", Value);
 		}
 	}
 
@@ -457,7 +458,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 
 		public override string ToString ()
 		{
-			return string.Format ("MethodType(descriptorIndex={0} Descriptor=\"{1}\")",
+			return string.Format (CultureInfo.InvariantCulture, "MethodType(descriptorIndex={0} Descriptor=\"{1}\")",
 					descriptorIndex, Descriptor.Value);
 		}
 	}

--- a/tools/generator/Tests/expected.ji/CSharpKeywords/Xamarin.Test.CSharpKeywords-windows.cs
+++ b/tools/generator/Tests/expected.ji/CSharpKeywords/Xamarin.Test.CSharpKeywords-windows.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Xamarin.Test {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='CSharpKeywords']"
+	[global::Android.Runtime.Register ("xamarin/test/CSharpKeywords", DoNotGenerateAcw=true)]
+	public partial class CSharpKeywords : global::Java.Lang.Object {
+
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/CSharpKeywords", typeof (CSharpKeywords));
+		internal static new IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+		protected CSharpKeywords (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		static Delegate cb_usePartial_I;
+#pragma warning disable 0169
+		static Delegate GetUsePartial_IHandler ()
+		{
+			if (cb_usePartial_I == null)
+				cb_usePartial_I = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, int, IntPtr>) n_UsePartial_I);
+			return cb_usePartial_I;
+		}
+
+		static IntPtr n_UsePartial_I (IntPtr jnienv, IntPtr native__this, int partial)
+		{
+			global::Xamarin.Test.CSharpKeywords __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.CSharpKeywords> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.NewString (__this.UsePartial (partial));
+		}
+#pragma warning restore 0169
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='CSharpKeywords']/method[@name='usePartial' and count(parameter)=1 and parameter[1][@type='int']]"
+		[Register ("usePartial", "(I)Ljava/lang/String;", "GetUsePartial_IHandler")]
+		public virtual unsafe string UsePartial (int partial)
+		{
+			const string __id = "usePartial.(I)Ljava/lang/String;";
+			try {
+				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+				__args [0] = new JniArgumentValue (partial);
+				var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, __args);
+				return JNIEnv.GetString (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+			} finally {
+			}
+		}
+
+	}
+}

--- a/tools/generator/Tests/expected.targets
+++ b/tools/generator/Tests/expected.targets
@@ -42,7 +42,11 @@
     <Content Include='expected\CSharpKeywords\CSharpKeywords.xml'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include='expected\CSharpKeywords\Xamarin.Test.CSharpKeywords.cs'>
+    <Content Include='expected\CSharpKeywords\Xamarin.Test.CSharpKeywords.cs' Condition=" '$(OS)' != 'Windows_NT' ">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected\CSharpKeywords\Xamarin.Test.CSharpKeywords-windows.cs' Condition=" '$(OS)' == 'Windows_NT' ">
+      <Link>Xamarin.Test.CSharpKeywords.cs</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include='expected\EnumerationFixup\EnumerationFixupMap.xml'>
@@ -210,7 +214,11 @@
     <Content Include='expected.ji\CSharpKeywords\Mono.Android.projitems'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include='expected.ji\CSharpKeywords\Xamarin.Test.CSharpKeywords.cs'>
+    <Content Include='expected.ji\CSharpKeywords\Xamarin.Test.CSharpKeywords.cs' Condition=" '$(OS)' != 'Windows_NT' ">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected.ji\CSharpKeywords\Xamarin.Test.CSharpKeywords-windows.cs' Condition=" '$(OS)' == 'Windows_NT' ">
+      <Link>Xamarin.Test.CSharpKeywords.cs</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include='expected.ji\java.lang.Enum\enumlist'>

--- a/tools/generator/Tests/expected/CSharpKeywords/Xamarin.Test.CSharpKeywords-windows.cs
+++ b/tools/generator/Tests/expected/CSharpKeywords/Xamarin.Test.CSharpKeywords-windows.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Xamarin.Test {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='CSharpKeywords']"
+	[global::Android.Runtime.Register ("xamarin/test/CSharpKeywords", DoNotGenerateAcw=true)]
+	public partial class CSharpKeywords : global::Java.Lang.Object {
+
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("xamarin/test/CSharpKeywords", ref java_class_handle);
+			}
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (CSharpKeywords); }
+		}
+
+		protected CSharpKeywords (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		static Delegate cb_usePartial_I;
+#pragma warning disable 0169
+		static Delegate GetUsePartial_IHandler ()
+		{
+			if (cb_usePartial_I == null)
+				cb_usePartial_I = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, int, IntPtr>) n_UsePartial_I);
+			return cb_usePartial_I;
+		}
+
+		static IntPtr n_UsePartial_I (IntPtr jnienv, IntPtr native__this, int partial)
+		{
+			global::Xamarin.Test.CSharpKeywords __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.CSharpKeywords> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.NewString (__this.UsePartial (partial));
+		}
+#pragma warning restore 0169
+
+		static IntPtr id_usePartial_I;
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='CSharpKeywords']/method[@name='usePartial' and count(parameter)=1 and parameter[1][@type='int']]"
+		[Register ("usePartial", "(I)Ljava/lang/String;", "GetUsePartial_IHandler")]
+		public virtual unsafe string UsePartial (int partial)
+		{
+			if (id_usePartial_I == IntPtr.Zero)
+				id_usePartial_I = JNIEnv.GetMethodID (class_ref, "usePartial", "(I)Ljava/lang/String;");
+			try {
+				JValue* __args = stackalloc JValue [1];
+				__args [0] = new JValue (partial);
+
+				if (((object) this).GetType () == ThresholdType)
+					return JNIEnv.GetString (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_usePartial_I, __args), JniHandleOwnership.TransferLocalRef);
+				else
+					return JNIEnv.GetString (JNIEnv.CallNonvirtualObjectMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "usePartial", "(I)Ljava/lang/String;"), __args), JniHandleOwnership.TransferLocalRef);
+			} finally {
+			}
+		}
+
+	}
+}

--- a/tools/generator/Tests/generator-Tests.csproj
+++ b/tools/generator/Tests/generator-Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -32,6 +32,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.7\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="nunit.framework">
@@ -150,6 +153,9 @@
     <Content Include="SupportFiles\JavaTypeParametersAttribute.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="expected.targets" />
 </Project>

--- a/tools/generator/Tests/packages.config
+++ b/tools/generator/Tests/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.7" targetFramework="net45" />
+  <package id="Microsoft.Net.Compilers" version="2.1.0" developmentDependency="true" />
   <package id="NUnit" version="2.6.3" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
This gets all the tests projects on Windows passing that _should_ pass
without compiling a Windows binary/equivalent of
`libjava-interop.dylib`.

In total, these test projects are passing:
- generator-Tests
- Java.Interop.Tools.JavaCallableWrappers-Tests
- LogcatParse-Tests
- Xamarin.Android.Tools.ApiXmlAdjuster-Tests
- Xamarin.Android.Tools.Bytecode-Tests

## Changes per test project

Xamarin.Android.Tools.Bytecode-Tests:
- Changes to normalize line endings, `ClassPath` should not hardcode `NewLineChars` to `\n`
- Fix for `CurrentCulture` on Windows:
  - Test for `POSITIVE_INFINITY` was getting `Expected: "Double(Infinity)"
But was: "Double(∞)"`
  - It seems all the `string.Format` calls in `ConstantPool` should use
`InvariantCulture`, I doubt anyone is going to desire these strings as
`CurrentCulture`. Seems better to be consistent for tests no matter the
culture of the machine.

generator-Tests:
- `CSharpCodeProvider` needs a `using` statement or the generated
assembly file is
locked for future tests. This causes many test failures.
- `CSharpCodeProvider` won't support C# 6 on Windows, using NuGet
package on Windows, and Microsoft.CSharp on other platforms
- The Roslyn package seems to require an environment variable to locate
`csc.exe`. See: https://stackoverflow.com/a/40311406/132442
- When running on Mono, the use of the `partial` keyword is generated as
`partial_`. This does not happen on Windows, so included a set of
"expected" files for Windows. This runs a different file comparison if
the tests are running on Windows.
- `--noshadow` is needed for generator-Tests to pass on Windows. Later
an upgrade to NUnit3 is ideal instead, but some test rework is needed due
to the use of the current directory in tests. We should do this after
tests are passing reliably on Windows.