### PR TITLE
[Java.Interop] Fix Runtime's Dispose method

### DIFF
--- a/src/Java.Interop/Java.Interop/JniRuntime.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.cs
@@ -297,9 +297,9 @@ namespace Java.Interop
 
 			Runtimes.TryUpdate (InvocationPointer, null, this);
 
-			JniObjectReference.Dispose (ref ClassLoader);
-
 			if (disposing) {
+				JniObjectReference.Dispose (ref ClassLoader);
+
 				ClearTrackedReferences ();
 #if !XA_INTEGRATION
 				ValueManager.Dispose ();
@@ -307,14 +307,14 @@ namespace Java.Interop
 				TypeManager.Dispose ();
 #endif  // !XA_INTEGRATION
 				ObjectReferenceManager.Dispose ();
-			}
 
-			var environments    = JniEnvironment.Info.Values;
-			for (int i = 0; i < environments.Count; ++i) {
-				var e   = environments [i];
-				if (e.Runtime != this)
-					continue;
-				environments [i].Dispose ();
+				var environments = JniEnvironment.Info.Values;
+				for (int i = 0; i < environments.Count; ++i) {
+					var e = environments [i];
+					if (e.Runtime != this)
+						continue;
+					environments [i].Dispose ();
+				}
 			}
 
 			if (DestroyRuntimeOnDispose) {


### PR DESCRIPTION
The dispose method of Runtime class wasn't working right when called
from finalizer.

That usually doesn't happen on Android, so it wasn't noticed until
now. It can happen even on Android though, when calling
System.Environment.Exit method.

In that case, the JniEnvironment's Info ThreadLocal object is already
disposed, so we cannot use it. It is also used in
JniObjectReference.Dispose so we should not try to call that as well.