### PR TITLE
[jnimarshalmethod-gen] Do not move "empty" classes

### DIFF
--- a/tools/jnimarshalmethod-gen/TypeMover.cs
+++ b/tools/jnimarshalmethod-gen/TypeMover.cs
@@ -48,11 +48,19 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator
 
 		Dictionary<string, MethodReference> newHelperMethods;
 
+		bool TypeIsEmptyOrHasOnlyDefaultConstructor (TypeDefinition type)
+		{
+			return !type.HasMethods || (type.Methods.Count == 1 && type.Methods [0].IsConstructor);
+		}
+
 		void Move (Type type)
 		{
 			var typeSrc = Source.MainModule.GetType (type.GetCecilName ());
 			var typeDst = Destination.MainModule.GetType (type.GetCecilName ());
 			var jniType = new TypeDefinition ("", nestedName, TypeAttributes.NestedPrivate | TypeAttributes.Sealed);
+
+			if (TypeIsEmptyOrHasOnlyDefaultConstructor (typeSrc))
+				return;
 
 			if (App.Verbose) {
 				Console.Write ($"Moving type ");


### PR DESCRIPTION
Do not move empty marshaling classes to the originating
assembly. These classes exist only as hosting classes for their
nested marshaling classes.

We have these, because we create the same class hierarchy in the
*-JniMarshalMethod assembly as is present in the originating
assembly. So some of the classes we create contain only nested
classes with marshal methods, but don't contain any marshal
methods itself. Like `Java.Interop.TypeManager` and
`Java.Interop.TypeManager+JavaTypeManager`.

When we are moving the marshal methods back to the originating
assembly, we don't need to create the `__<$>_jni_marshal_methods`
nested classes in the types, which don't have any marshal
methods (these are the "empty" classes on the *-JniMarshalMethod
side), so in the `Java.Interop.TypeManager` class for example.

It happened for 22 classes in the v8.1 `Mono.Android` assembly.