### PR TITLE
[generator] better support for "package-private" classes

### DIFF
--- a/tools/generator/CodeGenerator.cs
+++ b/tools/generator/CodeGenerator.cs
@@ -401,6 +401,8 @@ namespace Xamarin.Android.Binder {
 				foreach (GenBase gen in gens)
 					gen.ResetValidation ();
 				foreach (GenBase gen in gens)
+					gen.FixupAccessModifiers ();
+				foreach (GenBase gen in gens)
 					if ((opt.IgnoreNonPublicType &&
 					    (gen.RawVisibility != "public" && gen.RawVisibility != "internal"))
 					    || !gen.Validate (opt, null)) {

--- a/tools/generator/GenBase.cs
+++ b/tools/generator/GenBase.cs
@@ -727,6 +727,12 @@ namespace MonoDroid.Generation {
 				n.StripNonBindables ();
 		}
 
+		public virtual void FixupAccessModifiers ()
+		{
+			foreach (var nt in NestedTypes)
+				nt.FixupAccessModifiers ();
+		}
+
 		public void FillProperties ()
 		{
 			if (property_filled)

--- a/tools/generator/Tests/AccessModifiers.cs
+++ b/tools/generator/Tests/AccessModifiers.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace generatortests
+{
+	[TestFixture]
+	public class AccessModifiers : BaseGeneratorTest
+	{
+		[Test]
+		public void GeneratedOK ()
+		{
+			RunAllTargets (
+					outputRelativePath: "AccessModifiers",
+					apiDescriptionFile: "expected/AccessModifiers/AccessModifiers.xml",
+					expectedRelativePath: "AccessModifiers",
+					additionalSupportPaths: null);
+		}
+	}
+}
+

--- a/tools/generator/Tests/expected.ji/AccessModifiers/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/AccessModifiers/Mono.Android.projitems
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);ANDROID_1;ANDROID_2;ANDROID_3;ANDROID_4</DefineConstants>
+  </PropertyGroup>
+  <!-- Classes -->
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.BasePublicClass.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.ExtendPublicClass.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.PublicClass.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.PublicFinalClass.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+  </ItemGroup>
+  <!-- Enums -->
+  <ItemGroup />
+</Project>

--- a/tools/generator/Tests/expected.ji/AccessModifiers/Xamarin.Test.BasePublicClass.cs
+++ b/tools/generator/Tests/expected.ji/AccessModifiers/Xamarin.Test.BasePublicClass.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Xamarin.Test {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='BasePublicClass']"
+	[global::Android.Runtime.Register ("xamarin/test/BasePublicClass", DoNotGenerateAcw=true)]
+	public partial class BasePublicClass : global::Java.Lang.Object {
+
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/BasePublicClass", typeof (BasePublicClass));
+		internal static new IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+		protected BasePublicClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		static Delegate cb_baseMethod;
+#pragma warning disable 0169
+		static Delegate GetBaseMethodHandler ()
+		{
+			if (cb_baseMethod == null)
+				cb_baseMethod = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr>) n_BaseMethod);
+			return cb_baseMethod;
+		}
+
+		static void n_BaseMethod (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Xamarin.Test.BasePublicClass __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.BasePublicClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			__this.BaseMethod ();
+		}
+#pragma warning restore 0169
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='BasePublicClass']/method[@name='baseMethod' and count(parameter)=0]"
+		[Register ("baseMethod", "()V", "GetBaseMethodHandler")]
+		public virtual unsafe void BaseMethod ()
+		{
+			const string __id = "baseMethod.()V";
+			try {
+				_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, null);
+			} finally {
+			}
+		}
+
+	}
+}

