### PR TITLE
[generator] explicitly implemented properties for generic interfaces

### DIFF
--- a/tools/generator/ClassGen.cs
+++ b/tools/generator/ClassGen.cs
@@ -471,9 +471,26 @@ namespace MonoDroid.Generation {
 					GenericSymbol gs = isym as GenericSymbol;
 					if (gs.IsConcrete) {
 						// FIXME: not sure if excluding default methods is a valid idea...
-						foreach (Method m in gs.Gen.Methods.Where (m => !m.IsInterfaceDefaultMethod && !m.IsStatic))
+						foreach (Method m in gs.Gen.Methods) {
+							if (m.IsInterfaceDefaultMethod || m.IsStatic)
+								continue;
 							if (m.IsGeneric)
 								m.GenerateExplicitIface (sw, indent + "\t", opt, gs);
+						}
+
+						var adapter = gs.Gen.AssemblyQualifiedName + "Invoker";
+						foreach (Property p in gs.Gen.Properties) {
+							if (p.Getter != null) {
+								if (p.Getter.IsInterfaceDefaultMethod || p.Getter.IsStatic)
+									continue;
+							}
+							if (p.Setter != null) {
+								if (p.Setter.IsInterfaceDefaultMethod || p.Setter.IsStatic)
+									continue;
+							}
+							if (p.IsGeneric)
+								p.GenerateExplicitIface (sw, indent + "\t", opt, gs, adapter);
+						}
 					}
 				} else if (isym.FullName == "Java.Lang.ICharSequence")
 					is_char_seq = true;

--- a/tools/generator/JavaInteropCodeGenerator.cs
+++ b/tools/generator/JavaInteropCodeGenerator.cs
@@ -56,7 +56,7 @@ namespace MonoDroid.Generation {
 
 		internal override void WriteClassHandle (InterfaceGen type, StreamWriter sw, string indent, CodeGenerationOptions opt, string declaringType)
 		{
-			sw.WriteLine ("{0}static JniPeerMembers _members = new JniPeerMembers (\"{1}\", typeof ({2}));",indent, type.RawJniName, declaringType);
+			sw.WriteLine ("{0}new static JniPeerMembers _members = new JniPeerMembers (\"{1}\", typeof ({2}));",indent, type.RawJniName, declaringType);
 		}
 
 		internal override void WriteClassInvokerHandle (ClassGen type, StreamWriter sw, string indent, CodeGenerationOptions opt, string declaringType)

--- a/tools/generator/Method.cs
+++ b/tools/generator/Method.cs
@@ -817,7 +817,8 @@ namespace MonoDroid.Generation {
 			sw.WriteLine ("{0}}}", indent);
 			sw.WriteLine ();
 
-			if (gen_string_overload || gen_as_formatted)
+			//NOTE: Invokers are the only place false is passed for generate_callbacks, they do not need string overloads
+			if (generate_callbacks && (gen_string_overload || gen_as_formatted))
 				GenerateStringOverload (sw, indent, opt);
 
 			GenerateAsyncWrapper (sw, indent, opt);

--- a/tools/generator/Parameter.cs
+++ b/tools/generator/Parameter.cs
@@ -55,6 +55,11 @@ namespace MonoDroid.Generation {
 			get { return sym.GetGenericType (null) ?? Type; }
 		}
 
+		public string GetGenericType (Dictionary<string, string> mappings)
+		{
+			return sym.GetGenericType (mappings) ?? Type;
+		}
+
 		public bool IsArray {
 			get { return sym.IsArray; }
 		}

--- a/tools/generator/Tests/Interfaces.cs
+++ b/tools/generator/Tests/Interfaces.cs
@@ -9,7 +9,6 @@ namespace generatortests
 		[Test]
 		public void Generated_OK ()
 		{
-			AllowWarnings = true;
 			RunAllTargets (
 					outputRelativePath:     "TestInterface",
 					apiDescriptionFile:     "expected/TestInterface/TestInterface.xml",

--- a/tools/generator/Tests/expected.ji/TestInterface/Java.Lang.String.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Java.Lang.String.cs
@@ -7,7 +7,7 @@ namespace Java.Lang {
 
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='String']"
 	[global::Android.Runtime.Register ("java/lang/String", DoNotGenerateAcw=true)]
-	public partial class String : global::Java.Lang.Object {
+	public sealed partial class String : global::Java.Lang.Object {
 
 		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/String", typeof (String));
 		internal static new IntPtr class_ref {
@@ -28,7 +28,7 @@ namespace Java.Lang {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected String (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		internal String (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
 
 	}
 }

--- a/tools/generator/Tests/expected.ji/TestInterface/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/TestInterface/Mono.Android.projitems
@@ -9,8 +9,11 @@
     <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.String.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Test.ME.GenericImplementation.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Test.ME.GenericObjectPropertyImplementation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Test.ME.GenericStringImplementation.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Test.ME.GenericStringPropertyImplementation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Test.ME.IGenericInterface.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Test.ME.IGenericPropertyInterface.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Test.ME.ITestInterface.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Test.ME.TestInterfaceImplementation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />

--- a/tools/generator/Tests/expected.ji/TestInterface/Test.ME.GenericObjectPropertyImplementation.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Test.ME.GenericObjectPropertyImplementation.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Test.ME {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='test.me']/class[@name='GenericObjectPropertyImplementation']"
+	[global::Android.Runtime.Register ("test/me/GenericObjectPropertyImplementation", DoNotGenerateAcw=true)]
+	public partial class GenericObjectPropertyImplementation : global::Java.Lang.Object, global::Test.ME.IGenericPropertyInterface {
+
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("test/me/GenericObjectPropertyImplementation", typeof (GenericObjectPropertyImplementation));
+		internal static new IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+		protected GenericObjectPropertyImplementation (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		// Metadata.xml XPath constructor reference: path="/api/package[@name='test.me']/class[@name='GenericObjectPropertyImplementation']/constructor[@name='GenericObjectPropertyImplementation' and count(parameter)=0]"
+		[Register (".ctor", "()V", "")]
+		public unsafe GenericObjectPropertyImplementation ()
+			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		{
+			const string __id = "()V";
+
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+				return;
+
+			try {
+				var __r = _members.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), null);
+				SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
+				_members.InstanceMethods.FinishCreateInstance (__id, this, null);
+			} finally {
+			}
+		}
+
+		static Delegate cb_getObject;
+#pragma warning disable 0169
+		static Delegate GetGetObjectHandler ()
+		{
+			if (cb_getObject == null)
+				cb_getObject = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_GetObject);
+			return cb_getObject;
+		}
+
+		static IntPtr n_GetObject (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Test.ME.GenericObjectPropertyImplementation __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericObjectPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.ToLocalJniHandle (__this.Object);
+		}
+#pragma warning restore 0169
+
+		static Delegate cb_setObject_Ljava_lang_Object_;
+#pragma warning disable 0169
+		static Delegate GetSetObject_Ljava_lang_Object_Handler ()
+		{
+			if (cb_setObject_Ljava_lang_Object_ == null)
+				cb_setObject_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr, IntPtr>) n_SetObject_Ljava_lang_Object_);
+			return cb_setObject_Ljava_lang_Object_;
+		}
+
+		static void n_SetObject_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
+		{
+			global::Test.ME.GenericObjectPropertyImplementation __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericObjectPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			global::Java.Lang.Object value = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_value, JniHandleOwnership.DoNotTransfer);
+			__this.Object = value;
+		}
+#pragma warning restore 0169
+
+		public virtual unsafe global::Java.Lang.Object Object {
+			// Metadata.xml XPath method reference: path="/api/package[@name='test.me']/class[@name='GenericObjectPropertyImplementation']/method[@name='getObject' and count(parameter)=0]"
+			[Register ("getObject", "()Ljava/lang/Object;", "GetGetObjectHandler")]
+			get {
+				const string __id = "getObject.()Ljava/lang/Object;";
+				try {
+					var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, null);
+					return global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+				} finally {
+				}
+			}
+			// Metadata.xml XPath method reference: path="/api/package[@name='test.me']/class[@name='GenericObjectPropertyImplementation']/method[@name='setObject' and count(parameter)=1 and parameter[1][@type='java.lang.Object']]"
+			[Register ("setObject", "(Ljava/lang/Object;)V", "GetSetObject_Ljava_lang_Object_Handler")]
+			set {
+				const string __id = "setObject.(Ljava/lang/Object;)V";
+				try {
+					JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+					__args [0] = new JniArgumentValue ((value == null) ? IntPtr.Zero : ((global::Java.Lang.Object) value).Handle);
+					_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, __args);
+				} finally {
+				}
+			}
+		}
+
+	}
+}

