### PR TITLE
[Java.Interop] Ignore ListsAreStronglyTypedRule

### DIFF
--- a/gendarme-ignore.txt
+++ b/gendarme-ignore.txt
@@ -614,6 +614,18 @@ R: Gendarme.Rules.Design.Generic.DoNotExposeGenericListsRule
 # We don't care here as we don't hold the list and create it on request. So to avoid performace penalty, we keep the list as return type
 M: System.Collections.Generic.List`1<Java.Interop.JniSurfacedPeerInfo> Java.Interop.JniRuntime/JniValueManager::GetSurfacedPeers()
 
+R: Gendarme.Rules.Design.ListsAreStronglyTypedRule
+# Add, Insert and Remove methods are not supported by design and thus lack strongly typed versions of these methods
+T: Java.Interop.JavaBooleanArray
+T: Java.Interop.JavaCharArray
+T: Java.Interop.JavaDoubleArray
+T: Java.Interop.JavaInt16Array
+T: Java.Interop.JavaInt32Array
+T: Java.Interop.JavaInt64Array
+T: Java.Interop.JavaObjectArray`1
+T: Java.Interop.JavaSByteArray
+T: Java.Interop.JavaSingleArray
+
 R: Gendarme.Rules.Concurrency.DoNotUseLockedRegionOutsideMethodRule
 # Looks like Gendarme issue, as there are both Monitor.TryEnter and Monitor.Exit used in this method
 M: System.Boolean Java.Interop.JniRuntime/JniTypeManager::TryRegisterNativeMembers(Java.Interop.JniType,System.Type,System.String)


### PR DESCRIPTION
Ignore ListsAreStronglyTypedRule for array marshaling types, which do
not support Add, Insert and Remove methods (they throw unsupported
exception in the abstract base class JavaArray<T>).

Thus there's not much sense in adding strongly typed versions just to
throw unsupported exception there as well.