### PR TITLE
[generator] initial unit tests for Xml* and Managed* classes

### DIFF
--- a/tools/generator/Tests/SupportFiles/RegisterAttribute.cs
+++ b/tools/generator/Tests/SupportFiles/RegisterAttribute.cs
@@ -13,7 +13,8 @@ namespace Android.Runtime {
 		public RegisterAttribute (string name, string signature, string connector)
 			: this (name)
 		{
-			throw new NotImplementedException ();
+			Signature = signature;
+			Connector = connector;
 		}
 
 		public string Connector {

--- a/tools/generator/Tests/Unit-Tests/ManagedTests.cs
+++ b/tools/generator/Tests/Unit-Tests/ManagedTests.cs
@@ -1,0 +1,161 @@
+﻿using Android.Runtime;
+using Mono.Cecil;
+using MonoDroid.Generation;
+using NUnit.Framework;
+using System.IO;
+using System.Linq;
+
+namespace Com.Mypackage
+{
+	[Register ("com/mypackage/foo")]
+	public class Foo
+	{
+		[Register ("foo", "()V", "")]
+		public Foo () { }
+
+		[Register ("bar", "()V", "")]
+		public void Bar () { }
+
+		[Register ("barWithParams", "(ZID)Ljava/lang/String;", "")]
+		public string BarWithParams (bool a, int b, double c) => string.Empty;
+
+		[Register ("value")]
+		public const int Value = 1234;
+	}
+
+	[Register ("com/mypackage/service")]
+	public interface IService { }
+}
+
+namespace generatortests
+{
+	[TestFixture]
+	public class ManagedTests
+	{
+		string tempFile;
+		ModuleDefinition module;
+
+		[SetUp]
+		public void SetUp ()
+		{
+			tempFile = Path.GetTempFileName ();
+			File.Copy (GetType ().Assembly.Location, tempFile, true);
+			module = ModuleDefinition.ReadModule (tempFile);
+		}
+
+		[TearDown]
+		public void TearDown ()
+		{
+			module.Dispose ();
+			if (File.Exists (tempFile))
+				File.Delete (tempFile);
+		}
+
+		[Test]
+		public void Class ()
+		{
+			var @class = new ManagedClassGen (module.GetType ("Com.Mypackage.Foo"));
+			Assert.AreEqual ("public", @class.Visibility);
+			Assert.AreEqual ("Foo", @class.Name);
+			Assert.AreEqual ("com.mypackage.foo", @class.JavaName);
+			Assert.AreEqual ("Lcom/mypackage/foo;", @class.JniName);
+			Assert.IsFalse (@class.IsAbstract);
+			Assert.IsFalse (@class.IsFinal);
+			Assert.IsFalse (@class.IsDeprecated);
+			Assert.IsNull (@class.DeprecatedComment);
+		}
+
+		[Test]
+		public void Method ()
+		{
+			var type = module.GetType ("Com.Mypackage.Foo");
+			var @class = new ManagedClassGen (type);
+			var method = new ManagedMethod (@class, type.Methods.First (m => m.Name == "Bar"));
+			Assert.IsTrue (method.Validate (new CodeGenerationOptions (), new GenericParameterDefinitionList ()), "method.Validate failed!");
+
+			Assert.AreEqual ("public", method.Visibility);
+			Assert.AreEqual ("void", method.Return);
+			Assert.AreEqual ("System.Void", method.ReturnType);
+			Assert.AreEqual ("Bar", method.Name);
+			Assert.AreEqual ("bar", method.JavaName);
+			Assert.AreEqual ("()V", method.JniSignature);
+			Assert.IsFalse (method.IsAbstract);
+			Assert.IsFalse (method.IsFinal);
+			Assert.IsFalse (method.IsStatic);
+			Assert.IsNull (method.Deprecated);
+		}
+
+		[Test]
+		public void MethodWithParameters ()
+		{
+			var type = module.GetType ("Com.Mypackage.Foo");
+			var @class = new ManagedClassGen (type);
+			var method = new ManagedMethod (@class, type.Methods.First (m => m.Name == "BarWithParams"));
+			Assert.IsTrue (method.Validate (new CodeGenerationOptions (), new GenericParameterDefinitionList ()), "method.Validate failed!");
+			Assert.AreEqual ("(ZID)Ljava/lang/String;", method.JniSignature);
+			Assert.AreEqual ("java.lang.String", method.Return);
+			Assert.AreEqual ("System.String", method.ManagedReturn);
+
+			var parameter = method.Parameters [0];
+			Assert.AreEqual ("a", parameter.Name);
+			Assert.AreEqual ("bool", parameter.Type);
+			Assert.AreEqual ("boolean", parameter.JavaType);
+			Assert.AreEqual ("Z", parameter.JniType);
+
+			parameter = method.Parameters [1];
+			Assert.AreEqual ("b", parameter.Name);
+			Assert.AreEqual ("int", parameter.Type);
+			Assert.AreEqual ("int", parameter.JavaType);
+			Assert.AreEqual ("I", parameter.JniType);
+
+			parameter = method.Parameters [2];
+			Assert.AreEqual ("c", parameter.Name);
+			Assert.AreEqual ("double", parameter.Type);
+			Assert.AreEqual ("double", parameter.JavaType);
+			Assert.AreEqual ("D", parameter.JniType);
+		}
+
+		[Test]
+		public void Ctor ()
+		{
+			var type = module.GetType ("Com.Mypackage.Foo");
+			var @class = new ManagedClassGen (type);
+			var ctor = new ManagedCtor (@class, type.Methods.First (m => m.IsConstructor && !m.IsStatic));
+			Assert.IsTrue (ctor.Validate (new CodeGenerationOptions (), new GenericParameterDefinitionList ()), "ctor.Validate failed!");
+
+			Assert.AreEqual ("public", ctor.Visibility);
+			Assert.AreEqual (".ctor", ctor.Name);
+			Assert.AreEqual ("()V", ctor.JniSignature);
+			Assert.IsNull (ctor.Deprecated);
+		}
+
+		[Test]
+		public void Field ()
+		{
+			var type = module.GetType ("Com.Mypackage.Foo");
+			var @class = new ManagedClassGen (type);
+			var field = new ManagedField (type.Fields.First (f => f.Name == "Value"));
+			Assert.IsTrue (field.Validate (new CodeGenerationOptions (), new GenericParameterDefinitionList ()), "field.Validate failed!");
+
+			Assert.AreEqual ("Value", field.Name);
+			Assert.AreEqual ("value", field.JavaName);
+			Assert.AreEqual ("1234", field.Value);
+			Assert.AreEqual ("System.Int32", field.TypeName);
+			Assert.IsTrue (field.IsStatic);
+			Assert.IsTrue (field.IsConst);
+		}
+
+		[Test]
+		public void Interface ()
+		{
+			var type = module.GetType ("Com.Mypackage.IService");
+			var @interface = new ManagedInterfaceGen (type);
+			Assert.IsTrue (@interface.Validate (new CodeGenerationOptions (), new GenericParameterDefinitionList ()), "interface.Validate failed!");
+
+			Assert.AreEqual ("public", @interface.Visibility);
+			Assert.AreEqual ("IService", @interface.Name);
+			Assert.AreEqual ("com.mypackage.service", @interface.JavaName);
+			Assert.AreEqual ("Lcom/mypackage/service;", @interface.JniName);
+		}
+	}
+}

--- a/tools/generator/Tests/Unit-Tests/XmlTests.cs
+++ b/tools/generator/Tests/Unit-Tests/XmlTests.cs
@@ -1,0 +1,163 @@
+﻿using MonoDroid.Generation;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace generatortests
+{
+	[TestFixture]
+	public class XmlTests
+	{
+		XDocument xml;
+		XElement package;
+		List<XmlClassGen> javaLangClasses;
+
+		[SetUp]
+		public void SetUp ()
+		{
+			using (var reader = new StringReader (@"<api>
+	<package name=""java.lang"">
+		<class abstract=""false"" deprecated=""not deprecated"" final=""false"" name=""Object"" static=""false"" visibility=""public"">
+		</class>
+		<class abstract=""false"" deprecated=""not deprecated"" extends=""java.lang.Object"" extends-generic-aware=""java.lang.Object""
+			final=""true"" name=""String"" static=""false"" visibility=""public"">
+		</class>
+	</package>
+	<package name=""com.mypackage"">
+		<class abstract=""false"" deprecated=""not deprecated"" final=""false"" name=""foo"" static=""false"" visibility=""public"">
+			<constructor deprecated=""not deprecated"" final=""false"" name=""foo"" static=""false"" visibility=""public"" />
+			<method abstract=""false"" deprecated=""not deprecated"" final=""false"" name=""bar"" native=""false"" return=""void"" static=""false"" synchronized=""false"" visibility=""public"" managedReturn=""System.Void"" />
+			<method abstract=""false"" deprecated=""not deprecated"" final=""false"" name=""barWithParams"" native=""false"" return=""java.lang.String"" static=""false"" synchronized=""false"" visibility=""public"" managedReturn=""System.String"">
+				<parameter name=""a"" type=""boolean"" />
+				<parameter name=""b"" type=""int"" />
+				<parameter name=""c"" type=""double"" />
+			</method>
+	  		<field deprecated=""not deprecated"" final=""true"" name=""value"" static=""true"" transient=""false"" type=""int"" type-generic-aware=""int"" visibility=""public"" volatile=""false"" value=""1234"" />
+		</class>
+		<interface abstract=""true"" deprecated=""not deprecated"" final=""false"" name=""service"" static=""false"" visibility=""public"" />
+	</package>
+</api>")) {
+				xml = XDocument.Load (reader);
+			}
+
+			//Configure java.lang package
+			var javaLang = xml.Element ("api").Element ("package");
+			javaLangClasses = new List<XmlClassGen> ();
+			foreach (var @class in javaLang.Elements("class")) {
+				javaLangClasses.Add (new XmlClassGen (javaLang, @class));
+			}
+
+			package = (XElement)javaLang.NextNode;
+		}
+
+		[Test]
+		public void Class ()
+		{
+			var element = package.Element ("class");
+			var @class = new XmlClassGen (package, element);
+			Assert.AreEqual ("public", @class.Visibility);
+			Assert.AreEqual ("Foo", @class.Name);
+			Assert.AreEqual ("com.mypackage.foo", @class.JavaName);
+			Assert.AreEqual ("Lcom/mypackage/foo;", @class.JniName);
+			Assert.IsFalse (@class.IsAbstract);
+			Assert.IsFalse (@class.IsFinal);
+			Assert.IsFalse (@class.IsDeprecated);
+			Assert.IsNull (@class.DeprecatedComment);
+		}
+
+		[Test]
+		public void Method ()
+		{
+			var element = package.Element ("class");
+			var @class = new XmlClassGen (package, element);
+			var method = new XmlMethod (@class, element.Element ("method"));
+			Assert.IsTrue (method.Validate (new CodeGenerationOptions (), new GenericParameterDefinitionList ()), "method.Validate failed!");
+
+			Assert.AreEqual ("public", method.Visibility);
+			Assert.AreEqual ("void", method.Return);
+			Assert.AreEqual ("System.Void", method.ReturnType);
+			Assert.AreEqual ("Bar", method.Name);
+			Assert.AreEqual ("bar", method.JavaName);
+			Assert.AreEqual ("()V", method.JniSignature);
+			Assert.IsFalse (method.IsAbstract);
+			Assert.IsFalse (method.IsFinal);
+			Assert.IsFalse (method.IsStatic);
+			Assert.IsNull (method.Deprecated);
+		}
+
+		[Test]
+		public void MethodWithParameters ()
+		{
+			var element = package.Element ("class");
+			var @class = new XmlClassGen (package, element);
+			var method = new XmlMethod (@class, element.Elements ("method").Where (e => e.Attribute ("name").Value == "barWithParams").First ());
+			Assert.IsTrue (method.Validate (new CodeGenerationOptions (), new GenericParameterDefinitionList ()), "method.Validate failed!");
+			Assert.AreEqual ("(ZID)Ljava/lang/String;", method.JniSignature);
+			Assert.AreEqual ("java.lang.String", method.Return);
+			Assert.AreEqual ("System.String", method.ManagedReturn);
+
+			var parameter = method.Parameters [0];
+			Assert.AreEqual ("a", parameter.Name);
+			Assert.AreEqual ("bool", parameter.Type);
+			Assert.AreEqual ("boolean", parameter.JavaType);
+			Assert.AreEqual ("Z", parameter.JniType);
+
+			parameter = method.Parameters [1];
+			Assert.AreEqual ("b", parameter.Name);
+			Assert.AreEqual ("int", parameter.Type);
+			Assert.AreEqual ("int", parameter.JavaType);
+			Assert.AreEqual ("I", parameter.JniType);
+
+			parameter = method.Parameters [2];
+			Assert.AreEqual ("c", parameter.Name);
+			Assert.AreEqual ("double", parameter.Type);
+			Assert.AreEqual ("double", parameter.JavaType);
+			Assert.AreEqual ("D", parameter.JniType);
+		}
+
+		[Test]
+		public void Ctor ()
+		{
+			var element = package.Element ("class");
+			var @class = new XmlClassGen (package, element);
+			var ctor = new XmlCtor (@class, element.Element ("constructor"));
+			Assert.IsTrue (ctor.Validate (new CodeGenerationOptions (), new GenericParameterDefinitionList ()), "ctor.Validate failed!");
+
+			Assert.AreEqual ("public", ctor.Visibility);
+			Assert.AreEqual ("foo", ctor.Name);
+			Assert.AreEqual ("()V", ctor.JniSignature);
+			Assert.IsNull (ctor.Deprecated);
+		}
+
+		[Test]
+		public void Field ()
+		{
+			var element = package.Element ("class");
+			var @class = new XmlClassGen (package, element);
+			var field = new XmlField (element.Element ("field"));
+			Assert.IsTrue (field.Validate (new CodeGenerationOptions (), new GenericParameterDefinitionList ()), "field.Validate failed!");
+
+			Assert.AreEqual ("Value", field.Name);
+			Assert.AreEqual ("value", field.JavaName);
+			Assert.AreEqual ("1234", field.Value);
+			Assert.AreEqual ("int", field.TypeName);
+			Assert.IsTrue (field.IsStatic);
+			Assert.IsTrue (field.IsConst);
+		}
+
+		[Test]
+		public void Interface ()
+		{
+			var element = package.Element ("interface");
+			var @interface = new XmlInterfaceGen (package, element);
+			Assert.IsTrue (@interface.Validate (new CodeGenerationOptions (), new GenericParameterDefinitionList ()), "interface.Validate failed!");
+
+			Assert.AreEqual ("public", @interface.Visibility);
+			Assert.AreEqual ("IService", @interface.Name);
+			Assert.AreEqual ("com.mypackage.service", @interface.JavaName);
+			Assert.AreEqual ("Lcom/mypackage/service;", @interface.JniName);
+		}
+	}
+}

--- a/tools/generator/Tests/generator-Tests.csproj
+++ b/tools/generator/Tests/generator-Tests.csproj
@@ -40,6 +40,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Integration-Tests\AccessModifiers.cs" />
@@ -66,9 +67,12 @@
     <Compile Include="Integration-Tests\CSharpKeywords.cs" />
     <Compile Include="Integration-Tests\GenericArguments.cs" />
     <Compile Include="Integration-Tests\InterfaceMethodsConflict.cs" />
+    <Compile Include="SupportFiles\RegisterAttribute.cs" />
     <Compile Include="Unit-Tests\JavaInteropCodeGeneratorTests.cs" />
+    <Compile Include="Unit-Tests\ManagedTests.cs" />
     <Compile Include="Unit-Tests\SupportTypes.cs" />
     <Compile Include="Unit-Tests\XamarinAndroidCodeGeneratorTests.cs" />
+    <Compile Include="Unit-Tests\XmlTests.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
@@ -79,6 +83,10 @@
     <ProjectReference Include="..\..\..\src\Xamarin.Android.Tools.ApiXmlAdjuster\Xamarin.Android.Tools.ApiXmlAdjuster.csproj">
       <Project>{1268EADF-8344-431C-81F6-FCB7CBC99F49}</Project>
       <Name>Xamarin.Android.Tools.ApiXmlAdjuster</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\src\Xamarin.Android.Cecil\Xamarin.Android.Cecil.csproj">
+      <Project>{15945D4B-FF56-4BCC-B598-2718D199DD08}</Project>
+      <Name>Xamarin.Android.Cecil</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
As I begin refactoring `generator`, it looks like I will be making
changes to `ManagedClassGen` and `XmlClassGen` as well as the various
other types that use either Mono.Cecil or XDocument to represent a type
in `generator`.

These are the first examples of unit tests that can be written against
these classes, and are just simple smoke tests for now.

ManagedTests
- C# types defined in a namespace at the top of the file
- Copies the current test assembly to `%TEMP%`, and loads it via Mono.Cecil
  - Mono.Cecil holds a lock on the file, so it was causing some issues
  with my IDE if I opened the current assembly with Mono.Cecil
- Had to change the build action for `SupportFiles\RegisterAttribute` so
I could use the type within the test assembly. It is still copied to the
output directory for the integration tests.
- Implemented a missing `ctor` for `RegisterAttribute` that was throwing
`NotImplementedException`

XmlTests
- Defined XML at the top of the file
- Use `System.Xml.Linq` to load specific elements as needed

Various smoke tests for:
- Classes
- Methods
- Parameters
- Fields
- Interfaces

In the future, I may need to expand on these tests to make sure I don't
break things. They may also get refactored/removed one day if we get
the classes under test refactored to POCOs.