### PR TITLE
[generator] support covariant return types

### DIFF
--- a/tools/generator/CodeGenerator.cs
+++ b/tools/generator/CodeGenerator.cs
@@ -323,16 +323,19 @@ namespace Xamarin.Android.Binder {
 			if (api_versions_xml != null)
 				ApiVersionsSupport.AssignApiLevels (gens, api_versions_xml);
 
-			foreach (GenBase gen in gens)
+			foreach (var gen in gens)
+				gen.FixupCovariantReturnTypes ();
+
+			foreach (var gen in gens)
 				gen.FillProperties ();
 
 			foreach (var gen in gens)
 				gen.UpdateEnums (opt);
 
-			foreach (GenBase gen in gens)
+			foreach (var gen in gens)
 				gen.FixupMethodOverrides ();
 
-			foreach (GenBase gen in gens)
+			foreach (var gen in gens)
 				gen.FixupExplicitImplementation ();
 
 			GenerateAnnotationAttributes (gens, annotations_zips);

--- a/tools/generator/GenBase.cs
+++ b/tools/generator/GenBase.cs
@@ -415,6 +415,19 @@ namespace MonoDroid.Generation {
 			if (!m.Validate (opt, TypeParameters)) {
 				return false;
 			}
+
+			//Fix up Java covariant return types, C# return type must match the base return type
+			var baseCovariantMethod = BaseGen?.methods.FirstOrDefault (bm => bm.IsCovariantOverride (m));
+			if (baseCovariantMethod == null) {
+				baseCovariantMethod = ifaces.OfType<InterfaceGen> ()
+				                            .SelectMany (i => i.methods)
+				                            .FirstOrDefault (im => im.IsCovariantOverride (m));
+			}
+			if (baseCovariantMethod != null && m.ManagedReturn == null) {
+				m.RetVal.FullName = baseCovariantMethod.ReturnType;
+				m.RetVal.ToNativeOverride = baseCovariantMethod.RetVal.ToNative;
+			}
+
 			return true;
 		}
 

--- a/tools/generator/Method.cs
+++ b/tools/generator/Method.cs
@@ -262,7 +262,7 @@ namespace MonoDroid.Generation {
 		
 		internal void FillReturnType ()
 		{
-			retval = new ReturnValue (this, Return, ManagedReturn, IsReturnEnumified);
+			retval = new ReturnValue (Return, ManagedReturn, IsReturnEnumified);
 		}
 
 		public bool GenerateDispatchingSetter { get; protected set; }
@@ -456,7 +456,22 @@ namespace MonoDroid.Generation {
 			}
 			return delegate_type;
 		}
-		
+
+		public bool IsCovariantOverride (Method overriddenMethod)
+		{
+			//A method with a covariant return type would have the following to be true:
+			// 1) Neither is generic
+			// 2) JavaName is the same
+			// 3) retval.JavaName is *different*
+			// 4) Same number of parameters
+			// 5) JavaSignature for parameters is the same
+			return !IsGeneric && !overriddenMethod.IsGeneric &&
+				JavaName == overriddenMethod.JavaName && 
+				retval.JavaName != overriddenMethod.retval.JavaName && 
+				Parameters.Count == overriddenMethod.Parameters.Count &&
+				Parameters.JavaSignature == overriddenMethod.Parameters.JavaSignature;
+		}
+
 		// it used to be private though...
 		internal string AdjustedName {
 			get { return IsReturnCharSequence ? Name + "Formatted" : Name; }

--- a/tools/generator/Tests/CovariantReturnTypes.cs
+++ b/tools/generator/Tests/CovariantReturnTypes.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace generatortests
+{
+	[TestFixture]
+	public class CovariantReturnTypes : BaseGeneratorTest
+	{
+		[Test]
+		public void GeneratedOK ()
+		{
+			AllowWarnings = true;
+			RunAllTargets (
+					outputRelativePath: "CovariantReturnTypes",
+					apiDescriptionFile: "expected/CovariantReturnTypes/CovariantReturnTypes.xml",
+					expectedRelativePath: "CovariantReturnTypes");
+		}
+	}
+}
+

--- a/tools/generator/Tests/expected.ji/CovariantReturnTypes/Covariant.Returntypes.CovariantClass.cs
+++ b/tools/generator/Tests/expected.ji/CovariantReturnTypes/Covariant.Returntypes.CovariantClass.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Covariant.Returntypes {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='covariant.returntypes']/class[@name='CovariantClass']"
+	[global::Android.Runtime.Register ("covariant/returntypes/CovariantClass", DoNotGenerateAcw=true)]
+	public partial class CovariantClass : global::Java.Lang.Object {
+
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("covariant/returntypes/CovariantClass", typeof (CovariantClass));
+		internal static new IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+		protected CovariantClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		static Delegate cb_someMethod;
+#pragma warning disable 0169
+		static Delegate GetSomeMethodHandler ()
+		{
+			if (cb_someMethod == null)
+				cb_someMethod = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_SomeMethod);
+			return cb_someMethod;
+		}
+
+		static IntPtr n_SomeMethod (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Covariant.Returntypes.CovariantClass __this = global::Java.Lang.Object.GetObject<global::Covariant.Returntypes.CovariantClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.ToLocalJniHandle (__this.SomeMethod ());
+		}
+#pragma warning restore 0169
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='covariant.returntypes']/class[@name='CovariantClass']/method[@name='someMethod' and count(parameter)=0]"
+		[Register ("someMethod", "()Ljava/lang/Object;", "GetSomeMethodHandler")]
+		public virtual unsafe global::Java.Lang.Object SomeMethod ()
+		{
+			const string __id = "someMethod.()Ljava/lang/Object;";
+			try {
+				var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, null);
+				return global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+			} finally {
+			}
+		}
+
+	}
+}

--- a/tools/generator/Tests/expected.ji/CovariantReturnTypes/Covariant.Returntypes.CovariantInterfaceImplementation.cs
+++ b/tools/generator/Tests/expected.ji/CovariantReturnTypes/Covariant.Returntypes.CovariantInterfaceImplementation.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Covariant.Returntypes {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='covariant.returntypes']/class[@name='CovariantInterfaceImplementation']"
+	[global::Android.Runtime.Register ("covariant/returntypes/CovariantInterfaceImplementation", DoNotGenerateAcw=true)]
+	public partial class CovariantInterfaceImplementation : global::Java.Lang.Object, global::Covariant.Returntypes.ICovariantInterface {
+
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("covariant/returntypes/CovariantInterfaceImplementation", typeof (CovariantInterfaceImplementation));
+		internal static new IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+		protected CovariantInterfaceImplementation (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		// Metadata.xml XPath constructor reference: path="/api/package[@name='covariant.returntypes']/class[@name='CovariantInterfaceImplementation']/constructor[@name='CovariantInterfaceImplementation' and count(parameter)=0]"
+		[Register (".ctor", "()V", "")]
+		public unsafe CovariantInterfaceImplementation ()
+			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		{
+			const string __id = "()V";
+
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+				return;
+
+			try {
+				var __r = _members.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), null);
+				SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
+				_members.InstanceMethods.FinishCreateInstance (__id, this, null);
+			} finally {
+			}
+		}
+
+		static Delegate cb_someMethod;
+#pragma warning disable 0169
+		static Delegate GetSomeMethodHandler ()
+		{
+			if (cb_someMethod == null)
+				cb_someMethod = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_SomeMethod);
+			return cb_someMethod;
+		}
+
+		static IntPtr n_SomeMethod (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Covariant.Returntypes.CovariantInterfaceImplementation __this = global::Java.Lang.Object.GetObject<global::Covariant.Returntypes.CovariantInterfaceImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.ToLocalJniHandle (__this.SomeMethod ());
+		}
+#pragma warning restore 0169
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='covariant.returntypes']/class[@name='CovariantInterfaceImplementation']/method[@name='someMethod' and count(parameter)=0]"
+		[Register ("someMethod", "()Ljava/lang/String;", "GetSomeMethodHandler")]
+		public virtual unsafe global::Java.Lang.Object SomeMethod ()
+		{
+			const string __id = "someMethod.()Ljava/lang/String;";
+			try {
+				var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, null);
+				return JNIEnv.GetString (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+			} finally {
+			}
+		}
+
+	}
+}

--- a/tools/generator/Tests/expected.ji/CovariantReturnTypes/Covariant.Returntypes.CovariantPropertyClass.cs
+++ b/tools/generator/Tests/expected.ji/CovariantReturnTypes/Covariant.Returntypes.CovariantPropertyClass.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Covariant.Returntypes {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='covariant.returntypes']/class[@name='CovariantPropertyClass']"
+	[global::Android.Runtime.Register ("covariant/returntypes/CovariantPropertyClass", DoNotGenerateAcw=true)]
+	public partial class CovariantPropertyClass : global::Java.Lang.Object {
+
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("covariant/returntypes/CovariantPropertyClass", typeof (CovariantPropertyClass));
+		internal static new IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+		protected CovariantPropertyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		static Delegate cb_getObject;
+#pragma warning disable 0169
+		static Delegate GetGetObjectHandler ()
+		{
+			if (cb_getObject == null)
+				cb_getObject = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_GetObject);
+			return cb_getObject;
+		}
+
+		static IntPtr n_GetObject (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Covariant.Returntypes.CovariantPropertyClass __this = global::Java.Lang.Object.GetObject<global::Covariant.Returntypes.CovariantPropertyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.ToLocalJniHandle (__this.Object);
+		}
+#pragma warning restore 0169
+
+		public virtual unsafe global::Java.Lang.Object Object {
+			// Metadata.xml XPath method reference: path="/api/package[@name='covariant.returntypes']/class[@name='CovariantPropertyClass']/method[@name='getObject' and count(parameter)=0]"
+			[Register ("getObject", "()Ljava/lang/Object;", "GetGetObjectHandler")]
+			get {
+				const string __id = "getObject.()Ljava/lang/Object;";
+				try {
+					var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, null);
+					return global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+				} finally {
+				}
+			}
+		}
+
+	}
+}

