### PR TITLE
[class-parse][api-xml-adjuster] add "platform" number on <api> element.

### DIFF
--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApi.XmlModel.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApi.XmlModel.cs
@@ -13,6 +13,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		}
 
 		public string ExtendedApiSource { get; set; }
+		public string Platform { get; set; }
 		public IList<JavaPackage> Packages { get; set; }
 	}
 

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiXmlGeneratorExtensions.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiXmlGeneratorExtensions.cs
@@ -21,7 +21,9 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		public static void Save (this JavaApi api, XmlWriter writer)
 		{
 			writer.WriteStartElement ("api");
-			
+			if (api.Platform != null)
+				writer.WriteAttributeString ("platform", api.Platform);
+
 			foreach (var pkg in api.Packages) {
 				if (!pkg.Types.Any (t => !t.IsReferenceOnly))
 					continue;

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiXmlLoaderExtensions.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiXmlLoaderExtensions.cs
@@ -20,7 +20,8 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			if (reader.LocalName != "api")
 				throw XmlUtil.UnexpectedElementOrContent (null, reader, "api");
 			api.ExtendedApiSource = reader.GetAttribute ("api-source");
-			XmlUtil.CheckExtraneousAttributes ("api", reader, "api-source");
+			api.Platform = reader.GetAttribute ("platform");
+			XmlUtil.CheckExtraneousAttributes ("api", reader, "api-source", "platform");
 			if (reader.IsEmptyElement)
 				reader.Read ();
 			else {

--- a/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
@@ -30,6 +30,8 @@ namespace Xamarin.Android.Tools.Bytecode {
 
 		public IEnumerable<string> DocumentationPaths { get; set; }
 
+		public string AndroidFrameworkPlatform { get; set; }
+
 		public bool AutoRename { get; set; }
 
 		public ClassPath (string path = null)
@@ -107,6 +109,13 @@ namespace Xamarin.Android.Tools.Bytecode {
 			if (string.IsNullOrEmpty (ApiSource))
 				return null;
 			return new XAttribute ("api-source", ApiSource);
+		}
+
+		XAttribute GetPlatform ()
+		{
+			if (string.IsNullOrEmpty (AndroidFrameworkPlatform))
+				return null;
+			return new XAttribute ("platform", AndroidFrameworkPlatform);
 		}
 
 		bool IsGeneratedName (string parameterName)
@@ -311,6 +320,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 			var packagesDictionary = GetPackages ();
 			var api = new XElement ("api",
 					GetApiSource (),
+					GetPlatform (),
 					packagesDictionary.Keys.OrderBy (p => p, StringComparer.OrdinalIgnoreCase)
 					.Select (p => new XElement ("package",
 						new XAttribute ("name", p),

--- a/tools/class-parse/Program.cs
+++ b/tools/class-parse/Program.cs
@@ -22,6 +22,7 @@ namespace Xamarin.Android.Tools {
 			int  verbosity  = 0;
 			bool autorename = false;
 			var  outputFile = (string) null;
+			string platform = null;
 			var  docsPaths  = new List<string> ();
 			var p = new OptionSet () {
 				"usage: class-dump [-dump] FILES",
@@ -48,6 +49,9 @@ namespace Xamarin.Android.Tools {
 				{ "autorename",
 				  "Renames parameter names in the interfaces by derived classes.",
 				  v => autorename = v != null },
+				{ "platform=",
+				  "(Internal use only) specify Android framework platform ID",
+				  v => platform = v },
 				{ "h|?|help",
 				  "Show this message and exit.",
 				  v => help = v != null },
@@ -65,6 +69,7 @@ namespace Xamarin.Android.Tools {
 			};
 			var classPath = new ClassPath () {
 				ApiSource         = "class-parse",
+				AndroidFrameworkPlatform = platform,
 				DocumentationPaths  = docsPaths.Count == 0 ? null : docsPaths,
 				DocletType = docsType,
 				AutoRename = autorename


### PR DESCRIPTION
https://github.com/xamarin/xamarin-android/pull/824 added some code to
api-merge to handle "platform" attributes on <api> element, but those
attributes on api-\*.xml.in were not automatically generated. That means,
every time we regenerate api-\*.xml.in from api-xml-adjuster, those files
are invalid and causes build breakages.

Add more code in class-parse and api-xml-adjuster so that they can be
automatically added, depending on the command line.