### PR TITLE
[Java.Interop] Silence Gendarme about ArgumentOutOfRangeException

### DIFF
--- a/gendarme-ignore.txt
+++ b/gendarme-ignore.txt
@@ -677,3 +677,7 @@ R: Gendarme.Rules.Performance.UseStringEmptyRule
 # these are compiler generated
 M: System.String <>__AnonType0`2::ToString()
 M: System.String <>__AnonType1`2::ToString()
+
+R: Gendarme.Rules.Exceptions.DoNotThrowInUnexpectedLocationRule
+# throwing ArgumentOutOfRangeException is OK according to the documentation https://msdn.microsoft.com/library/system.collections.ilist.item(v=vs.110).aspx
+M: T Java.Interop.JavaObjectArray`1::get_Item(System.Int32)


### PR DESCRIPTION
It is thrown in the `public override T this [int index]` method, which
is completely fine according to the documentation[0].

It was reported by the DoNotThrowInUnexpectedLocationRule[1]

[0] https://msdn.microsoft.com/library/system.collections.ilist.item(v=vs.110).aspx
[1] https://github.com/spouliot/gendarme/wiki/Gendarme.Rules.Exceptions.DoNotThrowInUnexpectedLocationRule(2.10)