### PR TITLE
[Java.Interop] JniType.RegisterNativeMethods() is public

### DIFF
--- a/src/Java.Interop/Java.Interop/JniType.cs
+++ b/src/Java.Interop/Java.Interop/JniType.cs
@@ -135,7 +135,7 @@ namespace Java.Interop {
 		JniNativeMethodRegistration[] methods;
 #pragma warning restore 0414
 
-		internal void RegisterNativeMethods (params JniNativeMethodRegistration[] methods)
+		public void RegisterNativeMethods (params JniNativeMethodRegistration[] methods)
 		{
 			AssertValid ();
 


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/1027
Context: https://jenkins.mono-project.com/job/xamarin-android-pr-builder/2048/

Commit 7d511631 changed the visibility of
`JniType.RegisterNativeMethods()` from `public` to `internal`, in an
effort to reduce the likelihood of "user error" from calling
`JNIEnv::RegisterNatives()` multiple times, as
`JNIEnv::RegisterNatives()` invocations are *replacements*, not
"additive"; calling it more than once is *generally* Wrong™.

*Unfortunately*, `JniType.RegisterNativeMethods()` is part of the
public and shipping API, so we can't remove it, as seen in the
[xamarin-android PR build][pr2048] output:

[pr2048]: https://jenkins.mono-project.com/job/xamarin-android-pr-builder/2048/consoleText

	ABI BREAK IN: Java.Interop.dll
	<!-- start namespace Java.Interop --> <div>
	<h2>Namespace Java.Interop</h2>
	<!-- start type JniType --> <div>
	<h3>Type Changed: Java.Interop.JniType</h3>
	<p>Removed method:</p>

	<pre>
	        <span class='removed removed-method breaking' data-is-breaking>public void RegisterNativeMethods (JniNativeMethodRegistration[]);</span>
	</pre>

Revert the visibility of `JniType.RegisterNativeMethods()` to
`public`, so that we don't break API compatibility.