--- a/tools/generator/Tests/expected.ji/AccessModifiers/Xamarin.Test.ExtendPublicClass.cs
+++ b/tools/generator/Tests/expected.ji/AccessModifiers/Xamarin.Test.ExtendPublicClass.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Xamarin.Test {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='ExtendPublicClass']"
+	[global::Android.Runtime.Register ("xamarin/test/ExtendPublicClass", DoNotGenerateAcw=true)]
+	public partial class ExtendPublicClass : global::Java.Lang.Object {
+
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/ExtendPublicClass", typeof (ExtendPublicClass));
+		internal static new IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+		protected ExtendPublicClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		// Metadata.xml XPath constructor reference: path="/api/package[@name='xamarin.test']/class[@name='ExtendPublicClass']/constructor[@name='ExtendPublicClass' and count(parameter)=0]"
+		[Register (".ctor", "()V", "")]
+		public unsafe ExtendPublicClass ()
+			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		{
+			const string __id = "()V";
+
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+				return;
+
+			try {
+				var __r = _members.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), null);
+				SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
+				_members.InstanceMethods.FinishCreateInstance (__id, this, null);
+			} finally {
+			}
+		}
+
+		static Delegate cb_foo;
+#pragma warning disable 0169
+		static Delegate GetFooHandler ()
+		{
+			if (cb_foo == null)
+				cb_foo = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr>) n_Foo);
+			return cb_foo;
+		}
+
+		static void n_Foo (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Xamarin.Test.ExtendPublicClass __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.ExtendPublicClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			__this.Foo ();
+		}
+#pragma warning restore 0169
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='ExtendPublicClass']/method[@name='foo' and count(parameter)=0]"
+		[Register ("foo", "()V", "GetFooHandler")]
+		public virtual unsafe void Foo ()
+		{
+			const string __id = "foo.()V";
+			try {
+				_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, null);
+			} finally {
+			}
+		}
+
+	}
+}

--- a/tools/generator/Tests/expected.ji/AccessModifiers/Xamarin.Test.PublicClass.cs
+++ b/tools/generator/Tests/expected.ji/AccessModifiers/Xamarin.Test.PublicClass.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Xamarin.Test {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='PublicClass']"
+	[global::Android.Runtime.Register ("xamarin/test/PublicClass", DoNotGenerateAcw=true)]
+	public partial class PublicClass : global::Java.Lang.Object {
+
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/PublicClass", typeof (PublicClass));
+		internal static new IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+		protected PublicClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		// Metadata.xml XPath constructor reference: path="/api/package[@name='xamarin.test']/class[@name='PublicClass']/constructor[@name='PublicClass' and count(parameter)=0]"
+		[Register (".ctor", "()V", "")]
+		public unsafe PublicClass ()
+			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		{
+			const string __id = "()V";
+
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+				return;
+
+			try {
+				var __r = _members.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), null);
+				SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
+				_members.InstanceMethods.FinishCreateInstance (__id, this, null);
+			} finally {
+			}
+		}
+
+		static Delegate cb_foo;
+#pragma warning disable 0169
+		static Delegate GetFooHandler ()
+		{
+			if (cb_foo == null)
+				cb_foo = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr>) n_Foo);
+			return cb_foo;
+		}
+
+		static void n_Foo (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Xamarin.Test.PublicClass __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.PublicClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			__this.Foo ();
+		}
+#pragma warning restore 0169
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='PublicClass']/method[@name='foo' and count(parameter)=0]"
+		[Register ("foo", "()V", "GetFooHandler")]
+		public virtual unsafe void Foo ()
+		{
+			const string __id = "foo.()V";
+			try {
+				_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, null);
+			} finally {
+			}
+		}
+
+	}
+}

--- a/tools/generator/Tests/expected.ji/AccessModifiers/Xamarin.Test.PublicFinalClass.cs
+++ b/tools/generator/Tests/expected.ji/AccessModifiers/Xamarin.Test.PublicFinalClass.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Xamarin.Test {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='PublicFinalClass']"
+	[global::Android.Runtime.Register ("xamarin/test/PublicFinalClass", DoNotGenerateAcw=true)]
+	public sealed partial class PublicFinalClass : global::Xamarin.Test.BasePublicClass {
+
+		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/PublicFinalClass", typeof (PublicFinalClass));
+		internal static new IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+		internal PublicFinalClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='PublicFinalClass']/method[@name='publicMethod' and count(parameter)=0]"
+		[Register ("publicMethod", "()V", "")]
+		public unsafe void PublicMethod ()
+		{
+			const string __id = "publicMethod.()V";
+			try {
+				_members.InstanceMethods.InvokeAbstractVoidMethod (__id, this, null);
+			} finally {
+			}
+		}
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='PackageClassB']/method[@name='packageMethodB' and count(parameter)=0]"
+		[Register ("packageMethodB", "()V", "")]
+		public unsafe void PackageMethodB ()
+		{
+			const string __id = "packageMethodB.()V";
+			try {
+				_members.InstanceMethods.InvokeAbstractVoidMethod (__id, this, null);
+			} finally {
+			}
+		}
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='PackageClassA']/method[@name='packageMethodA' and count(parameter)=0]"
+		[Register ("packageMethodA", "()V", "")]
+		public unsafe void PackageMethodA ()
+		{
+			const string __id = "packageMethodA.()V";
+			try {
+				_members.InstanceMethods.InvokeAbstractVoidMethod (__id, this, null);
+			} finally {
+			}
+		}
+
+	}
+}

