### PR TITLE
[Java.Interop] Fix JNI signature generating

### DIFF
--- a/src/Java.Interop.Tools.TypeNameMappings/Java.Interop.Tools.TypeNameMappings/JavaNativeTypeManager.cs
+++ b/src/Java.Interop.Tools.TypeNameMappings/Java.Interop.Tools.TypeNameMappings/JavaNativeTypeManager.cs
@@ -261,8 +261,8 @@ namespace Java.Interop.Tools.TypeNameMappings
 		// Keep in sync with ToJniNameFromAttributes(TypeDefinition)
 		public static string ToJniNameFromAttributes (Type type)
 		{
-			var a = type.GetCustomAttributes ().OfType<IJniNameProviderAttribute> ().FirstOrDefault (j => !string.IsNullOrEmpty (j.Name));
-			return a == null ? null : a.Name.Replace ('.', '/');
+			var aa = (IJniNameProviderAttribute []) type.GetCustomAttributes (typeof (IJniNameProviderAttribute), false);
+			return aa.Length > 0 && !string.IsNullOrEmpty (aa [0].Name) ? aa [0].Name.Replace ('.', '/') : null;
 		}
 
 		/*


### PR DESCRIPTION
Commit
https://github.com/xamarin/java.interop/commit/cb161d2031ac06f39b82e2d0d3f4ea1c60996afa
introduced a regression described in
https://github.com/xamarin/xamarin-android/issues/1149#issuecomment-356091294

The signature of the `InitializeCreator` method was wrongly calculated
as `()Ljava/lang/Object;` instead of original
`()Lmd59b7a7576784821ea63294fbca8600da1/Creator_1;`

The reason for that is, that
https://github.com/xamarin/java.interop/commit/cb161d2031ac06f39b82e2d0d3f4ea1c60996afa#diff-9e153905b02dbe50c0e0b874ba40bf3eR262
started using `IEnumerable<T>::OfType<T>`, which traverses
inheritance, unlike the original `Type::GetCustomAttributes` called
with `inherit = false`.

Thus for the `Creator<Player>` we got the `RegisterAttribute` from the
parent type `Java.Lang.Object` which led to non-null result from
`ToJniNameFromAttributes` method. At the end the result was used here
https://github.com/xamarin/java.interop/commit/cb161d2031ac06f39b82e2d0d3f4ea1c60996afa#diff-9e153905b02dbe50c0e0b874ba40bf3eR361
instead of returning `ToJniName (type, exportKind)` result.