### PR TITLE
[Java.Interop.Tools.Cecil] new exception type for DirectoryAssemblyResolver

### DIFF
--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil.csproj
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil.csproj
@@ -34,6 +34,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Java.Interop.Tools.Cecil\AssemblyNotFoundException.cs" />
     <Compile Include="Java.Interop.Tools.Cecil\CustomAttributeProviderRocks.cs" />
     <Compile Include="Java.Interop.Tools.Cecil\DirectoryAssemblyResolver.cs" />
     <Compile Include="Java.Interop.Tools.Cecil\MethodDefinitionRocks.cs" />

--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/AssemblyNotFoundException.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/AssemblyNotFoundException.cs
@@ -1,0 +1,24 @@
+﻿using Mono.Cecil;
+using System.IO;
+using System.Linq;
+
+namespace Java.Interop.Tools.Cecil
+{
+	public class AssemblyNotFoundException : FileNotFoundException
+	{
+		public AssemblyNotFoundException (AssemblyNameReference reference)
+			: base (string.Format ("Could not load assembly '{0}, Version={1}, Culture={2}, PublicKeyToken={3}'. Perhaps it doesn't exist in the Mono for Android profile?",
+				reference.Name,
+				reference.Version,
+				string.IsNullOrEmpty (reference.Culture) ? "neutral" : reference.Culture,
+				reference.PublicKeyToken == null
+				? "null"
+				: string.Join ("", reference.PublicKeyToken.Select (b => b.ToString ("x2")))),
+			reference.Name)
+		{
+			Reference = reference;
+		}
+
+		public AssemblyNameReference Reference { get; private set; }
+	}
+}

--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/DirectoryAssemblyResolver.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/DirectoryAssemblyResolver.cs
@@ -193,15 +193,7 @@ namespace Java.Interop.Tools.Cecil {
 				if ((assembly = SearchDirectory (name, dir)) != null)
 					return assembly;
 
-			throw new System.IO.FileNotFoundException (
-				string.Format ("Could not load assembly '{0}, Version={1}, Culture={2}, PublicKeyToken={3}'. Perhaps it doesn't exist in the Mono for Android profile?",
-						name,
-						reference.Version,
-						string.IsNullOrEmpty (reference.Culture) ? "neutral" : reference.Culture,
-						reference.PublicKeyToken == null
-						? "null"
-						: string.Join ("", reference.PublicKeyToken.Select(b => b.ToString ("x2")))),
-				name + ".dll");
+			throw new AssemblyNotFoundException (reference);
 		}
 
 		public AssemblyDefinition Resolve (AssemblyNameReference reference, ReaderParameters parameters)
@@ -226,15 +218,7 @@ namespace Java.Interop.Tools.Cecil {
 			if (candidate != null)
 				return candidate;
 
-			throw new System.IO.FileNotFoundException (
-					string.Format ("Could not load assembly '{0}, Version={1}, Culture={2}, PublicKeyToken={3}'. Perhaps it doesn't exist in the Mono for Android profile?",
-						name, 
-						reference.Version, 
-						string.IsNullOrEmpty (reference.Culture) ? "neutral" : reference.Culture, 
-						reference.PublicKeyToken == null
-						? "null"
-						: string.Join ("", reference.PublicKeyToken.Select(b => b.ToString ("x2")))),
-					name + ".dll");
+			throw new AssemblyNotFoundException (reference);
 		}
 
 		string SearchDirectory (string name, string directory)


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/1532

In discussion around this issue, we realized the error message is a bit
confusing for developers. After looking into it, the exception is thrown
inside java.interop, so it makes it a bit tough to do something specific
within an MSBuild task in xamarin-android.

By making a new `AssemblyNotFoundException` type, we can handle it
upstream in xamarin-android in the `ResolveAssemblies` MSBuild task, for
example. There we could have a specific `catch` statement and use the
`AssemblyNameReference` instance to present a better error message.

Currently users are getting:

    Could not load assembly XYZ. Perhaps it doesn't exist in the Mono for Android profile?

This message makes sense for `System.*` or framework assemblies.

We were thinking in some cases we could give an error such as:

    Could not load assembly XYZ. It was referenced by assembly ABC, but was not found. Are you missing a reference or nuget package?