### PR TITLE
[generator] fix C# compiler warning in every Invoker

### DIFF
--- a/tools/generator/InterfaceGen.cs
+++ b/tools/generator/InterfaceGen.cs
@@ -224,7 +224,7 @@ namespace MonoDroid.Generation {
 			sw.WriteLine ("{0}internal class {1}Invoker : global::Java.Lang.Object, {1} {{", indent, Name);
 			sw.WriteLine ();
 			opt.CodeGenerator.WriteInterfaceInvokerHandle (this, sw, indent + "\t", opt, Name + "Invoker");
-			sw.WriteLine ("{0}\tIntPtr class_ref;", indent);
+			sw.WriteLine ("{0}\tnew IntPtr class_ref;", indent);
 			sw.WriteLine ();
 			sw.WriteLine ("{0}\tpublic static {1} GetObject (IntPtr handle, JniHandleOwnership transfer)", indent, Name);
 			sw.WriteLine ("{0}\t{{", indent);

--- a/tools/generator/Tests/BaseGeneratorTest.cs
+++ b/tools/generator/Tests/BaseGeneratorTest.cs
@@ -30,6 +30,7 @@ namespace generatortests
 		protected CodeGeneratorOptions Options = null;
 		protected Assembly BuiltAssembly = null;
 		protected List<string> AdditionalSourceDirectories;
+		protected bool AllowWarnings;
 
 		public void Execute ()
 		{
@@ -41,7 +42,7 @@ namespace generatortests
 			bool    hasErrors;
 			string  compilerOutput;
 			BuiltAssembly = Compiler.Compile (Options, "Mono.Android", AdditionalSourceDirectories,
-				out hasErrors, out compilerOutput);
+				out hasErrors, out compilerOutput, AllowWarnings);
 			Assert.AreEqual (false, hasErrors, compilerOutput);
 			Assert.IsNotNull (BuiltAssembly);
 		}

