### PR TITLE
Bump to cecil/mono-2017-12/1afa0668

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,4 +5,4 @@
 [submodule "external/cecil"]
 	path = external/cecil
 	url = https://github.com/mono/cecil.git
-	branch = master
+	branch = mono-2017-12


### PR DESCRIPTION
Preparation & Harmonization for d15-7 branching.

There are no significant changes between cecil/mono-2017-10/76ffcda
(via commit 57d5d514) and cecil/mono-2017-12/1afa0668, because they're
the same tree! (76ffcda is a merge commit for 1afa0668.)