### PR TITLE
[Java.Interop] Ignore dispose rule for JniArrayElements

### DIFF
--- a/gendarme-ignore.txt
+++ b/gendarme-ignore.txt
@@ -165,6 +165,12 @@ R: Gendarme.Rules.Design.DisposableTypesShouldHaveFinalizerRule
 T: Java.Interop.JniArrayElements
 T: Java.Interop.JniEnvironmentInfo
 
+
+R: Gendarme.Rules.Design.UseCorrectDisposeSignaturesRule
+# we don't need virtual Dispose(bool) method here. we also fully control the type, as it has only internal constructor
+T: Java.Interop.JniArrayElements
+
+
 R: Gendarme.Rules.Design.EnumsShouldUseInt32Rule
 # It's a `uint` because I'm using bitwise operators and want to keep things sane.
 T: Java.Interop.JniObjectReferenceFlags


### PR DESCRIPTION
Ignore
https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Design.UseCorrectDisposeSignaturesRule(2.10)
for `JniArrayElements`. We don't need the virtual `Dispose` method
here as we control the inheritance by having single internal
constructor. Thus it cannot be subclassed outside of
`Java.Interop.dll`.