### PR TITLE
[Java.Interop] Ignore 2 more types for AvoidVisibleNestedTypesRule

### DIFF
--- a/gendarme-ignore.txt
+++ b/gendarme-ignore.txt
@@ -154,8 +154,10 @@ T: Java.Interop.JniPeerMembers/JniStaticMethods
 T: Java.Interop.JniPeerMembers/JniInstanceFields
 T: Java.Interop.JniPeerMembers/JniStaticFields
 T: Java.Interop.JniRuntime/CreationOptions
+T: Java.Interop.JniRuntime/JniMarshalMemberBuilder
 T: Java.Interop.JniRuntime/JniObjectReferenceManager
 T: Java.Interop.JniRuntime/JniTypeManager
+T: Java.Interop.JniRuntime/JniValueManager
 
 
 R: Gendarme.Rules.Design.DisposableTypesShouldHaveFinalizerRule


### PR DESCRIPTION
The reason is still the same, to avoid Java.Interop namespace
polution, so that code completion is well aranged.