### PR TITLE
[generator] fix for "this" keyword in parameter names

### DIFF
--- a/tools/generator/Parameter.cs
+++ b/tools/generator/Parameter.cs
@@ -47,8 +47,7 @@ namespace MonoDroid.Generation {
 
 		public string ToNative (CodeGenerationOptions opt)
 		{
-			var safeName = opt.GetSafeIdentifier (Name);
-			return NeedsPrep ? sym.Call (opt, safeName) : sym.ToNative (opt, safeName, null);
+			return NeedsPrep ? sym.Call (opt, Name) : sym.ToNative (opt, opt.GetSafeIdentifier (Name), null);
 		}
 
 		public string GenericType {

--- a/tools/generator/Tests/expected.ji/CSharpKeywords/Xamarin.Test.CSharpKeywords-windows.cs
+++ b/tools/generator/Tests/expected.ji/CSharpKeywords/Xamarin.Test.CSharpKeywords-windows.cs
@@ -60,5 +60,21 @@ namespace Xamarin.Test {
 			}
 		}
 
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='CSharpKeywords']/method[@name='useThis' and count(parameter)=1 and parameter[1][@type='java.lang.String']]"
+		[Register ("useThis", "(Ljava/lang/String;)Ljava/lang/String;", "")]
+		public static unsafe string UseThis (string this_)
+		{
+			const string __id = "useThis.(Ljava/lang/String;)Ljava/lang/String;";
+			IntPtr native_this = JNIEnv.NewString (this_);
+			try {
+				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+				__args [0] = new JniArgumentValue (native_this);
+				var __rm = _members.StaticMethods.InvokeObjectMethod (__id, __args);
+				return JNIEnv.GetString (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+			} finally {
+				JNIEnv.DeleteLocalRef (native_this);
+			}
+		}
+
 	}
 }

--- a/tools/generator/Tests/expected.ji/CSharpKeywords/Xamarin.Test.CSharpKeywords.cs
+++ b/tools/generator/Tests/expected.ji/CSharpKeywords/Xamarin.Test.CSharpKeywords.cs
@@ -60,5 +60,21 @@ namespace Xamarin.Test {
 			}
 		}
 
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='CSharpKeywords']/method[@name='useThis' and count(parameter)=1 and parameter[1][@type='java.lang.String']]"
+		[Register ("useThis", "(Ljava/lang/String;)Ljava/lang/String;", "")]
+		public static unsafe string UseThis (string this_)
+		{
+			const string __id = "useThis.(Ljava/lang/String;)Ljava/lang/String;";
+			IntPtr native_this = JNIEnv.NewString (this_);
+			try {
+				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+				__args [0] = new JniArgumentValue (native_this);
+				var __rm = _members.StaticMethods.InvokeObjectMethod (__id, __args);
+				return JNIEnv.GetString (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+			} finally {
+				JNIEnv.DeleteLocalRef (native_this);
+			}
+		}
+
 	}
 }

--- a/tools/generator/Tests/expected.targets
+++ b/tools/generator/Tests/expected.targets
@@ -46,7 +46,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include='expected\CSharpKeywords\Xamarin.Test.CSharpKeywords-windows.cs' Condition=" '$(OS)' == 'Windows_NT' ">
-      <Link>Xamarin.Test.CSharpKeywords.cs</Link>
+      <Link>expected\CSharpKeywords\Xamarin.Test.CSharpKeywords.cs</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include='expected\EnumerationFixup\EnumerationFixupMap.xml'>
@@ -218,7 +218,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include='expected.ji\CSharpKeywords\Xamarin.Test.CSharpKeywords-windows.cs' Condition=" '$(OS)' == 'Windows_NT' ">
-      <Link>Xamarin.Test.CSharpKeywords.cs</Link>
+      <Link>expected.ji\CSharpKeywords\Xamarin.Test.CSharpKeywords.cs</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include='expected.ji\java.lang.Enum\enumlist'>

--- a/tools/generator/Tests/expected/CSharpKeywords/CSharpKeywords.xml
+++ b/tools/generator/Tests/expected/CSharpKeywords/CSharpKeywords.xml
@@ -11,8 +11,10 @@
 	<package name="xamarin.test">
 		<class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="false" name="CSharpKeywords" static="false" visibility="public">
 			<method abstract="false" deprecated="not deprecated" final="false" name="usePartial" native="false" return="java.lang.String" static="false" synchronized="false" visibility="public">
