### PR TITLE
[Java.Interop] Add IEquality<T> to JavaProxyObject

### DIFF
--- a/gendarme-ignore.txt
+++ b/gendarme-ignore.txt
@@ -656,3 +656,8 @@ R: Gendarme.Rules.Performance.UseStringEmptyRule
 # these are compiler generated
 M: System.String <>__AnonType0`2::ToString()
 M: System.String <>__AnonType1`2::ToString()
+
+R: Gendarme.Rules.Performance.ImplementEqualsTypeRule
+# it doesn't make sense to implement IEquality<T> on unsealed classes
+T: Java.Interop.JavaException
+T: Java.Interop.JavaObject

--- a/src/Java.Interop/Java.Interop/JavaProxyObject.cs
+++ b/src/Java.Interop/Java.Interop/JavaProxyObject.cs
@@ -4,7 +4,7 @@ using System.Runtime.CompilerServices;
 namespace Java.Interop {
 
 	[JniTypeSignature (JniTypeName)]
-	sealed class JavaProxyObject : JavaObject
+	sealed class JavaProxyObject : JavaObject, IEquatable<JavaProxyObject>
 	{
 		internal const string JniTypeName = "com/xamarin/java_interop/internal/JavaProxyObject";
 
@@ -41,11 +41,12 @@ namespace Java.Interop {
 
 		public override bool Equals (object obj)
 		{
-			var other = obj as JavaProxyObject;
-			if (other != null)
+			if (obj is JavaProxyObject other)
 				return object.Equals (Value, other.Value);
 			return object.Equals (Value, obj);
 		}
+
+		public bool Equals (JavaProxyObject other) => object.Equals (Value, other.Value);
 
 		public override string ToString ()
 		{


### PR DESCRIPTION
It was suggested by
https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Performance.ImplementEqualsTypeRule(2.10). It
makes sense to implenent for JavaProxyObject as it is sealed class.

Ignore it for `Java.Interop.JavaException` and
`Java.Interop.JavaObject` as they are unsealed.