### PR TITLE
[Java.Interop] Ignore Gendarme's suffixes suggestions

### DIFF
--- a/gendarme-ignore.txt
+++ b/gendarme-ignore.txt
@@ -555,11 +555,14 @@ M: Java.Interop.JniObjectReferenceType Java.Interop.NativeMethods::java_interop_
 
 
 R: Gendarme.Rules.Naming.UseCorrectSuffixRule
-T: Java.Interop.DestroyJavaVMDelegate
-T: Java.Interop.GetEnvDelegate
-T: Java.Interop.AttachCurrentThreadDelegate
-T: Java.Interop.DetachCurrentThreadDelegate
 T: Java.Interop.AttachCurrentThreadAsDaemonDelegate
+T: Java.Interop.AttachCurrentThreadDelegate
+T: Java.Interop.DestroyJavaVMDelegate
+T: Java.Interop.DetachCurrentThreadDelegate
+T: Java.Interop.Expressions.VariableCollection
+T: Java.Interop.GetEnvDelegate
+T: Java.Interop.JavaArray`1
+T: Java.Interop.JavaProxyThrowable
 T: Java.Interop.JniObjectReferenceFlags
 
 


### PR DESCRIPTION
Added `Java.Interop.JavaArray<T>`, `Java.Interop.JavaProxyThrowable`
and `Java.Interop.Expressions.VariableCollection` to the list. These
don't follow the suggested[1] naming by design.

Also sorted the list of types for the UseCorrectSuffixRule rule.

[1] https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Naming.UseCorrectSuffixRule(2.10)