### PR TITLE
[tests] Run nunit tests in debug mode, so that we get line numbers

### DIFF
--- a/build-tools/scripts/RunNUnitTests.targets
+++ b/build-tools/scripts/RunNUnitTests.targets
@@ -4,7 +4,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <_TopDir>$(MSBuildThisFileDirectory)..\..</_TopDir>
     <_Runtime Condition=" '$(RUNTIME)' != '' ">$(RUNTIME)</_Runtime>
-    <_Runtime Condition=" '$(RUNTIME)' == '' And '$(OS)' != 'Windows_NT' ">mono</_Runtime>
+    <_Runtime Condition=" '$(RUNTIME)' == '' And '$(OS)' != 'Windows_NT' ">mono --debug</_Runtime>
     <_NUnit>$(_Runtime) packages\NUnit.Runners.2.6.3\tools\nunit-console.exe</_NUnit>
     <_Run Condition=" '$(RUN)' != '' ">--run=&quot;$(RUN)&quot;</_Run>
   </PropertyGroup>


### PR DESCRIPTION
Make the stacktraces in the nunit tests more useful by passing
`--debug` to mono to have line numbers in the error reports.

Example output:
```
Errors and Failures:
1) Test Error : Java.InteropTests.MarshalMemberBuilderTest.AddExportMethods
   System.MissingMethodException : void Java.Interop.JniObjectReference.Dispose(Java.Interop.JniObjectReference)
  at (wrapper managed-to-native) Java.Interop.NativeMethods.java_interop_jnienv_call_void_method(intptr,intptr&,intptr,intptr)
  at Java.Interop.JniEnvironment+InstanceMethods.CallVoidMethod (Java.Interop.JniObjectReference instance, Java.Interop.JniMethodInfo method) [0x00060] in /Users/rodo/git/java.interop/src/Java.Interop/Java.Interop/JniEnvironment.g.cs:11620
  at Java.InteropTests.MarshalMemberBuilderTest.AddExportMethods () [0x0010d] in /Users/rodo/git/java.interop/src/Java.Interop.Export/Tests/Java.Interop/MarshalMemberBuilderTest.cs:43
  at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00032] in /Users/builder/jenkins/workspace/build-package-osx-mono/2017-12/external/bockbuild/builds/mono-x64/mcs/class/corlib/System.Reflection/MonoMethod.cs:305
```