--- a/tools/generator/Tests/expected.ji/CovariantReturnTypes/Covariant.Returntypes.CovariantPropertyImplementation.cs
+++ b/tools/generator/Tests/expected.ji/CovariantReturnTypes/Covariant.Returntypes.CovariantPropertyImplementation.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Covariant.Returntypes {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='covariant.returntypes']/class[@name='CovariantPropertyImplementation']"
+	[global::Android.Runtime.Register ("covariant/returntypes/CovariantPropertyImplementation", DoNotGenerateAcw=true)]
+	public partial class CovariantPropertyImplementation : global::Java.Lang.Object, global::Covariant.Returntypes.ICovariantPropertyInterface {
+
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("covariant/returntypes/CovariantPropertyImplementation", typeof (CovariantPropertyImplementation));
+		internal static new IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+		protected CovariantPropertyImplementation (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		// Metadata.xml XPath constructor reference: path="/api/package[@name='covariant.returntypes']/class[@name='CovariantPropertyImplementation']/constructor[@name='CovariantPropertyImplementation' and count(parameter)=0]"
+		[Register (".ctor", "()V", "")]
+		public unsafe CovariantPropertyImplementation ()
+			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		{
+			const string __id = "()V";
+
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+				return;
+
+			try {
+				var __r = _members.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), null);
+				SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
+				_members.InstanceMethods.FinishCreateInstance (__id, this, null);
+			} finally {
+			}
+		}
+
+		static Delegate cb_getObject;
+#pragma warning disable 0169
+		static Delegate GetGetObjectHandler ()
+		{
+			if (cb_getObject == null)
+				cb_getObject = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_GetObject);
+			return cb_getObject;
+		}
+
+		static IntPtr n_GetObject (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Covariant.Returntypes.CovariantPropertyImplementation __this = global::Java.Lang.Object.GetObject<global::Covariant.Returntypes.CovariantPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.ToLocalJniHandle (__this.Object);
+		}
+#pragma warning restore 0169
+
+		public virtual unsafe global::Java.Lang.Object Object {
+			// Metadata.xml XPath method reference: path="/api/package[@name='covariant.returntypes']/class[@name='CovariantPropertyImplementation']/method[@name='getObject' and count(parameter)=0]"
+			[Register ("getObject", "()Ljava/lang/String;", "GetGetObjectHandler")]
+			get {
+				const string __id = "getObject.()Ljava/lang/String;";
+				try {
+					var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, null);
+					return JNIEnv.GetString (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+				} finally {
+				}
+			}
+		}
+
+	}
+}

--- a/tools/generator/Tests/expected.ji/CovariantReturnTypes/Covariant.Returntypes.CovariantPropertySubclass.cs
+++ b/tools/generator/Tests/expected.ji/CovariantReturnTypes/Covariant.Returntypes.CovariantPropertySubclass.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Covariant.Returntypes {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='covariant.returntypes']/class[@name='CovariantPropertySubclass']"
+	[global::Android.Runtime.Register ("covariant/returntypes/CovariantPropertySubclass", DoNotGenerateAcw=true)]
+	public partial class CovariantPropertySubclass : global::Covariant.Returntypes.CovariantPropertyClass {
+
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("covariant/returntypes/CovariantPropertySubclass", typeof (CovariantPropertySubclass));
+		internal static new IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+		protected CovariantPropertySubclass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		// Metadata.xml XPath constructor reference: path="/api/package[@name='covariant.returntypes']/class[@name='CovariantPropertySubclass']/constructor[@name='CovariantPropertySubclass' and count(parameter)=0]"
+		[Register (".ctor", "()V", "")]
+		public unsafe CovariantPropertySubclass ()
+			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		{
+			const string __id = "()V";
+
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+				return;
+
+			try {
+				var __r = _members.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), null);
+				SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
+				_members.InstanceMethods.FinishCreateInstance (__id, this, null);
+			} finally {
+			}
+		}
+
+		static Delegate cb_getObject;
+#pragma warning disable 0169
+		static Delegate GetGetObjectHandler ()
+		{
+			if (cb_getObject == null)
+				cb_getObject = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_GetObject);
+			return cb_getObject;
+		}
+
+		static IntPtr n_GetObject (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Covariant.Returntypes.CovariantPropertySubclass __this = global::Java.Lang.Object.GetObject<global::Covariant.Returntypes.CovariantPropertySubclass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.ToLocalJniHandle (__this.Object);
+		}
+#pragma warning restore 0169
+
+		public override unsafe global::Java.Lang.Object Object {
+			// Metadata.xml XPath method reference: path="/api/package[@name='covariant.returntypes']/class[@name='CovariantPropertySubclass']/method[@name='getObject' and count(parameter)=0]"
+			[Register ("getObject", "()Ljava/lang/String;", "GetGetObjectHandler")]
+			get {
+				const string __id = "getObject.()Ljava/lang/String;";
+				try {
+					var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, null);
+					return JNIEnv.GetString (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+				} finally {
+				}
+			}
+		}
+
+	}
+}

--- a/tools/generator/Tests/expected.ji/CovariantReturnTypes/Covariant.Returntypes.CovariantSubclass.cs
+++ b/tools/generator/Tests/expected.ji/CovariantReturnTypes/Covariant.Returntypes.CovariantSubclass.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Covariant.Returntypes {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='covariant.returntypes']/class[@name='CovariantSubclass']"
+	[global::Android.Runtime.Register ("covariant/returntypes/CovariantSubclass", DoNotGenerateAcw=true)]
+	public partial class CovariantSubclass : global::Covariant.Returntypes.CovariantClass {
+
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("covariant/returntypes/CovariantSubclass", typeof (CovariantSubclass));
+		internal static new IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+		protected CovariantSubclass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		// Metadata.xml XPath constructor reference: path="/api/package[@name='covariant.returntypes']/class[@name='CovariantSubclass']/constructor[@name='CovariantSubclass' and count(parameter)=0]"
+		[Register (".ctor", "()V", "")]
+		public unsafe CovariantSubclass ()
+			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		{
+			const string __id = "()V";
+
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+				return;
+
+			try {
+				var __r = _members.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), null);
+				SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
+				_members.InstanceMethods.FinishCreateInstance (__id, this, null);
+			} finally {
+			}
+		}
+
+		static Delegate cb_someMethod;
+#pragma warning disable 0169
+		static Delegate GetSomeMethodHandler ()
+		{
+			if (cb_someMethod == null)
+				cb_someMethod = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_SomeMethod);
+			return cb_someMethod;
+		}
+
+		static IntPtr n_SomeMethod (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Covariant.Returntypes.CovariantSubclass __this = global::Java.Lang.Object.GetObject<global::Covariant.Returntypes.CovariantSubclass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.ToLocalJniHandle (__this.SomeMethod ());
+		}
+#pragma warning restore 0169
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='covariant.returntypes']/class[@name='CovariantSubclass']/method[@name='someMethod' and count(parameter)=0]"
+		[Register ("someMethod", "()Ljava/lang/String;", "GetSomeMethodHandler")]
+		public override unsafe global::Java.Lang.Object SomeMethod ()
+		{
+			const string __id = "someMethod.()Ljava/lang/String;";
+			try {
+				var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, null);
+				return JNIEnv.GetString (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+			} finally {
+			}
+		}
+
+	}
+}

--- a/tools/generator/Tests/expected.ji/CovariantReturnTypes/Covariant.Returntypes.GenericCovariantImplementation.cs
+++ b/tools/generator/Tests/expected.ji/CovariantReturnTypes/Covariant.Returntypes.GenericCovariantImplementation.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Covariant.Returntypes {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='covariant.returntypes']/class[@name='GenericCovariantImplementation']"
+	[global::Android.Runtime.Register ("covariant/returntypes/GenericCovariantImplementation", DoNotGenerateAcw=true)]
+	public partial class GenericCovariantImplementation : global::Covariant.Returntypes.GenericImplementation {
+
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("covariant/returntypes/GenericCovariantImplementation", typeof (GenericCovariantImplementation));
+		internal static new IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+		protected GenericCovariantImplementation (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		// Metadata.xml XPath constructor reference: path="/api/package[@name='covariant.returntypes']/class[@name='GenericCovariantImplementation']/constructor[@name='GenericCovariantImplementation' and count(parameter)=0]"
+		[Register (".ctor", "()V", "")]
+		public unsafe GenericCovariantImplementation ()
+			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		{
+			const string __id = "()V";
+
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+				return;
+
+			try {
+				var __r = _members.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), null);
+				SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
+				_members.InstanceMethods.FinishCreateInstance (__id, this, null);
+			} finally {
+			}
+		}
+
+		static Delegate cb_someMethod;
+#pragma warning disable 0169
+		static Delegate GetSomeMethodHandler ()
+		{
+			if (cb_someMethod == null)
+				cb_someMethod = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_SomeMethod);
+			return cb_someMethod;
+		}
+
+		static IntPtr n_SomeMethod (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Covariant.Returntypes.GenericCovariantImplementation __this = global::Java.Lang.Object.GetObject<global::Covariant.Returntypes.GenericCovariantImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.ToLocalJniHandle (__this.SomeMethod ());
+		}
+#pragma warning restore 0169
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='covariant.returntypes']/class[@name='GenericCovariantImplementation']/method[@name='someMethod' and count(parameter)=0]"
+		[Register ("someMethod", "()Ljava/lang/String;", "GetSomeMethodHandler")]
+		public override unsafe global::Java.Lang.Object SomeMethod ()
+		{
+			const string __id = "someMethod.()Ljava/lang/String;";
+			try {
+				var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, null);
+				return JNIEnv.GetString (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+			} finally {
+			}
+		}
+
+	}
+}

--- a/tools/generator/Tests/expected.ji/CovariantReturnTypes/Covariant.Returntypes.GenericImplementation.cs
+++ b/tools/generator/Tests/expected.ji/CovariantReturnTypes/Covariant.Returntypes.GenericImplementation.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Covariant.Returntypes {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='covariant.returntypes']/class[@name='GenericImplementation']"
+	[global::Android.Runtime.Register ("covariant/returntypes/GenericImplementation", DoNotGenerateAcw=true)]
+	public partial class GenericImplementation : global::Java.Lang.Object, global::Covariant.Returntypes.IGenericInterface {
+
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("covariant/returntypes/GenericImplementation", typeof (GenericImplementation));
+		internal static new IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+		protected GenericImplementation (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		// Metadata.xml XPath constructor reference: path="/api/package[@name='covariant.returntypes']/class[@name='GenericImplementation']/constructor[@name='GenericImplementation' and count(parameter)=0]"
+		[Register (".ctor", "()V", "")]
+		public unsafe GenericImplementation ()
+			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		{
+			const string __id = "()V";
+
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+				return;
+
+			try {
+				var __r = _members.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), null);
+				SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
+				_members.InstanceMethods.FinishCreateInstance (__id, this, null);
+			} finally {
+			}
+		}
+
+		static Delegate cb_someMethod;
+#pragma warning disable 0169
+		static Delegate GetSomeMethodHandler ()
+		{
+			if (cb_someMethod == null)
+				cb_someMethod = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_SomeMethod);
+			return cb_someMethod;
+		}
+
+		static IntPtr n_SomeMethod (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Covariant.Returntypes.GenericImplementation __this = global::Java.Lang.Object.GetObject<global::Covariant.Returntypes.GenericImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.ToLocalJniHandle (__this.SomeMethod ());
+		}
+#pragma warning restore 0169
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='covariant.returntypes']/class[@name='GenericImplementation']/method[@name='someMethod' and count(parameter)=0]"
+		[Register ("someMethod", "()Ljava/lang/Object;", "GetSomeMethodHandler")]
+		public virtual unsafe global::Java.Lang.Object SomeMethod ()
+		{
+			const string __id = "someMethod.()Ljava/lang/Object;";
+			try {
+				var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, null);
+				return global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+			} finally {
+			}
+		}
+
+		// This method is explicitly implemented as a member of an instantiated Covariant.Returntypes.IGenericInterface
+		global::Java.Lang.Object global::Covariant.Returntypes.IGenericInterface.SomeMethod ()
+		{
+			return global::Java.Interop.JavaObjectExtensions.JavaCast<Java.Lang.Object>(SomeMethod ());
+		}
+
+	}
+}

