### PR TITLE
Call into libjli.dylib instead of libjvm.dylib to fix legacy Java SE 6 popup on OSX

### DIFF
--- a/Configuration.Override.props.in
+++ b/Configuration.Override.props.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <JdkJvmPath>/Library/Java/JavaVirtualMachines/jdk1.8.0_77.jdk/Contents/Home/jre/lib/server/libjvm.dylib</JdkJvmPath>
+    <JdkJvmPath>/Library/Java/JavaVirtualMachines/jdk1.8.0_77.jdk/Contents/Home/jre/jli/libjli.dylib</JdkJvmPath>
     <MonoFrameworkPath>/Library/Frameworks/Mono.framework/Libraries/libmonosgen-2.0.1.dylib</MonoFrameworkPath>
     <UtilityOutputFullPath>$(MSBuildThisFileDirectory)bin\$(Configuration)\</UtilityOutputFullPath>
   </PropertyGroup>

--- a/build-tools/scripts/jdk.mk
+++ b/build-tools/scripts/jdk.mk
@@ -64,7 +64,7 @@ JI_JDK_INCLUDE_PATHS  = \
 	$(_DARWIN_JDK_ROOT)/$(_DARWIN_JDK_JNI_OS_INCLUDE_DIR)
 
 ifeq ($(_MONO_BITNESS),64-bit)
-JI_JVM_PATH	= $(_DARWIN_JDK_ROOT)/Contents/Home/jre/lib/server/libjvm.dylib
+JI_JVM_PATH	= $(_DARWIN_JDK_ROOT)/Contents/Home/jre/lib/jli/libjli.dylib
 endif # 64-bit
 
 else    # (1) failed; try Xcode.app's copy?


### PR DESCRIPTION
If you don't have the legacy Java6 installed then the call to JNI_CreateJavaVM() will result in a popup requesting you to install it and abort, even if you call the libjvm.dylib that's included as part of JDK8.

According to https://github.com/originell/jpype/issues/160 and https://bugs.openjdk.java.net/browse/JDK-7131356 this is a Java8 bug and the recommended fix is to call into libjli.dylib instead.

Indeed this fixes the issue and the popup no longer shows up.