### PR TITLE
[Java.Interop.Tools.Cecil] Change DirectoryAssemblyResolver to allow forced loading.

### DIFF
--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/DirectoryAssemblyResolver.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/DirectoryAssemblyResolver.cs
@@ -110,14 +110,14 @@ namespace Java.Interop.Tools.Cecil {
 			return new Dictionary<string, AssemblyDefinition>(cache);
 		}
 
-		public virtual AssemblyDefinition Load (string fileName)
+		public virtual AssemblyDefinition Load (string fileName, bool forceLoad = false)
 		{
 			if (!File.Exists (fileName))
 				return null;
 
 			AssemblyDefinition assembly;
 			var name = Path.GetFileNameWithoutExtension (fileName);
-			if (cache.TryGetValue (name, out assembly))
+			if (!forceLoad && cache.TryGetValue (name, out assembly))
 				return assembly;
 
 			try {
@@ -125,7 +125,7 @@ namespace Java.Interop.Tools.Cecil {
 			} catch (Exception e) {
 				Diagnostic.Error (9, e, "Error while loading assembly: {0}", fileName);
 			}
-			cache.Add (name, assembly);
+			cache [name] = assembly;
 			return assembly;
 		}
 

--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/DirectoryAssemblyResolver.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/DirectoryAssemblyResolver.cs
@@ -115,7 +115,7 @@ namespace Java.Interop.Tools.Cecil {
 			if (!File.Exists (fileName))
 				return null;
 
-			AssemblyDefinition assembly;
+			AssemblyDefinition assembly = null;
 			var name = Path.GetFileNameWithoutExtension (fileName);
 			if (!forceLoad && cache.TryGetValue (name, out assembly))
 				return assembly;


### PR DESCRIPTION
Context https://github.com/xamarin/xamarin-android/issues/1154

One of the problems we currently face is that our build system
resolves `ref` netstandard libraries. With the current cache
system, onces an assembly has been loaded into the Cecil cache
it only ever uses that assembly. We might need to replace the
current cached version with a new one if we detect a `ref` and
need to reload the `lib`.