-				<parameter name="partial" type="int">
-				</parameter>
+				<parameter name="partial" type="int" />
+			</method>
+			<method abstract="false" deprecated="not deprecated" final="false" name="useThis" native="false" return="java.lang.String" static="true" synchronized="false" visibility="public">
+				<parameter name="this" type="java.lang.String" />
 			</method>
 		</class>
 	</package>

--- a/tools/generator/Tests/expected/CSharpKeywords/Xamarin.Test.CSharpKeywords-windows.cs
+++ b/tools/generator/Tests/expected/CSharpKeywords/Xamarin.Test.CSharpKeywords-windows.cs
@@ -60,5 +60,23 @@ namespace Xamarin.Test {
 			}
 		}
 
+		static IntPtr id_useThis_Ljava_lang_String_;
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='CSharpKeywords']/method[@name='useThis' and count(parameter)=1 and parameter[1][@type='java.lang.String']]"
+		[Register ("useThis", "(Ljava/lang/String;)Ljava/lang/String;", "")]
+		public static unsafe string UseThis (string this_)
+		{
+			if (id_useThis_Ljava_lang_String_ == IntPtr.Zero)
+				id_useThis_Ljava_lang_String_ = JNIEnv.GetStaticMethodID (class_ref, "useThis", "(Ljava/lang/String;)Ljava/lang/String;");
+			IntPtr native_this = JNIEnv.NewString (this_);
+			try {
+				JValue* __args = stackalloc JValue [1];
+				__args [0] = new JValue (native_this);
+				string __ret = JNIEnv.GetString (JNIEnv.CallStaticObjectMethod  (class_ref, id_useThis_Ljava_lang_String_, __args), JniHandleOwnership.TransferLocalRef);
+				return __ret;
+			} finally {
+				JNIEnv.DeleteLocalRef (native_this);
+			}
+		}
+
 	}
 }

--- a/tools/generator/Tests/expected/CSharpKeywords/Xamarin.Test.CSharpKeywords.cs
+++ b/tools/generator/Tests/expected/CSharpKeywords/Xamarin.Test.CSharpKeywords.cs
@@ -60,5 +60,23 @@ namespace Xamarin.Test {
 			}
 		}
 
+		static IntPtr id_useThis_Ljava_lang_String_;
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='CSharpKeywords']/method[@name='useThis' and count(parameter)=1 and parameter[1][@type='java.lang.String']]"
+		[Register ("useThis", "(Ljava/lang/String;)Ljava/lang/String;", "")]
+		public static unsafe string UseThis (string this_)
+		{
+			if (id_useThis_Ljava_lang_String_ == IntPtr.Zero)
+				id_useThis_Ljava_lang_String_ = JNIEnv.GetStaticMethodID (class_ref, "useThis", "(Ljava/lang/String;)Ljava/lang/String;");
+			IntPtr native_this = JNIEnv.NewString (this_);
+			try {
+				JValue* __args = stackalloc JValue [1];
+				__args [0] = new JValue (native_this);
+				string __ret = JNIEnv.GetString (JNIEnv.CallStaticObjectMethod  (class_ref, id_useThis_Ljava_lang_String_, __args), JniHandleOwnership.TransferLocalRef);
+				return __ret;
+			} finally {
+				JNIEnv.DeleteLocalRef (native_this);
+			}
+		}
+
 	}
 }


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/Xamarin%20Project%20Mgrs/_queries?id=568918

Apparently, it is possible for generator to receive the following method
as input:

    <method name="useThis" return="java.lang.String" static="true" visibility="public">
      <parameter name="this" type="java.lang.String"/>
    </method>

I wasn't able to create a method like this in Java (Android Studio), so
it must only be possible through some kind of Java bytecode
post-compilation step, or another JVM language. (perhaps Kotlin?)

The fix here was to modify `Parameter.ToNative` so it does not call
`CodeGenerationOptions.GetSafeIdentifier` for all cases. All
implementations of `ISymbol.Call` call `GetSafeIdentifier`, so I think
it was double-escaping the keyword in this example.

### Other changes

I found one of my older commits 968b474 was causing the
`CSharpKeywords.cs` expected file to not get copied to the correct
output directory. It needed to specify directories to go to the right
place. This meant that parts of the `CSharpKeywords` test wasn't being
verified--luckily it was all still working.