### PR TITLE
[Java.Interop] Ignore warnings for anonymous types

### DIFF
--- a/gendarme-ignore.txt
+++ b/gendarme-ignore.txt
@@ -648,3 +648,8 @@ T: Java.Interop.JniValueMarshalerAttribute
 R: Gendarme.Rules.Design.Generic.AvoidMethodWithUnusedGenericTypeRule
 # looks like Gendarme bug, the TArray is used in the cast
 M: System.Void Java.Interop.JavaArray`1::DestroyArgumentState(System.Collections.Generic.IList`1<T>,Java.Interop.JniValueMarshalerState&,System.Reflection.ParameterAttributes)
+
+R: Gendarme.Rules.Performance.UseStringEmptyRule
+# these are compiler generated
+M: System.String <>__AnonType0`2::ToString()
+M: System.String <>__AnonType1`2::ToString()


### PR DESCRIPTION
These are generated by the compiler and thus out of our control. These are also only generated by the mcs compiler and not by csc (Roslyn)

Gendarme reported 4 defects for
https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Performance.UseStringEmptyRule(2.10)