### PR TITLE
[jnimarshalmethod-gen] Generate helpers for methods with Register CA

### DIFF
--- a/src/Java.Interop/Java.Interop/JniRuntime.JniMarshalMemberBuilder.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniMarshalMemberBuilder.cs
@@ -135,7 +135,12 @@ namespace Java.Interop {
 				if (parameter.ParameterType == typeof (IntPtr))
 					return IntPtrValueMarshaler.Instance;
 
-				var attr = parameter.GetCustomAttribute<JniValueMarshalerAttribute> ();
+				JniValueMarshalerAttribute attr;
+				try {
+					attr = parameter.GetCustomAttribute<JniValueMarshalerAttribute> ();
+				} catch (System.IndexOutOfRangeException) {
+					attr = null;
+				}
 				if (attr != null) {
 					return (JniValueMarshaler) Activator.CreateInstance (attr.MarshalerType);
 				}

--- a/tools/jnimarshalmethod-gen/Xamarin.Android.Tools.JniMarshalMethodGenerator.csproj
+++ b/tools/jnimarshalmethod-gen/Xamarin.Android.Tools.JniMarshalMethodGenerator.csproj
@@ -31,11 +31,15 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="Mono.Options">
+      <HintPath>..\..\packages\Mono.Options.5.3.0.1\lib\net4-client\Mono.Options.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="App.cs" />
   </ItemGroup>
+  <Import Project="..\..\src\Java.Interop.NamingCustomAttributes\Java.Interop.NamingCustomAttributes.projitems" Label="Shared" Condition="Exists('..\..\src\Java.Interop.NamingCustomAttributes\Java.Interop.NamingCustomAttributes.projitems')" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <ProjectReference Include="..\..\src\Java.Interop.Export\Java.Interop.Export.csproj">
@@ -50,5 +54,16 @@
       <Project>{5887B410-D448-4257-A46B-EAC03C80BE93}</Project>
       <Name>Java.Runtime.Environment</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\src\Xamarin.Android.Cecil\Xamarin.Android.Cecil.csproj">
+      <Project>{15945D4B-FF56-4BCC-B598-2718D199DD08}</Project>
+      <Name>Xamarin.Android.Cecil</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Java.Interop.Tools.Cecil\Java.Interop.Tools.Cecil.csproj">
+      <Project>{D48EE8D0-0A0A-4493-AEF5-DAF5F8CF86AD}</Project>
+      <Name>Java.Interop.Tools.Cecil</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
 </Project>

--- a/tools/jnimarshalmethod-gen/packages.config
+++ b/tools/jnimarshalmethod-gen/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Mono.Options" version="5.3.0.1" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
Updated the generator to generate helper marshaling methods for
classes implementing `Java.Interop.IJavaPeerable` interface and their
methods with `Android.Runtime.RegisterAttribute` custom
attribute. Plus `__RegisterNativeMembers` method to register these
methods during runtime.

It is part of https://github.com/xamarin/xamarin-android/projects/1
project.

The JniRuntime.JniMarshalMemberBuilder.cs change is a workaround for
BCL bug, which causes this exception:

    Error: jnimarshalmethod-gen: Unable to process assembly '/Users/rodo/Projects/xatemplateaot/xatemplateaot/obj/Debug/android/assets/Mono.Android.dll'
    Index was outside the bounds of the array.
    System.IndexOutOfRangeException: Index was outside the bounds of the array.
      at System.Attribute.InternalParamGetCustomAttributes (System.Reflection.ParameterInfo parameter, System.Type attributeType, System.Boolean inherit) [0x0005b] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/attribute.cs:60
      at System.Attribute.GetCustomAttributes (System.Reflection.ParameterInfo element, System.Type attributeType, System.Boolean inherit) [0x0008b] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/attribute.cs:681
      at System.Attribute.GetCustomAttribute (System.Reflection.ParameterInfo element, System.Type attributeType, System.Boolean inherit) [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/attribute.cs:749
      at System.Attribute.GetCustomAttribute (System.Reflection.ParameterInfo element, System.Type attributeType) [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/attribute.cs:742
      at System.Reflection.CustomAttributeExtensions.GetCustomAttribute (System.Reflection.ParameterInfo element, System.Type attributeType) [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/reflection/CustomAttributeExtensions.cs:22
      at System.Reflection.CustomAttributeExtensions.GetCustomAttribute[T] (System.Reflection.ParameterInfo element) [0x00000] in <e36d106f4822473d8910305e5d059e11>:0
      at Java.Interop.JniRuntime+JniMarshalMemberBuilder.GetParameterMarshaler (System.Reflection.ParameterInfo parameter) [0x0001f] in /Users/rodo/git/clean-full/xamarin-android/external/Java.Interop/src/Java.Interop/Java.Interop/JniRuntime.JniMarshalMemberBuilder.cs:138
      at Java.Interop.MarshalMemberBuilder.CreateMarshalToManagedExpression (System.Reflection.MethodInfo method, Java.Interop.JavaCallableAttribute callable, System.Type type) [0x002f1] in /Users/rodo/git/clean-full/xamarin-android/external/Java.Interop/src/Java.Interop.Export/Java.Interop/MarshalMemberBuilder.cs:182
      at Java.Interop.MarshalMemberBuilder.CreateMarshalToManagedExpression (System.Reflection.MethodInfo method) [0x00014] in /Users/rodo/git/clean-full/xamarin-android/external/Java.Interop/src/Java.Interop.Export/Java.Interop/MarshalMemberBuilder.cs:32
      at Xamarin.Android.Tools.JniMarshalMethodGenerator.App.CreateMarshalMethodAssembly (System.String path) [0x00272] in /Users/rodo/git/clean-full/xamarin-android/external/Java.Interop/tools/jnimarshalmethod-gen/App.cs:183
      at Xamarin.Android.Tools.JniMarshalMethodGenerator.App.Main (System.String[] args) [0x001a5] in /Users/rodo/git/clean-full/xamarin-android/external/Java.Interop/tools/jnimarshalmethod-gen/App.cs:67