--- a/tools/generator/Tests/expected.targets
+++ b/tools/generator/Tests/expected.targets
@@ -1,5 +1,20 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
+    <Content Include='expected\AccessModifiers\AccessModifiers.xml'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected\AccessModifiers\Xamarin.Test.BasePublicClass.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected\AccessModifiers\Xamarin.Test.ExtendPublicClass.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected\AccessModifiers\Xamarin.Test.PublicClass.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected\AccessModifiers\Xamarin.Test.PublicFinalClass.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include='expected\Adapters\Adapters.xml'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -122,6 +137,21 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include='expected\java.util.List\Xamarin.Test.SomeObject.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected.ji\AccessModifiers\Mono.Android.projitems'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected.ji\AccessModifiers\Xamarin.Test.BasePublicClass.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected.ji\AccessModifiers\Xamarin.Test.ExtendPublicClass.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected.ji\AccessModifiers\Xamarin.Test.PublicClass.cs'>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include='expected.ji\AccessModifiers\Xamarin.Test.PublicFinalClass.cs'>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include='expected.ji\Adapters\enumlist'>

--- a/tools/generator/Tests/expected/AccessModifiers/AccessModifiers.xml
+++ b/tools/generator/Tests/expected/AccessModifiers/AccessModifiers.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<api>
+	<package name="java.lang">
+		<class abstract="false" deprecated="not deprecated" final="false" name="Object" static="false" visibility="public">
+		</class>
+	</package>
+	<package name="xamarin.test">
+		<!-- 
+			/* package */ abstract class PackageClass {
+				public abstract void foo();
+			}
+		-->
+		<class abstract="true" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="false" name="PackageClass" static="false" visibility="">
+			<method abstract="true" deprecated="not deprecated" final="false" name="foo" native="false" return="void" static="false" synchronized="false" visibility="public">
+			</method>
+		</class>
+		<!-- 
+			public class PublicClass extends PackageClass {
+				@Override
+				public void foo();
+			}
+		-->
+		<class abstract="false" deprecated="not deprecated" extends="xamarin.test.PackageClass" extends-generic-aware="xamarin.test.PackageClass" final="false" name="PublicClass" static="false" visibility="public">
+			<constructor deprecated="not deprecated" final="false" name="PublicClass" static="false" visibility="public" />
+			<method abstract="false" deprecated="not deprecated" final="false" name="foo" native="false" return="void" static="false" synchronized="false" visibility="public">
+			</method>
+		</class>
+		<!-- 
+			/* package */ abstract class ExtendPackageClass extends PackageClass {
+			}
+		-->
+		<class abstract="true" deprecated="not deprecated" extends="xamarin.test.PackageClass" extends-generic-aware="xamarin.test.PackageClass" final="false" name="ExtendPackageClass" static="false" visibility="">
+		</class>
+		<!-- 
+			public class ExtendPublicClass extends ExtendPackageClass {
+				@Override
+				public void foo();
+			}
+		-->
+		<class abstract="false" deprecated="not deprecated" extends="xamarin.test.ExtendPackageClass" extends-generic-aware="xamarin.test.ExtendPackageClass" final="false" name="ExtendPublicClass" static="false" visibility="public">
+			<constructor deprecated="not deprecated" final="false" name="ExtendPublicClass" static="false" visibility="public" />
+			<method abstract="false" deprecated="not deprecated" final="false" name="foo" native="false" return="void" static="false" synchronized="false" visibility="public">
+			</method>
+		</class>
+		<!-- 
+			public class BasePublicClass {
+				public void baseMethod();
+			}
+		-->
+		<class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="false" name="BasePublicClass" static="false" visibility="public">
+			<method abstract="false" deprecated="not deprecated" final="false" name="baseMethod" native="false" return="void" static="false" synchronized="false" visibility="public">
+			</method>
+		</class>
+		<!-- 
+			/* package */ class PackageClassA extends BasePublicClass {
+				public void packageMethodA();
+			}
+		-->
+		<class abstract="false" deprecated="not deprecated" extends="xamarin.test.BasePublicClass" extends-generic-aware="xamarin.test.BasePublicClass" final="false" name="PackageClassA" static="false" visibility="">
+			<method abstract="false" deprecated="not deprecated" final="false" name="packageMethodA" native="false" return="void" static="false" synchronized="false" visibility="public">
+			</method>
+		</class>
+		<!-- 
+			/* package */ class PackageClassB extends PackageClassA {
+				public void packageMethodB();
+			}
+		-->
+		<class abstract="false" deprecated="not deprecated" extends="xamarin.test.PackageClassA" extends-generic-aware="xamarin.test.PackageClassA" final="false" name="PackageClassB" static="false" visibility="">
+			<method abstract="false" deprecated="not deprecated" final="false" name="packageMethodB" native="false" return="void" static="false" synchronized="false" visibility="public">
+			</method>
+		</class>
+		<!-- 
+			public final class PublicFinalClass extends PackageClassB {
+				public void publicMethod();
+			}
+		-->
+		<class abstract="false" deprecated="not deprecated" extends="xamarin.test.PackageClassB" extends-generic-aware="xamarin.test.PackageClassB" final="true" name="PublicFinalClass" static="false" visibility="public">
+			<method abstract="false" deprecated="not deprecated" final="false" name="publicMethod" native="false" return="void" static="false" synchronized="false" visibility="public">
+			</method>
+		</class>
+	</package>
+</api>

