### PR TITLE
[Java.Interop] More Gendarme related cleaning

### DIFF
--- a/gendarme-ignore.txt
+++ b/gendarme-ignore.txt
@@ -198,6 +198,8 @@ M: System.Linq.Expressions.Expression`1<System.Func`4<System.Reflection.Construc
 
 R: Gendarme.Rules.Exceptions.DoNotSwallowErrorsCatchingNonSpecificExceptionsRule
 M: System.Reflection.Assembly Java.Interop.JniRuntime/JniTypeManager::TryLoadAssembly(System.Reflection.AssemblyName)
+# The exception is transitioned to Jni
+M:System.Void Java.Interop.ManagedPeer::Construct(System.IntPtr,System.IntPtr,System.IntPtr,System.IntPtr,System.IntPtr,System.IntPtr)
 
 R: Gendarme.Rules.Exceptions.ExceptionShouldBeVisibleRule
 T: Java.Interop.JniLocationException
@@ -525,7 +527,6 @@ R: Gendarme.Rules.Performance.AvoidRepetitiveCastsRule
 # The "repetitive" cast is in a Debug.Assert() call, which should be "stand-alone"
 M: Java.Interop.JniObjectReference Java.Interop.JniEnvironment/Strings::NewString(System.Object)
 
-
 R: Gendarme.Rules.Performance.AvoidUncalledPrivateCodeRule
 # These are `public` for "completeness" reasons.
 M: Java.Interop.JniObjectReferenceType Java.Interop.JniEnvironment/References::GetObjectRefType(Java.Interop.JniObjectReference)
@@ -554,7 +555,6 @@ R: Gendarme.Rules.Performance.AvoidUnusedParametersRule
 # This method is virtual; *overrides* need the parameter, not the default implementation.
 M: System.Collections.Generic.IEnumerable`1<System.Type> Java.Interop.JniRuntime/JniTypeManager::CreateGetTypesForSimpleReferenceEnumerator(System.String)
 
-
 R: Gendarme.Rules.Performance.UseTypeEmptyTypesRule
 # The PCL profile we're using doen't *have* Type.EmptyTypes!
 M: System.Void Java.Interop.JniRuntime/JniTypeManager::.cctor()
@@ -568,3 +568,12 @@ M: System.Void Java.Interop.JniEnvironment/Exceptions::Throw(System.Exception)
 R: Gendarme.Rules.Correctness.DisposableFieldsShouldBeDisposedRule
 # We call Dispose on marshalMemberBuilder field in the JniRuntime::Dispose method. Looks like gendarme bug, it doesn't handle well the `?.` operator.
 T: Java.Interop.JniRuntime
+
+R: Gendarme.Rules.Performance.AvoidUnusedPrivateFieldsRule
+# The weak_handle and refs_added fields are used from C code, in java-interop-gc-bridge-mono.c, and thus invisible to Gendarme
+T: Java.Interop.JavaException
+T: Java.Interop.JavaObject
+
+R: Gendarme.Rules.Design.Generic.DoNotExposeGenericListsRule
+# We don't care here as we don't hold the list and create it on request. So to avoid performace penalty, we keep the list as return type
+M: System.Collections.Generic.List`1<Java.Interop.JniSurfacedPeerInfo> Java.Interop.JniRuntime/JniValueManager::GetSurfacedPeers()

--- a/src/Java.Interop/Java.Interop/JavaArray.cs
+++ b/src/Java.Interop/Java.Interop/JavaArray.cs
@@ -14,7 +14,7 @@ namespace Java.Interop
 
 		// Value was created via CreateMarshalCollection, and thus can
 		// be disposed of with impunity when no longer needed.
-		protected bool forMarshalCollection;
+		internal bool forMarshalCollection;
 
 		internal JavaArray (ref JniObjectReference handle, JniObjectReferenceOptions transfer)
 			: base (ref handle, transfer)

--- a/src/Java.Interop/Java.Interop/JavaObjectArray.cs
+++ b/src/Java.Interop/Java.Interop/JavaObjectArray.cs
@@ -134,7 +134,7 @@ namespace Java.Interop
 				targetType == typeof (JavaObjectArray<T>);
 		}
 
