### PR TITLE
[Java.Interop] Call ManagedPeer.Init() last in JniRuntime

### DIFF
--- a/src/Java.Interop/Java.Interop/JniRuntime.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.cs
@@ -208,10 +208,6 @@ namespace Java.Interop
 			var env     = new JniEnvironmentInfo (envp, this);
 			JniEnvironment.SetEnvironmentInfo (env);
 
-#if !XA_INTEGRATION
-			ManagedPeer.Init ();
-#endif  // !XA_INTEGRATION
-
 			ClassLoader = options.ClassLoader;
 			if (options.ClassLoader_LoadClass_id != IntPtr.Zero) {
 				ClassLoader_LoadClass   = new JniMethodInfo (options.ClassLoader_LoadClass_id, isStatic: false);
@@ -234,6 +230,10 @@ namespace Java.Interop
 					}
 				}
 			}
+
+#if !XA_INTEGRATION
+			ManagedPeer.Init ();
+#endif  // !XA_INTEGRATION
 		}
 
 		T SetRuntime<T> (T value)


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/index?buildId=1374566

Commit b4d44e4b has a nasty corner case around `JniRuntime`
construction: it can go *boom*.

Imagine the following:

 1. A JVM environment in which `com.xamarin.java_interop.ManagedPeer`
    is *not* in `$CLASSPATH` or otherwise available from
    `JNIEnv::FindClass()`.

 2. `JniRuntime` is constructed within the environment of (1).

Expected behavior: some form of exception stating that `ManagedPeer`
couldn't be found.

Actual behavior: a `NullReferenceException` (?!):

	Unhandled Exception:
	System.TypeInitializationException: The type initializer for 'Java.Interop.ManagedPeer' threw an exception. --->
	System.NullReferenceException: Object reference not set to an instance of an object
	  at Java.Interop.JniEnvironment+Types.FindClass (System.String classname)
	  at Java.Interop.JniType..ctor (System.String classname)
	  at Java.Interop.JniType.GetCachedJniType (Java.Interop.JniType& cachedType, System.String classname)
	  at Java.Interop.JniPeerMembers.get_JniPeerType ()
	  at Java.Interop.ManagedPeer..cctor ()

After puzzling about this for a bit, the problem isn't (1) per-se.
((1) *is* a problem: we *require* `ManagedPeer`. The point is that
*how we fail* is wrong; we can and should fail w/ a better exception.)
The problem is that commit b4d44e4b updated
`JniEnvironment.Types.FindClass(string)` so so that if
`JNIEnv::FindClass()` failed, we "fall back" to invoking
`java.lang.ClassLoader.loadClass(String)`.

This is all (mostly) well and good, *except* that in order for
`JniEnvironment.Types.FindClass(string)` to call
`ClassLoader.loadClass(string)`, the appropriate `JniRuntime` fields
must *also* be set (`JniRuntime.ClassLoader` and
`JniRuntime.ClassLoader_LoadClass`).

Which brings us to the bug in b4d44e4b: if
`JNIEnv::FindClass("com/xamarin/java_interop/ManagedPeer")` fails --
for whatever reason! -- we (rightfully!) fallback to invoking
`ClassLoader.loadClass()`. The problem is, we're doing this *before*
`JniRuntime.ClassLoader`/etc. have been set, so the attempt to invoke
the `ClassLoader.loadClass()` fallback itself results in the
`NullReferenceException`. (Doh!)

The fix: move the `ManagedPeer.Init()` invocation to be the *last*
invocation within the `JniRuntime` constructor -- specifically *after*
`JniRuntime.ClassLoader`/etc. have been initialized. This allows
`ManagedPeer.Init()` to do something more "reasonable" than throw a
`NullReferenceException` -- ideally by throwing a well defined
exception type that states that `ManagedPeer` can't be found.