### PR TITLE
[jcw-gen] use Assembly Name instead of FullName for typemaps

### DIFF
--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/TypeDefinitionRocks.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/TypeDefinitionRocks.cs
@@ -64,7 +64,11 @@ namespace Java.Interop.Tools.Cecil {
 		public static string GetPartialAssemblyQualifiedName (this TypeReference type)
 		{
 			TypeDefinition def = type.Resolve ();
-			return string.Format ("{0}, {1}", type.FullName, (def ?? type).Module.Assembly.Name.Name);
+			return string.Format ("{0}, {1}",
+					// Cecil likes to use '/' as the nested type separator, while
+					// Reflection uses '+' as the nested type separator. Use Reflection.
+					type.FullName.Replace ('/', '+'),
+					(def ?? type).Module.Assembly.Name.Name);
 		}
 
 		public static string GetAssemblyQualifiedName (this TypeReference type)

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
@@ -385,9 +385,9 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 				if (sb.Length > 0)
 					sb.Append (':');
 				if (outerType != null && sb.Length == 0)
-					sb.Append (type.DeclaringType.GetAssemblyQualifiedName ());
+					sb.Append (type.DeclaringType.GetPartialAssemblyQualifiedName ());
 				else
-					sb.Append (pdef.ParameterType.GetAssemblyQualifiedName ());
+					sb.Append (pdef.ParameterType.GetPartialAssemblyQualifiedName ());
 			}
 			return sb.ToString ();
 		}
@@ -567,12 +567,12 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 
 			if (GenerateOnCreateOverrides && JavaNativeTypeManager.IsApplication (type) && !methods.Any (m => m.Name == "onCreate"))
 				WriteApplicationOnCreate (sw, w => {
-						w.WriteLine ("\t\tmono.android.Runtime.register (\"{0}\", {1}.class, __md_methods);", type.GetAssemblyQualifiedName (), name);
+						w.WriteLine ("\t\tmono.android.Runtime.register (\"{0}\", {1}.class, __md_methods);", type.GetPartialAssemblyQualifiedName (), name);
 						w.WriteLine ("\t\tsuper.onCreate ();");
 				});
 			if (GenerateOnCreateOverrides && JavaNativeTypeManager.IsInstrumentation (type) && !methods.Any (m => m.Name == "onCreate"))
 				WriteInstrumentationOnCreate (sw, w => {
-						w.WriteLine ("\t\tmono.android.Runtime.register (\"{0}\", {1}.class, __md_methods);", type.GetAssemblyQualifiedName (), name);
+						w.WriteLine ("\t\tmono.android.Runtime.register (\"{0}\", {1}.class, __md_methods);", type.GetPartialAssemblyQualifiedName (), name);
 						w.WriteLine ("\t\tsuper.onCreate (arguments);");
 				});
 
@@ -600,7 +600,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 			sw.WriteLine ("\t\t\t\"\";");
 			if (!CannotRegisterInStaticConstructor (self.type))
 				sw.WriteLine ("\t\tmono.android.Runtime.register (\"{0}\", {1}.class, {2});",
-						self.type.GetAssemblyQualifiedName (), self.name, field);
+						self.type.GetPartialAssemblyQualifiedName (), self.name, field);
 		}
 
 		void GenerateFooter (TextWriter sw)
@@ -767,7 +767,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 #endif
 			if (!CannotRegisterInStaticConstructor (type)) {
 				sw.WriteLine ("\t\tif (getClass () == {0}.class)", name);
-				sw.WriteLine ("\t\t\tmono.android.TypeManager.Activate (\"{0}\", \"{1}\", this, new java.lang.Object[] {{ {2} }});", type.GetAssemblyQualifiedName (), ctor.ManagedParameters, ctor.ActivateCall);
+				sw.WriteLine ("\t\t\tmono.android.TypeManager.Activate (\"{0}\", \"{1}\", this, new java.lang.Object[] {{ {2} }});", type.GetPartialAssemblyQualifiedName (), ctor.ManagedParameters, ctor.ActivateCall);
 			}
 			sw.WriteLine ("\t}");
 		}

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/TypeNameMapGenerator.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/TypeNameMapGenerator.cs
@@ -141,7 +141,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 			var typeMap = GetTypeMapping (
 					t => t.IsInterface || t.HasGenericParameters,
 					JavaNativeTypeManager.ToJniName,
-					t => t.GetAssemblyQualifiedName ());
+					t => t.GetPartialAssemblyQualifiedName ());
 
 			WriteBinaryMapping (output, typeMap);
 		}
