### PR TITLE
[tests] ported environment variables to MSBuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ TestResult-*.xml
 xa-gendarme.html
 packages
 .vs/
+*.userprefs

--- a/Java.Interop.sln
+++ b/Java.Interop.sln
@@ -97,6 +97,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Android.Cecil.Mdb",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Java.Interop.GenericMarshaler", "src\Java.Interop.GenericMarshaler\Java.Interop.GenericMarshaler.csproj", "{D1243BAB-23CA-4566-A2A3-3ADA2C2DC3AF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Java.Interop.BootstrapTasks", "src\Java.Interop.BootstrapTasks\Java.Interop.BootstrapTasks.csproj", "{3E8E5C8C-59A6-4A9A-B55D-46AB14431B2A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -339,6 +341,14 @@ Global
 		{D1243BAB-23CA-4566-A2A3-3ADA2C2DC3AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D1243BAB-23CA-4566-A2A3-3ADA2C2DC3AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D1243BAB-23CA-4566-A2A3-3ADA2C2DC3AF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3E8E5C8C-59A6-4A9A-B55D-46AB14431B2A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3E8E5C8C-59A6-4A9A-B55D-46AB14431B2A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3E8E5C8C-59A6-4A9A-B55D-46AB14431B2A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3E8E5C8C-59A6-4A9A-B55D-46AB14431B2A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3E8E5C8C-59A6-4A9A-B55D-46AB14431B2A}.XAIntegrationDebug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3E8E5C8C-59A6-4A9A-B55D-46AB14431B2A}.XAIntegrationDebug|Any CPU.Build.0 = Debug|Any CPU
+		{3E8E5C8C-59A6-4A9A-B55D-46AB14431B2A}.XAIntegrationRelease|Any CPU.ActiveCfg = Release|Any CPU
+		{3E8E5C8C-59A6-4A9A-B55D-46AB14431B2A}.XAIntegrationRelease|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{0C001D50-4176-45AE-BDC8-BA626508B0CC} = {C8F58966-94BF-407F-914A-8654F8B8AE3B}
@@ -381,5 +391,6 @@ Global
 		{15945D4B-FF56-4BCC-B598-2718D199DD08} = {C8F58966-94BF-407F-914A-8654F8B8AE3B}
 		{C0487169-8F81-497F-919E-EB42B1D0243F} = {C8F58966-94BF-407F-914A-8654F8B8AE3B}
 		{D1243BAB-23CA-4566-A2A3-3ADA2C2DC3AF} = {4C173212-371D-45D8-BA83-9226194F48DC}
+		{3E8E5C8C-59A6-4A9A-B55D-46AB14431B2A} = {172B608B-E6F3-41CC-9949-203A76BA247C}
 	EndGlobalSection
 EndGlobal

--- a/Makefile
+++ b/Makefile
@@ -137,8 +137,6 @@ shell:
 
 # $(call RUN_TEST,filename,log-lref?)
 define RUN_TEST
-	MONO_TRACE_LISTENER=Console.Out \
-	JAVA_INTEROP_GREF_LOG=g-$(basename $(notdir $(1))).txt $(if $(2),JAVA_INTEROP_LREF_LOG=l-$(basename $(notdir $(1))).txt,) \
 	$(MSBUILD) $(MSBUILD_FLAGS) build-tools/scripts/RunNUnitTests.targets /p:TestAssembly=$(1) ;
 endef
 

--- a/build-tools/scripts/RunNUnitTests.targets
+++ b/build-tools/scripts/RunNUnitTests.targets
@@ -8,11 +8,16 @@
     <_NUnit>$(_Runtime) packages\NUnit.Runners.2.6.3\tools\nunit-console.exe</_NUnit>
     <_Run Condition=" '$(RUN)' != '' ">--run=&quot;$(RUN)&quot;</_Run>
   </PropertyGroup>
+  <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Java.Interop.BootstrapTasks.dll" TaskName="Java.Interop.BootstrapTasks.SetEnvironmentVariable" />
   <ItemGroup>
     <_TestAssembly Include="$(_TopDir)\bin\Test$(Configuration)\*-*Tests.dll" Condition=" '$(TestAssembly)' == '' " />
     <_TestAssembly Include="$(TestAssembly)" Condition=" '$(TestAssembly)' != '' " />
   </ItemGroup>
-  <Target Name="RunTests">
+  <Target Name="RunTests"
+      Outputs="$(_TopDir)\TestResult-%(_TestAssembly.Filename).xml">
+    <SetEnvironmentVariable Name="MONO_TRACE_LISTENER" Value="Console.Out" />
+    <SetEnvironmentVariable Name="JAVA_INTEROP_GREF_LOG" Value="g-%(_TestAssembly.Filename).txt" />
+    <SetEnvironmentVariable Name="JAVA_INTEROP_LREF_LOG" Value="l-%(_TestAssembly.Filename).txt" />
     <Exec
         Command="$(_NUnit) $(NUNIT_EXTRA) %(_TestAssembly.Identity) $(_Run) --noshadow --result=&quot;TestResult-%(Filename).xml&quot; --output=&quot;bin\Test$(Configuration)\TestOutput-%(Filename).txt&quot;"
         WorkingDirectory="$(_TopDir)"

