### PR TITLE
Reduce Android.* dependencies from this not-only-about-Android repo, take 2

### DIFF
--- a/src/Java.Interop.NamingCustomAttributes/Android.App/InstrumentationAttribute.cs
+++ b/src/Java.Interop.NamingCustomAttributes/Android.App/InstrumentationAttribute.cs
@@ -1,8 +1,0 @@
-using System;
-
-namespace Android.App {
-	sealed partial class InstrumentationAttribute : Attribute {
-		public string Name { get; set; }
-	}
-}
-

--- a/src/Java.Interop.NamingCustomAttributes/Android.Content/BroadcastReceiverAttribute.cs
+++ b/src/Java.Interop.NamingCustomAttributes/Android.Content/BroadcastReceiverAttribute.cs
@@ -1,8 +1,0 @@
-using System;
-
-namespace Android.Content {
-
-	partial class BroadcastReceiverAttribute : Attribute {
-		public string Name { get; set; }
-	}
-}

--- a/src/Java.Interop.NamingCustomAttributes/Android.Content/ContentProviderAttribute.cs
+++ b/src/Java.Interop.NamingCustomAttributes/Android.Content/ContentProviderAttribute.cs
@@ -1,8 +1,0 @@
-using System;
-
-namespace Android.Content {
-
-	partial class ContentProviderAttribute : Attribute {
-		public string Name { get; set; }
-	}
-}

