### PR TITLE
[Java.Interop] Ignore AvoidMethodWithUnusedGenericTypeRule

### DIFF
--- a/gendarme-ignore.txt
+++ b/gendarme-ignore.txt
@@ -636,3 +636,7 @@ M: System.Boolean Java.Interop.JniRuntime/JniTypeManager::TryRegisterNativeMembe
 R: Gendarme.Rules.Performance.AvoidUnsealedConcreteAttributesRule
 # We would like users to be able to derive from this attribute
 T: Java.Interop.JniValueMarshalerAttribute
+
+R: Gendarme.Rules.Design.Generic.AvoidMethodWithUnusedGenericTypeRule
+# looks like Gendarme bug, the TArray is used in the cast
+M: System.Void Java.Interop.JavaArray`1::DestroyArgumentState(System.Collections.Generic.IList`1<T>,Java.Interop.JniValueMarshalerState&,System.Reflection.ParameterAttributes)


### PR DESCRIPTION
Looks like Gendarme bug, the TArray is used for the cast, so it is not
unused.