-		internal class ValueMarshaler : JniValueMarshaler<IList<T>> {
+		internal sealed class ValueMarshaler : JniValueMarshaler<IList<T>> {
 
 			public override IList<T> CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type targetType)
 			{

--- a/src/Java.Interop/Java.Interop/JavaProxyThrowable.cs
+++ b/src/Java.Interop/Java.Interop/JavaProxyThrowable.cs
@@ -3,7 +3,7 @@
 namespace Java.Interop {
 
 	[JniTypeSignature (JniTypeName)]
-	class JavaProxyThrowable : JavaException
+	sealed class JavaProxyThrowable : JavaException
 	{
 		new internal    const   string  JniTypeName = "com/xamarin/java_interop/internal/JavaProxyThrowable";
 

--- a/src/Java.Interop/Java.Interop/JniBuiltinMarshalers.cs
+++ b/src/Java.Interop/Java.Interop/JniBuiltinMarshalers.cs
@@ -86,7 +86,7 @@ namespace Java.Interop {
 		}
 	}
 
-	class JniBooleanValueMarshaler : JniValueMarshaler<Boolean> {
+	sealed class JniBooleanValueMarshaler : JniValueMarshaler<Boolean> {
 
 		internal    static  readonly    JniBooleanValueMarshaler   Instance    = new JniBooleanValueMarshaler ();
 
@@ -154,7 +154,7 @@ namespace Java.Interop {
 		}
 	}
 
-	class JniNullableBooleanValueMarshaler : JniValueMarshaler<Boolean?> {
+	sealed class JniNullableBooleanValueMarshaler : JniValueMarshaler<Boolean?> {
 
 		internal    static  readonly    JniNullableBooleanValueMarshaler   Instance    = new JniNullableBooleanValueMarshaler ();
 
@@ -213,7 +213,7 @@ namespace Java.Interop {
 		}
 	}
 
-	class JniSByteValueMarshaler : JniValueMarshaler<SByte> {
+	sealed class JniSByteValueMarshaler : JniValueMarshaler<SByte> {
 
 		internal    static  readonly    JniSByteValueMarshaler   Instance    = new JniSByteValueMarshaler ();
 
@@ -281,7 +281,7 @@ namespace Java.Interop {
 		}
 	}
 
-	class JniNullableSByteValueMarshaler : JniValueMarshaler<SByte?> {
+	sealed class JniNullableSByteValueMarshaler : JniValueMarshaler<SByte?> {
 
 		internal    static  readonly    JniNullableSByteValueMarshaler   Instance    = new JniNullableSByteValueMarshaler ();
 
@@ -340,7 +340,7 @@ namespace Java.Interop {
 		}
 	}
 
-	class JniCharValueMarshaler : JniValueMarshaler<Char> {
+	sealed class JniCharValueMarshaler : JniValueMarshaler<Char> {
 
 		internal    static  readonly    JniCharValueMarshaler   Instance    = new JniCharValueMarshaler ();
 
@@ -408,7 +408,7 @@ namespace Java.Interop {
 		}
 	}
 
-	class JniNullableCharValueMarshaler : JniValueMarshaler<Char?> {
+	sealed class JniNullableCharValueMarshaler : JniValueMarshaler<Char?> {
 
 		internal    static  readonly    JniNullableCharValueMarshaler   Instance    = new JniNullableCharValueMarshaler ();
 
@@ -467,7 +467,7 @@ namespace Java.Interop {
 		}
 	}
 
-	class JniInt16ValueMarshaler : JniValueMarshaler<Int16> {
+	sealed class JniInt16ValueMarshaler : JniValueMarshaler<Int16> {
 
 		internal    static  readonly    JniInt16ValueMarshaler   Instance    = new JniInt16ValueMarshaler ();
 
@@ -535,7 +535,7 @@ namespace Java.Interop {
 		}
 	}
 
-	class JniNullableInt16ValueMarshaler : JniValueMarshaler<Int16?> {
+	sealed class JniNullableInt16ValueMarshaler : JniValueMarshaler<Int16?> {
 
 		internal    static  readonly    JniNullableInt16ValueMarshaler   Instance    = new JniNullableInt16ValueMarshaler ();
 
@@ -594,7 +594,7 @@ namespace Java.Interop {
 		}
 	}
 
-	class JniInt32ValueMarshaler : JniValueMarshaler<Int32> {
+	sealed class JniInt32ValueMarshaler : JniValueMarshaler<Int32> {
 
 		internal    static  readonly    JniInt32ValueMarshaler   Instance    = new JniInt32ValueMarshaler ();
 
@@ -662,7 +662,7 @@ namespace Java.Interop {
 		}
 	}
 
-	class JniNullableInt32ValueMarshaler : JniValueMarshaler<Int32?> {
+	sealed class JniNullableInt32ValueMarshaler : JniValueMarshaler<Int32?> {
 
 		internal    static  readonly    JniNullableInt32ValueMarshaler   Instance    = new JniNullableInt32ValueMarshaler ();
 
@@ -721,7 +721,7 @@ namespace Java.Interop {
 		}
 	}
 
-	class JniInt64ValueMarshaler : JniValueMarshaler<Int64> {
+	sealed class JniInt64ValueMarshaler : JniValueMarshaler<Int64> {
 
 		internal    static  readonly    JniInt64ValueMarshaler   Instance    = new JniInt64ValueMarshaler ();
 
@@ -789,7 +789,7 @@ namespace Java.Interop {
 		}
 	}
 
-	class JniNullableInt64ValueMarshaler : JniValueMarshaler<Int64?> {
+	sealed class JniNullableInt64ValueMarshaler : JniValueMarshaler<Int64?> {
 
 		internal    static  readonly    JniNullableInt64ValueMarshaler   Instance    = new JniNullableInt64ValueMarshaler ();
 
@@ -848,7 +848,7 @@ namespace Java.Interop {
 		}
 	}
 
-	class JniSingleValueMarshaler : JniValueMarshaler<Single> {
+	sealed class JniSingleValueMarshaler : JniValueMarshaler<Single> {
 
 		internal    static  readonly    JniSingleValueMarshaler   Instance    = new JniSingleValueMarshaler ();
 
@@ -916,7 +916,7 @@ namespace Java.Interop {
 		}
 	}
 
-	class JniNullableSingleValueMarshaler : JniValueMarshaler<Single?> {
+	sealed class JniNullableSingleValueMarshaler : JniValueMarshaler<Single?> {
 
 		internal    static  readonly    JniNullableSingleValueMarshaler   Instance    = new JniNullableSingleValueMarshaler ();
 
@@ -975,7 +975,7 @@ namespace Java.Interop {
 		}
 	}
 
-	class JniDoubleValueMarshaler : JniValueMarshaler<Double> {
+	sealed class JniDoubleValueMarshaler : JniValueMarshaler<Double> {
 
 		internal    static  readonly    JniDoubleValueMarshaler   Instance    = new JniDoubleValueMarshaler ();
 
@@ -1043,7 +1043,7 @@ namespace Java.Interop {
 		}
 	}
 
-	class JniNullableDoubleValueMarshaler : JniValueMarshaler<Double?> {
+	sealed class JniNullableDoubleValueMarshaler : JniValueMarshaler<Double?> {
 
 		internal    static  readonly    JniNullableDoubleValueMarshaler   Instance    = new JniNullableDoubleValueMarshaler ();
 

--- a/src/Java.Interop/Java.Interop/JniBuiltinMarshalers.tt
+++ b/src/Java.Interop/Java.Interop/JniBuiltinMarshalers.tt
@@ -90,7 +90,7 @@ namespace Java.Interop {
 		}
 	}
 
-	class Jni<#= type.Type #>ValueMarshaler : JniValueMarshaler<<#= type.Type #>> {
+	sealed class Jni<#= type.Type #>ValueMarshaler : JniValueMarshaler<<#= type.Type #>> {
 
 		internal    static  readonly    Jni<#= type.Type #>ValueMarshaler   Instance    = new Jni<#= type.Type #>ValueMarshaler ();
 
@@ -158,7 +158,7 @@ namespace Java.Interop {
 		}
 	}
 
-	class JniNullable<#= type.Type #>ValueMarshaler : JniValueMarshaler<<#= type.Type #>?> {
+	sealed class JniNullable<#= type.Type #>ValueMarshaler : JniValueMarshaler<<#= type.Type #>?> {
 
 		internal    static  readonly    JniNullable<#= type.Type #>ValueMarshaler   Instance    = new JniNullable<#= type.Type #>ValueMarshaler ();
 

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniMarshalMemberBuilder.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniMarshalMemberBuilder.cs
@@ -143,7 +143,7 @@ namespace Java.Interop {
 		}
 	}
 
-	class IntPtrValueMarshaler : JniValueMarshaler<IntPtr> {
+	sealed class IntPtrValueMarshaler : JniValueMarshaler<IntPtr> {
 		internal    static  IntPtrValueMarshaler Instance = new IntPtrValueMarshaler ();
 
 		public override Expression CreateParameterFromManagedExpression (Java.Interop.Expressions.JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize)

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -441,9 +441,8 @@ namespace Java.Interop
 					return r;
 				lock (Marshalers) {
 					JniValueMarshaler d;
-					if (Marshalers.TryGetValue (typeof (T), out d))
-						return (JniValueMarshaler<T>) d;
-					Marshalers.Add (typeof (T), d = new DelegatingValueMarshaler<T> (m));
+					if (!Marshalers.TryGetValue (typeof (T), out d))
+						Marshalers.Add (typeof (T), d = new DelegatingValueMarshaler<T> (m));
 					return (JniValueMarshaler<T>) d;
 				}
 			}
@@ -503,7 +502,7 @@ namespace Java.Interop
 		}
 	}
 
-	class VoidValueMarshaler : JniValueMarshaler {
+	sealed class VoidValueMarshaler : JniValueMarshaler {
 
 		internal    static  VoidValueMarshaler              Instance    = new VoidValueMarshaler ();
 
@@ -527,7 +526,7 @@ namespace Java.Interop
 		}
 	}
 
-	class JavaPeerableValueMarshaler : JniValueMarshaler<IJavaPeerable> {
+	sealed class JavaPeerableValueMarshaler : JniValueMarshaler<IJavaPeerable> {
 
 		internal    static  JavaPeerableValueMarshaler      Instance    = new JavaPeerableValueMarshaler ();
 
@@ -594,7 +593,7 @@ namespace Java.Interop
 		}
 	}
 
-	class DelegatingValueMarshaler<T> : JniValueMarshaler<T> {
+	sealed class DelegatingValueMarshaler<T> : JniValueMarshaler<T> {
 
 		JniValueMarshaler   ValueMarshaler;
 
@@ -634,7 +633,7 @@ namespace Java.Interop
 		}
 	}
 
-	class ProxyValueMarshaler : JniValueMarshaler<object> {
+	sealed class ProxyValueMarshaler : JniValueMarshaler<object> {
 
 		internal    static  ProxyValueMarshaler     Instance    = new ProxyValueMarshaler ();
 

--- a/src/Java.Interop/Java.Interop/JniStringValueMarshaler.cs
+++ b/src/Java.Interop/Java.Interop/JniStringValueMarshaler.cs
@@ -7,7 +7,7 @@ using Java.Interop.Expressions;
 
 namespace Java.Interop {
 
-	class JniStringValueMarshaler : JniValueMarshaler<string> {
+	sealed class JniStringValueMarshaler : JniValueMarshaler<string> {
 
 		internal    static  readonly    JniStringValueMarshaler     Instance    = new JniStringValueMarshaler ();
 

--- a/src/Java.Interop/Java.Interop/JniValueMarshaler.cs
+++ b/src/Java.Interop/Java.Interop/JniValueMarshaler.cs
@@ -8,7 +8,7 @@ using Java.Interop.Expressions;
 
 namespace Java.Interop.Expressions {
 
-	class VariableCollection : KeyedCollection<string, ParameterExpression> {
+	sealed class VariableCollection : KeyedCollection<string, ParameterExpression> {
 
 		protected override string GetKeyForItem (ParameterExpression item)
 		{
@@ -162,6 +162,8 @@ namespace Java.Interop {
 		{
 			Func<JniObjectReference, IntPtr>    m = JniEnvironment.References.NewReturnToJniRef;
 			var r   = Expression.Variable (MarshalType, namePrefix + "_rtn");
+			if (context == null)
+				throw new ArgumentNullException (nameof (context));
 			context.LocalVariables.Add (r);
 			context.CreationStatements.Add (
 				Expression.Assign (r,

--- a/src/Java.Interop/Java.Interop/ManagedPeer.cs
+++ b/src/Java.Interop/Java.Interop/ManagedPeer.cs
@@ -10,7 +10,7 @@ using System.Text;
 namespace Java.Interop {
 
 	[JniTypeSignature (JniTypeName)]
-	/* static */ class ManagedPeer : JavaObject {
+	/* static */ sealed class ManagedPeer : JavaObject {
 
 		internal const string JniTypeName = "com/xamarin/java_interop/ManagedPeer";
 
@@ -209,7 +209,7 @@ namespace Java.Interop {
 		}
 	}
 
-	class JniLocationException : Exception {
+	sealed class JniLocationException : Exception {
 
 		string stackTrace;
 

--- a/src/Java.Interop/Tests/Java.Interop/JavaObjectTest.cs
+++ b/src/Java.Interop/Tests/Java.Interop/JavaObjectTest.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Reflection;
 using System.Threading;
 
 using Java.Interop;

--- a/src/Java.Runtime.Environment/Java.Interop/MonoRuntimeValueManager.cs
+++ b/src/Java.Runtime.Environment/Java.Interop/MonoRuntimeValueManager.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 


### PR DESCRIPTION
* Gendarme.Rules.Performance.AvoidRepetitiveCastsRule
M:Java.Interop.JniValueMarshaler`1<T> Java.Interop.JniRuntime/JniValueManager::GetValueMarshaler()
Refactored to cast only once and made shorter

* Gendarme.Rules.Performance.AvoidUnsealedUninheritedInternalTypeRule
Sealed the classes

* Gendarme.Rules.Design.AvoidVisibleFieldsRule
T:Java.Interop.JavaArray`1
The field is only used from internal methods, thus changed the field itself to internal.

* Gendarme.Rules.Correctness.CheckParametersNullityInVisibleMethodsRule
M:System.Linq.Expressions.Expression Java.Interop.JniValueMarshaler::ReturnObjectReferenceToJni(Java.Interop.Expressions.JniValueMarshalerContext,System.String,System.Linq.Expressions.Expression)
Check for context being null

After these we are down to 124 remaining Gendarme defects.