### PR TITLE
method parameter type may contain "params " and cannot be used by fields.

### DIFF
--- a/tools/generator/CodeGenerator.cs
+++ b/tools/generator/CodeGenerator.cs
@@ -626,7 +626,7 @@ namespace MonoDroid.Generation {
 			if (s == "System.Void")
 				return "void";
 			if (s.StartsWith ("params "))
-				return "params " + GetOutputName (s.Substring (6));
+				return "params " + GetOutputName (s.Substring (7));
 			if (s.StartsWith ("global::"))
 				Report.Error (Report.ErrorCodeGenerator + 0, null,  "Unexpected \"global::\" specification. This error happens if it is specified in the Metadata API fixup for example.");
 			if (!UseGlobal)

--- a/tools/generator/CodeGenerator.cs
+++ b/tools/generator/CodeGenerator.cs
@@ -626,7 +626,7 @@ namespace MonoDroid.Generation {
 			if (s == "System.Void")
 				return "void";
 			if (s.StartsWith ("params "))
-				return "params " + GetOutputName (s.Substring (7));
+				return "params " + GetOutputName (s.Substring ("params ".Length));
 			if (s.StartsWith ("global::"))
 				Report.Error (Report.ErrorCodeGenerator + 0, null,  "Unexpected \"global::\" specification. This error happens if it is specified in the Metadata API fixup for example.");
 			if (!UseGlobal)

--- a/tools/generator/InterfaceGen.cs
+++ b/tools/generator/InterfaceGen.cs
@@ -376,7 +376,7 @@ namespace MonoDroid.Generation {
 						if (p.IsSender)
 							continue;
 						sw.WriteLine ();
-						var safeTypeName = p.Type.StartsWith ("params ", StringComparison.Ordinal) ? p.Type.Substring (7) : p.Type;
+						var safeTypeName = p.Type.StartsWith ("params ", StringComparison.Ordinal) ? p.Type.Substring ("params ".Length) : p.Type;
 						sw.WriteLine ("{0}\t{1} {2};", indent, opt.GetOutputName (safeTypeName), opt.GetSafeIdentifier (p.Name));
 						// AbsListView.IMultiChoiceModeListener.onItemCheckedStateChanged() hit this strict name check, at parameter "@checked".
 						sw.WriteLine ("{0}\tpublic {1} {2} {{", indent, opt.GetOutputName (safeTypeName), p.PropertyName);

--- a/tools/generator/InterfaceGen.cs
+++ b/tools/generator/InterfaceGen.cs
@@ -349,6 +349,7 @@ namespace MonoDroid.Generation {
 			string args_name = GetArgsName (m);
 			if (m.RetVal.IsVoid || m.IsEventHandlerWithHandledProperty) {
 				if (!m.IsSimpleEventHandler || m.IsEventHandlerWithHandledProperty) {
+					sw.WriteLine ("{0}// event args for {1}.{2}", indent, this.JavaName, m.JavaName);
 					sw.WriteLine ("{0}public partial class {1} : global::System.EventArgs {{", indent, args_name);
 					sw.WriteLine ();
 					var signature = m.Parameters.GetSignatureDropSender (opt);
@@ -375,9 +376,10 @@ namespace MonoDroid.Generation {
 						if (p.IsSender)
 							continue;
 						sw.WriteLine ();
-						sw.WriteLine ("{0}\t{1} {2};", indent, opt.GetOutputName (p.Type), opt.GetSafeIdentifier (p.Name));
+						var safeTypeName = p.Type.StartsWith ("params ", StringComparison.Ordinal) ? p.Type.Substring (7) : p.Type;
+						sw.WriteLine ("{0}\t{1} {2};", indent, opt.GetOutputName (safeTypeName), opt.GetSafeIdentifier (p.Name));
 						// AbsListView.IMultiChoiceModeListener.onItemCheckedStateChanged() hit this strict name check, at parameter "@checked".
-						sw.WriteLine ("{0}\tpublic {1} {2} {{", indent, opt.GetOutputName (p.Type), p.PropertyName);
+						sw.WriteLine ("{0}\tpublic {1} {2} {{", indent, opt.GetOutputName (safeTypeName), p.PropertyName);
 						sw.WriteLine ("{0}\t\tget {{ return {1}; }}", indent, opt.GetSafeIdentifier (p.Name));
 						sw.WriteLine ("{0}\t}}", indent);
 					}

--- a/tools/generator/Tests/expected.ji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
+++ b/tools/generator/Tests/expected.ji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
@@ -116,6 +116,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 
 	}
 
+	// event args for com.google.android.exoplayer.drm.ExoMediaDrm.OnEventListener.onEvent
 	public partial class ExoMediaDrmOnEventEventArgs : global::System.EventArgs {
 
 		public ExoMediaDrmOnEventEventArgs (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm p0, byte[] p1, int p2, int p3, byte[] p4)

--- a/tools/generator/Tests/expected/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
+++ b/tools/generator/Tests/expected/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
@@ -107,6 +107,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 
 	}
 
+	// event args for com.google.android.exoplayer.drm.ExoMediaDrm.OnEventListener.onEvent
 	public partial class ExoMediaDrmOnEventEventArgs : global::System.EventArgs {
 
 		public ExoMediaDrmOnEventEventArgs (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm p0, byte[] p1, int p2, int p3, byte[] p4)


### PR DESCRIPTION
This fixes https://github.com/xamarin/xamarin-android/issues/1138

It is quite corner case, where ... arguments are used in interfaces that
can be converted to events.

Parameter types cannot be simply used for fields and parameters because
they cannot take "params" as their modifiers.

The real code fix should be in Parameter.cs, but that would require
a lot of changes unlike this tiny fix.