### PR TITLE
[jnimarshalmethod-gen] Delete the temporary files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,6 @@ run-android: $(ATESTS)
 run-test-jnimarshal: bin/Test$(CONFIGURATION)/Java.Interop.Export-Tests.dll bin/Test$(CONFIGURATION)/$(JAVA_INTEROP_LIB)
 	MONO_TRACE_LISTENER=Console.Out \
 	$(RUNTIME) bin/$(CONFIGURATION)/jnimarshalmethod-gen.exe -v -L $(JI_MONO_LIB_PATH)mono/4.5 -L $(JI_MONO_LIB_PATH)mono/4.5/Facades "$<"
-	$(RM) "$(basename $<)-JniMarshalMethods.dll"
 	$(call RUN_TEST,$<)
 
 


### PR DESCRIPTION
We don't want to leave the `*-JniMarshalMethods.dll` files behind, so
we need to delete them, once the methods are moved back to the
originating assemblies.

Because the dynamic assembly builder needs to save the temporary
assembly, we need it to use `AssemblyBuilderAccess.Save`, which means
the assembly cannot be unloaded from the domain.

Thus we do the work in separate `AppDomain` and unload the whole
domain at the end, so that the temporary files are not locked
anymore. A bit of refactoring was needed for that.

There is also new `--keeptemp` option to enable the old behavior and
keep the temporary files.

And finally the help message is printed when no arguments
supplied. Plus new error message in case no assemblies were specified.