--- a/tools/generator/Tests/Compiler.cs
+++ b/tools/generator/Tests/Compiler.cs
@@ -33,7 +33,7 @@ namespace generatortests
 
 		public static Assembly Compile (Xamarin.Android.Binder.CodeGeneratorOptions options,
 			string assemblyFileName, IEnumerable<string> AdditionalSourceDirectories,
-			out bool hasErrors, out string output)
+			out bool hasErrors, out string output, bool allowWarnings)
 		{
 			var generatedCodePath = options.ManagedCallableWrapperSourceOutputDirectory;
 			var sourceFiles = Directory.EnumerateFiles (generatedCodePath, "*.cs",
@@ -73,7 +73,7 @@ namespace generatortests
 				hasErrors = false;
 
 				foreach (CompilerError message in results.Errors) {
-					hasErrors = hasErrors || (!message.IsWarning);
+					hasErrors |= !message.IsWarning || !allowWarnings;
 				}
 				output = string.Join (Environment.NewLine, results.Output.Cast<string> ());
 

--- a/tools/generator/Tests/Interfaces.cs
+++ b/tools/generator/Tests/Interfaces.cs
@@ -9,6 +9,7 @@ namespace generatortests
 		[Test]
 		public void Generated_OK ()
 		{
+			AllowWarnings = true;
 			RunAllTargets (
 					outputRelativePath:     "TestInterface",
 					apiDescriptionFile:     "expected/TestInterface/TestInterface.xml",

--- a/tools/generator/Tests/NormalMethods.cs
+++ b/tools/generator/Tests/NormalMethods.cs
@@ -9,6 +9,7 @@ namespace generatortests
 		[Test]
 		public void GeneratedOK ()
 		{
+			AllowWarnings = true;
 			RunAllTargets (
 					outputRelativePath:     "NormalMethods",
 					apiDescriptionFile:     "expected/NormalMethods/NormalMethods.xml",

--- a/tools/generator/Tests/expected.ji/Adapters/Xamarin.Test.IAdapter.cs
+++ b/tools/generator/Tests/expected.ji/Adapters/Xamarin.Test.IAdapter.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Test {
 			get { return _members.ManagedPeerType; }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static IAdapter GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected.ji/Adapters/Xamarin.Test.ISpinnerAdapter.cs
+++ b/tools/generator/Tests/expected.ji/Adapters/Xamarin.Test.ISpinnerAdapter.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Test {
 			get { return _members.ManagedPeerType; }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static ISpinnerAdapter GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected.ji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
+++ b/tools/generator/Tests/expected.ji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
@@ -37,7 +37,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 			get { return _members.ManagedPeerType; }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static IExoMediaDrmOnEventListener GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{
@@ -217,7 +217,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 			get { return _members.ManagedPeerType; }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static IExoMediaDrm GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected.ji/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
+++ b/tools/generator/Tests/expected.ji/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
@@ -44,7 +44,7 @@ namespace Xamarin.Test {
 					get { return _members.ManagedPeerType; }
 				}
 
-				IntPtr class_ref;
+				new IntPtr class_ref;
 
 				public static IFactory GetObject (IntPtr handle, JniHandleOwnership transfer)
 				{

--- a/tools/generator/Tests/expected.ji/TestInterface/Test.ME.IGenericInterface.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Test.ME.IGenericInterface.cs
@@ -37,7 +37,7 @@ namespace Test.ME {
 			get { return _members.ManagedPeerType; }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static IGenericInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected.ji/TestInterface/Test.ME.ITestInterface.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Test.ME.ITestInterface.cs
@@ -98,7 +98,7 @@ namespace Test.ME {
 			get { return _members.ManagedPeerType; }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static ITestInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected.ji/java.lang.Enum/Java.Lang.IComparable.cs
+++ b/tools/generator/Tests/expected.ji/java.lang.Enum/Java.Lang.IComparable.cs
@@ -37,7 +37,7 @@ namespace Java.Lang {
 			get { return _members.ManagedPeerType; }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static IComparable GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected/Adapters/Xamarin.Test.IAdapter.cs
+++ b/tools/generator/Tests/expected/Adapters/Xamarin.Test.IAdapter.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Test {
 			get { return typeof (IAdapterInvoker); }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static IAdapter GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected/Adapters/Xamarin.Test.ISpinnerAdapter.cs
+++ b/tools/generator/Tests/expected/Adapters/Xamarin.Test.ISpinnerAdapter.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Test {
 			get { return typeof (ISpinnerAdapterInvoker); }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static ISpinnerAdapter GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
+++ b/tools/generator/Tests/expected/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
@@ -28,7 +28,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 			get { return typeof (IExoMediaDrmOnEventListenerInvoker); }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static IExoMediaDrmOnEventListener GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{
@@ -200,7 +200,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 			get { return typeof (IExoMediaDrmInvoker); }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static IExoMediaDrm GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
+++ b/tools/generator/Tests/expected/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
@@ -35,7 +35,7 @@ namespace Xamarin.Test {
 					get { return typeof (IFactoryInvoker); }
 				}
 
-				IntPtr class_ref;
+				new IntPtr class_ref;
 
 				public static IFactory GetObject (IntPtr handle, JniHandleOwnership transfer)
 				{

--- a/tools/generator/Tests/expected/TestInterface/Test.ME.IGenericInterface.cs
+++ b/tools/generator/Tests/expected/TestInterface/Test.ME.IGenericInterface.cs
@@ -28,7 +28,7 @@ namespace Test.ME {
 			get { return typeof (IGenericInterfaceInvoker); }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static IGenericInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected/TestInterface/Test.ME.ITestInterface.cs
+++ b/tools/generator/Tests/expected/TestInterface/Test.ME.ITestInterface.cs
@@ -90,7 +90,7 @@ namespace Test.ME {
 			get { return typeof (ITestInterfaceInvoker); }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static ITestInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected/java.lang.Enum/Java.Lang.IComparable.cs
+++ b/tools/generator/Tests/expected/java.lang.Enum/Java.Lang.IComparable.cs
@@ -28,7 +28,7 @@ namespace Java.Lang {
 			get { return typeof (IComparableInvoker); }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static IComparable GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{


### PR DESCRIPTION
Context: https://github.com/xamarin/AndroidSupportComponents

When compiling the Xamarin support libraries from source, its binding
projects generate thousands of warnings. Most of these warnings are
noise that could be fixed, and `generator` is just overdue for some
improvement.

My first steps to improve this:
- By default `generator-Tests` should fail if there is a C# compiler
warning
- Add an `AllowWarnings` option for `BaseGeneratorTest`, since there
are a few tests that generate C# compiler warnings that aren’t
addressed yet. The hope is this feature could be dropped from the tests
eventually.
- Fix the most common warning: `Invoker` types have a warning of a
missing `new` keyword on the generated `class_ref` field

Since `Java.Lang.Object` has a static `class_ref` property, all `Invoker`
types will produce this warning. An `Invoker` is generated for any
`interface` or `abstract` class, so you can see how a large binding
project could run into this warning many times.