### PR TITLE
Don't omit the extended API description attributes

### DIFF
--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApi.XmlModel.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApi.XmlModel.cs
@@ -29,6 +29,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		public JavaApi Parent { get; private set; }
 
 		public string Name { get; set; }
+		public string JniName { get; set; }
 		public IList<JavaType> Types { get; set; }
 		
 		// Content of this value is not stable.
@@ -166,6 +167,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		public string Name { get; set; }
 		public bool Static { get; set; }
 		public string Visibility { get; set; }
+		public string ExtendedJniSignature { get; set; }
 	}
 
 	public partial class JavaField : JavaMember
@@ -204,7 +206,6 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		public bool ExtendedBridge { get; set; }
 		public string ExtendedJniReturn { get; set; }
 		public bool ExtendedSynthetic { get; set; }
-		// We cannot get 'ExtendedJniSignature' from DLLs, so we don't have it here.
 
 		// Content of this value is not stable.
 		public string ToStringHelper (string returnType, string name, JavaTypeParameters typeParameters)
@@ -266,7 +267,8 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		public JavaMethodBase Parent { get; private set; }
 		public string Name { get; set; }
 		public string Type { get; set; }
-		
+		public string JniType { get; set; }
+
 		// Content of this value is not stable.
 		public override string ToString ()
 		{
@@ -278,6 +280,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 	{
 		public string Name { get; set; }
 		public string Type { get; set; }
+		public string TypeGenericAware { get; set; }
 	}
 
 	public partial class JavaTypeParameters

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiXmlLoaderExtensions.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiXmlLoaderExtensions.cs
@@ -49,6 +49,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		{
 			reader.MoveToContent ();
 			package.Name = XmlUtil.GetRequiredAttribute (reader, "name");
+			package.JniName = reader.GetAttribute ("jni-name");
 			if (reader.MoveToFirstAttribute ())
 				if (reader.LocalName != "name")
 					throw XmlUtil.UnexpectedAttribute (reader, "package");
@@ -203,6 +204,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			member.Name = XmlUtil.GetRequiredAttribute (reader, "name");
 			member.Static = XmlConvert.ToBoolean (XmlUtil.GetRequiredAttribute (reader, "static"));
 			member.Visibility = XmlUtil.GetRequiredAttribute (reader, "visibility");
+			member.ExtendedJniSignature = XmlUtil.GetRequiredAttribute (reader, "jni-signature");
 		}
 
 		public static void Load (this JavaField field, XmlReader reader)
@@ -222,7 +224,6 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			var method = methodBase as JavaMethod; // kind of ugly hack yeah...
 			
 			methodBase.LoadMemberAttributes (reader);
-			//methodBase.ExtendedJniSignature = reader.GetAttribute ("jni-signature");
 			methodBase.ExtendedJniReturn = reader.GetAttribute ("jni-return");
 			methodBase.ExtendedSynthetic = XmlConvert.ToBoolean (reader.GetAttribute ("synthetic") ?? "false");
 			methodBase.ExtendedBridge = XmlConvert.ToBoolean (reader.GetAttribute ("bridge") ?? "false");
@@ -282,6 +283,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		{
 			p.Name = XmlUtil.GetRequiredAttribute (reader, "name");
 			p.Type = XmlUtil.GetRequiredAttribute (reader, "type");
+			p.JniType = XmlUtil.GetRequiredAttribute (reader, "jni-type");
 			reader.Skip ();
 		}
 
@@ -289,6 +291,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		{
 			e.Name = XmlUtil.GetRequiredAttribute (reader, "name");
 			e.Type = XmlUtil.GetRequiredAttribute (reader, "type");
+			e.Type = XmlUtil.GetRequiredAttribute (reader, "type-generic-aware");
 			reader.Skip ();
 		}
 		

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/Tests/OverrideMarkerTest.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/Tests/OverrideMarkerTest.cs
@@ -37,11 +37,11 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster.Tests
 		{
 			string xml = @"<api>
   <package name='XXX'>
-    <class abstract='true' deprecated='not deprecated' extends='android.app.ExpandableListActivity' extends-generic-aware='android.app.ExpandableListActivity' final='false' name='SherlockExpandableListActivity' static='false' visibility='public'>
-      <method abstract='false' deprecated='not deprecated' final='false' name='addContentView' native='false' return='void' static='false' synchronized='false' visibility='public'>
-        <parameter name = 'view' type='android.view.View'>
+    <class abstract='true' deprecated='not deprecated' extends='android.app.ExpandableListActivity' extends-generic-aware='android.app.ExpandableListActivity' final='false' name='SherlockExpandableListActivity' static='false' visibility='public' jni-signature='Landroid/app/ExpandableListActivity;'>
+      <method abstract='false' deprecated='not deprecated' final='false' name='addContentView' native='false' return='void' static='false' synchronized='false' visibility='public' jni-signature='(Landroid/view/View;Landroid/view/ViewGroup$LayoutParams;)V'>
+        <parameter name = 'view' type='android.view.View' jni-type='Landroid/view/View;'>
         </parameter>
-        <parameter name = 'params' type='android.view.ViewGroup.LayoutParams'>
+        <parameter name = 'params' type='android.view.ViewGroup.LayoutParams' jni-type='Landroid/view/ViewGroup$LayoutParams;'>
         </parameter>
       </method>
     </class>
@@ -63,8 +63,8 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster.Tests
 		{
 			string xml = @"<api>
   <package name='XXX'>
-    <class abstract='true' deprecated='not deprecated' final='false' name='GenericConstructors' static='false' visibility='public'>
-      <constructor deprecated='not deprecated' final='false' name='GenericConstructors' static='false' visibility='public'>
+    <class abstract='true' deprecated='not deprecated' final='false' name='GenericConstructors' static='false' visibility='public' jni-signature='Landroid/app/GenericConstructors'>
+      <constructor deprecated='not deprecated' final='false' name='GenericConstructors' static='false' visibility='public' jni-signature='(LTTE;)V'>
         <typeParameters>
           <typeParameter name='E' interfaceBounds='' jni-interfaceBounds='' />
         </typeParameters>


### PR DESCRIPTION
class-parse emits a number of useful attributes which contain information about
the JNI signatures, return and parameter types etc. Currently, API XML adjuster
removes them from its output.
The information in extended attributes is (will be) useful for code generation
and thus this commit makes sure that all of them made it to the adjusted XML.