--- a/tools/generator/Tests/expected.ji/CovariantReturnTypes/Covariant.Returntypes.GenericStringImplementation.cs
+++ b/tools/generator/Tests/expected.ji/CovariantReturnTypes/Covariant.Returntypes.GenericStringImplementation.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Covariant.Returntypes {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='covariant.returntypes']/class[@name='GenericStringImplementation']"
+	[global::Android.Runtime.Register ("covariant/returntypes/GenericStringImplementation", DoNotGenerateAcw=true)]
+	public partial class GenericStringImplementation : global::Java.Lang.Object, global::Covariant.Returntypes.IGenericInterface {
+
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("covariant/returntypes/GenericStringImplementation", typeof (GenericStringImplementation));
+		internal static new IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+		protected GenericStringImplementation (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		// Metadata.xml XPath constructor reference: path="/api/package[@name='covariant.returntypes']/class[@name='GenericStringImplementation']/constructor[@name='GenericStringImplementation' and count(parameter)=0]"
+		[Register (".ctor", "()V", "")]
+		public unsafe GenericStringImplementation ()
+			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		{
+			const string __id = "()V";
+
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+				return;
+
+			try {
+				var __r = _members.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), null);
+				SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
+				_members.InstanceMethods.FinishCreateInstance (__id, this, null);
+			} finally {
+			}
+		}
+
+		static Delegate cb_someMethod;
+#pragma warning disable 0169
+		static Delegate GetSomeMethodHandler ()
+		{
+			if (cb_someMethod == null)
+				cb_someMethod = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_SomeMethod);
+			return cb_someMethod;
+		}
+
+		static IntPtr n_SomeMethod (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Covariant.Returntypes.GenericStringImplementation __this = global::Java.Lang.Object.GetObject<global::Covariant.Returntypes.GenericStringImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.NewString (__this.SomeMethod ());
+		}
+#pragma warning restore 0169
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='covariant.returntypes']/class[@name='GenericStringImplementation']/method[@name='someMethod' and count(parameter)=0]"
+		[Register ("someMethod", "()Ljava/lang/String;", "GetSomeMethodHandler")]
+		public virtual unsafe string SomeMethod ()
+		{
+			const string __id = "someMethod.()Ljava/lang/String;";
+			try {
+				var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, null);
+				return JNIEnv.GetString (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+			} finally {
+			}
+		}
+
+		// This method is explicitly implemented as a member of an instantiated Covariant.Returntypes.IGenericInterface
+		global::Java.Lang.Object global::Covariant.Returntypes.IGenericInterface.SomeMethod ()
+		{
+			return SomeMethod ().ToString ();
+		}
+
+	}
+}

--- a/tools/generator/Tests/expected.ji/CovariantReturnTypes/Covariant.Returntypes.ICovariantInterface.cs
+++ b/tools/generator/Tests/expected.ji/CovariantReturnTypes/Covariant.Returntypes.ICovariantInterface.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Covariant.Returntypes {
+
+	// Metadata.xml XPath interface reference: path="/api/package[@name='covariant.returntypes']/interface[@name='CovariantInterface']"
+	[Register ("covariant/returntypes/CovariantInterface", "", "Covariant.Returntypes.ICovariantInterfaceInvoker")]
+	public partial interface ICovariantInterface : IJavaObject {
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='covariant.returntypes']/interface[@name='CovariantInterface']/method[@name='someMethod' and count(parameter)=0]"
+		[Register ("someMethod", "()Ljava/lang/Object;", "GetSomeMethodHandler:Covariant.Returntypes.ICovariantInterfaceInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
+		global::Java.Lang.Object SomeMethod ();
+
+	}
+
+	[global::Android.Runtime.Register ("covariant/returntypes/CovariantInterface", DoNotGenerateAcw=true)]
+	internal class ICovariantInterfaceInvoker : global::Java.Lang.Object, ICovariantInterface {
+
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("covariant/returntypes/CovariantInterface", typeof (ICovariantInterfaceInvoker));
+
+		static IntPtr java_class_ref {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+		new IntPtr class_ref;
+
+		public static ICovariantInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
+		{
+			return global::Java.Lang.Object.GetObject<ICovariantInterface> (handle, transfer);
+		}
+
+		static IntPtr Validate (IntPtr handle)
+		{
+			if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
+				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
+							JNIEnv.GetClassNameFromInstance (handle), "covariant.returntypes.CovariantInterface"));
+			return handle;
+		}
+
+		protected override void Dispose (bool disposing)
+		{
+			if (this.class_ref != IntPtr.Zero)
+				JNIEnv.DeleteGlobalRef (this.class_ref);
+			this.class_ref = IntPtr.Zero;
+			base.Dispose (disposing);
+		}
+
+		public ICovariantInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
+		{
+			IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
+			this.class_ref = JNIEnv.NewGlobalRef (local_ref);
+			JNIEnv.DeleteLocalRef (local_ref);
+		}
+
+		static Delegate cb_someMethod;
+#pragma warning disable 0169
+		static Delegate GetSomeMethodHandler ()
+		{
+			if (cb_someMethod == null)
+				cb_someMethod = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_SomeMethod);
+			return cb_someMethod;
+		}
+
+		static IntPtr n_SomeMethod (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Covariant.Returntypes.ICovariantInterface __this = global::Java.Lang.Object.GetObject<global::Covariant.Returntypes.ICovariantInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.ToLocalJniHandle (__this.SomeMethod ());
+		}
+#pragma warning restore 0169
+
+		IntPtr id_someMethod;
+		public unsafe global::Java.Lang.Object SomeMethod ()
+		{
+			if (id_someMethod == IntPtr.Zero)
+				id_someMethod = JNIEnv.GetMethodID (class_ref, "someMethod", "()Ljava/lang/Object;");
+			return global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_someMethod), JniHandleOwnership.TransferLocalRef);
+		}
+
+	}
+
+}

--- a/tools/generator/Tests/expected.ji/CovariantReturnTypes/Covariant.Returntypes.ICovariantPropertyInterface.cs
+++ b/tools/generator/Tests/expected.ji/CovariantReturnTypes/Covariant.Returntypes.ICovariantPropertyInterface.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Covariant.Returntypes {
+
+	// Metadata.xml XPath interface reference: path="/api/package[@name='covariant.returntypes']/interface[@name='CovariantPropertyInterface']"
+	[Register ("covariant/returntypes/CovariantPropertyInterface", "", "Covariant.Returntypes.ICovariantPropertyInterfaceInvoker")]
+	public partial interface ICovariantPropertyInterface : IJavaObject {
+
+		global::Java.Lang.Object Object {
+			// Metadata.xml XPath method reference: path="/api/package[@name='covariant.returntypes']/interface[@name='CovariantPropertyInterface']/method[@name='getObject' and count(parameter)=0]"
+			[Register ("getObject", "()Ljava/lang/Object;", "GetGetObjectHandler:Covariant.Returntypes.ICovariantPropertyInterfaceInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")] get;
+		}
+
+	}
+
+	[global::Android.Runtime.Register ("covariant/returntypes/CovariantPropertyInterface", DoNotGenerateAcw=true)]
+	internal class ICovariantPropertyInterfaceInvoker : global::Java.Lang.Object, ICovariantPropertyInterface {
+
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("covariant/returntypes/CovariantPropertyInterface", typeof (ICovariantPropertyInterfaceInvoker));
+
+		static IntPtr java_class_ref {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+		new IntPtr class_ref;
+
+		public static ICovariantPropertyInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
+		{
+			return global::Java.Lang.Object.GetObject<ICovariantPropertyInterface> (handle, transfer);
+		}
+
+		static IntPtr Validate (IntPtr handle)
+		{
+			if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
+				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
+							JNIEnv.GetClassNameFromInstance (handle), "covariant.returntypes.CovariantPropertyInterface"));
+			return handle;
+		}
+
+		protected override void Dispose (bool disposing)
+		{
+			if (this.class_ref != IntPtr.Zero)
+				JNIEnv.DeleteGlobalRef (this.class_ref);
+			this.class_ref = IntPtr.Zero;
+			base.Dispose (disposing);
+		}
+
+		public ICovariantPropertyInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
+		{
+			IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
+			this.class_ref = JNIEnv.NewGlobalRef (local_ref);
+			JNIEnv.DeleteLocalRef (local_ref);
+		}
+
+		static Delegate cb_getObject;
+#pragma warning disable 0169
+		static Delegate GetGetObjectHandler ()
+		{
+			if (cb_getObject == null)
+				cb_getObject = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_GetObject);
+			return cb_getObject;
+		}
+
+		static IntPtr n_GetObject (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Covariant.Returntypes.ICovariantPropertyInterface __this = global::Java.Lang.Object.GetObject<global::Covariant.Returntypes.ICovariantPropertyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.ToLocalJniHandle (__this.Object);
+		}
+#pragma warning restore 0169
+
+		IntPtr id_getObject;
+		public unsafe global::Java.Lang.Object Object {
+			get {
+				if (id_getObject == IntPtr.Zero)
+					id_getObject = JNIEnv.GetMethodID (class_ref, "getObject", "()Ljava/lang/Object;");
+				return global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_getObject), JniHandleOwnership.TransferLocalRef);
+			}
+		}
+
+	}
+
+}

