### PR TITLE
[Java.Interop] Implement == != operators for JniValueMarshallerState

### DIFF
--- a/src/Java.Interop/Java.Interop/JniValueMarshaler.cs
+++ b/src/Java.Interop/Java.Interop/JniValueMarshaler.cs
@@ -94,6 +94,9 @@ namespace Java.Interop {
 				object.ReferenceEquals (Extra, value.Extra);
 		}
 
+		public static bool operator == (JniValueMarshalerState a, JniValueMarshalerState b) => a.Equals (b);
+		public static bool operator != (JniValueMarshalerState a, JniValueMarshalerState b) => !a.Equals (b);
+
 		public override string ToString ()
 		{
 			return string.Format ("JniValueMarshalerState({0}, ReferenceValue={1}, PeerableValue=0x{2}, Extra={3})",


### PR DESCRIPTION
This was reported by
https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Design.OperatorEqualsShouldBeOverloadedRule(2.10)
and
https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Performance.OverrideValueTypeDefaultsRule(2.10)
rules.