### PR TITLE
[Java.Interop] Ignore Gendarme's warning of JniValueMarshalerState size

### DIFF
--- a/gendarme-ignore.txt
+++ b/gendarme-ignore.txt
@@ -569,6 +569,8 @@ R: Gendarme.Rules.Performance.AvoidLargeStructureRule
 T: Java.Interop.JniArgumentValue
 # This we can't make smaller; it *must* match the corresponding native struct!
 T: Java.Interop.JniNativeInterfaceStruct
+# I think we cannot make this one smaller. Also the reported size is wrong as it contains Java.Interop.JniArgumentValue, which is a union (see above)
+T: Java.Interop.JniValueMarshalerState
 
 
 R: Gendarme.Rules.Performance.AvoidRepetitiveCastsRule


### PR DESCRIPTION
Gendarme reports defect with
https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Performance.AvoidLargeStructureRule(2.10).

I think we cannot reduce the size of the state struct. The reported
size (54 bytes) is even larger than a real size as it contains
`Java.Interop.JniArgumentValue` field, whose size is calculated wrong
by Gendarme. It is probably larger than 16 bytes though.