### PR TITLE
[class-parse] Fix Java parameter loader for generics involved methods.

### DIFF
--- a/src/Xamarin.Android.Tools.Bytecode/JavaParameterNamesLoader.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/JavaParameterNamesLoader.cs
@@ -97,7 +97,7 @@ namespace Xamarin.Android.Tools.Bytecode
 						Name = name,
 						Parameters = parameters.Replace (", ", "\0").Split ('\0')
 								       .Select (s => s.Split (' '))
-						                       .Select (a => new Parameter { Type = string.Join (" ", a.Take (a.Length - 1)), Name = a.Last () }).ToList ()
+						                       .Select (a => new Parameter { Type = string.Join (" ", a.Take (a.Length - 1)).Replace (",", ", "), Name = a.Last () }).ToList ()
 					});
 				} else {
 					type = line.Substring (line.IndexOf (' ', 2) + 1);

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/ParameterDescription.txt
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/ParameterDescription.txt
@@ -4,3 +4,7 @@ package java.util ; Anything after semicolon is comment.
   class Collection<E>
     add(E e)
     #ctor()
+
+package com.xamarin
+  interface NestedInterface.DnsSdTxtRecordListener
+    onDnsSdTxtRecordAvailable(java.lang.String fullDomainName, java.util.Map<java.lang.String,java.lang.String> txtRecordMap, java.lang.String srcDevice)

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/ParameterFixupFromDescriptionText.xml
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/ParameterFixupFromDescriptionText.xml
@@ -1,0 +1,43 @@
+<api
+  api-source="class-parse">
+  <package
+    name="com.xamarin"
+    jni-name="com/xamarin">
+    <interface
+      abstract="true"
+      deprecated="not deprecated"
+      final="false"
+      name="NestedInterface.DnsSdTxtRecordListener"
+      jni-signature="Lcom/xamarin/NestedInterface$DnsSdTxtRecordListener;"
+      static="true"
+      visibility="public">
+      <method
+        abstract="true"
+        deprecated="not deprecated"
+        final="false"
+        name="onDnsSdTxtRecordAvailable"
+        native="false"
+        return="void"
+        jni-return="V"
+        static="false"
+        synchronized="false"
+        visibility="public"
+        bridge="false"
+        synthetic="false"
+        jni-signature="(Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;)V">
+        <parameter
+          name="fullDomainName"
+          type="java.lang.String"
+          jni-type="Ljava/lang/String;" />
+        <parameter
+          name="txtRecordMap"
+          type="java.util.Map&lt;java.lang.String, java.lang.String&gt;"
+          jni-type="Ljava/util/Map&lt;Ljava/lang/String;Ljava/lang/String;&gt;;" />
+        <parameter
+          name="srcDevice"
+          type="java.lang.String"
+          jni-type="Ljava/lang/String;" />
+      </method>
+    </interface>
+  </package>
+</api>

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/ParameterFixupTests.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/ParameterFixupTests.cs
@@ -102,6 +102,15 @@ namespace Xamarin.Android.Tools.BytecodeTests
 				if (File.Exists (tempFile))
 					File.Delete (tempFile);
 			}
+
+			try {
+				tempFile = LoadToTempFile ("ParameterDescription.txt");
+
+				AssertXmlDeclaration (new string [] { "NestedInterface$DnsSdTxtRecordListener.class" }, "ParameterFixupFromDescriptionText.xml", tempFile);
+			} finally {
+				if (File.Exists (tempFile))
+					File.Delete (tempFile);
+			}
 		}
 	}
 }

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj
@@ -57,13 +57,9 @@
     <Compile Include="ParameterFixupTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <TestJar
-        Include="java\**\*.java"
-        Exclude="java\java\util\Collection.java"
-    />
-    <TestJarNoParameters
-        Include="java\java\util\Collection.java"
-    />
+    <TestJar Include="java\**\*.java" Exclude="java\java\util\Collection.java" />
+    <TestJarNoParameters Include="java\java\util\Collection.java" />
+    <TestJar Include="java\com\xamarin\NestedInterface.java" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
@@ -74,8 +70,8 @@
   </PropertyGroup>
   <Target Name="BuildClasses" Inputs="@(TestJar)" Outputs="@(TestJar-&gt;'$(IntermediateOutputPath)classes\%(RecursiveDir)%(Filename).class')">
     <MakeDir Directories="$(IntermediateOutputPath)classes" />
-    <Exec Command="&quot;$(JavaCPath)&quot; -parameters -source 1.5 -target 1.6 -g -d &quot;$(IntermediateOutputPath)classes&quot; @(TestJar->'%(Identity)', ' ')" />
-    <Exec Command="&quot;$(JavaCPath)&quot; -source 1.5 -target 1.6 -g -d &quot;$(IntermediateOutputPath)classes&quot; @(TestJarNoParameters->'%(Identity)', ' ')" />
+    <Exec Command="&quot;$(JavaCPath)&quot; -parameters -source 1.5 -target 1.6 -g -d &quot;$(IntermediateOutputPath)classes&quot; @(TestJar-&gt;'%(Identity)', ' ')" />
+    <Exec Command="&quot;$(JavaCPath)&quot; -source 1.5 -target 1.6 -g -d &quot;$(IntermediateOutputPath)classes&quot; @(TestJarNoParameters-&gt;'%(Identity)', ' ')" />
   </Target>
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Android.Tools.Bytecode.csproj">
@@ -141,6 +137,9 @@
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\xamarin\IJavaInterface.class">
       <LogicalName>IJavaInterface.class</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\xamarin\NestedInterface$DnsSdTxtRecordListener.class">
+      <LogicalName>NestedInterface$DnsSdTxtRecordListener.class</LogicalName>
+    </EmbeddedResource>
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\NonGenericGlobalType.class">
       <LogicalName>NonGenericGlobalType.class</LogicalName>
     </EmbeddedResource>
@@ -164,7 +163,11 @@
     </EmbeddedResource>
     <EmbeddedResource Include="ParameterDescription.txt">
       <LogicalName>ParameterDescription.txt</LogicalName>
-    </EmbeddedResource>  </ItemGroup>
+    </EmbeddedResource>
+    <EmbeddedResource Include="ParameterFixupFromDescriptionText.xml">
+      <LogicalName>ParameterFixupFromDescriptionText.xml</LogicalName>
+    </EmbeddedResource>
+</ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/java/com/xamarin/NestedInterface.java
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/java/com/xamarin/NestedInterface.java
@@ -1,0 +1,11 @@
+package com.xamarin;
+
+import java.util.Map;
+
+public class NestedInterface
+{
+    public interface DnsSdTxtRecordListener
+    {
+        void onDnsSdTxtRecordAvailable(String p1, Map<String, String> p2, String p3);
+    }
+}


### PR DESCRIPTION
When there is a method that takes one or more parameters that are generic
instances whose type definition contains more than one type parameters
(e.g. `java.util.Map<K,V>`), they resulted in java.util.Map<X,Y> whereas
API XML contains java.util.Map<X, Y> (notice the extra space between generic
arguments) and method type matching failed.

We should not change parameter definitions format (it is clearly declared
to NOT contain spaces within generic arguments), so expand that at loader.