--- a/tools/generator/Tests/expected.ji/TestInterface/Test.ME.GenericStringPropertyImplementation.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Test.ME.GenericStringPropertyImplementation.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Test.ME {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='test.me']/class[@name='GenericStringPropertyImplementation']"
+	[global::Android.Runtime.Register ("test/me/GenericStringPropertyImplementation", DoNotGenerateAcw=true)]
+	public partial class GenericStringPropertyImplementation : global::Java.Lang.Object, global::Test.ME.IGenericPropertyInterface {
+
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("test/me/GenericStringPropertyImplementation", typeof (GenericStringPropertyImplementation));
+		internal static new IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+		protected GenericStringPropertyImplementation (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		// Metadata.xml XPath constructor reference: path="/api/package[@name='test.me']/class[@name='GenericStringPropertyImplementation']/constructor[@name='GenericStringPropertyImplementation' and count(parameter)=0]"
+		[Register (".ctor", "()V", "")]
+		public unsafe GenericStringPropertyImplementation ()
+			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		{
+			const string __id = "()V";
+
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+				return;
+
+			try {
+				var __r = _members.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), null);
+				SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
+				_members.InstanceMethods.FinishCreateInstance (__id, this, null);
+			} finally {
+			}
+		}
+
+		static Delegate cb_getObject;
+#pragma warning disable 0169
+		static Delegate GetGetObjectHandler ()
+		{
+			if (cb_getObject == null)
+				cb_getObject = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_GetObject);
+			return cb_getObject;
+		}
+
+		static IntPtr n_GetObject (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Test.ME.GenericStringPropertyImplementation __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericStringPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.NewString (__this.Object);
+		}
+#pragma warning restore 0169
+
+		static Delegate cb_SetObject_Ljava_lang_String_;
+#pragma warning disable 0169
+		static Delegate GetSetObject_Ljava_lang_String_Handler ()
+		{
+			if (cb_SetObject_Ljava_lang_String_ == null)
+				cb_SetObject_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr, IntPtr>) n_SetObject_Ljava_lang_String_);
+			return cb_SetObject_Ljava_lang_String_;
+		}
+
+		static void n_SetObject_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
+		{
+			global::Test.ME.GenericStringPropertyImplementation __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericStringPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			string value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
+			__this.Object = value;
+		}
+#pragma warning restore 0169
+
+		public virtual unsafe string Object {
+			// Metadata.xml XPath method reference: path="/api/package[@name='test.me']/class[@name='GenericStringPropertyImplementation']/method[@name='getObject' and count(parameter)=0]"
+			[Register ("getObject", "()Ljava/lang/String;", "GetGetObjectHandler")]
+			get {
+				const string __id = "getObject.()Ljava/lang/String;";
+				try {
+					var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, null);
+					return JNIEnv.GetString (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+				} finally {
+				}
+			}
+			// Metadata.xml XPath method reference: path="/api/package[@name='test.me']/class[@name='GenericStringPropertyImplementation']/method[@name='SetObject' and count(parameter)=1 and parameter[1][@type='java.lang.String']]"
+			[Register ("SetObject", "(Ljava/lang/String;)V", "GetSetObject_Ljava_lang_String_Handler")]
+			set {
+				const string __id = "SetObject.(Ljava/lang/String;)V";
+				IntPtr native_value = JNIEnv.NewString (value);
+				try {
+					JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+					__args [0] = new JniArgumentValue (native_value);
+					_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, __args);
+				} finally {
+					JNIEnv.DeleteLocalRef (native_value);
+				}
+			}
+		}
+
+		// This method is explicitly implemented as a member of an instantiated Test.ME.IGenericPropertyInterface
+		global::Java.Lang.Object global::Test.ME.IGenericPropertyInterface.Object {
+			// Metadata.xml XPath method reference: path="/api/package[@name='test.me']/interface[@name='GenericPropertyInterface']/method[@name='getObject' and count(parameter)=0]"
+			[Register ("getObject", "()Ljava/lang/Object;", "GetGetObjectHandler:Test.ME.IGenericPropertyInterfaceInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")] get {
+				return Object;
+			}
+			// Metadata.xml XPath method reference: path="/api/package[@name='test.me']/interface[@name='GenericPropertyInterface']/method[@name='setObject' and count(parameter)=1 and parameter[1][@type='T']]"
+			[Register ("setObject", "(Ljava/lang/Object;)V", "GetSetObject_Ljava_lang_Object_Handler:Test.ME.IGenericPropertyInterfaceInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")] set {
+				Object = value.ToString ();
+			}
+		}
+
+	}
+}

