### PR TITLE
[generator] fixed new warnings introduced

### DIFF
--- a/tools/generator/InterfaceGen.cs
+++ b/tools/generator/InterfaceGen.cs
@@ -224,7 +224,7 @@ namespace MonoDroid.Generation {
 			sw.WriteLine ("{0}internal class {1}Invoker : global::Java.Lang.Object, {1} {{", indent, Name);
 			sw.WriteLine ();
 			opt.CodeGenerator.WriteInterfaceInvokerHandle (this, sw, indent + "\t", opt, Name + "Invoker");
-			sw.WriteLine ("{0}\tnew IntPtr class_ref;", indent);
+			sw.WriteLine ("{0}\tIntPtr class_ref;", indent);
 			sw.WriteLine ();
 			sw.WriteLine ("{0}\tpublic static {1} GetObject (IntPtr handle, JniHandleOwnership transfer)", indent, Name);
 			sw.WriteLine ("{0}\t{{", indent);

--- a/tools/generator/Tests/Adapters.cs
+++ b/tools/generator/Tests/Adapters.cs
@@ -9,6 +9,8 @@ namespace generatortests
 		[Test]
 		public void GeneratedOK ()
 		{
+			//hides inherited member `Java.Lang.Object.class_ref'
+			AllowWarnings = true;
 			RunAllTargets (
 					outputRelativePath:     "Adapters",
 					apiDescriptionFile:     "expected/Adapters/Adapters.xml",

--- a/tools/generator/Tests/GenericArguments.cs
+++ b/tools/generator/Tests/GenericArguments.cs
@@ -9,6 +9,8 @@ namespace generatortests
 		[Test]
 		public void GeneratedOK ()
 		{
+			//hides inherited member `Java.Lang.Object.class_ref'
+			AllowWarnings = true;
 			RunAllTargets (
 					outputRelativePath: "GenericArguments",
 					apiDescriptionFile: "expected/GenericArguments/GenericArguments.xml",

--- a/tools/generator/Tests/InterfaceMethodsConflict.cs
+++ b/tools/generator/Tests/InterfaceMethodsConflict.cs
@@ -9,6 +9,8 @@ namespace generatortests
 		[Test]
 		public void GeneratedOK ()
 		{
+			//hides inherited member `Java.Lang.Object.class_ref'
+			AllowWarnings = true;
 			RunAllTargets (
 					outputRelativePath:     "InterfaceMethodsConflict",
 					apiDescriptionFile:     "expected/InterfaceMethodsConflict/InterfaceMethodsConflict.xml",

--- a/tools/generator/Tests/Interfaces.cs
+++ b/tools/generator/Tests/Interfaces.cs
@@ -9,6 +9,8 @@ namespace generatortests
 		[Test]
 		public void Generated_OK ()
 		{
+			//hides inherited member `Java.Lang.Object.class_ref'
+			AllowWarnings = true;
 			RunAllTargets (
 					outputRelativePath:     "TestInterface",
 					apiDescriptionFile:     "expected/TestInterface/TestInterface.xml",

--- a/tools/generator/Tests/Java_Lang_Enum.cs
+++ b/tools/generator/Tests/Java_Lang_Enum.cs
@@ -9,6 +9,8 @@ namespace generatortests
 		[Test]
 		public void Generated_OK ()
 		{
+			//hides inherited member `Java.Lang.Object.class_ref'
+			AllowWarnings = true;
 			RunAllTargets (
 					outputRelativePath:     "java.lang.Enum",
 					apiDescriptionFile:     "expected/java.lang.Enum/Java.Lang.Enum.xml",

--- a/tools/generator/Tests/NestedTypes.cs
+++ b/tools/generator/Tests/NestedTypes.cs
@@ -9,6 +9,8 @@ namespace generatortests
 		[Test]
 		public void GeneratedOK ()
 		{
+			//hides inherited member `Java.Lang.Object.class_ref'
+			AllowWarnings = true;
 			RunAllTargets (
 					outputRelativePath:     "NestedTypes",
 					apiDescriptionFile:     "expected/NestedTypes/NestedTypes.xml",

--- a/tools/generator/Tests/NormalMethods.cs
+++ b/tools/generator/Tests/NormalMethods.cs
@@ -9,6 +9,8 @@ namespace generatortests
 		[Test]
 		public void GeneratedOK ()
 		{
+			//`Xamarin.Test.SomeObject.GetType()' hides inherited member `object.GetType()'
+			//`Xamarin.Test.SomeObject.ObsoleteMethod()' is obsolete
 			AllowWarnings = true;
 			RunAllTargets (
 					outputRelativePath:     "NormalMethods",

--- a/tools/generator/Tests/expected.ji/Adapters/Xamarin.Test.IAdapter.cs
+++ b/tools/generator/Tests/expected.ji/Adapters/Xamarin.Test.IAdapter.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Test {
 			get { return _members.ManagedPeerType; }
 		}
 
-		new IntPtr class_ref;
+		IntPtr class_ref;
 
 		public static IAdapter GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected.ji/Adapters/Xamarin.Test.ISpinnerAdapter.cs
+++ b/tools/generator/Tests/expected.ji/Adapters/Xamarin.Test.ISpinnerAdapter.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Test {
 			get { return _members.ManagedPeerType; }
 		}
 
-		new IntPtr class_ref;
+		IntPtr class_ref;
 
 		public static ISpinnerAdapter GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected.ji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
+++ b/tools/generator/Tests/expected.ji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
@@ -37,7 +37,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 			get { return _members.ManagedPeerType; }
 		}
 
-		new IntPtr class_ref;
+		IntPtr class_ref;
 
 		public static IExoMediaDrmOnEventListener GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{
@@ -217,7 +217,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 			get { return _members.ManagedPeerType; }
 		}
 
-		new IntPtr class_ref;
+		IntPtr class_ref;
 
 		public static IExoMediaDrm GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected.ji/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
+++ b/tools/generator/Tests/expected.ji/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
@@ -44,7 +44,7 @@ namespace Xamarin.Test {
 					get { return _members.ManagedPeerType; }
 				}
 
-				new IntPtr class_ref;
+				IntPtr class_ref;
 
 				public static IFactory GetObject (IntPtr handle, JniHandleOwnership transfer)
 				{

--- a/tools/generator/Tests/expected.ji/TestInterface/Test.ME.IGenericInterface.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Test.ME.IGenericInterface.cs
@@ -37,7 +37,7 @@ namespace Test.ME {
 			get { return _members.ManagedPeerType; }
 		}
 
-		new IntPtr class_ref;
+		IntPtr class_ref;
 
 		public static IGenericInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected.ji/TestInterface/Test.ME.IGenericPropertyInterface.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Test.ME.IGenericPropertyInterface.cs
@@ -40,7 +40,7 @@ namespace Test.ME {
 			get { return _members.ManagedPeerType; }
 		}
 
-		new IntPtr class_ref;
+		IntPtr class_ref;
 
 		public static IGenericPropertyInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected.ji/TestInterface/Test.ME.ITestInterface.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Test.ME.ITestInterface.cs
@@ -98,7 +98,7 @@ namespace Test.ME {
 			get { return _members.ManagedPeerType; }
 		}
 
-		new IntPtr class_ref;
+		IntPtr class_ref;
 
 		public static ITestInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected.ji/java.lang.Enum/Java.Lang.IComparable.cs
+++ b/tools/generator/Tests/expected.ji/java.lang.Enum/Java.Lang.IComparable.cs
@@ -37,7 +37,7 @@ namespace Java.Lang {
 			get { return _members.ManagedPeerType; }
 		}
 
-		new IntPtr class_ref;
+		IntPtr class_ref;
 
 		public static IComparable GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected/Adapters/Xamarin.Test.IAdapter.cs
+++ b/tools/generator/Tests/expected/Adapters/Xamarin.Test.IAdapter.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Test {
 			get { return typeof (IAdapterInvoker); }
 		}
 
-		new IntPtr class_ref;
+		IntPtr class_ref;
 
 		public static IAdapter GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected/Adapters/Xamarin.Test.ISpinnerAdapter.cs
+++ b/tools/generator/Tests/expected/Adapters/Xamarin.Test.ISpinnerAdapter.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Test {
 			get { return typeof (ISpinnerAdapterInvoker); }
 		}
 
-		new IntPtr class_ref;
+		IntPtr class_ref;
 
 		public static ISpinnerAdapter GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
+++ b/tools/generator/Tests/expected/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
@@ -28,7 +28,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 			get { return typeof (IExoMediaDrmOnEventListenerInvoker); }
 		}
 
-		new IntPtr class_ref;
+		IntPtr class_ref;
 
 		public static IExoMediaDrmOnEventListener GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{
@@ -200,7 +200,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 			get { return typeof (IExoMediaDrmInvoker); }
 		}
 
-		new IntPtr class_ref;
+		IntPtr class_ref;
 
 		public static IExoMediaDrm GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
+++ b/tools/generator/Tests/expected/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
@@ -35,7 +35,7 @@ namespace Xamarin.Test {
 					get { return typeof (IFactoryInvoker); }
 				}
 
-				new IntPtr class_ref;
+				IntPtr class_ref;
 
 				public static IFactory GetObject (IntPtr handle, JniHandleOwnership transfer)
 				{

--- a/tools/generator/Tests/expected/TestInterface/Test.ME.IGenericInterface.cs
+++ b/tools/generator/Tests/expected/TestInterface/Test.ME.IGenericInterface.cs
@@ -28,7 +28,7 @@ namespace Test.ME {
 			get { return typeof (IGenericInterfaceInvoker); }
 		}
 
-		new IntPtr class_ref;
+		IntPtr class_ref;
 
 		public static IGenericInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected/TestInterface/Test.ME.IGenericPropertyInterface.cs
+++ b/tools/generator/Tests/expected/TestInterface/Test.ME.IGenericPropertyInterface.cs
@@ -31,7 +31,7 @@ namespace Test.ME {
 			get { return typeof (IGenericPropertyInterfaceInvoker); }
 		}
 
-		new IntPtr class_ref;
+		IntPtr class_ref;
 
 		public static IGenericPropertyInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected/TestInterface/Test.ME.ITestInterface.cs
+++ b/tools/generator/Tests/expected/TestInterface/Test.ME.ITestInterface.cs
@@ -90,7 +90,7 @@ namespace Test.ME {
 			get { return typeof (ITestInterfaceInvoker); }
 		}
 
-		new IntPtr class_ref;
+		IntPtr class_ref;
 
 		public static ITestInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected/java.lang.Enum/Java.Lang.IComparable.cs
+++ b/tools/generator/Tests/expected/java.lang.Enum/Java.Lang.IComparable.cs
@@ -28,7 +28,7 @@ namespace Java.Lang {
 			get { return typeof (IComparableInvoker); }
 		}
 
-		new IntPtr class_ref;
+		IntPtr class_ref;
 
 		public static IComparable GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{


### PR DESCRIPTION
Context: #217

When testing generator from xamarin-android/master, I noticed that
building a binding project has some *new* warnings:
```
obj/Debug/generated/src/GoogleAnalytics.Tracking.ILogger.cs(159,14): warning CS0109:
	The member 'ILoggerInvoker.class_ref' does not hide an accessible member.
	The new keyword is not required.
```
Binding project: https://github.com/jonathanpeppers/GoogleAnalytics/tree/master/GoogleAnalytics.Droid

This was due to a change made in #217, I was *tricked* by how warnings
operate differently in `generator-Tests` than what happens in a real
Xamarin.Android binding project.

The difference is:
- `generator-Tests` put everything in one assembly
- Real binding projects have `Java.Lang.*` and Android types in a
separate assembly

This means that some members that are marked `internal` will not need
the `new` keyword at all—even though the tests currently *would* need
the `new` keyword. The real fix here is to make the tests generate two
separate assemblies so that we are more closely reproducing the
situation of a Xamarin.Android binding project.

Since we are branching for 15-6 soon, it seems better to revert the
`new` keyword change in `InterfaceGen`, and set `AllowWarnings=true`
where required in `generator-Tests`..

I also included a comment for every test that sets
`AllowWarnings=true`, so that it is clear which warning is occurring.