### PR TITLE
[jnimarshalmethod-gen] Added -t option

### DIFF
--- a/tools/jnimarshalmethod-gen/TypeMover.cs
+++ b/tools/jnimarshalmethod-gen/TypeMover.cs
@@ -34,8 +34,17 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator
 
 		public void Move ()
 		{
-			foreach (var type in Types.Values)
+			int movedTypesCount = 0;
+
+			foreach (var type in Types.Values) {
 				Move (type);
+				movedTypesCount++;
+			}
+
+			if (movedTypesCount <= 0) {
+				App.Warning ("No type was moved => nothing to write, no new assembly created.");
+				return;
+			}
 
 			var newName = $"{Path.Combine (Path.GetDirectoryName (Destination.MainModule.FileName), Path.GetFileNameWithoutExtension (Destination.MainModule.FileName))}-new{Path.GetExtension (Destination.MainModule.FileName)}";
 			Destination.Write (newName, new WriterParameters () { WriteSymbols = true });


### PR DESCRIPTION
This options tells the tool to generate the marshal methods only for
the given types. It comes handy when working with big assemblies like
`Mono.Android` and one is interested only in results for the given
types.

The option takes *regex* pattern as input and matches types name against it.

Also updated the help messages.