### PR TITLE
[Java.Interop] Rename _ToArray in .tt as well

### DIFF
--- a/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.tt
+++ b/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.tt
@@ -92,11 +92,11 @@ namespace Java.Interop {
 		public Java<#= info.TypeModifier #>Array (System.Collections.Generic.IList<<#= info.ManagedType #>> value)
 			: this (CheckLength (value))
 		{
-			CopyFrom (_ToArray (value), 0, 0, value.Count);
+			CopyFrom (ToArray (value), 0, 0, value.Count);
 		}
 
 		public Java<#= info.TypeModifier #>Array (System.Collections.Generic.IEnumerable<<#= info.ManagedType #>> value)
-			: this (_ToArray (value))
+			: this (ToArray (value))
 		{
 		}
 


### PR DESCRIPTION
In the commit
https://github.com/xamarin/java.interop/commit/b0497dd478f181078b8b10739a12ead5d5369238
I forgot to change the `JavaPrimitiveArrays.tt` source template, which
is used to generate `JavaPrimitiveArrays.cs` source files.