--- a/tools/generator/Tests/expected/AccessModifiers/Xamarin.Test.BasePublicClass.cs
+++ b/tools/generator/Tests/expected/AccessModifiers/Xamarin.Test.BasePublicClass.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Xamarin.Test {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='BasePublicClass']"
+	[global::Android.Runtime.Register ("xamarin/test/BasePublicClass", DoNotGenerateAcw=true)]
+	public partial class BasePublicClass : global::Java.Lang.Object {
+
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("xamarin/test/BasePublicClass", ref java_class_handle);
+			}
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (BasePublicClass); }
+		}
+
+		protected BasePublicClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		static Delegate cb_baseMethod;
+#pragma warning disable 0169
+		static Delegate GetBaseMethodHandler ()
+		{
+			if (cb_baseMethod == null)
+				cb_baseMethod = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr>) n_BaseMethod);
+			return cb_baseMethod;
+		}
+
+		static void n_BaseMethod (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Xamarin.Test.BasePublicClass __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.BasePublicClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			__this.BaseMethod ();
+		}
+#pragma warning restore 0169
+
+		static IntPtr id_baseMethod;
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='BasePublicClass']/method[@name='baseMethod' and count(parameter)=0]"
+		[Register ("baseMethod", "()V", "GetBaseMethodHandler")]
+		public virtual unsafe void BaseMethod ()
+		{
+			if (id_baseMethod == IntPtr.Zero)
+				id_baseMethod = JNIEnv.GetMethodID (class_ref, "baseMethod", "()V");
+			try {
+
+				if (((object) this).GetType () == ThresholdType)
+					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_baseMethod);
+				else
+					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "baseMethod", "()V"));
+			} finally {
+			}
+		}
+
+	}
+}