--- a/tools/generator/Tests/expected.ji/CovariantReturnTypes/Covariant.Returntypes.IGenericInterface.cs
+++ b/tools/generator/Tests/expected.ji/CovariantReturnTypes/Covariant.Returntypes.IGenericInterface.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Covariant.Returntypes {
+
+	// Metadata.xml XPath interface reference: path="/api/package[@name='covariant.returntypes']/interface[@name='GenericInterface']"
+	[Register ("covariant/returntypes/GenericInterface", "", "Covariant.Returntypes.IGenericInterfaceInvoker")]
+	[global::Java.Interop.JavaTypeParameters (new string [] {"T"})]
+	public partial interface IGenericInterface : IJavaObject {
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='covariant.returntypes']/interface[@name='GenericInterface']/method[@name='someMethod' and count(parameter)=0]"
+		[Register ("someMethod", "()Ljava/lang/Object;", "GetSomeMethodHandler:Covariant.Returntypes.IGenericInterfaceInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
+		global::Java.Lang.Object SomeMethod ();
+
+	}
+
+	[global::Android.Runtime.Register ("covariant/returntypes/GenericInterface", DoNotGenerateAcw=true)]
+	internal class IGenericInterfaceInvoker : global::Java.Lang.Object, IGenericInterface {
+
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("covariant/returntypes/GenericInterface", typeof (IGenericInterfaceInvoker));
+
+		static IntPtr java_class_ref {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+		new IntPtr class_ref;
+
+		public static IGenericInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
+		{
+			return global::Java.Lang.Object.GetObject<IGenericInterface> (handle, transfer);
+		}
+
+		static IntPtr Validate (IntPtr handle)
+		{
+			if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
+				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
+							JNIEnv.GetClassNameFromInstance (handle), "covariant.returntypes.GenericInterface"));
+			return handle;
+		}
+
+		protected override void Dispose (bool disposing)
+		{
+			if (this.class_ref != IntPtr.Zero)
+				JNIEnv.DeleteGlobalRef (this.class_ref);
+			this.class_ref = IntPtr.Zero;
+			base.Dispose (disposing);
+		}
+
+		public IGenericInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
+		{
+			IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
+			this.class_ref = JNIEnv.NewGlobalRef (local_ref);
+			JNIEnv.DeleteLocalRef (local_ref);
+		}
+
+		static Delegate cb_someMethod;
+#pragma warning disable 0169
+		static Delegate GetSomeMethodHandler ()
+		{
+			if (cb_someMethod == null)
+				cb_someMethod = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_SomeMethod);
+			return cb_someMethod;
+		}
+
+		static IntPtr n_SomeMethod (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Covariant.Returntypes.IGenericInterface __this = global::Java.Lang.Object.GetObject<global::Covariant.Returntypes.IGenericInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.ToLocalJniHandle (__this.SomeMethod ());
+		}
+#pragma warning restore 0169
+
+		IntPtr id_someMethod;
+		public unsafe global::Java.Lang.Object SomeMethod ()
+		{
+			if (id_someMethod == IntPtr.Zero)
+				id_someMethod = JNIEnv.GetMethodID (class_ref, "someMethod", "()Ljava/lang/Object;");
+			return (Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_someMethod), JniHandleOwnership.TransferLocalRef);
+		}
+
+	}
+
+}

--- a/tools/generator/Tests/expected.ji/CovariantReturnTypes/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/CovariantReturnTypes/Mono.Android.projitems
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);ANDROID_1;ANDROID_2;ANDROID_3;ANDROID_4</DefineConstants>
+  </PropertyGroup>
+  <!-- Classes -->
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)\Covariant.Returntypes.CovariantClass.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Covariant.Returntypes.CovariantInterfaceImplementation.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Covariant.Returntypes.CovariantPropertyClass.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Covariant.Returntypes.CovariantPropertyImplementation.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Covariant.Returntypes.CovariantPropertySubclass.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Covariant.Returntypes.CovariantSubclass.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Covariant.Returntypes.GenericCovariantImplementation.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Covariant.Returntypes.GenericImplementation.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Covariant.Returntypes.GenericStringImplementation.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Covariant.Returntypes.ICovariantInterface.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Covariant.Returntypes.ICovariantPropertyInterface.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Covariant.Returntypes.IGenericInterface.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.String.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+  </ItemGroup>
+  <!-- Enums -->
+  <ItemGroup />
+</Project>

--- a/tools/generator/Tests/expected.targets
+++ b/tools/generator/Tests/expected.targets
@@ -39,6 +39,45 @@
     <Content Include='expected\Constructors\Xamarin.Test.SomeObject.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include='expected\CovariantReturnTypes\Covariant.Returntypes.CovariantClass.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected\CovariantReturnTypes\Covariant.Returntypes.CovariantInterfaceImplementation.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected\CovariantReturnTypes\Covariant.Returntypes.CovariantPropertyClass.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected\CovariantReturnTypes\Covariant.Returntypes.CovariantPropertyImplementation.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected\CovariantReturnTypes\Covariant.Returntypes.CovariantPropertySubclass.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected\CovariantReturnTypes\Covariant.Returntypes.CovariantSubclass.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected\CovariantReturnTypes\Covariant.Returntypes.GenericCovariantImplementation.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected\CovariantReturnTypes\Covariant.Returntypes.GenericImplementation.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected\CovariantReturnTypes\Covariant.Returntypes.GenericStringImplementation.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected\CovariantReturnTypes\Covariant.Returntypes.ICovariantInterface.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected\CovariantReturnTypes\Covariant.Returntypes.ICovariantPropertyInterface.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected\CovariantReturnTypes\Covariant.Returntypes.IGenericInterface.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected\CovariantReturnTypes\CovariantReturnTypes.xml'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include='expected\CSharpKeywords\CSharpKeywords.xml'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -206,6 +245,45 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include='expected.ji\Constructors\Xamarin.Test.SomeObject.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected.ji\CovariantReturnTypes\Covariant.Returntypes.CovariantClass.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected.ji\CovariantReturnTypes\Covariant.Returntypes.CovariantInterfaceImplementation.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected.ji\CovariantReturnTypes\Covariant.Returntypes.CovariantPropertyClass.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected.ji\CovariantReturnTypes\Covariant.Returntypes.CovariantPropertyImplementation.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected.ji\CovariantReturnTypes\Covariant.Returntypes.CovariantPropertySubclass.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected.ji\CovariantReturnTypes\Covariant.Returntypes.CovariantSubclass.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected.ji\CovariantReturnTypes\Covariant.Returntypes.GenericCovariantImplementation.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected.ji\CovariantReturnTypes\Covariant.Returntypes.GenericImplementation.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected.ji\CovariantReturnTypes\Covariant.Returntypes.GenericStringImplementation.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected.ji\CovariantReturnTypes\Covariant.Returntypes.ICovariantInterface.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected.ji\CovariantReturnTypes\Covariant.Returntypes.ICovariantPropertyInterface.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected.ji\CovariantReturnTypes\Covariant.Returntypes.IGenericInterface.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected.ji\CovariantReturnTypes\Mono.Android.projitems'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include='expected.ji\CSharpKeywords\CSharpKeywords.xml'>

--- a/tools/generator/Tests/expected/CovariantReturnTypes/Covariant.Returntypes.CovariantClass.cs
+++ b/tools/generator/Tests/expected/CovariantReturnTypes/Covariant.Returntypes.CovariantClass.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Covariant.Returntypes {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='covariant.returntypes']/class[@name='CovariantClass']"
+	[global::Android.Runtime.Register ("covariant/returntypes/CovariantClass", DoNotGenerateAcw=true)]
+	public partial class CovariantClass : global::Java.Lang.Object {
+
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("covariant/returntypes/CovariantClass", ref java_class_handle);
+			}
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (CovariantClass); }
+		}
+
+		protected CovariantClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		static Delegate cb_someMethod;
+#pragma warning disable 0169
+		static Delegate GetSomeMethodHandler ()
+		{
+			if (cb_someMethod == null)
+				cb_someMethod = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_SomeMethod);
+			return cb_someMethod;
+		}
+
+		static IntPtr n_SomeMethod (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Covariant.Returntypes.CovariantClass __this = global::Java.Lang.Object.GetObject<global::Covariant.Returntypes.CovariantClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.ToLocalJniHandle (__this.SomeMethod ());
+		}
+#pragma warning restore 0169
+
+		static IntPtr id_someMethod;
+		// Metadata.xml XPath method reference: path="/api/package[@name='covariant.returntypes']/class[@name='CovariantClass']/method[@name='someMethod' and count(parameter)=0]"
+		[Register ("someMethod", "()Ljava/lang/Object;", "GetSomeMethodHandler")]
+		public virtual unsafe global::Java.Lang.Object SomeMethod ()
+		{
+			if (id_someMethod == IntPtr.Zero)
+				id_someMethod = JNIEnv.GetMethodID (class_ref, "someMethod", "()Ljava/lang/Object;");
+			try {
+
+				if (((object) this).GetType () == ThresholdType)
+					return global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_someMethod), JniHandleOwnership.TransferLocalRef);
+				else
+					return global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallNonvirtualObjectMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "someMethod", "()Ljava/lang/Object;")), JniHandleOwnership.TransferLocalRef);
+			} finally {
+			}
+		}
+
+	}
+}

--- a/tools/generator/Tests/expected/CovariantReturnTypes/Covariant.Returntypes.CovariantInterfaceImplementation.cs
+++ b/tools/generator/Tests/expected/CovariantReturnTypes/Covariant.Returntypes.CovariantInterfaceImplementation.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Covariant.Returntypes {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='covariant.returntypes']/class[@name='CovariantInterfaceImplementation']"
+	[global::Android.Runtime.Register ("covariant/returntypes/CovariantInterfaceImplementation", DoNotGenerateAcw=true)]
+	public partial class CovariantInterfaceImplementation : global::Java.Lang.Object, global::Covariant.Returntypes.ICovariantInterface {
+
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("covariant/returntypes/CovariantInterfaceImplementation", ref java_class_handle);
+			}
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (CovariantInterfaceImplementation); }
+		}
+
+		protected CovariantInterfaceImplementation (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		static IntPtr id_ctor;
+		// Metadata.xml XPath constructor reference: path="/api/package[@name='covariant.returntypes']/class[@name='CovariantInterfaceImplementation']/constructor[@name='CovariantInterfaceImplementation' and count(parameter)=0]"
+		[Register (".ctor", "()V", "")]
+		public unsafe CovariantInterfaceImplementation ()
+			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		{
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+				return;
+
+			try {
+				if (((object) this).GetType () != typeof (CovariantInterfaceImplementation)) {
+					SetHandle (
+							global::Android.Runtime.JNIEnv.StartCreateInstance (((object) this).GetType (), "()V"),
+							JniHandleOwnership.TransferLocalRef);
+					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "()V");
+					return;
+				}
+
+				if (id_ctor == IntPtr.Zero)
+					id_ctor = JNIEnv.GetMethodID (class_ref, "<init>", "()V");
+				SetHandle (
+						global::Android.Runtime.JNIEnv.StartCreateInstance (class_ref, id_ctor),
+						JniHandleOwnership.TransferLocalRef);
+				JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, class_ref, id_ctor);
+			} finally {
+			}
+		}
+
+		static Delegate cb_someMethod;
+#pragma warning disable 0169
+		static Delegate GetSomeMethodHandler ()
+		{
+			if (cb_someMethod == null)
+				cb_someMethod = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_SomeMethod);
+			return cb_someMethod;
+		}
+
+		static IntPtr n_SomeMethod (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Covariant.Returntypes.CovariantInterfaceImplementation __this = global::Java.Lang.Object.GetObject<global::Covariant.Returntypes.CovariantInterfaceImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.ToLocalJniHandle (__this.SomeMethod ());
+		}
+#pragma warning restore 0169
+
+		static IntPtr id_someMethod;
+		// Metadata.xml XPath method reference: path="/api/package[@name='covariant.returntypes']/class[@name='CovariantInterfaceImplementation']/method[@name='someMethod' and count(parameter)=0]"
+		[Register ("someMethod", "()Ljava/lang/String;", "GetSomeMethodHandler")]
+		public virtual unsafe global::Java.Lang.Object SomeMethod ()
+		{
+			if (id_someMethod == IntPtr.Zero)
+				id_someMethod = JNIEnv.GetMethodID (class_ref, "someMethod", "()Ljava/lang/String;");
+			try {
+
+				if (((object) this).GetType () == ThresholdType)
+					return JNIEnv.GetString (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_someMethod), JniHandleOwnership.TransferLocalRef);
+				else
+					return JNIEnv.GetString (JNIEnv.CallNonvirtualObjectMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "someMethod", "()Ljava/lang/String;")), JniHandleOwnership.TransferLocalRef);
+			} finally {
+			}
+		}
+
+	}
+}

