### PR TITLE
[tests] fix for ANDROID_SDK_PATH

### DIFF
--- a/build-tools/scripts/RunNUnitTests.targets
+++ b/build-tools/scripts/RunNUnitTests.targets
@@ -23,7 +23,8 @@
         DestinationFolder="$(_TopDir)\bin\Test$(Configuration)"
         SkipUnchangedFiles="True"
     />
-    <SetEnvironmentVariable Name="MONO_TRACE_LISTENER" Value="Console.Out" />
+    <SetEnvironmentVariable Name="ANDROID_SDK_PATH"      Value="$(AndroidSdkDirectory)" Condition=" '$(AndroidSdkDirectory)' != '' " />
+    <SetEnvironmentVariable Name="MONO_TRACE_LISTENER"   Value="Console.Out" />
     <SetEnvironmentVariable Name="JAVA_INTEROP_GREF_LOG" Value="g-%(_TestAssembly.Filename).txt" />
     <SetEnvironmentVariable Name="JAVA_INTEROP_LREF_LOG" Value="l-%(_TestAssembly.Filename).txt" />
     <Exec


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/blob/master/build-tools/scripts/RunTests.targets#L50
Context: https://devdiv.visualstudio.com/DevDiv/Default/_build/index?buildId=1138588&_a=summary&tab=ms.vss-test-web.test-result-details

On Windows, the Java.Interop tests are not getting the `ANDROID_SDK_PATH`
environment variable set. This is somehow working on macOS, but I think
it might be simpler in this case to pass in the `AndroidSdkDirectory`
property from `RunTests.targets` in xamarin-android.

This approach worked when testing locally. I will need to bump Java.Interop
and make one further change in xamarin-android to pass in
`AndroidSdkDirectory`. This will get a few skipped tests in Java.Interop
running and passing on Windows.