--- a/tools/generator/Tests/expected.ji/TestInterface/Test.ME.IGenericPropertyInterface.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Test.ME.IGenericPropertyInterface.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Test.ME {
+
+	// Metadata.xml XPath interface reference: path="/api/package[@name='test.me']/interface[@name='GenericPropertyInterface']"
+	[Register ("test/me/GenericPropertyInterface", "", "Test.ME.IGenericPropertyInterfaceInvoker")]
+	[global::Java.Interop.JavaTypeParameters (new string [] {"T"})]
+	public partial interface IGenericPropertyInterface : IJavaObject {
+
+		global::Java.Lang.Object Object {
+			// Metadata.xml XPath method reference: path="/api/package[@name='test.me']/interface[@name='GenericPropertyInterface']/method[@name='getObject' and count(parameter)=0]"
+			[Register ("getObject", "()Ljava/lang/Object;", "GetGetObjectHandler:Test.ME.IGenericPropertyInterfaceInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")] get;
+			// Metadata.xml XPath method reference: path="/api/package[@name='test.me']/interface[@name='GenericPropertyInterface']/method[@name='setObject' and count(parameter)=1 and parameter[1][@type='T']]"
+			[Register ("setObject", "(Ljava/lang/Object;)V", "GetSetObject_Ljava_lang_Object_Handler:Test.ME.IGenericPropertyInterfaceInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")] set;
+		}
+
+	}
+
+	[global::Android.Runtime.Register ("test/me/GenericPropertyInterface", DoNotGenerateAcw=true)]
+	internal class IGenericPropertyInterfaceInvoker : global::Java.Lang.Object, IGenericPropertyInterface {
+
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("test/me/GenericPropertyInterface", typeof (IGenericPropertyInterfaceInvoker));
+
+		static IntPtr java_class_ref {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+		new IntPtr class_ref;
+
+		public static IGenericPropertyInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
+		{
+			return global::Java.Lang.Object.GetObject<IGenericPropertyInterface> (handle, transfer);
+		}
+
+		static IntPtr Validate (IntPtr handle)
+		{
+			if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
+				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
+							JNIEnv.GetClassNameFromInstance (handle), "test.me.GenericPropertyInterface"));
+			return handle;
+		}
+
+		protected override void Dispose (bool disposing)
+		{
+			if (this.class_ref != IntPtr.Zero)
+				JNIEnv.DeleteGlobalRef (this.class_ref);
+			this.class_ref = IntPtr.Zero;
+			base.Dispose (disposing);
+		}
+
+		public IGenericPropertyInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
+		{
+			IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
+			this.class_ref = JNIEnv.NewGlobalRef (local_ref);
+			JNIEnv.DeleteLocalRef (local_ref);
+		}
+
+		static Delegate cb_getObject;
+#pragma warning disable 0169
+		static Delegate GetGetObjectHandler ()
+		{
+			if (cb_getObject == null)
+				cb_getObject = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_GetObject);
+			return cb_getObject;
+		}
+
+		static IntPtr n_GetObject (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Test.ME.IGenericPropertyInterface __this = global::Java.Lang.Object.GetObject<global::Test.ME.IGenericPropertyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.ToLocalJniHandle (__this.Object);
+		}
+#pragma warning restore 0169
+
+		static Delegate cb_setObject_Ljava_lang_Object_;
+#pragma warning disable 0169
+		static Delegate GetSetObject_Ljava_lang_Object_Handler ()
+		{
+			if (cb_setObject_Ljava_lang_Object_ == null)
+				cb_setObject_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr, IntPtr>) n_SetObject_Ljava_lang_Object_);
+			return cb_setObject_Ljava_lang_Object_;
+		}
+
+		static void n_SetObject_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
+		{
+			global::Test.ME.IGenericPropertyInterface __this = global::Java.Lang.Object.GetObject<global::Test.ME.IGenericPropertyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			global::Java.Lang.Object value = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_value, JniHandleOwnership.DoNotTransfer);
+			__this.Object = value;
+		}
+#pragma warning restore 0169
+
+		IntPtr id_getObject;
+		IntPtr id_setObject_Ljava_lang_Object_;
+		public unsafe global::Java.Lang.Object Object {
+			get {
+				if (id_getObject == IntPtr.Zero)
+					id_getObject = JNIEnv.GetMethodID (class_ref, "getObject", "()Ljava/lang/Object;");
+				return (Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_getObject), JniHandleOwnership.TransferLocalRef);
+			}
+			set {
+				if (id_setObject_Ljava_lang_Object_ == IntPtr.Zero)
+					id_setObject_Ljava_lang_Object_ = JNIEnv.GetMethodID (class_ref, "setObject", "(Ljava/lang/Object;)V");
+				IntPtr native_value = JNIEnv.ToLocalJniHandle (value);
+				JValue* __args = stackalloc JValue [1];
+				__args [0] = new JValue (native_value);
+				JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_setObject_Ljava_lang_Object_, __args);
+				JNIEnv.DeleteLocalRef (native_value);
+			}
+		}
+
+	}
+
+}

