### PR TITLE
[jnimarshalmethod-gen] Update the originating assembly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,9 +159,7 @@ run-android: $(ATESTS)
 run-test-jnimarshal: bin/Test$(CONFIGURATION)/Java.Interop.Export-Tests.dll bin/Test$(CONFIGURATION)/$(JAVA_INTEROP_LIB)
 	MONO_TRACE_LISTENER=Console.Out \
 	$(RUNTIME) bin/$(CONFIGURATION)/jnimarshalmethod-gen.exe -v -L $(JI_MONO_LIB_PATH)mono/4.5 -L $(JI_MONO_LIB_PATH)mono/4.5/Facades "$<"
-	$(RM) "$<" "$(basename $<)-JniMarshalMethods.dll"
-	mv "$(basename $<)-new.dll" "$<"
-	mv "$(basename $<)-new.pdb" "$(basename $<).pdb"
+	$(RM) "$(basename $<)-JniMarshalMethods.dll"
 	$(call RUN_TEST,$<)
 
 

--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/DirectoryAssemblyResolver.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/DirectoryAssemblyResolver.cs
@@ -110,6 +110,18 @@ namespace Java.Interop.Tools.Cecil {
 			return new Dictionary<string, AssemblyDefinition>(cache);
 		}
 
+		public bool AddToCache (AssemblyDefinition assembly)
+		{
+			var name = Path.GetFileNameWithoutExtension (assembly.MainModule.FileName);
+
+			if (cache.ContainsKey (name))
+				return false;
+
+			cache [name] = assembly;
+
+			return true;
+		}
+
 		public virtual AssemblyDefinition Load (string fileName, bool forceLoad = false)
 		{
 			if (!File.Exists (fileName))

--- a/tools/jnimarshalmethod-gen/App.cs
+++ b/tools/jnimarshalmethod-gen/App.cs
@@ -62,7 +62,11 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 				return 0;
 			}
 
-			var readWriteParameters = new ReaderParameters { ReadWrite = true, AssemblyResolver = resolver, ReadSymbols = true };
+			var readWriteParameters    = new ReaderParameters {
+				AssemblyResolver   = resolver,
+				ReadSymbols        = true,
+				ReadWrite          = true,
+			};
 			foreach (var assembly in assemblies) {
 				if (!File.Exists (assembly)) {
 					Error ($"Path '{assembly}' does not exist.");

--- a/tools/jnimarshalmethod-gen/App.cs
+++ b/tools/jnimarshalmethod-gen/App.cs
@@ -62,6 +62,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 				return 0;
 			}
 
+			var readWriteParameters = new ReaderParameters { ReadWrite = true, AssemblyResolver = resolver, ReadSymbols = true };
 			foreach (var assembly in assemblies) {
 				if (!File.Exists (assembly)) {
 					Error ($"Path '{assembly}' does not exist.");
@@ -69,7 +70,8 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 				}
 
 				resolver.SearchDirectories.Add (Path.GetDirectoryName (assembly));
-				resolver.Load (assembly);
+				var ad = AssemblyDefinition.ReadAssembly (assembly, readWriteParameters);
+				resolver.AddToCache (ad);
 
 				try {
 					CreateMarshalMethodAssembly (assembly);

--- a/tools/jnimarshalmethod-gen/TypeMover.cs
+++ b/tools/jnimarshalmethod-gen/TypeMover.cs
@@ -46,11 +46,10 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator
 				return;
 			}
 
-			var newName = $"{Path.Combine (Path.GetDirectoryName (Destination.MainModule.FileName), Path.GetFileNameWithoutExtension (Destination.MainModule.FileName))}-new{Path.GetExtension (Destination.MainModule.FileName)}";
-			Destination.Write (newName, new WriterParameters () { WriteSymbols = true });
+			Destination.Write (new WriterParameters () { WriteSymbols = true });
 
 			if (App.Verbose)
-				App.ColorWriteLine ($"Wrote {newName} assembly", ConsoleColor.Cyan);
+				App.ColorWriteLine ($"Wrote updated {Destination.MainModule.FileName} assembly", ConsoleColor.Cyan);
 		}
 
 		static readonly string nestedName = "__<$>_jni_marshal_methods";


### PR DESCRIPTION
Update the originating assembly instead of creating a *new* one,
called `<AssemblyName>-new.dll`

I expected I would need to load the originating assembly in the
separate AppDomain, but instead it was enough to load it with cecil
with reading parameters having `ReadWrite = true`.

Because the referenced assemblies might not be writable, we need to
keep loading them as read only, thus with default `ReadWrite = false`.

For that I added new method to our cecil assembly resolver, to add
existing assembly definition to its cache. We first read the
originating assemblies as *ReadWrite* and add them to the resolver
cache.