### PR TITLE
[Java.Interop] Allow null methods in registration arguments

### DIFF
--- a/src/Java.Interop/Java.Interop/JniNativeMethodRegistrationArguments.cs
+++ b/src/Java.Interop/Java.Interop/JniNativeMethodRegistrationArguments.cs
@@ -14,7 +14,7 @@ namespace Java.Interop
 		public JniNativeMethodRegistrationArguments (ICollection<JniNativeMethodRegistration> registrations, string methods)
 		{
 			_registrations = registrations ?? throw new ArgumentNullException (nameof (registrations));
-			Methods = methods ?? throw new ArgumentNullException (nameof (methods));
+			Methods = methods;
 		}
 
 		public void AddRegistrations (IEnumerable<JniNativeMethodRegistration> registrations)


### PR DESCRIPTION
The methods part of `JniNativeMethodRegistrationArguments` is not
needed in most common case, where the marshaling methods generated by
jnimarshalmethod-gen are used.

This will save an unnecessary allocations in XA, when registering
native methods.