--- a/tools/generator/Tests/expected.ji/TestInterface/Test.ME.ITestInterface.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Test.ME.ITestInterface.cs
@@ -28,7 +28,7 @@ namespace Test.ME {
 			}
 		}
 
-		static JniPeerMembers _members = new JniPeerMembers ("test/me/TestInterface", typeof (TestInterface));
+		new static JniPeerMembers _members = new JniPeerMembers ("test/me/TestInterface", typeof (TestInterface));
 	}
 
 	[Register ("test/me/TestInterface", DoNotGenerateAcw=true)]

--- a/tools/generator/Tests/expected.ji/TestInterface/Test.ME.TestInterfaceImplementation.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Test.ME.TestInterfaceImplementation.cs
@@ -212,16 +212,6 @@ namespace Test.ME {
 				JNIEnv.DeleteLocalRef (native_value);
 			}
 		}
-
-		public string Identity (string value)
-		{
-			global::Java.Lang.String jls_value = value == null ? null : new global::Java.Lang.String (value);
-			global::Java.Lang.ICharSequence __result = IdentityFormatted (jls_value);
-			var __rsval = __result?.ToString ();
-			jls_value?.Dispose ();
-			return __rsval;
-		}
-
 	}
 
 }

--- a/tools/generator/Tests/expected.targets
+++ b/tools/generator/Tests/expected.targets
@@ -491,10 +491,19 @@
     <Content Include='expected.ji\TestInterface\Test.ME.GenericImplementation.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include='expected.ji\TestInterface\Test.ME.GenericObjectPropertyImplementation.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include='expected.ji\TestInterface\Test.ME.GenericStringImplementation.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include='expected.ji\TestInterface\Test.ME.GenericStringPropertyImplementation.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include='expected.ji\TestInterface\Test.ME.IGenericInterface.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected.ji\TestInterface\Test.ME.IGenericPropertyInterface.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include='expected.ji\TestInterface\Test.ME.ITestInterface.cs'>
@@ -617,10 +626,19 @@
     <Content Include='expected\TestInterface\Test.ME.GenericImplementation.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include='expected\TestInterface\Test.ME.GenericObjectPropertyImplementation.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include='expected\TestInterface\Test.ME.GenericStringImplementation.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include='expected\TestInterface\Test.ME.GenericStringPropertyImplementation.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include='expected\TestInterface\Test.ME.IGenericInterface.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected\TestInterface\Test.ME.IGenericPropertyInterface.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include='expected\TestInterface\Test.ME.ITestInterface.cs'>

