### PR TITLE
[build] fix for unit tests to run on VSTS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ xa-gendarme.html
 packages
 .vs/
 *.userprefs
+Resource.designer.cs

--- a/build-tools/scripts/RunNUnitTests.targets
+++ b/build-tools/scripts/RunNUnitTests.targets
@@ -30,7 +30,7 @@
     <Exec
         Command="$(_NUnit) $(NUNIT_EXTRA) %(_TestAssembly.Identity) $(_Run) --noshadow --result=&quot;TestResult-%(Filename).xml&quot; --output=&quot;bin\Test$(Configuration)\TestOutput-%(Filename).txt&quot;"
         WorkingDirectory="$(_TopDir)"
-        ContinueOnError="True"
+        ContinueOnError="ErrorAndContinue"
     />
   </Target>
 </Project>


### PR DESCRIPTION
To get our desired behavior on VSTS, we have to:
- Make sure our call to NUnit returns a failing exit code
- Set the "Continue on Error" option in VSTS
- Add a step at the end of our build definition in VSTS to fail the
build if any issues ocurred

To make this work, we have to change our `<Exec />` task usage to
`ContinueOnError="ErrorAndContinue"`.

I tested the VSTS behavior upstream in xamarin-android, see a build here:
https://devdiv.visualstudio.com/DevDiv/_build/index?buildId=1478269

Other changes:
- Added `Resource.designer.cs` to .gitignore to match xamarin-android