@@ -234,7 +234,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 
 			var typeMap = GetTypeMapping (
 					t => false,
-					t => t.GetAssemblyQualifiedName (),
+					t => t.GetPartialAssemblyQualifiedName (),
 					JavaNativeTypeManager.ToJniName);
 
 			WriteBinaryMapping (output, typeMap);

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGeneratorTests.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGeneratorTests.cs
@@ -93,7 +93,7 @@ public class Name
 		)
 		{
 			var actual      = Generate (typeof (IndirectApplication), applicationJavaClass);
-			var expected    = @"package md5fef72cac46d04ae5bdc90af5bb6221ad;
+			var expected    = @"package md5f43cdfade412ae71b21bb70a5c2841ab;
 
 
 public class IndirectApplication
@@ -144,7 +144,7 @@ public class IndirectApplication
 		public void GenerateExportedMembers ()
 		{
 			var actual = Generate (typeof (ExportsMembers));
-			var expected = @"package md5fef72cac46d04ae5bdc90af5bb6221ad;
+			var expected = @"package md5f43cdfade412ae71b21bb70a5c2841ab;
 
 
 public class ExportsMembers
@@ -156,28 +156,28 @@ public class ExportsMembers
 	public static final String __md_methods;
 	static {
 		__md_methods = 
-			""n_GetInstance:()Lmd5fef72cac46d04ae5bdc90af5bb6221ad/ExportsMembers;:__export__\n"" +
+			""n_GetInstance:()Lmd5f43cdfade412ae71b21bb70a5c2841ab/ExportsMembers;:__export__\n"" +
 			""n_GetValue:()Ljava/lang/String;:__export__\n"" +
 			""n_methodNamesNotMangled:()V:__export__\n"" +
 			""n_CompletelyDifferentName:(Ljava/lang/String;I)Ljava/lang/String;:__export__\n"" +
 			""n_methodThatThrows:()V:__export__\n"" +
 			""n_methodThatThrowsEmptyArray:()V:__export__\n"" +
 			"""";
-		mono.android.Runtime.register (""Xamarin.Android.ToolsTests.ExportsMembers, Java.Interop.Tools.JavaCallableWrappers-Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"", ExportsMembers.class, __md_methods);
+		mono.android.Runtime.register (""Xamarin.Android.ToolsTests.ExportsMembers, Java.Interop.Tools.JavaCallableWrappers-Tests"", ExportsMembers.class, __md_methods);
 	}
 
 
-	public static md5fef72cac46d04ae5bdc90af5bb6221ad.ExportsMembers STATIC_INSTANCE = GetInstance ();
+	public static md5f43cdfade412ae71b21bb70a5c2841ab.ExportsMembers STATIC_INSTANCE = GetInstance ();
 
 
 	public java.lang.String VALUE = GetValue ();
 
-	public static md5fef72cac46d04ae5bdc90af5bb6221ad.ExportsMembers GetInstance ()
+	public static md5f43cdfade412ae71b21bb70a5c2841ab.ExportsMembers GetInstance ()
 	{
 		return n_GetInstance ();
 	}
 
-	private static native md5fef72cac46d04ae5bdc90af5bb6221ad.ExportsMembers n_GetInstance ();
+	private static native md5f43cdfade412ae71b21bb70a5c2841ab.ExportsMembers n_GetInstance ();
 
 	public java.lang.String GetValue ()
 	{
@@ -240,7 +240,7 @@ public class ExportsMembers
 		public void GenerateInnerClass ()
 		{
 			var actual = Generate (typeof (ExampleOuterClass));
-			var expected = @"package md5fef72cac46d04ae5bdc90af5bb6221ad;
+			var expected = @"package md5f43cdfade412ae71b21bb70a5c2841ab;
 
 
 public class ExampleOuterClass
@@ -254,10 +254,10 @@ public class ExampleOuterClass
 	static {
 		__md_methods = 
 			"""";
-		mono.android.Runtime.register (""Xamarin.Android.ToolsTests.ExampleOuterClass, Java.Interop.Tools.JavaCallableWrappers-Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"", ExampleOuterClass.class, __md_methods);
+		mono.android.Runtime.register (""Xamarin.Android.ToolsTests.ExampleOuterClass, Java.Interop.Tools.JavaCallableWrappers-Tests"", ExampleOuterClass.class, __md_methods);
 		__md_1_methods = 
 			"""";
-		mono.android.Runtime.register (""Xamarin.Android.ToolsTests.ExampleOuterClass+ExampleInnerClass, Java.Interop.Tools.JavaCallableWrappers-Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"", ExampleOuterClass_ExampleInnerClass.class, __md_1_methods);
+		mono.android.Runtime.register (""Xamarin.Android.ToolsTests.ExampleOuterClass+ExampleInnerClass, Java.Interop.Tools.JavaCallableWrappers-Tests"", ExampleOuterClass_ExampleInnerClass.class, __md_1_methods);
 	}
 
 	private java.util.ArrayList refList;
@@ -316,7 +316,7 @@ public class Name_DefaultNestedName
 	static {
 		__md_methods = 
 			"""";
-		mono.android.Runtime.register (""Xamarin.Android.ToolsTests.RegisterName+DefaultNestedName, Java.Interop.Tools.JavaCallableWrappers-Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"", Name_DefaultNestedName.class, __md_methods);
+		mono.android.Runtime.register (""Xamarin.Android.ToolsTests.RegisterName+DefaultNestedName, Java.Interop.Tools.JavaCallableWrappers-Tests"", Name_DefaultNestedName.class, __md_methods);
 	}
 
 	private java.util.ArrayList refList;
@@ -354,7 +354,7 @@ public class Name$Override
 	static {
 		__md_methods = 
 			"""";
-		mono.android.Runtime.register (""Xamarin.Android.ToolsTests.RegisterName+OverrideNestedName, Java.Interop.Tools.JavaCallableWrappers-Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"", Name$Override.class, __md_methods);
+		mono.android.Runtime.register (""Xamarin.Android.ToolsTests.RegisterName+OverrideNestedName, Java.Interop.Tools.JavaCallableWrappers-Tests"", Name$Override.class, __md_methods);
 	}
 
 	private java.util.ArrayList refList;
@@ -392,7 +392,7 @@ public class ExportsConstructors
 	static {
 		__md_methods = 
 			"""";
-		mono.android.Runtime.register (""Xamarin.Android.ToolsTests.ExportsConstructors, Java.Interop.Tools.JavaCallableWrappers-Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"", ExportsConstructors.class, __md_methods);
+		mono.android.Runtime.register (""Xamarin.Android.ToolsTests.ExportsConstructors, Java.Interop.Tools.JavaCallableWrappers-Tests"", ExportsConstructors.class, __md_methods);
 	}
 
 
@@ -400,7 +400,7 @@ public class ExportsConstructors
 	{
 		super ();
 		if (getClass () == ExportsConstructors.class)
-			mono.android.TypeManager.Activate (""Xamarin.Android.ToolsTests.ExportsConstructors, Java.Interop.Tools.JavaCallableWrappers-Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"", """", this, new java.lang.Object[] {  });
+			mono.android.TypeManager.Activate (""Xamarin.Android.ToolsTests.ExportsConstructors, Java.Interop.Tools.JavaCallableWrappers-Tests"", """", this, new java.lang.Object[] {  });
 	}
 
 
@@ -408,7 +408,7 @@ public class ExportsConstructors
 	{
 		super (p0);
 		if (getClass () == ExportsConstructors.class)
-			mono.android.TypeManager.Activate (""Xamarin.Android.ToolsTests.ExportsConstructors, Java.Interop.Tools.JavaCallableWrappers-Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"", """", this, new java.lang.Object[] { p0 });
+			mono.android.TypeManager.Activate (""Xamarin.Android.ToolsTests.ExportsConstructors, Java.Interop.Tools.JavaCallableWrappers-Tests"", """", this, new java.lang.Object[] { p0 });
 	}
 
 	private java.util.ArrayList refList;
@@ -446,7 +446,7 @@ public class ExportsThrowsConstructors
 	static {
 		__md_methods = 
 			"""";
-		mono.android.Runtime.register (""Xamarin.Android.ToolsTests.ExportsThrowsConstructors, Java.Interop.Tools.JavaCallableWrappers-Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"", ExportsThrowsConstructors.class, __md_methods);
+		mono.android.Runtime.register (""Xamarin.Android.ToolsTests.ExportsThrowsConstructors, Java.Interop.Tools.JavaCallableWrappers-Tests"", ExportsThrowsConstructors.class, __md_methods);
 	}
 
 
@@ -454,7 +454,7 @@ public class ExportsThrowsConstructors
 	{
 		super ();
 		if (getClass () == ExportsThrowsConstructors.class)
-			mono.android.TypeManager.Activate (""Xamarin.Android.ToolsTests.ExportsThrowsConstructors, Java.Interop.Tools.JavaCallableWrappers-Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"", """", this, new java.lang.Object[] {  });
+			mono.android.TypeManager.Activate (""Xamarin.Android.ToolsTests.ExportsThrowsConstructors, Java.Interop.Tools.JavaCallableWrappers-Tests"", """", this, new java.lang.Object[] {  });
 	}
 
 
@@ -462,7 +462,7 @@ public class ExportsThrowsConstructors
 	{
 		super (p0);
 		if (getClass () == ExportsThrowsConstructors.class)
-			mono.android.TypeManager.Activate (""Xamarin.Android.ToolsTests.ExportsThrowsConstructors, Java.Interop.Tools.JavaCallableWrappers-Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"", """", this, new java.lang.Object[] { p0 });
+			mono.android.TypeManager.Activate (""Xamarin.Android.ToolsTests.ExportsThrowsConstructors, Java.Interop.Tools.JavaCallableWrappers-Tests"", """", this, new java.lang.Object[] { p0 });
 	}
 
 
@@ -470,7 +470,7 @@ public class ExportsThrowsConstructors
 	{
 		super (p0);
 		if (getClass () == ExportsThrowsConstructors.class)
-			mono.android.TypeManager.Activate (""Xamarin.Android.ToolsTests.ExportsThrowsConstructors, Java.Interop.Tools.JavaCallableWrappers-Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"", """", this, new java.lang.Object[] { p0 });
+			mono.android.TypeManager.Activate (""Xamarin.Android.ToolsTests.ExportsThrowsConstructors, Java.Interop.Tools.JavaCallableWrappers-Tests"", """", this, new java.lang.Object[] { p0 });
 	}
 
 	private java.util.ArrayList refList;

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers/TypeNameMapGeneratorTests.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers/TypeNameMapGeneratorTests.cs
@@ -49,7 +49,7 @@ namespace Xamarin.Android.ToolsTests
 			v.WriteJavaToManaged (o);
 			var a = ToArray (o);
 			Save (a, "__j2m");
-			var length = 259;
+			var length = 204;
 			var offset = 90;
 			var e =
 				"version=1\u0000" +
@@ -59,12 +59,12 @@ namespace Xamarin.Android.ToolsTests
 				GetJ2MEntryLine (typeof (ActivityName),                             "activity/Name",                                                                                offset, length) +
 				GetJ2MEntryLine (typeof (ApplicationName),                          "application/Name",                                                                             offset, length) +
 				GetJ2MEntryLine (typeof (InstrumentationName),                      "instrumentation/Name",                                                                         offset, length) +
-				GetJ2MEntryLine (typeof (DefaultName),                              "md5fef72cac46d04ae5bdc90af5bb6221ad/DefaultName",                                              offset, length) +
-				GetJ2MEntryLine (typeof (DefaultName.A),                            "md5fef72cac46d04ae5bdc90af5bb6221ad/DefaultName_A",                                            offset, length) +
-				GetJ2MEntryLine (typeof (DefaultName.A.B),                          "md5fef72cac46d04ae5bdc90af5bb6221ad/DefaultName_A_B",                                          offset, length) +
-				GetJ2MEntryLine (typeof (DefaultName.C.D),                          "md5fef72cac46d04ae5bdc90af5bb6221ad/DefaultName_C_D",                                          offset, length) +
-				GetJ2MEntryLine (typeof (ExampleOuterClass),                        "md5fef72cac46d04ae5bdc90af5bb6221ad/ExampleOuterClass",                                        offset, length) +
-				GetJ2MEntryLine (typeof (ExampleOuterClass.ExampleInnerClass),      "md5fef72cac46d04ae5bdc90af5bb6221ad/ExampleOuterClass$ExampleOuterClass_ExampleInnerClass",    offset, length) +
+				GetJ2MEntryLine (typeof (DefaultName),                              "md5f43cdfade412ae71b21bb70a5c2841ab/DefaultName",                                              offset, length) +
+				GetJ2MEntryLine (typeof (DefaultName.A),                            "md5f43cdfade412ae71b21bb70a5c2841ab/DefaultName_A",                                            offset, length) +
+				GetJ2MEntryLine (typeof (DefaultName.A.B),                          "md5f43cdfade412ae71b21bb70a5c2841ab/DefaultName_A_B",                                          offset, length) +
+				GetJ2MEntryLine (typeof (DefaultName.C.D),                          "md5f43cdfade412ae71b21bb70a5c2841ab/DefaultName_C_D",                                          offset, length) +
+				GetJ2MEntryLine (typeof (ExampleOuterClass),                        "md5f43cdfade412ae71b21bb70a5c2841ab/ExampleOuterClass",                                        offset, length) +
+				GetJ2MEntryLine (typeof (ExampleOuterClass.ExampleInnerClass),      "md5f43cdfade412ae71b21bb70a5c2841ab/ExampleOuterClass$ExampleOuterClass_ExampleInnerClass",    offset, length) +
 				GetJ2MEntryLine (typeof (AbstractClass),                            "my/AbstractClass",                                                                             offset, length) +
 				GetJ2MEntryLine (typeof (ProviderName),                             "provider/Name",                                                                                offset, length) +
 				GetJ2MEntryLine (typeof (ReceiverName),                             "receiver/Name",                                                                                offset, length) +
@@ -97,7 +97,7 @@ namespace Xamarin.Android.ToolsTests
 
 		static string GetJ2MEntryLine (Type type, string jniName, int offset, int length)
 		{
-			return GetEntryPart (jniName, offset) + GetEntryPart (type.AssemblyQualifiedName, length - offset);
+			return GetEntryPart (jniName, offset) + GetEntryPart (GetTypeName (type), length - offset);
 		}
 
 		static string GetEntryPart (string value, int length)
@@ -113,8 +113,8 @@ namespace Xamarin.Android.ToolsTests
 			v.WriteManagedToJava (o);
 			var a = ToArray (o);
 			Save (a, "__m2j");
-			var length = 259;
-			var offset = 169;
+			var length = 204;
+			var offset = 114;
 			var e =
 				"version=1\u0000" +
 				"entry-count=19\u0000" +
@@ -124,12 +124,12 @@ namespace Xamarin.Android.ToolsTests
 				GetM2JEntryLine (typeof (AbstractClassInvoker),                     "my/AbstractClass",                                                                             offset, length) +
 				GetM2JEntryLine (typeof (ActivityName),                             "activity/Name",                                                                                offset, length) +
 				GetM2JEntryLine (typeof (ApplicationName),                          "application/Name",                                                                             offset, length) +
-				GetM2JEntryLine (typeof (DefaultName.A.B),                          "md5fef72cac46d04ae5bdc90af5bb6221ad/DefaultName_A_B",                                          offset, length) +
-				GetM2JEntryLine (typeof (DefaultName.A),                            "md5fef72cac46d04ae5bdc90af5bb6221ad/DefaultName_A",                                            offset, length) +
-				GetM2JEntryLine (typeof (DefaultName.C.D),                          "md5fef72cac46d04ae5bdc90af5bb6221ad/DefaultName_C_D",                                          offset, length) +
-				GetM2JEntryLine (typeof (DefaultName),                              "md5fef72cac46d04ae5bdc90af5bb6221ad/DefaultName",                                              offset, length) +
-				GetM2JEntryLine (typeof (ExampleOuterClass.ExampleInnerClass),      "md5fef72cac46d04ae5bdc90af5bb6221ad/ExampleOuterClass$ExampleOuterClass_ExampleInnerClass",    offset, length) +
-				GetM2JEntryLine (typeof (ExampleOuterClass),                        "md5fef72cac46d04ae5bdc90af5bb6221ad/ExampleOuterClass",                                        offset, length) +
+				GetM2JEntryLine (typeof (DefaultName.A.B),                          "md5f43cdfade412ae71b21bb70a5c2841ab/DefaultName_A_B",                                          offset, length) +
+				GetM2JEntryLine (typeof (DefaultName.A),                            "md5f43cdfade412ae71b21bb70a5c2841ab/DefaultName_A",                                            offset, length) +
+				GetM2JEntryLine (typeof (DefaultName.C.D),                          "md5f43cdfade412ae71b21bb70a5c2841ab/DefaultName_C_D",                                          offset, length) +
+				GetM2JEntryLine (typeof (DefaultName),                              "md5f43cdfade412ae71b21bb70a5c2841ab/DefaultName",                                              offset, length) +
+				GetM2JEntryLine (typeof (ExampleOuterClass.ExampleInnerClass),      "md5f43cdfade412ae71b21bb70a5c2841ab/ExampleOuterClass$ExampleOuterClass_ExampleInnerClass",    offset, length) +
+				GetM2JEntryLine (typeof (ExampleOuterClass),                        "md5f43cdfade412ae71b21bb70a5c2841ab/ExampleOuterClass",                                        offset, length) +
 				GetM2JEntryLine (typeof (InstrumentationName),                      "instrumentation/Name",                                                                         offset, length) +
 				GetM2JEntryLine (typeof (NonStaticOuterClass.NonStaticInnerClass),  "register/NonStaticOuterClass$NonStaticInnerClass",                                             offset, length) +
 				GetM2JEntryLine (typeof (NonStaticOuterClass),                      "register/NonStaticOuterClass",                                                                 offset, length) +
@@ -147,7 +147,12 @@ namespace Xamarin.Android.ToolsTests
 
 		static string GetM2JEntryLine (Type type, string jniName, int offset, int length)
 		{
-			return GetEntryPart (type.AssemblyQualifiedName, offset) + GetEntryPart (jniName, length - offset);
+			return GetEntryPart (GetTypeName (type), offset) + GetEntryPart (jniName, length - offset);
+		}
+
+		static string GetTypeName (Type type)
+		{
+			return type.FullName + ", " + type.Assembly.GetName ().Name;
 		}
 	}
 }

--- a/src/Java.Interop.Tools.TypeNameMappings/Java.Interop.Tools.TypeNameMappings/JavaNativeTypeManager.cs
+++ b/src/Java.Interop.Tools.TypeNameMappings/Java.Interop.Tools.TypeNameMappings/JavaNativeTypeManager.cs
@@ -187,15 +187,16 @@ namespace Java.Interop.Tools.TypeNameMappings
 
 		public static string GetPackageName (Type type)
 		{
-			if (IsPackageNamePreservedForAssembly (type.Assembly.GetName ().Name))
+			string assemblyName = type.Assembly.GetName ().Name;
+			if (IsPackageNamePreservedForAssembly (assemblyName))
 				return type.Namespace.ToLowerInvariant ();
 			switch (PackageNamingPolicy) {
 			case PackageNamingPolicy.Lowercase:
 				return type.Namespace.ToLowerInvariant ();
 			case PackageNamingPolicy.LowercaseWithAssemblyName:
-				return "assembly_" + (type.Assembly.GetName ().Name.Replace ('.', '_') + "." + type.Namespace).ToLowerInvariant ();
+				return "assembly_" + (assemblyName.Replace ('.', '_') + "." + type.Namespace).ToLowerInvariant ();
 			default:
-				return "md5" + ToMd5 (type.Namespace + ":" + type.Assembly.FullName);
+				return "md5" + ToMd5 (type.Namespace + ":" + assemblyName);
 			}
 		}
 
@@ -515,7 +516,7 @@ namespace Java.Interop.Tools.TypeNameMappings
 			case PackageNamingPolicy.LowercaseWithAssemblyName:
 				return "assembly_" + (type.Module.Assembly.Name.Name.Replace ('.', '_') + "." + type.Namespace).ToLowerInvariant ();
 			default:
-				return "md5" + ToMd5 (type.Namespace + ":" + type.Module.Assembly.Name.FullName);
+				return "md5" + ToMd5 (type.Namespace + ":" + type.Module.Assembly.Name.Name);
 			}
 		}
 #endif


### PR DESCRIPTION
Context: https://bugzilla.xamarin.com/show_bug.cgi?id=61073

The Java-to-Managed typemaps list types such as:
```
android/app/Activity
Android.App.Activity, Mono.Android, Version=0.0.0.0, Culture=neutral,
PublicKeyToken=84e04ff9cfb79065
```

Let’s assume you have an Android project with the following
assembly-level attribute:
```
[assembly:AssemblyVersion("1.0.0.*")]
```

Then on *every* build, the typemap is invalidated because your version
number has been incremented.

The fix here is to use the assembly’s short name via `GetName ().Name`
or Mono.Cecil’s equivalent `AssemblyDefinition.Name.Name`. So the above
typemap would only be `Android.App.Activity, Mono.Android`. These
changes needed to happen in both `JavaNativeTypeManager` and
`TypeNameMapGenerator`.

The final fix is to find *every* instance of
`TypeDefinitionRocks.GetAssemblyQualifiedName` and use
`TypeDefinitionRocks.GetPartialAssemblyQualifiedName` in its place.
The latter also had the issue of needing to replace the `/` character
with `+`, so both methods return valid nested type names.