--- a/tools/generator/Tests/expected/TestInterface/Test.ME.GenericObjectPropertyImplementation.cs
+++ b/tools/generator/Tests/expected/TestInterface/Test.ME.GenericObjectPropertyImplementation.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Test.ME {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='test.me']/class[@name='GenericObjectPropertyImplementation']"
+	[global::Android.Runtime.Register ("test/me/GenericObjectPropertyImplementation", DoNotGenerateAcw=true)]
+	public partial class GenericObjectPropertyImplementation : global::Java.Lang.Object, global::Test.ME.IGenericPropertyInterface {
+
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("test/me/GenericObjectPropertyImplementation", ref java_class_handle);
+			}
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (GenericObjectPropertyImplementation); }
+		}
+
+		protected GenericObjectPropertyImplementation (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		static IntPtr id_ctor;
+		// Metadata.xml XPath constructor reference: path="/api/package[@name='test.me']/class[@name='GenericObjectPropertyImplementation']/constructor[@name='GenericObjectPropertyImplementation' and count(parameter)=0]"
+		[Register (".ctor", "()V", "")]
+		public unsafe GenericObjectPropertyImplementation ()
+			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		{
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+				return;
+
+			try {
+				if (((object) this).GetType () != typeof (GenericObjectPropertyImplementation)) {
+					SetHandle (
+							global::Android.Runtime.JNIEnv.StartCreateInstance (((object) this).GetType (), "()V"),
+							JniHandleOwnership.TransferLocalRef);
+					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "()V");
+					return;
+				}
+
+				if (id_ctor == IntPtr.Zero)
+					id_ctor = JNIEnv.GetMethodID (class_ref, "<init>", "()V");
+				SetHandle (
+						global::Android.Runtime.JNIEnv.StartCreateInstance (class_ref, id_ctor),
+						JniHandleOwnership.TransferLocalRef);
+				JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, class_ref, id_ctor);
+			} finally {
+			}
+		}
+
+		static Delegate cb_getObject;
+#pragma warning disable 0169
+		static Delegate GetGetObjectHandler ()
+		{
+			if (cb_getObject == null)
+				cb_getObject = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_GetObject);
+			return cb_getObject;
+		}
+
+		static IntPtr n_GetObject (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Test.ME.GenericObjectPropertyImplementation __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericObjectPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.ToLocalJniHandle (__this.Object);
+		}
+#pragma warning restore 0169
+
+		static Delegate cb_setObject_Ljava_lang_Object_;
+#pragma warning disable 0169
+		static Delegate GetSetObject_Ljava_lang_Object_Handler ()
+		{
+			if (cb_setObject_Ljava_lang_Object_ == null)
+				cb_setObject_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr, IntPtr>) n_SetObject_Ljava_lang_Object_);
+			return cb_setObject_Ljava_lang_Object_;
+		}
+
+		static void n_SetObject_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
+		{
+			global::Test.ME.GenericObjectPropertyImplementation __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericObjectPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			global::Java.Lang.Object value = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_value, JniHandleOwnership.DoNotTransfer);
+			__this.Object = value;
+		}
+#pragma warning restore 0169
+
+		static IntPtr id_getObject;
+		static IntPtr id_setObject_Ljava_lang_Object_;
+		public virtual unsafe global::Java.Lang.Object Object {
+			// Metadata.xml XPath method reference: path="/api/package[@name='test.me']/class[@name='GenericObjectPropertyImplementation']/method[@name='getObject' and count(parameter)=0]"
+			[Register ("getObject", "()Ljava/lang/Object;", "GetGetObjectHandler")]
+			get {
+				if (id_getObject == IntPtr.Zero)
+					id_getObject = JNIEnv.GetMethodID (class_ref, "getObject", "()Ljava/lang/Object;");
+				try {
+
+					if (((object) this).GetType () == ThresholdType)
+						return global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_getObject), JniHandleOwnership.TransferLocalRef);
+					else
+						return global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallNonvirtualObjectMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "getObject", "()Ljava/lang/Object;")), JniHandleOwnership.TransferLocalRef);
+				} finally {
+				}
+			}
+			// Metadata.xml XPath method reference: path="/api/package[@name='test.me']/class[@name='GenericObjectPropertyImplementation']/method[@name='setObject' and count(parameter)=1 and parameter[1][@type='java.lang.Object']]"
+			[Register ("setObject", "(Ljava/lang/Object;)V", "GetSetObject_Ljava_lang_Object_Handler")]
+			set {
+				if (id_setObject_Ljava_lang_Object_ == IntPtr.Zero)
+					id_setObject_Ljava_lang_Object_ = JNIEnv.GetMethodID (class_ref, "setObject", "(Ljava/lang/Object;)V");
+				try {
+					JValue* __args = stackalloc JValue [1];
+					__args [0] = new JValue (value);
+
+					if (((object) this).GetType () == ThresholdType)
+						JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_setObject_Ljava_lang_Object_, __args);
+					else
+						JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "setObject", "(Ljava/lang/Object;)V"), __args);
+				} finally {
+				}
+			}
+		}
+
+	}
+}