--- a/tools/generator/Tests/expected/CovariantReturnTypes/Covariant.Returntypes.CovariantPropertyClass.cs
+++ b/tools/generator/Tests/expected/CovariantReturnTypes/Covariant.Returntypes.CovariantPropertyClass.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Covariant.Returntypes {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='covariant.returntypes']/class[@name='CovariantPropertyClass']"
+	[global::Android.Runtime.Register ("covariant/returntypes/CovariantPropertyClass", DoNotGenerateAcw=true)]
+	public partial class CovariantPropertyClass : global::Java.Lang.Object {
+
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("covariant/returntypes/CovariantPropertyClass", ref java_class_handle);
+			}
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (CovariantPropertyClass); }
+		}
+
+		protected CovariantPropertyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		static Delegate cb_getObject;
+#pragma warning disable 0169
+		static Delegate GetGetObjectHandler ()
+		{
+			if (cb_getObject == null)
+				cb_getObject = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_GetObject);
+			return cb_getObject;
+		}
+
+		static IntPtr n_GetObject (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Covariant.Returntypes.CovariantPropertyClass __this = global::Java.Lang.Object.GetObject<global::Covariant.Returntypes.CovariantPropertyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.ToLocalJniHandle (__this.Object);
+		}
+#pragma warning restore 0169
+
+		static IntPtr id_getObject;
+		public virtual unsafe global::Java.Lang.Object Object {
+			// Metadata.xml XPath method reference: path="/api/package[@name='covariant.returntypes']/class[@name='CovariantPropertyClass']/method[@name='getObject' and count(parameter)=0]"
+			[Register ("getObject", "()Ljava/lang/Object;", "GetGetObjectHandler")]
+			get {
+				if (id_getObject == IntPtr.Zero)
+					id_getObject = JNIEnv.GetMethodID (class_ref, "getObject", "()Ljava/lang/Object;");
+				try {
+
+					if (((object) this).GetType () == ThresholdType)
+						return global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_getObject), JniHandleOwnership.TransferLocalRef);
+					else
+						return global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallNonvirtualObjectMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "getObject", "()Ljava/lang/Object;")), JniHandleOwnership.TransferLocalRef);
+				} finally {
+				}
+			}
+		}
+
+	}
+}

--- a/tools/generator/Tests/expected/CovariantReturnTypes/Covariant.Returntypes.CovariantPropertyImplementation.cs
+++ b/tools/generator/Tests/expected/CovariantReturnTypes/Covariant.Returntypes.CovariantPropertyImplementation.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Covariant.Returntypes {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='covariant.returntypes']/class[@name='CovariantPropertyImplementation']"
+	[global::Android.Runtime.Register ("covariant/returntypes/CovariantPropertyImplementation", DoNotGenerateAcw=true)]
+	public partial class CovariantPropertyImplementation : global::Java.Lang.Object, global::Covariant.Returntypes.ICovariantPropertyInterface {
+
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("covariant/returntypes/CovariantPropertyImplementation", ref java_class_handle);
+			}
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (CovariantPropertyImplementation); }
+		}
+
+		protected CovariantPropertyImplementation (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		static IntPtr id_ctor;
+		// Metadata.xml XPath constructor reference: path="/api/package[@name='covariant.returntypes']/class[@name='CovariantPropertyImplementation']/constructor[@name='CovariantPropertyImplementation' and count(parameter)=0]"
+		[Register (".ctor", "()V", "")]
+		public unsafe CovariantPropertyImplementation ()
+			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		{
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+				return;
+
+			try {
+				if (((object) this).GetType () != typeof (CovariantPropertyImplementation)) {
+					SetHandle (
+							global::Android.Runtime.JNIEnv.StartCreateInstance (((object) this).GetType (), "()V"),
+							JniHandleOwnership.TransferLocalRef);
+					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "()V");
+					return;
+				}
+
+				if (id_ctor == IntPtr.Zero)
+					id_ctor = JNIEnv.GetMethodID (class_ref, "<init>", "()V");
+				SetHandle (
+						global::Android.Runtime.JNIEnv.StartCreateInstance (class_ref, id_ctor),
+						JniHandleOwnership.TransferLocalRef);
+				JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, class_ref, id_ctor);
+			} finally {
+			}
+		}
+
+		static Delegate cb_getObject;
+#pragma warning disable 0169
+		static Delegate GetGetObjectHandler ()
+		{
+			if (cb_getObject == null)
+				cb_getObject = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_GetObject);
+			return cb_getObject;
+		}
+
+		static IntPtr n_GetObject (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Covariant.Returntypes.CovariantPropertyImplementation __this = global::Java.Lang.Object.GetObject<global::Covariant.Returntypes.CovariantPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.ToLocalJniHandle (__this.Object);
+		}
+#pragma warning restore 0169
+
+		static IntPtr id_getObject;
+		public virtual unsafe global::Java.Lang.Object Object {
+			// Metadata.xml XPath method reference: path="/api/package[@name='covariant.returntypes']/class[@name='CovariantPropertyImplementation']/method[@name='getObject' and count(parameter)=0]"
+			[Register ("getObject", "()Ljava/lang/String;", "GetGetObjectHandler")]
+			get {
+				if (id_getObject == IntPtr.Zero)
+					id_getObject = JNIEnv.GetMethodID (class_ref, "getObject", "()Ljava/lang/String;");
+				try {
+
+					if (((object) this).GetType () == ThresholdType)
+						return JNIEnv.GetString (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_getObject), JniHandleOwnership.TransferLocalRef);
+					else
+						return JNIEnv.GetString (JNIEnv.CallNonvirtualObjectMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "getObject", "()Ljava/lang/String;")), JniHandleOwnership.TransferLocalRef);
+				} finally {
+				}
+			}
+		}
+
+	}
+}

--- a/tools/generator/Tests/expected/CovariantReturnTypes/Covariant.Returntypes.CovariantPropertySubclass.cs
+++ b/tools/generator/Tests/expected/CovariantReturnTypes/Covariant.Returntypes.CovariantPropertySubclass.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Covariant.Returntypes {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='covariant.returntypes']/class[@name='CovariantPropertySubclass']"
+	[global::Android.Runtime.Register ("covariant/returntypes/CovariantPropertySubclass", DoNotGenerateAcw=true)]
+	public partial class CovariantPropertySubclass : global::Covariant.Returntypes.CovariantPropertyClass {
+
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("covariant/returntypes/CovariantPropertySubclass", ref java_class_handle);
+			}
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (CovariantPropertySubclass); }
+		}
+
+		protected CovariantPropertySubclass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		static IntPtr id_ctor;
+		// Metadata.xml XPath constructor reference: path="/api/package[@name='covariant.returntypes']/class[@name='CovariantPropertySubclass']/constructor[@name='CovariantPropertySubclass' and count(parameter)=0]"
+		[Register (".ctor", "()V", "")]
+		public unsafe CovariantPropertySubclass ()
+			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		{
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+				return;
+
+			try {
+				if (((object) this).GetType () != typeof (CovariantPropertySubclass)) {
+					SetHandle (
+							global::Android.Runtime.JNIEnv.StartCreateInstance (((object) this).GetType (), "()V"),
+							JniHandleOwnership.TransferLocalRef);
+					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "()V");
+					return;
+				}
+
+				if (id_ctor == IntPtr.Zero)
+					id_ctor = JNIEnv.GetMethodID (class_ref, "<init>", "()V");
+				SetHandle (
+						global::Android.Runtime.JNIEnv.StartCreateInstance (class_ref, id_ctor),
+						JniHandleOwnership.TransferLocalRef);
+				JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, class_ref, id_ctor);
+			} finally {
+			}
+		}
+
+		static Delegate cb_getObject;
+#pragma warning disable 0169
+		static Delegate GetGetObjectHandler ()
+		{
+			if (cb_getObject == null)
+				cb_getObject = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_GetObject);
+			return cb_getObject;
+		}
+
+		static IntPtr n_GetObject (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Covariant.Returntypes.CovariantPropertySubclass __this = global::Java.Lang.Object.GetObject<global::Covariant.Returntypes.CovariantPropertySubclass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.ToLocalJniHandle (__this.Object);
+		}
+#pragma warning restore 0169
+
+		static IntPtr id_getObject;
+		public override unsafe global::Java.Lang.Object Object {
+			// Metadata.xml XPath method reference: path="/api/package[@name='covariant.returntypes']/class[@name='CovariantPropertySubclass']/method[@name='getObject' and count(parameter)=0]"
+			[Register ("getObject", "()Ljava/lang/String;", "GetGetObjectHandler")]
+			get {
+				if (id_getObject == IntPtr.Zero)
+					id_getObject = JNIEnv.GetMethodID (class_ref, "getObject", "()Ljava/lang/String;");
+				try {
+
+					if (((object) this).GetType () == ThresholdType)
+						return JNIEnv.GetString (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_getObject), JniHandleOwnership.TransferLocalRef);
+					else
+						return JNIEnv.GetString (JNIEnv.CallNonvirtualObjectMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "getObject", "()Ljava/lang/String;")), JniHandleOwnership.TransferLocalRef);
+				} finally {
+				}
+			}
+		}
+
+	}
+}

