### PR TITLE
[build] Generate $(JdkBinPath)` property

### DIFF
--- a/build-tools/scripts/jdk.mk
+++ b/build-tools/scripts/jdk.mk
@@ -22,10 +22,14 @@
 #       It DOES NOT contain the -I itself; use $(JI_JDK_INCLUDE_PATHS:%=-I%) for that.
 #   $(JI_JVM_PATH):
 #       Location of the Java native library that contains e.g. JNI_CreateJavaVM().
+#   $(JI_JDK_BIN_PATH):
+#       Location of the JDK `/bin` directory, which contains `java/`javac`/etc.
 
 OS           ?= $(shell uname)
 JI_JAVAC_PATH = javac
 JI_JAR_PATH   = jar
+
+JI_JDK_BIN_PATH = $(dir $(shell which java))
 
 
 # Filter on <= JI_MAX_JDK
@@ -75,6 +79,7 @@ _APPLE_JDK6_URL                   = http://adcdownload.apple.com/Developer_Tools
 
 ifneq ($(_DARWIN_JDK_FALLBACK_DIRS),)
 _DARWIN_JDK_ROOT      := $(shell ls -dtr $(_DARWIN_JDK_FALLBACK_DIRS) | $(_VERSION_SORT))
+JI_JDK_BIN_PATH       = $(_DARWIN_JDK_ROOT)/Contents/Home/bin
 JI_JAVAC_PATH         = $(_DARWIN_JDK_ROOT)/Contents/Home/bin/javac
 JI_JAR_PATH           = $(_DARWIN_JDK_ROOT)/Contents/Home/bin/jar
 JI_JDK_INCLUDE_PATHS  = \
@@ -82,7 +87,7 @@ JI_JDK_INCLUDE_PATHS  = \
 	$(_DARWIN_JDK_ROOT)/$(_DARWIN_JDK_JNI_OS_INCLUDE_DIR)
 
 ifeq ($(_MONO_BITNESS),64-bit)
-JI_JVM_PATH	= $(_DARWIN_JDK_ROOT)/Contents/Home/jre/lib/jli/libjli.dylib
+JI_JVM_PATH	= $(shell find $(_DARWIN_JDK_ROOT)/Contents/Home -name libjli.dylib)
 endif # 64-bit
 
 else    # (1) failed; try Xcode.app's copy?
@@ -143,6 +148,7 @@ JI_JVM_PATH                 = $(_LINUX_JAVA_ROOT)/jre/lib/$(_LINUX_JAVA_ARCH_32)
 endif # (2)
 endif # (1)
 
+JI_JDK_BIN_PATH             = $(_LINUX_JAVA_ROOT)/bin
 JI_JAVAC_PATH               = $(_LINUX_JAVA_ROOT)/bin/javac
 JI_JAR_PATH                 = $(_LINUX_JAVA_ROOT)/bin/jar
 
@@ -169,6 +175,7 @@ bin/Build$(CONFIGURATION)/JdkInfo.props: $(JI_JDK_INCLUDE_PATHS) $(JI_JVM_PATH)
 	echo '    </When>' >> "$@"
 	echo '  </Choose>' >> "$@"
 	echo '  <PropertyGroup>' >> "$@"
+	echo "    <JdkBinPath Condition=\" '\$$(JdkBinPath)' == '' \">$(JI_JDK_BIN_PATH)</JdkBinPath>" >> "$@"
 	echo "    <JavaCPath Condition=\" '\$$(JavaCPath)' == '' \">$(JI_JAVAC_PATH)</JavaCPath>" >> "$@"
 	echo "    <JarPath Condition=\" '\$$(JarPath)' == '' \">$(JI_JAR_PATH)</JarPath>" >> "$@"
 	echo '  </PropertyGroup>' >> "$@"


### PR DESCRIPTION
We're trying to build xamarin-android on a VSTS macOS instance which
has multiple Java JDKs installed, including JDK 9.

The problem is that the Android SDK and JDK 9 don't get along. The
`xamarin-android/tests/CodeGen-Binding/Xamarin.Android.LibraryProjectZip-LibBinding`
build invokes `gradlew`, `gradlew` uses whatever `java` is in `$PATH`,
and when using JDK 9 `gradlew` fails:

	Executing: ./gradlew assembleDebug --stacktrace
	...
	org.gradle.api.ProjectConfigurationException: A problem occurred configuring project ':library'.
	  ...
	Caused by: org.gradle.internal.event.ListenerNotificationException:
	Failed to notify project evaluation listener.
	  ...
	Caused by: java.lang.NoClassDefFoundError: javax/xml/bind/annotation/XmlSchema
	  ...
	Caused by: java.lang.ClassNotFoundException: javax.xml.bind.annotation.XmlSchema

(Rephrased: JDK 9 removed the type
`javax.xml.bind.annotation.XmlSchema`, which broke some dependency.)

55c56f7a was an attempt to support this environment, by *allowing*
JDK 9 to be filtered out when computing `$(JdkJvmPath)`,
`$(JavaCPath)`, and `$(JarPath)`.

Unfortunately this was inadequate: we need to override `$PATH` so that
the "right" JDK is used, not whatever happens to be first in `$PATH`.

In manual testing, this fails:

	ANDROID_HOME=... ./gradlew assembleDebug --stacktrace

while this works:

	ANDROID_HOME=... PATH=/path/to/jdk8/bin:$PATH ./gradlew assembleDebug --stacktrace --no-daemon

(The `--no-daemon` is needed so that we don't use some previously
launched gradle daemon under the wrong JDK.)

Thus, we want a way to easily insert the appropriate JDK path into
`$PATH` for the `gradlew` command.

Export a new `$(JdkBinPath)` MSBuild property which contains the JDK
`bin` directory. This will allow us to fix the
`Xamarin.Android.LibraryProjectZip-LibBinding` project:

	<Exec
	    EnvironmentVariables="ANDROID_HOME=$(AndroidSdkDirectory)"
	    Command="PATH=$(JdkBinPath):%24PATH .\gradlew assembleDebug --stacktrace --no-daemon"
	    WorkingDirectory="$(MSBuildThisFileDirectory)java\JavaLib"
	/>

and (hopefully) allow us to build on our VSTS bot which contains both
JDK 8 and 9.