### PR TITLE
[Java.Interop] Improve lookup of register method

### DIFF
--- a/gendarme-ignore.txt
+++ b/gendarme-ignore.txt
@@ -657,7 +657,7 @@ T: Java.Interop.JavaSingleArray
 
 R: Gendarme.Rules.Concurrency.DoNotUseLockedRegionOutsideMethodRule
 # Looks like Gendarme issue, as there are both Monitor.TryEnter and Monitor.Exit used in this method
-M: System.Boolean Java.Interop.JniRuntime/JniTypeManager::TryRegisterNativeMembers(Java.Interop.JniType,System.Type,System.String)
+M: System.Boolean Java.Interop.JniRuntime/JniTypeManager::TryRegisterNativeMembers(Java.Interop.JniType,System.Type,System.String,System.Reflection.MethodInfo)
 
 R: Gendarme.Rules.Performance.AvoidUnsealedConcreteAttributesRule
 # We would like users to be able to derive from this attribute


### PR DESCRIPTION
In case of generated nested types, named `__<$>_jni_marshal_methods`,
we don't need to check all of the methods, just use the
`__RegisterNativeMembers` one.

This saves many GetCustomAttribute calls and should also be faster
than iterating over all methods of given type.

Also updated `TryRegisterNativeMembers` signature in the gendarme
ignore list.