--- a/tools/generator/Tests/expected/TestInterface/Test.ME.GenericStringPropertyImplementation.cs
+++ b/tools/generator/Tests/expected/TestInterface/Test.ME.GenericStringPropertyImplementation.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Test.ME {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='test.me']/class[@name='GenericStringPropertyImplementation']"
+	[global::Android.Runtime.Register ("test/me/GenericStringPropertyImplementation", DoNotGenerateAcw=true)]
+	public partial class GenericStringPropertyImplementation : global::Java.Lang.Object, global::Test.ME.IGenericPropertyInterface {
+
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("test/me/GenericStringPropertyImplementation", ref java_class_handle);
+			}
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (GenericStringPropertyImplementation); }
+		}
+
+		protected GenericStringPropertyImplementation (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		static IntPtr id_ctor;
+		// Metadata.xml XPath constructor reference: path="/api/package[@name='test.me']/class[@name='GenericStringPropertyImplementation']/constructor[@name='GenericStringPropertyImplementation' and count(parameter)=0]"
+		[Register (".ctor", "()V", "")]
+		public unsafe GenericStringPropertyImplementation ()
+			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		{
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+				return;
+
+			try {
+				if (((object) this).GetType () != typeof (GenericStringPropertyImplementation)) {
+					SetHandle (
+							global::Android.Runtime.JNIEnv.StartCreateInstance (((object) this).GetType (), "()V"),
+							JniHandleOwnership.TransferLocalRef);
+					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "()V");
+					return;
+				}
+
+				if (id_ctor == IntPtr.Zero)
+					id_ctor = JNIEnv.GetMethodID (class_ref, "<init>", "()V");
+				SetHandle (
+						global::Android.Runtime.JNIEnv.StartCreateInstance (class_ref, id_ctor),
+						JniHandleOwnership.TransferLocalRef);
+				JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, class_ref, id_ctor);
+			} finally {
+			}
+		}
+
+		static Delegate cb_getObject;
+#pragma warning disable 0169
+		static Delegate GetGetObjectHandler ()
+		{
+			if (cb_getObject == null)
+				cb_getObject = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_GetObject);
+			return cb_getObject;
+		}
+
+		static IntPtr n_GetObject (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Test.ME.GenericStringPropertyImplementation __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericStringPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.NewString (__this.Object);
+		}
+#pragma warning restore 0169
+
+		static Delegate cb_SetObject_Ljava_lang_String_;
+#pragma warning disable 0169
+		static Delegate GetSetObject_Ljava_lang_String_Handler ()
+		{
+			if (cb_SetObject_Ljava_lang_String_ == null)
+				cb_SetObject_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr, IntPtr>) n_SetObject_Ljava_lang_String_);
+			return cb_SetObject_Ljava_lang_String_;
+		}
+
+		static void n_SetObject_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
+		{
+			global::Test.ME.GenericStringPropertyImplementation __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericStringPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			string value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
+			__this.Object = value;
+		}
+#pragma warning restore 0169
+
+		static IntPtr id_getObject;
+		static IntPtr id_SetObject_Ljava_lang_String_;
+		public virtual unsafe string Object {
+			// Metadata.xml XPath method reference: path="/api/package[@name='test.me']/class[@name='GenericStringPropertyImplementation']/method[@name='getObject' and count(parameter)=0]"
+			[Register ("getObject", "()Ljava/lang/String;", "GetGetObjectHandler")]
+			get {
+				if (id_getObject == IntPtr.Zero)
+					id_getObject = JNIEnv.GetMethodID (class_ref, "getObject", "()Ljava/lang/String;");
+				try {
+
+					if (((object) this).GetType () == ThresholdType)
+						return JNIEnv.GetString (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_getObject), JniHandleOwnership.TransferLocalRef);
+					else
+						return JNIEnv.GetString (JNIEnv.CallNonvirtualObjectMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "getObject", "()Ljava/lang/String;")), JniHandleOwnership.TransferLocalRef);
+				} finally {
+				}
+			}
+			// Metadata.xml XPath method reference: path="/api/package[@name='test.me']/class[@name='GenericStringPropertyImplementation']/method[@name='SetObject' and count(parameter)=1 and parameter[1][@type='java.lang.String']]"
+			[Register ("SetObject", "(Ljava/lang/String;)V", "GetSetObject_Ljava_lang_String_Handler")]
+			set {
+				if (id_SetObject_Ljava_lang_String_ == IntPtr.Zero)
+					id_SetObject_Ljava_lang_String_ = JNIEnv.GetMethodID (class_ref, "SetObject", "(Ljava/lang/String;)V");
+				IntPtr native_value = JNIEnv.NewString (value);
+				try {
+					JValue* __args = stackalloc JValue [1];
+					__args [0] = new JValue (native_value);
+
+					if (((object) this).GetType () == ThresholdType)
+						JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_SetObject_Ljava_lang_String_, __args);
+					else
+						JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "SetObject", "(Ljava/lang/String;)V"), __args);
+				} finally {
+					JNIEnv.DeleteLocalRef (native_value);
+				}
+			}
+		}
+
+		// This method is explicitly implemented as a member of an instantiated Test.ME.IGenericPropertyInterface
+		global::Java.Lang.Object global::Test.ME.IGenericPropertyInterface.Object {
+			// Metadata.xml XPath method reference: path="/api/package[@name='test.me']/interface[@name='GenericPropertyInterface']/method[@name='getObject' and count(parameter)=0]"
+			[Register ("getObject", "()Ljava/lang/Object;", "GetGetObjectHandler:Test.ME.IGenericPropertyInterfaceInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")] get {
+				return Object;
+			}
+			// Metadata.xml XPath method reference: path="/api/package[@name='test.me']/interface[@name='GenericPropertyInterface']/method[@name='setObject' and count(parameter)=1 and parameter[1][@type='T']]"
+			[Register ("setObject", "(Ljava/lang/Object;)V", "GetSetObject_Ljava_lang_Object_Handler:Test.ME.IGenericPropertyInterfaceInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")] set {
+				Object = value.ToString ();
+			}
+		}
+
+	}
+}

