### PR TITLE
[api-xml-adjuster] generate type parameters in <constructor>.

### DIFF
--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiXmlGeneratorExtensions.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiXmlGeneratorExtensions.cs
@@ -138,7 +138,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		
 		static void Save (this JavaConstructor ctor, XmlWriter writer)
 		{
-			SaveCommon (ctor, writer, "constructor", null, null, null, null, null, ctor.Type ?? ctor.Parent.FullName, null, null, null, null, ctor.Parameters, ctor.Exceptions);
+			SaveCommon (ctor, writer, "constructor", null, null, null, null, null, ctor.Type ?? ctor.Parent.FullName, null, null, null, ctor.TypeParameters, ctor.Parameters, ctor.Exceptions);
 		}
 		
 		static void Save (this JavaMethod method, XmlWriter writer)

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/Tests/OverrideMarkerTest.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/Tests/OverrideMarkerTest.cs
@@ -57,6 +57,41 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster.Tests
 			var m = t.Members.OfType<JavaMethod> ().First (_ => _.Name == "addContentView");
 			Assert.IsNotNull (m.BaseMethod, "base method not found");
 		}
+
+		[Test]
+		public void GenericConstructors ()
+		{
+			string xml = @"<api>
+  <package name='XXX'>
+    <class abstract='true' deprecated='not deprecated' final='false' name='GenericConstructors' static='false' visibility='public'>
+      <constructor deprecated='not deprecated' final='false' name='GenericConstructors' static='false' visibility='public'>
+        <typeParameters>
+          <typeParameter name='E' interfaceBounds='' jni-interfaceBounds='' />
+        </typeParameters>
+        <parameter name = 'e' type='E' jni-type='TE;'>
+        </parameter>
+      </constructor>
+    </class>
+  </package>
+</api>";
+			var xapi = new JavaApi ();
+			using (var xr = XmlReader.Create (new StringReader (xml)))
+				xapi.Load (xr, false);
+			xapi.StripNonBindables ();
+			xapi.Resolve ();
+			xapi.CreateGenericInheritanceMapping ();
+			xapi.MarkOverrides ();
+			xapi.FindDefects ();
+			var sw = new StringWriter ();
+			using (var xw = XmlWriter.Create (sw))
+				xapi.Save (xw);
+			xapi = new JavaApi ();
+			using (var xr = XmlReader.Create (new StringReader (sw.ToString ())))
+				xapi.Load (xr, true);
+			var t = xapi.Packages.First (_ => _.Name == "XXX").Types.First (_ => _.Name == "GenericConstructors");
+			var m = t.Members.OfType<JavaConstructor> ().FirstOrDefault ();
+			Assert.IsNotNull (m.TypeParameters, "constructor not found");
+		}
 	}
 }
 

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/XmlUtil.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/XmlUtil.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		static string GetLocation (XmlReader reader)
 		{
 			var li = reader as IXmlLineInfo;
-			return string.Format ("{0} ({1},{2})", new Uri (reader.BaseURI).LocalPath, li.LineNumber, li.LinePosition);
+			return string.Format ("{0} ({1},{2})", string.IsNullOrEmpty (reader.BaseURI) ? null : new Uri (reader.BaseURI).LocalPath, li.LineNumber, li.LinePosition);
 		}
 		
 		public static Exception UnexpectedElementOrContent (string elementName, XmlReader reader, params string [] expected)


### PR DESCRIPTION
This should be part or all of fixing bug #59770.