### PR TITLE
[build] fix gendarme download

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ endif
 
 XA_CONFIGURATION  = XAIntegrationDebug
 
-GENDARME_URL = https://cloud.github.com/downloads/spouliot/gendarme/gendarme-2.10-bin.zip
+GENDARME_URL = https://github.com/downloads/spouliot/gendarme/gendarme-2.10-bin.zip
 
 PACKAGES = \
 	packages/NUnit.2.6.3/NUnit.2.6.3.nupkg \
@@ -82,7 +82,7 @@ fxcop: lib/gendarme-2.10/gendarme.exe bin/$(CONFIGURATION)/Java.Interop.dll
 
 lib/gendarme-2.10/gendarme.exe:
 	-mkdir -p `dirname "$@"`
-	curl -o lib/gendarme-2.10/gendarme-2.10-bin.zip $(GENDARME_URL)
+	curl -L -o lib/gendarme-2.10/gendarme-2.10-bin.zip $(GENDARME_URL)
 	(cd lib/gendarme-2.10 ; unzip gendarme-2.10-bin.zip)
 
 JAVA_INTEROP_LIB    = libjava-interop$(NATIVE_EXT)


### PR DESCRIPTION
Github seems to have changed their download URLs, our old URL is no
longer working:
https://cloud.github.com/downloads/spouliot/gendarme/gendarme-2.10-bin.zip

If I go to the download page:
https://github.com/spouliot/gendarme/downloads

The URL looks like it should now be:
https://github.com/downloads/spouliot/gendarme/gendarme-2.10-bin.zip

However, after this it still failed due to Github wanting to redirect.
I had to add a `-L` switch to the `curl` command to allow redirects.

I think we can close #220 in favor of this.