### PR TITLE
[Java.Interop] Do not throw in RegisterNativeMembers

### DIFF
--- a/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
@@ -212,12 +212,14 @@ namespace Java.Interop {
 
 			public virtual void RegisterNativeMembers (JniType nativeClass, Type type, string methods)
 			{
+				TryRegisterNativeMembers (nativeClass, type, methods);
+			}
+
+			protected bool TryRegisterNativeMembers (JniType nativeClass, Type type, string methods)
+			{
 				AssertValid ();
 
-				if (!TryLoadJniMarshalMethods (nativeClass, type, methods) &&
-						!TryRegisterNativeMembers (nativeClass, type, methods)) {
-					throw new NotSupportedException ($"Could not register Java.class={nativeClass.Name} Managed.type={type.FullName}");
-				}
+				return TryLoadJniMarshalMethods (nativeClass, type, methods) || TryRegisterNativeMembers (nativeClass, type, methods, null);
 			}
 
 			static Type [] registerMethodParameters = new Type [] { typeof (JniNativeMethodRegistrationArguments) };
@@ -235,7 +237,7 @@ namespace Java.Interop {
 
 			static List<JniNativeMethodRegistration> sharedRegistrations = new List<JniNativeMethodRegistration> ();
 
-			static bool TryRegisterNativeMembers (JniType nativeClass, Type marshalType, string methods, MethodInfo registerMethod = null)
+			static bool TryRegisterNativeMembers (JniType nativeClass, Type marshalType, string methods, MethodInfo registerMethod)
 			{
 				bool lockTaken = false;
 				bool rv = false;

--- a/src/Java.Interop/java/com/xamarin/java_interop/internal/JavaProxyThrowable.java
+++ b/src/Java.Interop/java/com/xamarin/java_interop/internal/JavaProxyThrowable.java
@@ -11,7 +11,7 @@ import com.xamarin.java_interop.GCUserPeerable;
 	static  final   String  assemblyQualifiedName   = "Java.Interop.JavaProxyThrowable, Java.Interop, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null";
 	static {
 		com.xamarin.java_interop.ManagedPeer.registerNativeMembers (
-				JavaProxyObject.class,
+				JavaProxyThrowable.class,
 				assemblyQualifiedName,
 				"");
 	}


### PR DESCRIPTION
Do not throw the `NotSupportedException` exception in
`JniRuntime+JniTypeManager::RegisterNativeMembers` anymore. Throwing
that exception ment that every type to be registered had to have
register method to register marshaling methods, even when there were
no methods to register.

With recent changes by
https://github.com/xamarin/java.interop/commit/3f96359469b09602dc69bfa4b658a27c9128f243,
where we started to throw that exception again, we run into issues as
JavaProxyThrowable didn't have the *empty* register method
anymore. That led to a crash in the PropagateException tests, where
JavaProxyThrowable needed to be ready, but wasn't becase its
registration failed and thrown the exception, which cannot be
propagated because we didn't have JavaProxyThrowable in valid state.

To provide a way for XA's `AndroidRuntime.AndroidTypeManager` to know
whether the register method was found and used, we introduce new
protected `TryRegisterNativeMembers` method, which returns *bool*
value with that information, so that XA can do legacy fallback.

It also fixes Java side registration of JavaProxyThrowable, which was
using wrong class.