### PR TITLE
[Java.Interop] Ignore Gendarme's PreferLiteralOverInitOnlyFieldsRule

### DIFF
--- a/gendarme-ignore.txt
+++ b/gendarme-ignore.txt
@@ -656,3 +656,8 @@ R: Gendarme.Rules.Performance.UseStringEmptyRule
 # these are compiler generated
 M: System.String <>__AnonType0`2::ToString()
 M: System.String <>__AnonType1`2::ToString()
+
+R: Gendarme.Rules.Performance.PreferLiteralOverInitOnlyFieldsRule
+# static readonly fields here need to be static
+T: Java.Interop.JavaException
+T: Java.Interop.JavaObject

--- a/gendarme-ignore.txt
+++ b/gendarme-ignore.txt
@@ -652,12 +652,13 @@ R: Gendarme.Rules.Design.Generic.AvoidMethodWithUnusedGenericTypeRule
 # looks like Gendarme bug, the TArray is used in the cast
 M: System.Void Java.Interop.JavaArray`1::DestroyArgumentState(System.Collections.Generic.IList`1<T>,Java.Interop.JniValueMarshalerState&,System.Reflection.ParameterAttributes)
 
+R: Gendarme.Rules.Performance.PreferLiteralOverInitOnlyFieldsRule
+# Warning is about e.g. JavaObject.InvalidJniObjectReference
+# InvalidJniObjectReference *must* be a field, not a literal, so that we can use `ref *InvalidJniObjectReference`.
+T: Java.Interop.JavaException
+T: Java.Interop.JavaObject
+
 R: Gendarme.Rules.Performance.UseStringEmptyRule
 # these are compiler generated
 M: System.String <>__AnonType0`2::ToString()
 M: System.String <>__AnonType1`2::ToString()
-
-R: Gendarme.Rules.Performance.PreferLiteralOverInitOnlyFieldsRule
-# static readonly fields here need to be static
-T: Java.Interop.JavaException
-T: Java.Interop.JavaObject


### PR DESCRIPTION
Both of the types reported contain field, which needs to remain
static.