--- a/tools/generator/Tests/expected/CovariantReturnTypes/Covariant.Returntypes.CovariantSubclass.cs
+++ b/tools/generator/Tests/expected/CovariantReturnTypes/Covariant.Returntypes.CovariantSubclass.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Covariant.Returntypes {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='covariant.returntypes']/class[@name='CovariantSubclass']"
+	[global::Android.Runtime.Register ("covariant/returntypes/CovariantSubclass", DoNotGenerateAcw=true)]
+	public partial class CovariantSubclass : global::Covariant.Returntypes.CovariantClass {
+
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("covariant/returntypes/CovariantSubclass", ref java_class_handle);
+			}
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (CovariantSubclass); }
+		}
+
+		protected CovariantSubclass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		static IntPtr id_ctor;
+		// Metadata.xml XPath constructor reference: path="/api/package[@name='covariant.returntypes']/class[@name='CovariantSubclass']/constructor[@name='CovariantSubclass' and count(parameter)=0]"
+		[Register (".ctor", "()V", "")]
+		public unsafe CovariantSubclass ()
+			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		{
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+				return;
+
+			try {
+				if (((object) this).GetType () != typeof (CovariantSubclass)) {
+					SetHandle (
+							global::Android.Runtime.JNIEnv.StartCreateInstance (((object) this).GetType (), "()V"),
+							JniHandleOwnership.TransferLocalRef);
+					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "()V");
+					return;
+				}
+
+				if (id_ctor == IntPtr.Zero)
+					id_ctor = JNIEnv.GetMethodID (class_ref, "<init>", "()V");
+				SetHandle (
+						global::Android.Runtime.JNIEnv.StartCreateInstance (class_ref, id_ctor),
+						JniHandleOwnership.TransferLocalRef);
+				JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, class_ref, id_ctor);
+			} finally {
+			}
+		}
+
+		static Delegate cb_someMethod;
+#pragma warning disable 0169
+		static Delegate GetSomeMethodHandler ()
+		{
+			if (cb_someMethod == null)
+				cb_someMethod = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_SomeMethod);
+			return cb_someMethod;
+		}
+
+		static IntPtr n_SomeMethod (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Covariant.Returntypes.CovariantSubclass __this = global::Java.Lang.Object.GetObject<global::Covariant.Returntypes.CovariantSubclass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.ToLocalJniHandle (__this.SomeMethod ());
+		}
+#pragma warning restore 0169
+
+		static IntPtr id_someMethod;
+		// Metadata.xml XPath method reference: path="/api/package[@name='covariant.returntypes']/class[@name='CovariantSubclass']/method[@name='someMethod' and count(parameter)=0]"
+		[Register ("someMethod", "()Ljava/lang/String;", "GetSomeMethodHandler")]
+		public override unsafe global::Java.Lang.Object SomeMethod ()
+		{
+			if (id_someMethod == IntPtr.Zero)
+				id_someMethod = JNIEnv.GetMethodID (class_ref, "someMethod", "()Ljava/lang/String;");
+			try {
+
+				if (((object) this).GetType () == ThresholdType)
+					return JNIEnv.GetString (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_someMethod), JniHandleOwnership.TransferLocalRef);
+				else
+					return JNIEnv.GetString (JNIEnv.CallNonvirtualObjectMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "someMethod", "()Ljava/lang/String;")), JniHandleOwnership.TransferLocalRef);
+			} finally {
+			}
+		}
+
+	}
+}

--- a/tools/generator/Tests/expected/CovariantReturnTypes/Covariant.Returntypes.GenericCovariantImplementation.cs
+++ b/tools/generator/Tests/expected/CovariantReturnTypes/Covariant.Returntypes.GenericCovariantImplementation.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Covariant.Returntypes {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='covariant.returntypes']/class[@name='GenericCovariantImplementation']"
+	[global::Android.Runtime.Register ("covariant/returntypes/GenericCovariantImplementation", DoNotGenerateAcw=true)]
+	public partial class GenericCovariantImplementation : global::Covariant.Returntypes.GenericImplementation {
+
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("covariant/returntypes/GenericCovariantImplementation", ref java_class_handle);
+			}
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (GenericCovariantImplementation); }
+		}
+
+		protected GenericCovariantImplementation (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		static IntPtr id_ctor;
+		// Metadata.xml XPath constructor reference: path="/api/package[@name='covariant.returntypes']/class[@name='GenericCovariantImplementation']/constructor[@name='GenericCovariantImplementation' and count(parameter)=0]"
+		[Register (".ctor", "()V", "")]
+		public unsafe GenericCovariantImplementation ()
+			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		{
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+				return;
+
+			try {
+				if (((object) this).GetType () != typeof (GenericCovariantImplementation)) {
+					SetHandle (
+							global::Android.Runtime.JNIEnv.StartCreateInstance (((object) this).GetType (), "()V"),
+							JniHandleOwnership.TransferLocalRef);
+					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "()V");
+					return;
+				}
+
+				if (id_ctor == IntPtr.Zero)
+					id_ctor = JNIEnv.GetMethodID (class_ref, "<init>", "()V");
+				SetHandle (
+						global::Android.Runtime.JNIEnv.StartCreateInstance (class_ref, id_ctor),
+						JniHandleOwnership.TransferLocalRef);
+				JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, class_ref, id_ctor);
+			} finally {
+			}
+		}
+
+		static Delegate cb_someMethod;
+#pragma warning disable 0169
+		static Delegate GetSomeMethodHandler ()
+		{
+			if (cb_someMethod == null)
+				cb_someMethod = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_SomeMethod);
+			return cb_someMethod;
+		}
+
+		static IntPtr n_SomeMethod (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Covariant.Returntypes.GenericCovariantImplementation __this = global::Java.Lang.Object.GetObject<global::Covariant.Returntypes.GenericCovariantImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.ToLocalJniHandle (__this.SomeMethod ());
+		}
+#pragma warning restore 0169
+
+		static IntPtr id_someMethod;
+		// Metadata.xml XPath method reference: path="/api/package[@name='covariant.returntypes']/class[@name='GenericCovariantImplementation']/method[@name='someMethod' and count(parameter)=0]"
+		[Register ("someMethod", "()Ljava/lang/String;", "GetSomeMethodHandler")]
+		public override unsafe global::Java.Lang.Object SomeMethod ()
+		{
+			if (id_someMethod == IntPtr.Zero)
+				id_someMethod = JNIEnv.GetMethodID (class_ref, "someMethod", "()Ljava/lang/String;");
+			try {
+
+				if (((object) this).GetType () == ThresholdType)
+					return JNIEnv.GetString (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_someMethod), JniHandleOwnership.TransferLocalRef);
+				else
+					return JNIEnv.GetString (JNIEnv.CallNonvirtualObjectMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "someMethod", "()Ljava/lang/String;")), JniHandleOwnership.TransferLocalRef);
+			} finally {
+			}
+		}
+
+	}
+}

--- a/tools/generator/Tests/expected/CovariantReturnTypes/Covariant.Returntypes.GenericImplementation.cs
+++ b/tools/generator/Tests/expected/CovariantReturnTypes/Covariant.Returntypes.GenericImplementation.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Covariant.Returntypes {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='covariant.returntypes']/class[@name='GenericImplementation']"
+	[global::Android.Runtime.Register ("covariant/returntypes/GenericImplementation", DoNotGenerateAcw=true)]
+	public partial class GenericImplementation : global::Java.Lang.Object, global::Covariant.Returntypes.IGenericInterface {
+
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("covariant/returntypes/GenericImplementation", ref java_class_handle);
+			}
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (GenericImplementation); }
+		}
+
+		protected GenericImplementation (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		static IntPtr id_ctor;
+		// Metadata.xml XPath constructor reference: path="/api/package[@name='covariant.returntypes']/class[@name='GenericImplementation']/constructor[@name='GenericImplementation' and count(parameter)=0]"
+		[Register (".ctor", "()V", "")]
+		public unsafe GenericImplementation ()
+			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		{
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+				return;
+
+			try {
+				if (((object) this).GetType () != typeof (GenericImplementation)) {
+					SetHandle (
+							global::Android.Runtime.JNIEnv.StartCreateInstance (((object) this).GetType (), "()V"),
+							JniHandleOwnership.TransferLocalRef);
+					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "()V");
+					return;
+				}
+
+				if (id_ctor == IntPtr.Zero)
+					id_ctor = JNIEnv.GetMethodID (class_ref, "<init>", "()V");
+				SetHandle (
+						global::Android.Runtime.JNIEnv.StartCreateInstance (class_ref, id_ctor),
+						JniHandleOwnership.TransferLocalRef);
+				JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, class_ref, id_ctor);
+			} finally {
+			}
+		}
+
+		static Delegate cb_someMethod;
+#pragma warning disable 0169
+		static Delegate GetSomeMethodHandler ()
+		{
+			if (cb_someMethod == null)
+				cb_someMethod = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_SomeMethod);
+			return cb_someMethod;
+		}
+
+		static IntPtr n_SomeMethod (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Covariant.Returntypes.GenericImplementation __this = global::Java.Lang.Object.GetObject<global::Covariant.Returntypes.GenericImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.ToLocalJniHandle (__this.SomeMethod ());
+		}
+#pragma warning restore 0169
+
+		static IntPtr id_someMethod;
+		// Metadata.xml XPath method reference: path="/api/package[@name='covariant.returntypes']/class[@name='GenericImplementation']/method[@name='someMethod' and count(parameter)=0]"
+		[Register ("someMethod", "()Ljava/lang/Object;", "GetSomeMethodHandler")]
+		public virtual unsafe global::Java.Lang.Object SomeMethod ()
+		{
+			if (id_someMethod == IntPtr.Zero)
+				id_someMethod = JNIEnv.GetMethodID (class_ref, "someMethod", "()Ljava/lang/Object;");
+			try {
+
+				if (((object) this).GetType () == ThresholdType)
+					return global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_someMethod), JniHandleOwnership.TransferLocalRef);
+				else
+					return global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallNonvirtualObjectMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "someMethod", "()Ljava/lang/Object;")), JniHandleOwnership.TransferLocalRef);
+			} finally {
+			}
+		}
+
+		// This method is explicitly implemented as a member of an instantiated Covariant.Returntypes.IGenericInterface
+		global::Java.Lang.Object global::Covariant.Returntypes.IGenericInterface.SomeMethod ()
+		{
+			return global::Java.Interop.JavaObjectExtensions.JavaCast<Java.Lang.Object>(SomeMethod ());
+		}
+
+	}
+}