--- a/src/Java.Interop.NamingCustomAttributes/Android.Runtime/RegisterAttribute.cs
+++ b/src/Java.Interop.NamingCustomAttributes/Android.Runtime/RegisterAttribute.cs
@@ -6,7 +6,7 @@ namespace Android.Runtime {
 #if !JCW_ONLY_TYPE_NAMES
 	public
 #endif  // !JCW_ONLY_TYPE_NAMES
-	sealed class RegisterAttribute : Attribute {
+	sealed class RegisterAttribute : Attribute, Java.Interop.IJniNameProviderAttribute {
 
 		string connector;
 		string name;

--- a/src/Java.Interop.NamingCustomAttributes/Java.Interop.NamingCustomAttributes.projitems
+++ b/src/Java.Interop.NamingCustomAttributes/Java.Interop.NamingCustomAttributes.projitems
@@ -9,16 +9,14 @@
     <Import_RootNamespace>Java.Interop.NamingCustomAttributes</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)Android.Content\BroadcastReceiverAttribute.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Android.Content\ContentProviderAttribute.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Android.Runtime\RegisterAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Java.Interop\ExportAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Java.Interop\ExportFieldAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Java.Interop\ExportParameterAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Java.Interop\ExportParameterKind.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Android.App\ActivityAttribute.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Android.App\ApplicationAttribute.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Android.App\ServiceAttribute.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Android.App\InstrumentationAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Interop\IJniNameProviderAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Android.Runtime\RegisterAttribute.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="$(MSBuildThisFileDirectory)Android.Runtime\" />
   </ItemGroup>
 </Project>

--- a/src/Java.Interop.NamingCustomAttributes/Java.Interop/IJniNameProviderAttribute.cs
+++ b/src/Java.Interop.NamingCustomAttributes/Java.Interop/IJniNameProviderAttribute.cs
@@ -1,0 +1,8 @@
+﻿using System;
+namespace Java.Interop
+{
+	public interface IJniNameProviderAttribute
+	{
+		string Name { get; }
+	}
+}

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
@@ -9,9 +9,7 @@ using System.Text.RegularExpressions;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 
-using Android.App;
 using Android.Runtime;
-using Java.Interop;
 
 using Java.Interop.Tools.Cecil;
 using Java.Interop.Tools.Diagnostics;

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Test/Android.App/ActivityAttribute.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Test/Android.App/ActivityAttribute.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Android.App
 {
-	sealed partial class ActivityAttribute : Attribute {
+	sealed partial class ActivityAttribute : Attribute, Java.Interop.IJniNameProviderAttribute {
 		public string                 Name                    {get; set;}
 	}
 }

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Test/Android.App/ApplicationAttribute.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Test/Android.App/ApplicationAttribute.cs
@@ -1,7 +1,7 @@
 using System;
 
 namespace Android.App {
-	sealed partial class ApplicationAttribute : Attribute {
+	sealed partial class ApplicationAttribute : Attribute, Java.Interop.IJniNameProviderAttribute {
 		public string                 Name                    {get; set;}
 	}
 }

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Test/Android.App/InstrumentationAttribute.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Test/Android.App/InstrumentationAttribute.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace Android.App {
+	sealed partial class InstrumentationAttribute : Attribute, Java.Interop.IJniNameProviderAttribute {
+		public string Name { get; set; }
+	}
+}
+

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Test/Android.App/ServiceAttribute.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Test/Android.App/ServiceAttribute.cs
@@ -1,7 +1,7 @@
 using System;
 
 namespace Android.App {
-	sealed partial class ServiceAttribute : Attribute {
+	sealed partial class ServiceAttribute : Attribute, Java.Interop.IJniNameProviderAttribute {
 		public string                 Name                    {get; set;}
 	}
 }

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Test/Android.Content/BroadcastReceiverAttribute.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Test/Android.Content/BroadcastReceiverAttribute.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace Android.Content {
+
+	partial class BroadcastReceiverAttribute : Attribute, Java.Interop.IJniNameProviderAttribute {
+		public string Name { get; set; }
+	}
+}

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Test/Android.Content/ContentProviderAttribute.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Test/Android.Content/ContentProviderAttribute.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace Android.Content {
+
+	partial class ContentProviderAttribute : Attribute, Java.Interop.IJniNameProviderAttribute {
+		public string Name { get; set; }
+	}
+}

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers-Tests.csproj
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers-Tests.csproj
@@ -39,6 +39,12 @@
     <Compile Include="Java.Interop.Tools.JavaCallableWrappers\JavaCallableWrapperGeneratorTests.cs" />
     <Compile Include="Java.Interop.Tools.JavaCallableWrappers\TypeNameMapGeneratorTests.cs" />
     <Compile Include="Java.Interop.Tools.JavaCallableWrappers\SupportDeclarations.cs" />
+    <Compile Include="Android.App\ActivityAttribute.cs" />
+    <Compile Include="Android.App\ApplicationAttribute.cs" />
+    <Compile Include="Android.App\InstrumentationAttribute.cs" />
+    <Compile Include="Android.App\ServiceAttribute.cs" />
+    <Compile Include="Android.Content\BroadcastReceiverAttribute.cs" />
+    <Compile Include="Android.Content\ContentProviderAttribute.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -63,6 +69,8 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Java.Interop.Tools.JavaCallableWrappers\" />
+    <Folder Include="Android.App\" />
+    <Folder Include="Android.Content\" />
   </ItemGroup>
   <Import Project="..\..\Java.Interop.NamingCustomAttributes\Java.Interop.NamingCustomAttributes.projitems" Label="Shared" Condition="Exists('..\..\Java.Interop.NamingCustomAttributes\Java.Interop.NamingCustomAttributes.projitems')" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers/SupportDeclarations.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers/SupportDeclarations.cs
@@ -11,6 +11,8 @@ using Android.App;
 using Android.Content;
 using Android.Runtime;
 
+using RegisterAttribute = Android.Runtime.RegisterAttribute;
+
 namespace Android.App {
 
 	[Register ("android/app/Application", DoNotGenerateAcw = true)]


### PR DESCRIPTION
This overlaps https://github.com/xamarin/java.interop/pull/219 so only either of this or that can be applied, but this goes one step further and completely removes Android.* attributes from Java.Interop codebase.

There are still tests that depend on those types, so they are moved to the test csproj.