### PR TITLE
[jnimarshalmethod-gen] Improve generated __RegisterNativeMembers

### DIFF
--- a/tools/jnimarshalmethod-gen/App.cs
+++ b/tools/jnimarshalmethod-gen/App.cs
@@ -209,7 +209,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 				ColorWriteLine ($"Marshal method assembly '{assemblyName}' created", ConsoleColor.Cyan);
 
 			var dstAssembly = resolver.GetAssembly (destPath);
-			var mover = new TypeMover (dstAssembly, ad, definedTypes);
+			var mover = new TypeMover (dstAssembly, ad, definedTypes, resolver);
 			mover.Move ();
 		}
 


### PR DESCRIPTION
Replace the `Type.GetType (string)` call with `typeof (...)`. Example
improved method:

```
[JniAddNativeMethodRegistration]
public static void __RegisterNativeMembers (JniNativeMethodRegistrationArguments args)
{
	Type typeFromHandle = typeof(MainActivity.__<$>_jni_marshal_methods);
	args.AddRegistrations (new JniNativeMethodRegistration[] {
		new JniNativeMethodRegistration ("n_onCreate", "(Landroid/os/Bundle;)V", Delegate.CreateDelegate (typeof(Action<IntPtr, IntPtr, IntPtr>), typeFromHandle, "n_onCreate_Landroid_os_Bundle_"))
	});
}
```

Also refactor the code a bit to improve speed.