--- a/src/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks.csproj
+++ b/src/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks.csproj
@@ -1,0 +1,44 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{3E8E5C8C-59A6-4A9A-B55D-46AB14431B2A}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Java.Interop.BootstrapTasks</RootNamespace>
+    <AssemblyName>Java.Interop.BootstrapTasks</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="..\..\Configuration.props" />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>Full</DebugType>
+    <Optimize>False</Optimize>
+    <OutputPath>..\..\bin\BuildDebug</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\bin\BuildRelease</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="Microsoft.Build.Framework" />
+    <Reference Include="Microsoft.Build.Utilities.v4.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Java.Interop.BootstrapTasks\SetEnvironmentVariable.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks/SetEnvironmentVariable.cs
+++ b/src/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks/SetEnvironmentVariable.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Java.Interop.BootstrapTasks
+{
+	public class SetEnvironmentVariable : Task
+	{
+		[Required]
+		public string Name { get; set; }
+
+		[Required]
+		public string Value { get; set; }
+
+		public override bool Execute ()
+		{
+			Log.LogMessage (MessageImportance.Low, $"Task {nameof (SetEnvironmentVariable)}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (Name)}: {Name}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (Value)}: {Value}");
+
+			Environment.SetEnvironmentVariable (Name, Value);
+
+			return !Log.HasLoggedErrors;
+		}
+	}
+}
+

--- a/src/Java.Interop.BootstrapTasks/Properties/AssemblyInfo.cs
+++ b/src/Java.Interop.BootstrapTasks/Properties/AssemblyInfo.cs
@@ -1,0 +1,27 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+
+// Information about this assembly is defined by the following attributes. 
+// Change them to the values specific to your project.
+
+[assembly: AssemblyTitle ("Java.Interop.BootstrapTasks")]
+[assembly: AssemblyDescription ("")]
+[assembly: AssemblyConfiguration ("")]
+[assembly: AssemblyCompany ("Xamarin Inc.")]
+[assembly: AssemblyProduct ("")]
+[assembly: AssemblyCopyright ("Xamarin Inc.")]
+[assembly: AssemblyTrademark ("Xamarin")]
+[assembly: AssemblyCulture ("")]
+
+// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
+// The form "{Major}.{Minor}.*" will automatically update the build and revision,
+// and "{Major}.{Minor}.{Build}.*" will update just the revision.
+
+[assembly: AssemblyVersion ("1.0.*")]
+
+// The following attributes are used to specify the signing key for the assembly, 
+// if desired. See the Mono documentation for more information about signing.
+
+//[assembly: AssemblyDelaySign(false)]
+//[assembly: AssemblyKeyFile("")]
+

--- a/tests/PerformanceTests/TimingTests.cs
+++ b/tests/PerformanceTests/TimingTests.cs
@@ -260,18 +260,18 @@ namespace Java.Interop.PerformanceTests {
 
 				var ct = TimeSpan.FromMilliseconds (jniTimes [jniTimeIndex++]);
 				Console.WriteLine ("\t  C/JNI: {0} ms               | average: {1} ms",
-						FormatFraction (ct.TotalMilliseconds, 10, 5),
+						FormatFraction (ct.TotalMilliseconds, 12, 5),
 						FormatFraction (ct.TotalMilliseconds / count, 12, 5));
 				Console.WriteLine ("\t    JNI: {0} ms; {1,3}x C/JNI   | average: {2} ms",
-						FormatFraction (jw.Elapsed.TotalMilliseconds, 10, 5),
+						FormatFraction (jw.Elapsed.TotalMilliseconds, 12, 5),
 						ToString (jw.Elapsed, ct),
 						FormatFraction (jw.Elapsed.TotalMilliseconds / count, 12, 5));
 				Console.WriteLine ("\tManaged: {0} ms               | average: {1} ms",
-						FormatFraction (mw.Elapsed.TotalMilliseconds, 10, 5),
+						FormatFraction (mw.Elapsed.TotalMilliseconds, 12, 5),
 						FormatFraction (mw.Elapsed.TotalMilliseconds / count, 12, 5));
 				if (pw != null)
 					Console.WriteLine ("\tPinvoke: {0} ms; {1,3}x managed | average: {2} ms",
-							FormatFraction (pw.Elapsed.TotalMilliseconds, 10, 5),
+							FormatFraction (pw.Elapsed.TotalMilliseconds, 12, 5),
 							ToString (pw.Elapsed, mw.Elapsed),
 							FormatFraction (pw.Elapsed.TotalMilliseconds / count, 12, 5));
 			}


### PR DESCRIPTION
This ensures the following values are set on Windows:
- MONO_TRACE_LISTENER
- JAVA_INTEROP_GREF_LOG
- JAVA_INTEROP_LREF_LOG

This also cleans up what needs to be done downstream in xamarin-android:
https://github.com/xamarin/xamarin-android/pull/949

This required a new `Java.Interop.BootstrapTasks` project
that adds a `SetEnvironmentVariable` MSBuild task.
This will be useful down the road, for setting up "prepare"
steps in this repo for Windows.

Mono 5.8 also seems to have introduced a slowness in the
PerformanceTests, included a fix to allow more digits in
the time elapsed. This prevents a test failure on Mono 5.8.

Also minor updates to `.gitignore` file.