### PR TITLE
Fix bug #59046 - annotation value could be somehow empty, so skip it …

### DIFF
--- a/src/Xamarin.Android.Tools.AnnotationSupport/Objects/AnnotationValue.cs
+++ b/src/Xamarin.Android.Tools.AnnotationSupport/Objects/AnnotationValue.cs
@@ -26,7 +26,8 @@ namespace Xamarin.AndroidTools.AnnotationSupport
 						}
 					}
 				}
-			}
+			} else
+				ValueAsArray = new string [] {Val};
 		}
 		
 		public string Name { get; set; }


### PR DESCRIPTION
…when it's null.

I cannot see any empty annotation value linked from https://bugzilla.xamarin.com/show_bug.cgi?id=59046
but there seems to be, and for such annotation value it will raise
null argument error at linq Select(). Check if it's null and skip further
processing if it actually is.

The attached repro on the bug is proprietary so I cannot add it.