### PR TITLE
[tests] better assertion failure for Windows devs

### DIFF
--- a/tools/generator/Tests/BaseGeneratorTest.cs
+++ b/tools/generator/Tests/BaseGeneratorTest.cs
@@ -61,7 +61,10 @@ namespace generatortests
 				} else if (!FileCompare (file, dest)) {
 					var fullSource  = Path.GetFullPath (file);
 					var fullDest    = Path.GetFullPath (dest);
-					string message  = $"File contents differ; run: diff -u {fullSource} \\{Environment.NewLine}\t{fullDest}";
+					//Error message for diff in powershell vs bash
+					string message  = Environment.OSVersion.Platform == PlatformID.Win32NT ?
+						$"File contents differ; run: diff (cat {fullSource}) `{Environment.NewLine}\t(cat {fullDest})" :
+						$"File contents differ; run: diff -u {fullSource} \\{Environment.NewLine}\t{fullDest}";
 					Assert.Fail (message);
 				}
 			}


### PR DESCRIPTION
I've been doing all my development on Windows lately (as a way to
experience what our Windows userbase encounters). One of the painpoints
of working on generator is the fact that the failing assertion message
is not very useful. I changed the message to a valid powershell command,
which seems inherently more useful on Windows.

This allows me to just paste error into powershell and view the diff
like macOS/linux users can do with the unix/bash command.