--- a/tools/generator/Tests/expected/CovariantReturnTypes/Covariant.Returntypes.GenericStringImplementation.cs
+++ b/tools/generator/Tests/expected/CovariantReturnTypes/Covariant.Returntypes.GenericStringImplementation.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Covariant.Returntypes {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='covariant.returntypes']/class[@name='GenericStringImplementation']"
+	[global::Android.Runtime.Register ("covariant/returntypes/GenericStringImplementation", DoNotGenerateAcw=true)]
+	public partial class GenericStringImplementation : global::Java.Lang.Object, global::Covariant.Returntypes.IGenericInterface {
+
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("covariant/returntypes/GenericStringImplementation", ref java_class_handle);
+			}
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (GenericStringImplementation); }
+		}
+
+		protected GenericStringImplementation (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		static IntPtr id_ctor;
+		// Metadata.xml XPath constructor reference: path="/api/package[@name='covariant.returntypes']/class[@name='GenericStringImplementation']/constructor[@name='GenericStringImplementation' and count(parameter)=0]"
+		[Register (".ctor", "()V", "")]
+		public unsafe GenericStringImplementation ()
+			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		{
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+				return;
+
+			try {
+				if (((object) this).GetType () != typeof (GenericStringImplementation)) {
+					SetHandle (
+							global::Android.Runtime.JNIEnv.StartCreateInstance (((object) this).GetType (), "()V"),
+							JniHandleOwnership.TransferLocalRef);
+					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "()V");
+					return;
+				}
+
+				if (id_ctor == IntPtr.Zero)
+					id_ctor = JNIEnv.GetMethodID (class_ref, "<init>", "()V");
+				SetHandle (
+						global::Android.Runtime.JNIEnv.StartCreateInstance (class_ref, id_ctor),
+						JniHandleOwnership.TransferLocalRef);
+				JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, class_ref, id_ctor);
+			} finally {
+			}
+		}
+
+		static Delegate cb_someMethod;
+#pragma warning disable 0169
+		static Delegate GetSomeMethodHandler ()
+		{
+			if (cb_someMethod == null)
+				cb_someMethod = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_SomeMethod);
+			return cb_someMethod;
+		}
+
+		static IntPtr n_SomeMethod (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Covariant.Returntypes.GenericStringImplementation __this = global::Java.Lang.Object.GetObject<global::Covariant.Returntypes.GenericStringImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.NewString (__this.SomeMethod ());
+		}
+#pragma warning restore 0169
+
+		static IntPtr id_someMethod;
+		// Metadata.xml XPath method reference: path="/api/package[@name='covariant.returntypes']/class[@name='GenericStringImplementation']/method[@name='someMethod' and count(parameter)=0]"
+		[Register ("someMethod", "()Ljava/lang/String;", "GetSomeMethodHandler")]
+		public virtual unsafe string SomeMethod ()
+		{
+			if (id_someMethod == IntPtr.Zero)
+				id_someMethod = JNIEnv.GetMethodID (class_ref, "someMethod", "()Ljava/lang/String;");
+			try {
+
+				if (((object) this).GetType () == ThresholdType)
+					return JNIEnv.GetString (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_someMethod), JniHandleOwnership.TransferLocalRef);
+				else
+					return JNIEnv.GetString (JNIEnv.CallNonvirtualObjectMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "someMethod", "()Ljava/lang/String;")), JniHandleOwnership.TransferLocalRef);
+			} finally {
+			}
+		}
+
+		// This method is explicitly implemented as a member of an instantiated Covariant.Returntypes.IGenericInterface
+		global::Java.Lang.Object global::Covariant.Returntypes.IGenericInterface.SomeMethod ()
+		{
+			return SomeMethod ().ToString ();
+		}
+
+	}
+}

--- a/tools/generator/Tests/expected/CovariantReturnTypes/Covariant.Returntypes.ICovariantInterface.cs
+++ b/tools/generator/Tests/expected/CovariantReturnTypes/Covariant.Returntypes.ICovariantInterface.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Covariant.Returntypes {
+
+	// Metadata.xml XPath interface reference: path="/api/package[@name='covariant.returntypes']/interface[@name='CovariantInterface']"
+	[Register ("covariant/returntypes/CovariantInterface", "", "Covariant.Returntypes.ICovariantInterfaceInvoker")]
+	public partial interface ICovariantInterface : IJavaObject {
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='covariant.returntypes']/interface[@name='CovariantInterface']/method[@name='someMethod' and count(parameter)=0]"
+		[Register ("someMethod", "()Ljava/lang/Object;", "GetSomeMethodHandler:Covariant.Returntypes.ICovariantInterfaceInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
+		global::Java.Lang.Object SomeMethod ();
+
+	}
+
+	[global::Android.Runtime.Register ("covariant/returntypes/CovariantInterface", DoNotGenerateAcw=true)]
+	internal class ICovariantInterfaceInvoker : global::Java.Lang.Object, ICovariantInterface {
+
+		static IntPtr java_class_ref = JNIEnv.FindClass ("covariant/returntypes/CovariantInterface");
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (ICovariantInterfaceInvoker); }
+		}
+
+		new IntPtr class_ref;
+
+		public static ICovariantInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
+		{
+			return global::Java.Lang.Object.GetObject<ICovariantInterface> (handle, transfer);
+		}
+
+		static IntPtr Validate (IntPtr handle)
+		{
+			if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
+				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
+							JNIEnv.GetClassNameFromInstance (handle), "covariant.returntypes.CovariantInterface"));
+			return handle;
+		}
+
+		protected override void Dispose (bool disposing)
+		{
+			if (this.class_ref != IntPtr.Zero)
+				JNIEnv.DeleteGlobalRef (this.class_ref);
+			this.class_ref = IntPtr.Zero;
+			base.Dispose (disposing);
+		}
+
+		public ICovariantInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
+		{
+			IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
+			this.class_ref = JNIEnv.NewGlobalRef (local_ref);
+			JNIEnv.DeleteLocalRef (local_ref);
+		}
+
+		static Delegate cb_someMethod;
+#pragma warning disable 0169
+		static Delegate GetSomeMethodHandler ()
+		{
+			if (cb_someMethod == null)
+				cb_someMethod = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_SomeMethod);
+			return cb_someMethod;
+		}
+
+		static IntPtr n_SomeMethod (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Covariant.Returntypes.ICovariantInterface __this = global::Java.Lang.Object.GetObject<global::Covariant.Returntypes.ICovariantInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.ToLocalJniHandle (__this.SomeMethod ());
+		}
+#pragma warning restore 0169
+
+		IntPtr id_someMethod;
+		public unsafe global::Java.Lang.Object SomeMethod ()
+		{
+			if (id_someMethod == IntPtr.Zero)
+				id_someMethod = JNIEnv.GetMethodID (class_ref, "someMethod", "()Ljava/lang/Object;");
+			return global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_someMethod), JniHandleOwnership.TransferLocalRef);
+		}
+
+	}
+
+}

--- a/tools/generator/Tests/expected/CovariantReturnTypes/Covariant.Returntypes.ICovariantPropertyInterface.cs
+++ b/tools/generator/Tests/expected/CovariantReturnTypes/Covariant.Returntypes.ICovariantPropertyInterface.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Covariant.Returntypes {
+
+	// Metadata.xml XPath interface reference: path="/api/package[@name='covariant.returntypes']/interface[@name='CovariantPropertyInterface']"
+	[Register ("covariant/returntypes/CovariantPropertyInterface", "", "Covariant.Returntypes.ICovariantPropertyInterfaceInvoker")]
+	public partial interface ICovariantPropertyInterface : IJavaObject {
+
+		global::Java.Lang.Object Object {
+			// Metadata.xml XPath method reference: path="/api/package[@name='covariant.returntypes']/interface[@name='CovariantPropertyInterface']/method[@name='getObject' and count(parameter)=0]"
+			[Register ("getObject", "()Ljava/lang/Object;", "GetGetObjectHandler:Covariant.Returntypes.ICovariantPropertyInterfaceInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")] get;
+		}
+
+	}
+
+	[global::Android.Runtime.Register ("covariant/returntypes/CovariantPropertyInterface", DoNotGenerateAcw=true)]
+	internal class ICovariantPropertyInterfaceInvoker : global::Java.Lang.Object, ICovariantPropertyInterface {
+
+		static IntPtr java_class_ref = JNIEnv.FindClass ("covariant/returntypes/CovariantPropertyInterface");
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (ICovariantPropertyInterfaceInvoker); }
+		}
+
+		new IntPtr class_ref;
+
+		public static ICovariantPropertyInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
+		{
+			return global::Java.Lang.Object.GetObject<ICovariantPropertyInterface> (handle, transfer);
+		}
+
+		static IntPtr Validate (IntPtr handle)
+		{
+			if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
+				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
+							JNIEnv.GetClassNameFromInstance (handle), "covariant.returntypes.CovariantPropertyInterface"));
+			return handle;
+		}
+
+		protected override void Dispose (bool disposing)
+		{
+			if (this.class_ref != IntPtr.Zero)
+				JNIEnv.DeleteGlobalRef (this.class_ref);
+			this.class_ref = IntPtr.Zero;
+			base.Dispose (disposing);
+		}
+
+		public ICovariantPropertyInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
+		{
+			IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
+			this.class_ref = JNIEnv.NewGlobalRef (local_ref);
+			JNIEnv.DeleteLocalRef (local_ref);
+		}
+
+		static Delegate cb_getObject;
+#pragma warning disable 0169
+		static Delegate GetGetObjectHandler ()
+		{
+			if (cb_getObject == null)
+				cb_getObject = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_GetObject);
+			return cb_getObject;
+		}
+
+		static IntPtr n_GetObject (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Covariant.Returntypes.ICovariantPropertyInterface __this = global::Java.Lang.Object.GetObject<global::Covariant.Returntypes.ICovariantPropertyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.ToLocalJniHandle (__this.Object);
+		}
+#pragma warning restore 0169
+
+		IntPtr id_getObject;
+		public unsafe global::Java.Lang.Object Object {
+			get {
+				if (id_getObject == IntPtr.Zero)
+					id_getObject = JNIEnv.GetMethodID (class_ref, "getObject", "()Ljava/lang/Object;");
+				return global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_getObject), JniHandleOwnership.TransferLocalRef);
+			}
+		}
+
+	}
+
+}