--- a/tools/generator/Tests/expected/TestInterface/Test.ME.IGenericPropertyInterface.cs
+++ b/tools/generator/Tests/expected/TestInterface/Test.ME.IGenericPropertyInterface.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Test.ME {
+
+	// Metadata.xml XPath interface reference: path="/api/package[@name='test.me']/interface[@name='GenericPropertyInterface']"
+	[Register ("test/me/GenericPropertyInterface", "", "Test.ME.IGenericPropertyInterfaceInvoker")]
+	[global::Java.Interop.JavaTypeParameters (new string [] {"T"})]
+	public partial interface IGenericPropertyInterface : IJavaObject {
+
+		global::Java.Lang.Object Object {
+			// Metadata.xml XPath method reference: path="/api/package[@name='test.me']/interface[@name='GenericPropertyInterface']/method[@name='getObject' and count(parameter)=0]"
+			[Register ("getObject", "()Ljava/lang/Object;", "GetGetObjectHandler:Test.ME.IGenericPropertyInterfaceInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")] get;
+			// Metadata.xml XPath method reference: path="/api/package[@name='test.me']/interface[@name='GenericPropertyInterface']/method[@name='setObject' and count(parameter)=1 and parameter[1][@type='T']]"
+			[Register ("setObject", "(Ljava/lang/Object;)V", "GetSetObject_Ljava_lang_Object_Handler:Test.ME.IGenericPropertyInterfaceInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")] set;
+		}
+
+	}
+
+	[global::Android.Runtime.Register ("test/me/GenericPropertyInterface", DoNotGenerateAcw=true)]
+	internal class IGenericPropertyInterfaceInvoker : global::Java.Lang.Object, IGenericPropertyInterface {
+
+		static IntPtr java_class_ref = JNIEnv.FindClass ("test/me/GenericPropertyInterface");
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (IGenericPropertyInterfaceInvoker); }
+		}
+
+		new IntPtr class_ref;
+
+		public static IGenericPropertyInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
+		{
+			return global::Java.Lang.Object.GetObject<IGenericPropertyInterface> (handle, transfer);
+		}
+
+		static IntPtr Validate (IntPtr handle)
+		{
+			if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
+				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
+							JNIEnv.GetClassNameFromInstance (handle), "test.me.GenericPropertyInterface"));
+			return handle;
+		}
+
+		protected override void Dispose (bool disposing)
+		{
+			if (this.class_ref != IntPtr.Zero)
+				JNIEnv.DeleteGlobalRef (this.class_ref);
+			this.class_ref = IntPtr.Zero;
+			base.Dispose (disposing);
+		}
+
+		public IGenericPropertyInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
+		{
+			IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
+			this.class_ref = JNIEnv.NewGlobalRef (local_ref);
+			JNIEnv.DeleteLocalRef (local_ref);
+		}
+
+		static Delegate cb_getObject;
+#pragma warning disable 0169
+		static Delegate GetGetObjectHandler ()
+		{
+			if (cb_getObject == null)
+				cb_getObject = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_GetObject);
+			return cb_getObject;
+		}
+
+		static IntPtr n_GetObject (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Test.ME.IGenericPropertyInterface __this = global::Java.Lang.Object.GetObject<global::Test.ME.IGenericPropertyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.ToLocalJniHandle (__this.Object);
+		}
+#pragma warning restore 0169
+
+		static Delegate cb_setObject_Ljava_lang_Object_;
+#pragma warning disable 0169
+		static Delegate GetSetObject_Ljava_lang_Object_Handler ()
+		{
+			if (cb_setObject_Ljava_lang_Object_ == null)
+				cb_setObject_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr, IntPtr>) n_SetObject_Ljava_lang_Object_);
+			return cb_setObject_Ljava_lang_Object_;
+		}
+
+		static void n_SetObject_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
+		{
+			global::Test.ME.IGenericPropertyInterface __this = global::Java.Lang.Object.GetObject<global::Test.ME.IGenericPropertyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			global::Java.Lang.Object value = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_value, JniHandleOwnership.DoNotTransfer);
+			__this.Object = value;
+		}
+#pragma warning restore 0169
+
+		IntPtr id_getObject;
+		IntPtr id_setObject_Ljava_lang_Object_;
+		public unsafe global::Java.Lang.Object Object {
+			get {
+				if (id_getObject == IntPtr.Zero)
+					id_getObject = JNIEnv.GetMethodID (class_ref, "getObject", "()Ljava/lang/Object;");
+				return (Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_getObject), JniHandleOwnership.TransferLocalRef);
+			}
+			set {
+				if (id_setObject_Ljava_lang_Object_ == IntPtr.Zero)
+					id_setObject_Ljava_lang_Object_ = JNIEnv.GetMethodID (class_ref, "setObject", "(Ljava/lang/Object;)V");
+				IntPtr native_value = JNIEnv.ToLocalJniHandle (value);
+				JValue* __args = stackalloc JValue [1];
+				__args [0] = new JValue (native_value);
+				JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_setObject_Ljava_lang_Object_, __args);
+				JNIEnv.DeleteLocalRef (native_value);
+			}
+		}
+
+	}
+
+}

--- a/tools/generator/Tests/expected/TestInterface/Test.ME.ITestInterface.cs
+++ b/tools/generator/Tests/expected/TestInterface/Test.ME.ITestInterface.cs
@@ -28,7 +28,7 @@ namespace Test.ME {
 			}
 		}
 
-		static IntPtr class_ref = JNIEnv.FindClass ("test/me/TestInterface");
+		new static IntPtr class_ref = JNIEnv.FindClass ("test/me/TestInterface");
 	}
 
 	[Register ("test/me/TestInterface", DoNotGenerateAcw=true)]

--- a/tools/generator/Tests/expected/TestInterface/Test.ME.TestInterfaceImplementation.cs
+++ b/tools/generator/Tests/expected/TestInterface/Test.ME.TestInterfaceImplementation.cs
@@ -218,16 +218,6 @@ namespace Test.ME {
 				JNIEnv.DeleteLocalRef (native_value);
 			}
 		}
-
-		public string Identity (string value)
-		{
-			global::Java.Lang.String jls_value = value == null ? null : new global::Java.Lang.String (value);
-			global::Java.Lang.ICharSequence __result = IdentityFormatted (jls_value);
-			var __rsval = __result?.ToString ();
-			jls_value?.Dispose ();
-			return __rsval;
-		}
-
 	}
 
 }

