### PR TITLE
[jnimarshalmethod-gen] Further improve the marshaling

### DIFF
--- a/tools/jnimarshalmethod-gen/App.cs
+++ b/tools/jnimarshalmethod-gen/App.cs
@@ -20,6 +20,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 		internal const string Name = "jnimarshalmethod-gen";
 		static DirectoryAssemblyResolver resolver = new DirectoryAssemblyResolver (logger: (l, v) => { Console.WriteLine (v); }, loadDebugSymbols: true, loadReaderParameters: new ReaderParameters () { ReadSymbols = true });
 		static Dictionary<string, TypeBuilder> definedTypes = new Dictionary<string, TypeBuilder> ();
+		static public bool Debug;
 		static public bool Verbose;
 
 		public static int Main (string [] args)
@@ -33,6 +34,9 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 				"Copyright 2018 Microsoft Corporation",
 				"",
 				"Options:",
+				{ "d",
+				  "Inject debug messages",
+				  v => Debug = true },
 				{ "L=",
 				  "{DIRECTORY} to resolve assemblies from.",
 				  v => resolver.SearchDirectories.Add (v) },


### PR DESCRIPTION
Improve the marshaling methods registration by removing/replacing
calls to `System.Type::GetType (string)` and
`System.Delegate::CreateDelegate (...)` in the registration methods.

This should improve the registration time and also reduces the
registration method size. In case of activity overriding OnCreate the
code size shrinks from 68 to 48. The registration method now looks
like this:
```
.method public static void  __RegisterNativeMembers([Java.Interop]Java.Interop.JniNativeMethodRegistrationArguments args) cil managed
{
  .custom instance void [Java.Interop]Java.Interop.JniAddNativeMethodRegistrationAttribute::.ctor() = ( 01 00 00 00 )
  // Code size       48 (0x30)
  .maxstack  8
  IL_0000:  ldarga.s   args
  IL_0002:  ldc.i4.1
  IL_0003:  newarr     [Java.Interop]Java.Interop.JniNativeMethodRegistration
  IL_0008:  dup
  IL_0009:  ldc.i4.0
  IL_000a:  ldstr      "n_onCreate"
  IL_000f:  ldstr      "(Landroid/os/Bundle;)V"
  IL_0014:  ldnull
  IL_0015:  ldftn      void xatemplateaot.MainActivity/'__<$>_jni_marshal_methods'::n_onCreate_Landroid_os_Bundle_(native int,
                                                                                                                   native int,
                                                                                                                   native int)
  IL_001b:  newobj     instance void [mscorlib]System.Action`3<native int,native int,native int>::.ctor(object,
                                                                                                        native int)
  IL_0020:  newobj     instance void [Java.Interop]Java.Interop.JniNativeMethodRegistration::.ctor(string,
                                                                                                   string,
                                                                                                   [mscorlib_3]System.Delegate)
  IL_0025:  stelem     [Java.Interop]Java.Interop.JniNativeMethodRegistration
  IL_002a:  call       instance void [Java.Interop]Java.Interop.JniNativeMethodRegistrationArguments::AddRegistrations([mscorlib]System.Collections.Generic.IEnumerable`1<[Java.Interop]Java.Interop.JniNativeMethodRegistration>)
  IL_002f:  ret
} // end of method '__<$>_jni_marshal_methods'::__RegisterNativeMembers
```

Also added new option to inject debug output into the registration
method.