--- a/tools/generator/Tests/expected/CovariantReturnTypes/Covariant.Returntypes.IGenericInterface.cs
+++ b/tools/generator/Tests/expected/CovariantReturnTypes/Covariant.Returntypes.IGenericInterface.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Covariant.Returntypes {
+
+	// Metadata.xml XPath interface reference: path="/api/package[@name='covariant.returntypes']/interface[@name='GenericInterface']"
+	[Register ("covariant/returntypes/GenericInterface", "", "Covariant.Returntypes.IGenericInterfaceInvoker")]
+	[global::Java.Interop.JavaTypeParameters (new string [] {"T"})]
+	public partial interface IGenericInterface : IJavaObject {
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='covariant.returntypes']/interface[@name='GenericInterface']/method[@name='someMethod' and count(parameter)=0]"
+		[Register ("someMethod", "()Ljava/lang/Object;", "GetSomeMethodHandler:Covariant.Returntypes.IGenericInterfaceInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
+		global::Java.Lang.Object SomeMethod ();
+
+	}
+
+	[global::Android.Runtime.Register ("covariant/returntypes/GenericInterface", DoNotGenerateAcw=true)]
+	internal class IGenericInterfaceInvoker : global::Java.Lang.Object, IGenericInterface {
+
+		static IntPtr java_class_ref = JNIEnv.FindClass ("covariant/returntypes/GenericInterface");
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (IGenericInterfaceInvoker); }
+		}
+
+		new IntPtr class_ref;
+
+		public static IGenericInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
+		{
+			return global::Java.Lang.Object.GetObject<IGenericInterface> (handle, transfer);
+		}
+
+		static IntPtr Validate (IntPtr handle)
+		{
+			if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
+				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
+							JNIEnv.GetClassNameFromInstance (handle), "covariant.returntypes.GenericInterface"));
+			return handle;
+		}
+
+		protected override void Dispose (bool disposing)
+		{
+			if (this.class_ref != IntPtr.Zero)
+				JNIEnv.DeleteGlobalRef (this.class_ref);
+			this.class_ref = IntPtr.Zero;
+			base.Dispose (disposing);
+		}
+
+		public IGenericInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
+		{
+			IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
+			this.class_ref = JNIEnv.NewGlobalRef (local_ref);
+			JNIEnv.DeleteLocalRef (local_ref);
+		}
+
+		static Delegate cb_someMethod;
+#pragma warning disable 0169
+		static Delegate GetSomeMethodHandler ()
+		{
+			if (cb_someMethod == null)
+				cb_someMethod = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_SomeMethod);
+			return cb_someMethod;
+		}
+
+		static IntPtr n_SomeMethod (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Covariant.Returntypes.IGenericInterface __this = global::Java.Lang.Object.GetObject<global::Covariant.Returntypes.IGenericInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.ToLocalJniHandle (__this.SomeMethod ());
+		}
+#pragma warning restore 0169
+
+		IntPtr id_someMethod;
+		public unsafe global::Java.Lang.Object SomeMethod ()
+		{
+			if (id_someMethod == IntPtr.Zero)
+				id_someMethod = JNIEnv.GetMethodID (class_ref, "someMethod", "()Ljava/lang/Object;");
+			return (Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_someMethod), JniHandleOwnership.TransferLocalRef);
+		}
+
+	}
+
+}

--- a/tools/generator/Tests/expected/CovariantReturnTypes/CovariantReturnTypes.xml
+++ b/tools/generator/Tests/expected/CovariantReturnTypes/CovariantReturnTypes.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="utf-8"?>
+<api>
+	<package name="java.lang">
+		<class abstract="false" deprecated="not deprecated" final="false" name="Object" static="false" visibility="public">
+		</class>
+		<class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object"
+			final="false" name="String" static="false" visibility="public">
+		</class>
+	</package>
+	<package name="covariant.returntypes">
+		<!--
+			public interface CovariantInterface {
+				Object someMethod();
+			}
+		-->
+		<interface abstract="true" deprecated="not deprecated" final="false" name="CovariantInterface" static="false" visibility="public">
+			<method abstract="true" deprecated="not deprecated" final="false" name="someMethod" native="false" return="java.lang.Object" static="false" synchronized="false" visibility="public">
+			</method>
+		</interface>
+		<!--
+			public class CovariantInterfaceImplementation implements CovariantInterface {
+				@Override
+				String someMethod();
+			}
+		-->
+		<class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="false" name="CovariantInterfaceImplementation" static="false" visibility="public">
+			<implements name="covariant.returntypes.CovariantInterface" name-generic-aware="covariant.returntypes.CovariantInterface" />
+			<constructor deprecated="not deprecated" final="false" name="CovariantInterfaceImplementation" static="false" visibility="public" />
+			<method abstract="false" deprecated="not deprecated" final="false" name="someMethod" native="false" return="java.lang.String" static="false" synchronized="false" visibility="public">
+			</method>
+		</class>
+		<!--
+			public class CovariantClass {
+				Object someMethod();
+			}
+		-->
+		<class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="false" name="CovariantClass" static="false" visibility="public">
+			<method abstract="false" deprecated="not deprecated" final="false" name="someMethod" native="false" return="java.lang.Object" static="false" synchronized="false" visibility="public">
+			</method>
+		</class>
+		<!--
+			public class CovariantSubclass extends CovariantClass {
+				@Override
+				String someMethod();
+			}
+		-->
+		<class abstract="false" deprecated="not deprecated" extends="covariant.returntypes.CovariantClass" extends-generic-aware="covariant.returntypes.CovariantClass" final="false" name="CovariantSubclass" static="false" visibility="public">
+			<constructor deprecated="not deprecated" final="false" name="CovariantSubclass" static="false" visibility="public" />
+			<method abstract="false" deprecated="not deprecated" final="false" name="someMethod" native="false" return="java.lang.String" static="false" synchronized="false" visibility="public">
+			</method>
+		</class>
+		<!--
+			public interface CovariantPropertyInterface {
+				Object getObject();
+			}
+		-->
+		<interface abstract="true" deprecated="not deprecated" final="false" name="CovariantPropertyInterface" static="false" visibility="public">
+			<method abstract="true" deprecated="not deprecated" final="false" name="getObject" native="false" return="java.lang.Object" static="false" synchronized="false" visibility="public">
+			</method>
+		</interface>
+		<!--
+			public class CovariantPropertyImplementation implements CovariantPropertyInterface {
+				@Override
+				String getObject();
+			}
+		-->
+		<class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="false" name="CovariantPropertyImplementation" static="false" visibility="public">
+			<implements name="covariant.returntypes.CovariantPropertyInterface" name-generic-aware="covariant.returntypes.CovariantPropertyInterface" />
+			<constructor deprecated="not deprecated" final="false" name="CovariantPropertyImplementation" static="false" visibility="public" />
+			<method abstract="false" deprecated="not deprecated" final="false" name="getObject" native="false" return="java.lang.String" static="false" synchronized="false" visibility="public">
+			</method>
+		</class>
+		<!--
+			public class CovariantPropertyClass {
+				Object getObject();
+			}
+		-->
+		<class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="false" name="CovariantPropertyClass" static="false" visibility="public">
+			<method abstract="false" deprecated="not deprecated" final="false" name="getObject" native="false" return="java.lang.Object" static="false" synchronized="false" visibility="public">
+			</method>
+		</class>
+		<!--
+			public class CovariantPropertySubclass extends CovariantPropertyClass {
+				@Override
+				String getObject();
+			}
+		-->
+		<class abstract="false" deprecated="not deprecated" extends="covariant.returntypes.CovariantPropertyClass" extends-generic-aware="covariant.returntypes.CovariantPropertyClass" final="false" name="CovariantPropertySubclass" static="false" visibility="public">
+			<constructor deprecated="not deprecated" final="false" name="CovariantInterfaceImplementation" static="false" visibility="public" />
+			<method abstract="false" deprecated="not deprecated" final="false" name="getObject" native="false" return="java.lang.String" static="false" synchronized="false" visibility="public">
+			</method>
+		</class>
+		<!-- 
+			public interface GenericInterface<T> {
+				T someMethod();
+			}
+		-->
+		<interface abstract="true" deprecated="not deprecated" final="false" name="GenericInterface" static="false" visibility="public">
+			<typeParameters>
+				<typeParameter name="T" classBound="java.lang.Object" interfaceBounds="" />
+			</typeParameters>
+			<method abstract="true" deprecated="not deprecated" final="false" name="someMethod" native="false" return="T" static="false" synchronized="false" visibility="public">
+			</method>
+		</interface>
+		<!--
+			public class GenericImplementation implements GenericInterface<Object> {
+				@Override
+				public Object someMethod();
+			}
+		-->
+		<class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="false" name="GenericImplementation" static="false" visibility="public">
+			<implements name="covariant.returntypes.GenericInterface" name-generic-aware="covariant.returntypes.GenericInterface&lt;java.lang.Object&gt;" />
+			<constructor deprecated="not deprecated" final="false" name="GenericImplementation" static="false" visibility="public" />
+			<method abstract="false" deprecated="not deprecated" final="false" name="someMethod" native="false" return="java.lang.Object" static="false" synchronized="false" visibility="public">
+			</method>
+		</class>
+		<!--
+			public class GenericStringImplementation implements GenericInterface<String> {
+				@Override
+				public String someMethod();
+			}
+		-->
+		<class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="false" name="GenericStringImplementation" static="false" visibility="public">
+			<implements name="covariant.returntypes.GenericInterface" name-generic-aware="covariant.returntypes.GenericInterface&lt;java.lang.String&gt;" />
+			<constructor deprecated="not deprecated" final="false" name="GenericStringImplementation" static="false" visibility="public" />
+			<method abstract="false" deprecated="not deprecated" final="false" name="someMethod" native="false" return="java.lang.String" static="false" synchronized="false" visibility="public">
+			</method>
+		</class>
+		<!--
+			public class GenericCovariantImplementation extends GenericImplementation {
+				@Override
+				public String someMethod();
+			}
+		-->
+		<class abstract="false" deprecated="not deprecated" extends="covariant.returntypes.GenericImplementation" extends-generic-aware="covariant.returntypes.GenericImplementation" final="false" name="GenericCovariantImplementation" static="false" visibility="public">
+			<constructor deprecated="not deprecated" final="false" name="GenericCovariantImplementation" static="false" visibility="public" />
+			<method abstract="false" deprecated="not deprecated" final="false" name="someMethod" native="false" return="java.lang.String" static="false" synchronized="false" visibility="public">
+			</method>
+		</class>
+	</package>
+</api>

--- a/tools/generator/Tests/generator-Tests.csproj
+++ b/tools/generator/Tests/generator-Tests.csproj
@@ -65,6 +65,7 @@
     <Compile Include="CSharpKeywords.cs" />
     <Compile Include="GenericArguments.cs" />
     <Compile Include="InterfaceMethodsConflict.cs" />
+    <Compile Include="CovariantReturnTypes.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
Java has the ability to define a method, `Object getObject()` and then
change the return type to `String getObject()` in an overridden method.
This is *not* possible in C#, so cases like this cause the generator to
create invalid C# code.

My current thoughts to fix this are:
- Look for “covariant return types” on interfaces and base classes via
a `IsCovariantOverride` method
- `IsCovariant` is held true if: neither are generic, have the same
method name, have a different return type, and the signature of the
parameters is the same.
- If a covariant return value is found, override `RetVal.FullName`
with the `ReturnType` of the base method.
- Also need to set a new override/callback, so that the base method's
`RetVal.ToNative` can be called. Otherwise, the wrong code is generated
for the `return` statement.
- Include test cases for covariance, and hope we have enough test
coverage to show if this breaks anything

Other changes:
- Removed unused `Method owner` parameter from `ReturnValue` type