### PR TITLE
[tests] fix for Xamarin.Android.Tools.Bytecode-Tests

### DIFF
--- a/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
@@ -251,13 +251,15 @@ namespace Xamarin.Android.Tools.Bytecode {
 				kind = JavaDocletType.Java8;
 
 			// Check to see if it's an api.xml formatted doc
-			string rawXML = null;
-			using (var reader = File.OpenText (path)) {
-				int len = reader.ReadBlock (buf, 0, buf.Length);
-				rawXML = new string (buf, 0, len);
+			if (File.Exists (path)) {
+				string rawXML = null;
+				using (var reader = File.OpenText (path)) {
+					int len = reader.ReadBlock (buf, 0, buf.Length);
+					rawXML = new string (buf, 0, len);
+				}
+				if (rawXML.Contains ("<api>") && rawXML.Contains ("<package"))
+					kind = JavaDocletType._ApiXml;
 			}
-			if (rawXML.Contains ("<api>") && rawXML.Contains ("<package"))
-				kind = JavaDocletType._ApiXml;
 
 			return kind;
 		}


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/978

When bumping java.interop in xamarin-android, a test failure occurred
in the `ClassPath.GetDocletType` method. This was added in #188, but
since `ANDROID_SDK_PATH` is not set during java.interop’s test runs the
test was skipped.

The incoming `path` can be a directory, so the `File.OpenText` call
will fail in that case. Added a `File.Exists` check as a fix.