--- a/tools/generator/Tests/expected/AccessModifiers/Xamarin.Test.ExtendPublicClass.cs
+++ b/tools/generator/Tests/expected/AccessModifiers/Xamarin.Test.ExtendPublicClass.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Xamarin.Test {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='ExtendPublicClass']"
+	[global::Android.Runtime.Register ("xamarin/test/ExtendPublicClass", DoNotGenerateAcw=true)]
+	public partial class ExtendPublicClass : global::Java.Lang.Object {
+
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("xamarin/test/ExtendPublicClass", ref java_class_handle);
+			}
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (ExtendPublicClass); }
+		}
+
+		protected ExtendPublicClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		static IntPtr id_ctor;
+		// Metadata.xml XPath constructor reference: path="/api/package[@name='xamarin.test']/class[@name='ExtendPublicClass']/constructor[@name='ExtendPublicClass' and count(parameter)=0]"
+		[Register (".ctor", "()V", "")]
+		public unsafe ExtendPublicClass ()
+			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		{
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+				return;
+
+			try {
+				if (((object) this).GetType () != typeof (ExtendPublicClass)) {
+					SetHandle (
+							global::Android.Runtime.JNIEnv.StartCreateInstance (((object) this).GetType (), "()V"),
+							JniHandleOwnership.TransferLocalRef);
+					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "()V");
+					return;
+				}
+
+				if (id_ctor == IntPtr.Zero)
+					id_ctor = JNIEnv.GetMethodID (class_ref, "<init>", "()V");
+				SetHandle (
+						global::Android.Runtime.JNIEnv.StartCreateInstance (class_ref, id_ctor),
+						JniHandleOwnership.TransferLocalRef);
+				JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, class_ref, id_ctor);
+			} finally {
+			}
+		}
+
+		static Delegate cb_foo;
+#pragma warning disable 0169
+		static Delegate GetFooHandler ()
+		{
+			if (cb_foo == null)
+				cb_foo = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr>) n_Foo);
+			return cb_foo;
+		}
+
+		static void n_Foo (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Xamarin.Test.ExtendPublicClass __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.ExtendPublicClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			__this.Foo ();
+		}
+#pragma warning restore 0169
+
+		static IntPtr id_foo;
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='ExtendPublicClass']/method[@name='foo' and count(parameter)=0]"
+		[Register ("foo", "()V", "GetFooHandler")]
+		public virtual unsafe void Foo ()
+		{
+			if (id_foo == IntPtr.Zero)
+				id_foo = JNIEnv.GetMethodID (class_ref, "foo", "()V");
+			try {
+
+				if (((object) this).GetType () == ThresholdType)
+					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_foo);
+				else
+					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "foo", "()V"));
+			} finally {
+			}
+		}
+
+	}
+}

--- a/tools/generator/Tests/expected/AccessModifiers/Xamarin.Test.PublicClass.cs
+++ b/tools/generator/Tests/expected/AccessModifiers/Xamarin.Test.PublicClass.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Xamarin.Test {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='PublicClass']"
+	[global::Android.Runtime.Register ("xamarin/test/PublicClass", DoNotGenerateAcw=true)]
+	public partial class PublicClass : global::Java.Lang.Object {
+
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("xamarin/test/PublicClass", ref java_class_handle);
+			}
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (PublicClass); }
+		}
+
+		protected PublicClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		static IntPtr id_ctor;
+		// Metadata.xml XPath constructor reference: path="/api/package[@name='xamarin.test']/class[@name='PublicClass']/constructor[@name='PublicClass' and count(parameter)=0]"
+		[Register (".ctor", "()V", "")]
+		public unsafe PublicClass ()
+			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		{
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+				return;
+
+			try {
+				if (((object) this).GetType () != typeof (PublicClass)) {
+					SetHandle (
+							global::Android.Runtime.JNIEnv.StartCreateInstance (((object) this).GetType (), "()V"),
+							JniHandleOwnership.TransferLocalRef);
+					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "()V");
+					return;
+				}
+
+				if (id_ctor == IntPtr.Zero)
+					id_ctor = JNIEnv.GetMethodID (class_ref, "<init>", "()V");
+				SetHandle (
+						global::Android.Runtime.JNIEnv.StartCreateInstance (class_ref, id_ctor),
+						JniHandleOwnership.TransferLocalRef);
+				JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, class_ref, id_ctor);
+			} finally {
+			}
+		}
+
+		static Delegate cb_foo;
+#pragma warning disable 0169
+		static Delegate GetFooHandler ()
+		{
+			if (cb_foo == null)
+				cb_foo = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr>) n_Foo);
+			return cb_foo;
+		}
+
+		static void n_Foo (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Xamarin.Test.PublicClass __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.PublicClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			__this.Foo ();
+		}
+#pragma warning restore 0169
+
+		static IntPtr id_foo;
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='PublicClass']/method[@name='foo' and count(parameter)=0]"
+		[Register ("foo", "()V", "GetFooHandler")]
+		public virtual unsafe void Foo ()
+		{
+			if (id_foo == IntPtr.Zero)
+				id_foo = JNIEnv.GetMethodID (class_ref, "foo", "()V");
+			try {
+
+				if (((object) this).GetType () == ThresholdType)
+					JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_foo);
+				else
+					JNIEnv.CallNonvirtualVoidMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "foo", "()V"));
+			} finally {
+			}
+		}
+
+	}
+}

