### PR TITLE
[build] setup PrepareWindows.targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ TestResult-*.xml
 xa-gendarme.html
 packages
 .vs/
+.nuget/
 *.userprefs
 *.user
 Resource.designer.cs

--- a/Before.Java.Interop.sln.targets
+++ b/Before.Java.Interop.sln.targets
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildThisFileDirectory)build-tools\scripts\PrepareWindows.targets" Condition=" '$(OS)' == 'Windows_NT' " />
+</Project>

--- a/README.md
+++ b/README.md
@@ -210,3 +210,30 @@ I halted the above loop after reaching 25686556 instances.
 I'm not sure when the JDK would stop handing out references, but it's probably
 bound to process heap limits (e.g. depends on 32-bit vs. 64-bit process).
 
+### Building on Windows
+
+Building Java.Interop on Windows requires .NET and the `msbuild` command
+be available within the Command-Line environment.
+(The **Developer Command Prompt** that Visual Studio installs is sufficient.)
+
+MSBuild version 15 or later is required.
+
+ 1. Install the [build requirements](#build-requirements).
+
+ 2. Clone the java.interop repo:
+
+        git clone https://github.com/xamarin/java.interop.git
+
+ 3. Navigate to the `java.interop` directory
+
+ 4. Prepare the project:
+
+        msbuild Java.Interop.sln /t:Prepare
+
+    This will ensure that the build dependencies are installed, perform
+    `git submodule update`, download NuGet dependencies, and other
+    "preparatory" and pre-build tasks that need to be performed.
+
+ 5. Build the project (or open and build with an IDE):
+
+        msbuild Java.Interop.sln

--- a/build-tools/scripts/PrepareWindows.targets
+++ b/build-tools/scripts/PrepareWindows.targets
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Prepare" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <_TopDir>$(MSBuildThisFileDirectory)..\..</_TopDir>
+    <_NuGetUri>https://dist.nuget.org/win-x86-commandline/latest/nuget.exe</_NuGetUri>
+    <_NuGetPath>$(_TopDir)\.nuget</_NuGetPath>
+    <_NuGet>$(_NuGetPath)\NuGet.exe</_NuGet>
+  </PropertyGroup>
+  <Import Project="$(_TopDir)\Configuration.props" />
+  <UsingTask AssemblyFile="$(_TopDir)\bin\Build$(Configuration)\Java.Interop.BootstrapTasks.dll" TaskName="Java.Interop.BootstrapTasks.JdkInfo" />
+  <UsingTask AssemblyFile="$(_TopDir)\bin\Build$(Configuration)\Java.Interop.BootstrapTasks.dll" TaskName="Java.Interop.BootstrapTasks.DownloadUri" />
+  <Target Name="Prepare">
+    <Exec Command="git submodule update --init --recursive" WorkingDirectory="$(_TopDir)" />
+    <MSBuild Projects="$(MSBuildThisFileDirectory)..\..\src\Java.Interop.BootstrapTasks\Java.Interop.BootstrapTasks.csproj" />
+    <MakeDir Directories="$(_NuGetPath)" />
+    <DownloadUri
+        SourceUris="$(_NuGetUri)"
+        DestinationFiles="$(_NuGet)"
+    />
+    <Exec Command="$(_NuGet) restore Java.Interop.sln" WorkingDirectory="$(_TopDir)" />
+    <JdkInfo Output="$(_TopDir)\bin\Build$(Configuration)\JdkInfo.props">
+      <Output TaskParameter="JavaSdkDirectory" PropertyName="_JavaSdkDirectory" />
+    </JdkInfo>
+  </Target>
+</Project>

--- a/src/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks.csproj
+++ b/src/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks.csproj
@@ -37,6 +37,9 @@
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Java.Interop.BootstrapTasks\DownloadUri.cs" />
+    <Compile Include="Java.Interop.BootstrapTasks\JdkInfo.cs" />
+    <Compile Include="Java.Interop.BootstrapTasks\RegistryEx.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Java.Interop.BootstrapTasks\SetEnvironmentVariable.cs" />
   </ItemGroup>

--- a/src/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks/DownloadUri.cs
+++ b/src/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks/DownloadUri.cs
@@ -1,0 +1,81 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+using TTask = System.Threading.Tasks.Task;
+using MTask = Microsoft.Build.Utilities.Task;
+
+namespace Java.Interop.BootstrapTasks {
+
+	public class DownloadUri : MTask
+	{
+		public DownloadUri ()
+		{
+		}
+
+		[Required]
+		public string[]     SourceUris          { get; set; }
+
+		[Required]
+		public ITaskItem[]  DestinationFiles    { get; set; }
+
+		public override bool Execute ()
+		{
+			Log.LogMessage (MessageImportance.Low, "DownloadUri:");
+			Log.LogMessage (MessageImportance.Low, "  SourceUris:");
+			foreach (var uri in SourceUris) {
+				Log.LogMessage (MessageImportance.Low, "    {0}", uri);
+			}
+			Log.LogMessage (MessageImportance.Low, "  DestinationFiles:");
+			foreach (var dest in DestinationFiles) {
+				Log.LogMessage (MessageImportance.Low, "    {0}", dest.ItemSpec);
+			}
+
+			if (SourceUris.Length != DestinationFiles.Length) {
+				Log.LogError ("SourceUris.Length must equal DestinationFiles.Length.");
+				return false;
+			}
+
+			var tasks   = new TTask [SourceUris.Length];
+			using (var client = new HttpClient ()) {
+				client.Timeout = TimeSpan.FromHours (3);
+				for (int i = 0; i < SourceUris.Length; ++i) {
+					tasks [i] = DownloadFile (client, SourceUris [i], DestinationFiles [i].ItemSpec);
+				}
+				TTask.WaitAll (tasks);
+			}
+
+			return !Log.HasLoggedErrors;
+		}
+
+		async TTask DownloadFile (HttpClient client, string uri, string destinationFile)
+		{
+			if (File.Exists (destinationFile)) {
+				Log.LogMessage (MessageImportance.Normal, $"Skipping uri '{uri}' as destination file already exists '{destinationFile}'.");
+				return;
+			}
+			var dp       = Path.GetDirectoryName (destinationFile);
+			var dn       = Path.GetFileName (destinationFile);
+			var tempPath = Path.Combine (dp, "." + dn + ".download");
+			Directory.CreateDirectory(dp);
+
+			Log.LogMessage (MessageImportance.Normal, $"Downloading `{uri}` to `{tempPath}`.");
+			try {
+				using (var s = await client.GetStreamAsync (uri))
+				using (var o = File.OpenWrite (tempPath)) {
+					await s.CopyToAsync (o);
+				}
+				Log.LogMessage (MessageImportance.Low, $"mv '{tempPath}' '{destinationFile}'.");
+				File.Move (tempPath, destinationFile);
+			}
+			catch (Exception e) {
+				Log.LogError ("Unable to download URL `{0}` to `{1}`: {2}", uri, destinationFile, e.Message);
+				Log.LogErrorFromException (e);
+			}
+		}
+	}
+}

--- a/src/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks/JdkInfo.cs
+++ b/src/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks/JdkInfo.cs
@@ -1,0 +1,164 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Java.Interop.BootstrapTasks
+{
+	public class JdkInfo : Task
+	{
+		const string JARSIGNER = "jarsigner.exe";
+		const string MDREG_KEY = @"SOFTWARE\Novell\Mono for Android";
+		const string MDREG_JAVA_SDK = "JavaSdkDirectory";
+
+		[Required]
+		public ITaskItem Output { get; set; }
+
+		[Output]
+		public string JavaSdkDirectory { get; set; }
+
+		public override bool Execute ()
+		{
+			Log.LogMessage (MessageImportance.Low, $"Task {nameof (JdkInfo)}");
+			Log.LogMessage (MessageImportance.Low, $"  {nameof (Output)}: {Output}");
+
+			var javaSdkPath = GetJavaSdkPath ();
+			if (string.IsNullOrEmpty(javaSdkPath)) {
+				Log.LogError ("JavaSdkPath is blank");
+				return false;
+			}
+
+			Log.LogMessage (MessageImportance.Low, $"  JavaSdkPath: {javaSdkPath}");
+
+			var jvmPath = Path.Combine (javaSdkPath, "jre", "bin", "server", "jvm.dll");
+			if (!File.Exists (jvmPath)) {
+				Log.LogError ($"JdkJvmPath not found at {jvmPath}");
+				return false;
+			}
+
+			var javaIncludePath = Path.Combine (javaSdkPath, "include");
+			var includes = new List<string> { javaIncludePath };
+			includes.AddRange (Directory.GetDirectories (javaIncludePath)); //Include dirs such as "win32"
+
+			var includeXmlTags = new StringBuilder ();
+			foreach (var include in includes) {
+				includeXmlTags.AppendLine ($"<JdkIncludePath Include=\"{include}\" />");
+			}
+
+			Directory.CreateDirectory (Path.GetDirectoryName (Output.ItemSpec));
+			File.WriteAllText (Output.ItemSpec, $@"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+  <Choose>
+    <When Condition="" '$(JdkJvmPath)' == '' "">
+      <PropertyGroup>
+        <JdkJvmPath>{jvmPath}</JdkJvmPath>
+      </PropertyGroup>
+      <ItemGroup>
+        {includeXmlTags}
+      </ItemGroup>
+    </When>
+  </Choose>
+  <PropertyGroup>
+    <JavaCPath Condition="" '$(JavaCPath)' == '' "">{Path.Combine (javaSdkPath, "bin", "javac.exe")}</JavaCPath>
+    <JarPath Condition="" '$(JarPath)' == '' "">{Path.Combine (javaSdkPath, "bin", "jar.exe")}</JarPath>
+  </PropertyGroup>
+</Project>");
+
+			JavaSdkDirectory = javaSdkPath;
+			Log.LogMessage (MessageImportance.Low, $"  [Output] {nameof (JavaSdkDirectory)}: {JavaSdkDirectory}");
+
+			return !Log.HasLoggedErrors;
+		}
+
+		string GetJavaSdkPath ()
+		{
+			// check the user specified path
+			var roots = new [] { RegistryEx.CurrentUser, RegistryEx.LocalMachine };
+			const RegistryEx.Wow64 wow = RegistryEx.Wow64.Key32;
+			var regKey = GetMDRegistryKey ();
+
+			foreach (var root in roots) {
+				if (CheckRegistryKeyForExecutable (root, regKey, MDREG_JAVA_SDK, wow, "bin", JARSIGNER))
+					return RegistryEx.GetValueString (root, regKey, MDREG_JAVA_SDK, wow);
+			}
+
+			string subkey = @"SOFTWARE\JavaSoft\Java Development Kit";
+
+			Log.LogMessage (MessageImportance.Low, "Looking for Java 6 SDK...");
+
+			foreach (var wow64 in new [] { RegistryEx.Wow64.Key32, RegistryEx.Wow64.Key64 }) {
+				string key_name = string.Format (@"{0}\{1}\{2}", "HKLM", subkey, "CurrentVersion");
+				var currentVersion = RegistryEx.GetValueString (RegistryEx.LocalMachine, subkey, "CurrentVersion", wow64);
+
+				if (!string.IsNullOrEmpty (currentVersion)) {
+					Log.LogMessage (MessageImportance.Low, $"  Key {key_name} found.");
+
+					// No matter what the CurrentVersion is, look for 1.6 or 1.7 or 1.8
+					if (CheckRegistryKeyForExecutable (RegistryEx.LocalMachine, subkey + "\\" + "1.8", "JavaHome", wow64, "bin", JARSIGNER))
+						return RegistryEx.GetValueString (RegistryEx.LocalMachine, subkey + "\\" + "1.8", "JavaHome", wow64);
+
+					if (CheckRegistryKeyForExecutable (RegistryEx.LocalMachine, subkey + "\\" + "1.7", "JavaHome", wow64, "bin", JARSIGNER))
+						return RegistryEx.GetValueString (RegistryEx.LocalMachine, subkey + "\\" + "1.7", "JavaHome", wow64);
+
+					if (CheckRegistryKeyForExecutable (RegistryEx.LocalMachine, subkey + "\\" + "1.6", "JavaHome", wow64, "bin", JARSIGNER))
+						return RegistryEx.GetValueString (RegistryEx.LocalMachine, subkey + "\\" + "1.6", "JavaHome", wow64);
+				}
+
+				Log.LogMessage (MessageImportance.Low, $"  Key {key_name} not found.");
+			}
+
+			// We ran out of things to check..
+			return null;
+		}
+
+		string GetMDRegistryKey ()
+		{
+			var regKey = Environment.GetEnvironmentVariable ("XAMARIN_ANDROID_REGKEY");
+			return string.IsNullOrWhiteSpace (regKey) ? MDREG_KEY : regKey;
+		}
+
+		private bool CheckRegistryKeyForExecutable (UIntPtr key, string subkey, string valueName, RegistryEx.Wow64 wow64, string subdir, string exe)
+		{
+			string key_name = string.Format (@"{0}\{1}\{2}", key == RegistryEx.CurrentUser ? "HKCU" : "HKLM", subkey, valueName);
+
+			var value = RegistryEx.GetValueString (key, subkey, valueName, wow64);
+			var path = string.IsNullOrEmpty (value) ? null : value;
+
+			if (path == null) {
+				Log.LogMessage (MessageImportance.Low, $"  Key {key_name} not found.");
+				return false;
+			}
+
+			if (!FindExecutableInDirectory (exe, Path.Combine (path, subdir)).Any ()) {
+				Log.LogMessage (MessageImportance.Low, $"  Key {key_name} found:\n    Path does not contain {exe} in \\{subdir} ({path}).");
+				return false;
+			}
+
+			Log.LogMessage (MessageImportance.Low, $"  Key {key_name} found:\n    Path contains {exe} in \\{subdir} ({path}).");
+
+			return true;
+		}
+
+		IEnumerable<string> FindExecutableInDirectory (string executable, string dir)
+		{
+			foreach (var exe in Executables (executable))
+				if (File.Exists (Path.Combine (dir, exe)))
+					yield return dir;
+		}
+
+		IEnumerable<string> Executables (string executable)
+		{
+			yield return executable;
+			var pathExt = Environment.GetEnvironmentVariable ("PATHEXT");
+			var pathExts = pathExt?.Split (new char [] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries);
+
+			if (pathExts == null)
+				yield break;
+
+			foreach (var ext in pathExts)
+				yield return Path.ChangeExtension (executable, ext);
+		}
+	}
+}

--- a/src/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks/RegistryEx.cs
+++ b/src/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks/RegistryEx.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Java.Interop.BootstrapTasks
+{
+	internal static class RegistryEx
+	{
+		const string ADVAPI = "advapi32.dll";
+
+		public static UIntPtr CurrentUser = (UIntPtr)0x80000001;
+		public static UIntPtr LocalMachine = (UIntPtr)0x80000002;
+
+		[DllImport (ADVAPI, CharSet = CharSet.Unicode, SetLastError = true)]
+		static extern int RegOpenKeyEx (UIntPtr hKey, string subKey, uint reserved, uint sam, out UIntPtr phkResult);
+
+		[DllImport (ADVAPI, CharSet = CharSet.Unicode, SetLastError = true)]
+		static extern int RegQueryValueExW (UIntPtr hKey, string lpValueName, int lpReserved, out uint lpType,
+			StringBuilder lpData, ref uint lpcbData);
+
+		[DllImport (ADVAPI, CharSet = CharSet.Unicode, SetLastError = true)]
+		static extern int RegSetValueExW (UIntPtr hKey, string lpValueName, int lpReserved,
+			uint dwType, string data, uint cbData);
+
+		[DllImport (ADVAPI, CharSet = CharSet.Unicode, SetLastError = true)]
+		static extern int RegSetValueExW (UIntPtr hKey, string lpValueName, int lpReserved,
+			uint dwType, IntPtr data, uint cbData);
+
+		[DllImport (ADVAPI, CharSet = CharSet.Unicode, SetLastError = true)]
+		static extern int RegCreateKeyEx (UIntPtr hKey, string subKey, uint reserved, string @class, uint options,
+			uint samDesired, IntPtr lpSecurityAttributes, out UIntPtr phkResult, out Disposition lpdwDisposition);
+
+		[DllImport ("advapi32.dll", SetLastError = true)]
+		static extern int RegCloseKey (UIntPtr hKey);
+
+		public static string GetValueString (UIntPtr key, string subkey, string valueName, Wow64 wow64)
+		{
+			UIntPtr regKeyHandle;
+			uint sam = (uint)Rights.QueryValue + (uint)wow64;
+			if (RegOpenKeyEx (key, subkey, 0, sam, out regKeyHandle) != 0)
+				return null;
+
+			try {
+				uint type;
+				var sb = new StringBuilder (2048);
+				uint cbData = (uint)sb.Capacity;
+				if (RegQueryValueExW (regKeyHandle, valueName, 0, out type, sb, ref cbData) == 0) {
+					return sb.ToString ();
+				}
+				return null;
+			} finally {
+				RegCloseKey (regKeyHandle);
+			}
+		}
+
+		public static void SetValueString (UIntPtr key, string subkey, string valueName, string value, Wow64 wow64)
+		{
+			UIntPtr regKeyHandle;
+			uint sam = (uint)(Rights.CreateSubKey | Rights.SetValue) + (uint)wow64;
+			uint options = (uint)Options.NonVolatile;
+			Disposition disposition;
+			if (RegCreateKeyEx (key, subkey, 0, null, options, sam, IntPtr.Zero, out regKeyHandle, out disposition) != 0) {
+				throw new Exception ("Could not open or craete key");
+			}
+
+			try {
+				uint type = (uint)ValueType.String;
+				uint lenBytesPlusNull = ((uint)value.Length + 1) * 2;
+				var result = RegSetValueExW (regKeyHandle, valueName, 0, type, value, lenBytesPlusNull);
+				if (result != 0)
+					throw new Exception (string.Format ("Error {0} setting registry key '{1}{2}@{3}'='{4}'",
+						result, key, subkey, valueName, value));
+			} finally {
+				RegCloseKey (regKeyHandle);
+			}
+		}
+
+		[Flags]
+		enum Rights : uint
+		{
+			None = 0,
+			QueryValue = 0x0001,
+			SetValue = 0x0002,
+			CreateSubKey = 0x0004,
+			EnumerateSubKey = 0x0008,
+		}
+
+		enum Options
+		{
+			BackupRestore = 0x00000004,
+			CreateLink = 0x00000002,
+			NonVolatile = 0x00000000,
+			Volatile = 0x00000001,
+		}
+
+		public enum Wow64 : uint
+		{
+			Key64 = 0x0100,
+			Key32 = 0x0200,
+		}
+
+		enum ValueType : uint
+		{
+			None = 0, //REG_NONE
+			String = 1, //REG_SZ
+			UnexpandedString = 2, //REG_EXPAND_SZ
+			Binary = 3, //REG_BINARY
+			DWord = 4, //REG_DWORD
+			DWordLittleEndian = 4, //REG_DWORD_LITTLE_ENDIAN
+			DWordBigEndian = 5, //REG_DWORD_BIG_ENDIAN
+			Link = 6, //REG_LINK
+			MultiString = 7, //REG_MULTI_SZ
+			ResourceList = 8, //REG_RESOURCE_LIST
+			FullResourceDescriptor = 9, //REG_FULL_RESOURCE_DESCRIPTOR
+			ResourceRequirementsList = 10, //REG_RESOURCE_REQUIREMENTS_LIST
+			QWord = 11, //REG_QWORD
+			QWordLittleEndian = 11, //REG_QWORD_LITTLE_ENDIAN
+		}
+
+		enum Disposition : uint
+		{
+			CreatedNewKey = 0x00000001,
+			OpenedExistingKey = 0x00000002,
+		}
+	}
+}


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/blob/master/build-tools/scripts/PrepareWindows.targets

Similar to what was setup in `xamarin-android`, this enables Windows
developers to build via:

    msbuild Java.Interop.sln /t:Prepare

Following this you can build the solution as you would expect in
Windows (or use an IDE):

    msbuild Java.Interop.sln

Steps needed to "prepare" Java.Interop:
- `git submodule update`
- Build `Java.Interop.BootstrapTasks`
- Download NuGet to `.nuget/NuGet.exe`
- NuGet restore `Java.Interop.sln`
- Run a `JdkInfo` task to get the Java SDK directories on Windows

To implement this, I had to:
- Add `PrepareWindows.targets` and `Before.Java.Interop.sln.targets`
- Port the `JdkInfo` and `DownloadUri` tasks from `xamarin-android`
- Port some code from `xamarin-android-tools` to find the Java SDK
directory on Windows
- This included a `RegistryEx` class. We could look into including
`xamarin-android-tools` as a submodule as an alternative.

After this gets merged, upstream in `xamarin-android` we can:
- Drop the `JdkInfo` task used in its `PrepareWindows.targets`
- Just call `msbuild /t:Prepare` against `external/Java.Interop/Java.Interop.sln`