--- a/tools/generator/Tests/expected/TestInterface/TestInterface.xml
+++ b/tools/generator/Tests/expected/TestInterface/TestInterface.xml
@@ -4,7 +4,7 @@
 		<class abstract="false" deprecated="not deprecated" final="false" name="Object" static="false" visibility="public">
 		</class>
 		<class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object"
-			final="false" name="String" static="false" visibility="public">
+			final="true" name="String" static="false" visibility="public">
 		</class>
 	</package>
 	<package name="test.me">
@@ -85,6 +85,56 @@
 			<constructor deprecated="not deprecated" final="false" name="GenericImplementation" static="false" visibility="public" />
 			<method abstract="false" deprecated="not deprecated" final="false" name="SetObject" native="false" return="void" static="false" synchronized="false" visibility="public">
 				<parameter name="value" type="java.lang.String[]" />
+			</method>
+		</class>
+		<!-- 
+			public interface GenericPropertyInterface<T> {
+				T getObject();
+				void setObject(T value);
+			}
+		-->
+		<interface abstract="true" deprecated="not deprecated" final="false" name="GenericPropertyInterface" static="false" visibility="public">
+			<typeParameters>
+				<typeParameter name="T" classBound="java.lang.Object" interfaceBounds="" />
+			</typeParameters>
+			<method abstract="true" deprecated="not deprecated" final="false" name="getObject" native="false" return="T" static="false" synchronized="false" visibility="public">
+			</method>
+			<method abstract="true" deprecated="not deprecated" final="false" name="setObject" native="false" return="void" static="false" synchronized="false" visibility="public">
+				<parameter name="value" type="T" />
+			</method>
+		</interface>
+		<!--
+			public class GenericObjectPropertyImplementation implements GenericPropertyInterface<java.lang.Object> {
+				@Override
+				Object getObject();
+				@Override
+				void setObject(Object value);
+			}
+		-->
+		<class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="false" name="GenericObjectPropertyImplementation" static="false" visibility="public">
+			<implements name="test.me.GenericPropertyInterface" name-generic-aware="test.me.GenericPropertyInterface&lt;java.lang.Object&gt;" />
+			<constructor deprecated="not deprecated" final="false" name="GenericObjectPropertyImplementation" static="false" visibility="public" />
+			<method abstract="false" deprecated="not deprecated" final="false" name="getObject" native="false" return="java.lang.Object" static="false" synchronized="false" visibility="public">
+			</method>
+			<method abstract="false" deprecated="not deprecated" final="false" name="setObject" native="false" return="void" static="false" synchronized="false" visibility="public">
+				<parameter name="value" type="java.lang.Object" />
+			</method>
+		</class>
+		<!--
+			public class GenericStringPropertyImplementation implements GenericPropertyInterface<java.lang.String> {
+				@Override
+				String getObject();
+				@Override
+				void setObject(String value);
+			}
+		-->
+		<class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="false" name="GenericStringPropertyImplementation" static="false" visibility="public">
+			<implements name="test.me.GenericPropertyInterface" name-generic-aware="test.me.GenericPropertyInterface&lt;java.lang.String&gt;" />
+			<constructor deprecated="not deprecated" final="false" name="GenericStringPropertyImplementation" static="false" visibility="public" />
+			<method abstract="false" deprecated="not deprecated" final="false" name="getObject" native="false" return="java.lang.String" static="false" synchronized="false" visibility="public">
+			</method>
+			<method abstract="false" deprecated="not deprecated" final="false" name="SetObject" native="false" return="void" static="false" synchronized="false" visibility="public">
+				<parameter name="value" type="java.lang.String" />
 			</method>
 		</class>
 	</package>

--- a/tools/generator/XamarinAndroidCodeGenerator.cs
+++ b/tools/generator/XamarinAndroidCodeGenerator.cs
@@ -29,7 +29,7 @@ namespace MonoDroid.Generation {
 
 		internal override void WriteClassHandle (InterfaceGen type, StreamWriter sw, string indent, CodeGenerationOptions opt, string declaringType)
 		{
-			sw.WriteLine ("{0}static IntPtr class_ref = JNIEnv.FindClass (\"{1}\");", indent, type.RawJniName);
+			sw.WriteLine ("{0}new static IntPtr class_ref = JNIEnv.FindClass (\"{1}\");", indent, type.RawJniName);
 		}
 
 		internal override void WriteClassInvokerHandle (ClassGen type, StreamWriter sw, string indent, CodeGenerationOptions opt, string declaringType)


### PR DESCRIPTION
In the case of a generic interface `IFoo<T>`, generator creates:
- C# interface `IFoo` that uses `Java.Lang.Object` for `T`
- C# classes implementing `IFoo` will have the appropriate generic
types swapped out for `T`/`Java.Lang.Object`
- Therefore, C# classes implementing `IFoo` need to explicitly
implement everything in `IFoo` using `Java.Lang.Object` instead of the
generic type

Whew!

So this was already working for methods, but not properties. This adds
an  equivalent implementation for properties.

Also fixed a few warnings in the process:
- `java.lang.String` in some tests needed to be marked as `final`
- `Invokers` do not need to generate `string` overloads for
`java.lang.CharSequence`
- all interfaces needed to declare `class_ref` as `new` in XA
- all interfaces needed to declare `members` as `new` in JI

Upstream in xamarin-android:
- `make run-api-compatibility-tests` passes
- Diff of Mono.Android/mcw: https://gist.github.com/jonathanpeppers/5a8a761101d2afe024a140e372291eb5
    - Many instances of `new`
    - A few unnecessary internal `Invoker` string/formatted overloads are removed