### PR TITLE
[Java.Interop] Ignore Gendarme's SafeHandle rule

### DIFF
--- a/gendarme-ignore.txt
+++ b/gendarme-ignore.txt
@@ -19,12 +19,14 @@ T: Java.Interop.JniObjectReference
 
 
 R: Gendarme.Rules.BadPractice.PreferSafeHandleRule
+# We don't want to use the SafeHandle here to improve the performance; see tests/invocation-overhead/README.md
+# We *can't* use SafeHandles here because the GC bridge needs to be able to write into JavaException & JavaObject.
+T: Java.Interop.JavaException
+T: Java.Interop.JavaObject
 # No, we don't want/need a SafeHandle for JniRuntime.InvocationPointer!
 T: Java.Interop.JniEnvironmentInfo
 T: Java.Interop.JniRuntime
-# We don't want to use the SafeHandle here to improve the performance
-T: Java.Interop.JavaException
-T: Java.Interop.JavaObject
+# We don't want/need a SafeHandle for JNIEnv::Get<PrimitiveType>ArrayElements()
 T: Java.Interop.JniArrayElements
 
 R: Gendarme.Rules.Correctness.AvoidFloatingPointEqualityRule

--- a/gendarme-ignore.txt
+++ b/gendarme-ignore.txt
@@ -22,6 +22,10 @@ R: Gendarme.Rules.BadPractice.PreferSafeHandleRule
 # No, we don't want/need a SafeHandle for JniRuntime.InvocationPointer!
 T: Java.Interop.JniEnvironmentInfo
 T: Java.Interop.JniRuntime
+# We don't want to use the SafeHandle here to improve the performance
+T: Java.Interop.JavaException
+T: Java.Interop.JavaObject
+T: Java.Interop.JniArrayElements
 
 R: Gendarme.Rules.Correctness.AvoidFloatingPointEqualityRule
 # This is in from generated code. We could plausibly fix the generated code, but I'm not at all sure what to change it *to*.


### PR DESCRIPTION
Ignore
https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.BadPractice.PreferSafeHandleRule(2.10)
for these types for performance reasons.