### PR TITLE
[Java.Interop] Ignore swallowing exceptions for optional assembly load

### DIFF
--- a/gendarme-ignore.txt
+++ b/gendarme-ignore.txt
@@ -224,6 +224,8 @@ R: Gendarme.Rules.Design.Generic.DoNotExposeNestedGenericSignaturesRule
 M: System.Linq.Expressions.Expression`1<System.Func`4<System.Reflection.ConstructorInfo,Java.Interop.JniObjectReference,System.Object[],System.Object>> Java.Interop.JniRuntime/JniMarshalMemberBuilder::CreateConstructActivationPeerExpression(System.Reflection.ConstructorInfo)
 
 R: Gendarme.Rules.Exceptions.DoNotSwallowErrorsCatchingNonSpecificExceptionsRule
+# the *.Export assemblies are optional, so we don't care when they cannot be loaded (they are presumably missing)
+M: System.Void Java.Interop.JniRuntime::SetMarshalMemberBuilder(Java.Interop.JniRuntime/CreationOptions)
 M: System.Reflection.Assembly Java.Interop.JniRuntime/JniTypeManager::TryLoadAssembly(System.Reflection.AssemblyName)
 # The exception is transitioned to Jni
 M:System.Void Java.Interop.ManagedPeer::Construct(System.IntPtr,System.IntPtr,System.IntPtr,System.IntPtr,System.IntPtr,System.IntPtr)

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniMarshalMemberBuilder.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniMarshalMemberBuilder.cs
@@ -32,7 +32,8 @@ namespace Java.Interop {
 			Assembly jie;
 			try {
 				jie = Assembly.Load (new AssemblyName ("Java.Interop.Export"));
-			} catch (Exception) {
+			} catch (Exception e) {
+				System.Diagnostics.Debug.WriteLine ($"Java.Interop.Export assembly was not loaded: {e}");
 				return;
 			}
 			var t   = jie.GetType ("Java.Interop.MarshalMemberBuilder");


### PR DESCRIPTION
System.Void
Java.Interop.JniRuntime::SetMarshalMemberBuilder(Java.Interop.JniRuntime/CreationOptions)
tries to load optional Export assembly. We don't care about the
problem loading it and pressume it is missing when exception is
caught.

Also added debug output in case we were able to load the assembly,
which might be handly while tracing issues in marshaling.