--- a/tools/generator/Tests/expected/AccessModifiers/Xamarin.Test.PublicFinalClass.cs
+++ b/tools/generator/Tests/expected/AccessModifiers/Xamarin.Test.PublicFinalClass.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Xamarin.Test {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='PublicFinalClass']"
+	[global::Android.Runtime.Register ("xamarin/test/PublicFinalClass", DoNotGenerateAcw=true)]
+	public sealed partial class PublicFinalClass : global::Xamarin.Test.BasePublicClass {
+
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("xamarin/test/PublicFinalClass", ref java_class_handle);
+			}
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (PublicFinalClass); }
+		}
+
+		internal PublicFinalClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		static IntPtr id_publicMethod;
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='PublicFinalClass']/method[@name='publicMethod' and count(parameter)=0]"
+		[Register ("publicMethod", "()V", "")]
+		public unsafe void PublicMethod ()
+		{
+			if (id_publicMethod == IntPtr.Zero)
+				id_publicMethod = JNIEnv.GetMethodID (class_ref, "publicMethod", "()V");
+			try {
+				JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_publicMethod);
+			} finally {
+			}
+		}
+
+		static IntPtr id_packageMethodB;
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='PackageClassB']/method[@name='packageMethodB' and count(parameter)=0]"
+		[Register ("packageMethodB", "()V", "")]
+		public unsafe void PackageMethodB ()
+		{
+			if (id_packageMethodB == IntPtr.Zero)
+				id_packageMethodB = JNIEnv.GetMethodID (class_ref, "packageMethodB", "()V");
+			try {
+				JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_packageMethodB);
+			} finally {
+			}
+		}
+
+		static IntPtr id_packageMethodA;
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='PackageClassA']/method[@name='packageMethodA' and count(parameter)=0]"
+		[Register ("packageMethodA", "()V", "")]
+		public unsafe void PackageMethodA ()
+		{
+			if (id_packageMethodA == IntPtr.Zero)
+				id_packageMethodA = JNIEnv.GetMethodID (class_ref, "packageMethodA", "()V");
+			try {
+				JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_packageMethodA);
+			} finally {
+			}
+		}
+
+	}
+}

--- a/tools/generator/Tests/generator-Tests.csproj
+++ b/tools/generator/Tests/generator-Tests.csproj
@@ -65,6 +65,7 @@
     <Compile Include="CSharpKeywords.cs" />
     <Compile Include="GenericArguments.cs" />
     <Compile Include="InterfaceMethodsConflict.cs" />
+    <Compile Include="AccessModifiers.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
Fixes #168

Java allows public classes to inherit from "package-private" classes, in
which case the `public` & `protected` members of the "package-private"
class are visible within the public class:

    // Java
    /* package */ abstract class SpannableStringInternal {
      public void getChars(int start, int end, char[] dest, int off);
      // ...
    }
    public class SpannableString extends SpannableStringInternal {
      // ...
    }

The problem is that `generator` didn't properly support this construct,
and *skips* binding of "package-private" types, resulting in generated
C# code such as:

    // C#
    public partial class SpannableString : SpannableStringInternal {
      // CS0246: The type or namespace name `SpannableStringInternal` could not be found
    }

This could be worked aroudn via Metadata by making the "package-private"
class `public`, but this means that if (when?) the "package-private"
class is *removed*, we have an ABI break.

Support this construct by updating `generator` to "copy" the members
from the "package-private" class into the declaring class:

    // C#
    public partial class SpannableString : Java.Lang.Object {
      public void GetChars(int start, int end, char[] dest, int off);
      // ...
    }

This allows the generated code to compile without metadata fixup.

Specifics in implementing this:
- Add a `FixupAccessModifiers` method to `GenBase`, later this may
need to be further extended for methods
- Call `FixupAccessModifiers` in the "validation" step
- Added a setter for `BaseType` so it can be modified
- In `FixupAccessModifiers`, lookup the base class of the current type
and check if it is non-public
- Skip the package-private types, and replace them with that class's
base type
- Look for each method on the base type, and copy it to the public type
if it does not exist
- Added tests for this scenario