### PR TITLE
[tests] adding missing copy command to MSBuild test targets

### DIFF
--- a/build-tools/scripts/RunNUnitTests.targets
+++ b/build-tools/scripts/RunNUnitTests.targets
@@ -15,6 +15,14 @@
   </ItemGroup>
   <Target Name="RunTests"
       Outputs="$(_TopDir)\TestResult-%(_TestAssembly.Filename).xml">
+    <ItemGroup>
+      <_JavaInteropNativeLibrary Include="$(_TopDir)\bin\$(Configuration)\libjava-interop.*" />
+    </ItemGroup>
+    <Copy
+        SourceFiles="@(_JavaInteropNativeLibrary)"
+        DestinationFolder="$(_TopDir)\bin\Test$(Configuration)"
+        SkipUnchangedFiles="True"
+    />
     <SetEnvironmentVariable Name="MONO_TRACE_LISTENER" Value="Console.Out" />
     <SetEnvironmentVariable Name="JAVA_INTEROP_GREF_LOG" Value="g-%(_TestAssembly.Filename).txt" />
     <SetEnvironmentVariable Name="JAVA_INTEROP_LREF_LOG" Value="l-%(_TestAssembly.Filename).txt" />


### PR DESCRIPTION
Context:
https://github.com/xamarin/java.interop/blob/master/Makefile#L149

When we ported the NUnit tests from `Makefile` to `MSBuild`, there was
a target missing that copies `libjava-interop.dylib` from `bin/Debug`
to `bin/TestDebug`. It went unnoticed on Windows, because these tests
are not passing yet there.