### PR TITLE
[generator] SymbolTable is no longer static

### DIFF
--- a/tools/generator/ClassGen.cs
+++ b/tools/generator/ClassGen.cs
@@ -199,9 +199,16 @@ namespace MonoDroid.Generation {
 			
 			validated = true;
 
-			// We're validating this in prior to BaseType.
-			if (TypeParameters != null && !TypeParameters.Validate (opt, type_params))
+			if (!support.OnValidate (opt)) {
+				is_valid = false;
 				return false;
+			}
+
+			// We're validating this in prior to BaseType.
+			if (TypeParameters != null && !TypeParameters.Validate (opt, type_params)) {
+				is_valid = false;
+				return false;
+			}
 
 			if (Char.IsNumber (Name [0])) {
 				// it is an anonymous class which does not need output.
@@ -209,7 +216,7 @@ namespace MonoDroid.Generation {
 				return false;
 			}
 			
-			base_symbol = IsAnnotation ? SymbolTable.Lookup ("java.lang.Object") : BaseType != null ? SymbolTable.Lookup (BaseType) : null;
+			base_symbol = IsAnnotation ? opt.SymbolTable.Lookup ("java.lang.Object") : BaseType != null ? opt.SymbolTable.Lookup (BaseType) : null;
 			if (base_symbol == null && FullName != "Java.Lang.Object" && FullName != "System.Object") {
 				Report.Warning (0, Report.WarningClassGen + 2, "Class {0} has unknown base type {1}.", FullName, BaseType);
 				is_valid = false;
@@ -231,10 +238,10 @@ namespace MonoDroid.Generation {
 			return true;
 		}
 
-		public override void FixupAccessModifiers ()
+		public override void FixupAccessModifiers (CodeGenerationOptions opt)
 		{
 			while (!IsAnnotation && !string.IsNullOrEmpty (BaseType)) {
-				var baseClass = SymbolTable.Lookup (BaseType) as ClassGen;
+				var baseClass = opt.SymbolTable.Lookup (BaseType) as ClassGen;
 				if (baseClass != null && RawVisibility == "public" && baseClass.RawVisibility != "public") {
 					//Skip the BaseType and copy over any "missing" methods
 					foreach (var baseMethod in baseClass.Methods) {
@@ -248,7 +255,7 @@ namespace MonoDroid.Generation {
 				}
 			}
 
-			base.FixupAccessModifiers ();
+			base.FixupAccessModifiers (opt);
 		}
 		
 		public override void FixupExplicitImplementation ()

--- a/tools/generator/Field.cs
+++ b/tools/generator/Field.cs
@@ -236,7 +236,7 @@ namespace MonoDroid.Generation {
 
 		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params)
 		{
-			symbol = SymbolTable.Lookup (TypeName, type_params);
+			symbol = opt.SymbolTable.Lookup (TypeName, type_params);
 			
 			if (symbol == null || !symbol.Validate (opt, type_params)) {
 				Report.Warning (0, Report.WarningField + 0, "unexpected field type {0} {1}.", TypeName, opt.ContextString);

--- a/tools/generator/GenBaseSupport.cs
+++ b/tools/generator/GenBaseSupport.cs
@@ -33,7 +33,7 @@ namespace MonoDroid.Generation
 			get { return String.Empty; }
 		}
 		
-		public virtual bool ValidateNamespace ()
+		public virtual bool OnValidate (CodeGenerationOptions opt)
 		{
 			// See com.google.inject.internal.util package for this case.
 			// Some Java compiler-generated internals are named as $foobar (dollar prefixed).
@@ -62,6 +62,10 @@ namespace MonoDroid.Generation
 		public ManagedGenBaseSupport (TypeDefinition t)
 		{
 			this.t = t;
+		}
+
+		public override bool OnValidate (CodeGenerationOptions opt)
+		{
 			var regatt = t.CustomAttributes.FirstOrDefault (a => a.AttributeType.FullNameCorrected () == "Android.Runtime.RegisterAttribute");
 			is_acw = regatt != null;
 			string jn = regatt != null ? ((string) regatt.ConstructorArguments [0].Value).Replace ('/', '.') : t.FullNameCorrected ();
@@ -72,7 +76,7 @@ namespace MonoDroid.Generation
 				java_name = idx < 0 ? jn : jn.Substring (idx + 1);
 				full_name = t.FullNameCorrected ();
 			} else {
-				var sym = SymbolTable.Lookup (java_name);
+				var sym = opt.SymbolTable.Lookup (java_name);
 				full_name = sym != null ? sym.FullName : t.FullNameCorrected ();
 			}
 			java_name = java_name.Replace ('$', '.');
@@ -85,6 +89,8 @@ namespace MonoDroid.Generation
 					? obsolete.ConstructorArguments [0].Value.ToString ()
 					: "This class is obsoleted in this android platform";
 			}
+
+			return base.OnValidate (opt);
 		}
 
 		public override bool IsAcw {
@@ -284,10 +290,10 @@ namespace MonoDroid.Generation
 		public override string Visibility {
 			get { return visibility; }
 		}
-		
-		public override bool ValidateNamespace ()
+
+		public override bool OnValidate (CodeGenerationOptions opt)
 		{
-			if (!base.ValidateNamespace ())
+			if (!base.OnValidate (opt))
 				return false;
 			string topmost;
 			int split = ns.LastIndexOf ('.');

--- a/tools/generator/GenericParameterDefinition.cs
+++ b/tools/generator/GenericParameterDefinition.cs
@@ -36,7 +36,7 @@ namespace MonoDroid.Generation
 				return is_valid;
 			var syms = new List<ISymbol> ();
 			foreach (var c in ConstraintExpressions) {
-				var sym = SymbolTable.Lookup (c, type_params);
+				var sym = opt.SymbolTable.Lookup (c, type_params);
 				if (sym == null) {
 					Report.Warning (0, Report.WarningGenericParameterDefinition + 0, "Unknown generic argument constraint type {0} {1}.", c, opt.ContextString);
 					validated = true;

--- a/tools/generator/GenericParameterList.cs
+++ b/tools/generator/GenericParameterList.cs
@@ -88,7 +88,7 @@ namespace MonoDroid.Generation {
 					continue;
 				}
 
-				ISymbol psym = SymbolTable.Lookup (tp, in_params);
+				ISymbol psym = opt.SymbolTable.Lookup (tp, in_params);
 				if (psym == null || !psym.Validate (opt, in_params))
 					return false;
 				

--- a/tools/generator/GenericSymbol.cs
+++ b/tools/generator/GenericSymbol.cs
@@ -128,7 +128,7 @@ namespace MonoDroid.Generation {
 					continue;
 				}
 
-				ISymbol psym = SymbolTable.Lookup (tp, in_params);
+				ISymbol psym = opt.SymbolTable.Lookup (tp, in_params);
 				if (psym == null || !psym.Validate (opt, in_params))
 					return false;
 

--- a/tools/generator/JavaApiDllLoaderExtensions.cs
+++ b/tools/generator/JavaApiDllLoaderExtensions.cs
@@ -84,13 +84,13 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			return '<' + string.Join (", ", tps.Select (_ => _.JavaName)) + '>';
 		}
 
-		static void Load (this JavaClass kls, ClassGen gen)
+		static void Load (this JavaClass kls, CodeGenerationOptions opt, ClassGen gen)
 		{
 			((JavaType) kls).Load (gen);
 
 			kls.Abstract = gen.IsAbstract;
 			kls.Final = gen.IsFinal;
-			var baseGen = gen.BaseType != null ? SymbolTable.Lookup (gen.BaseType) : null;
+			var baseGen = gen.BaseType != null ? opt.SymbolTable.Lookup (gen.BaseType) : null;
 
 			if (baseGen != null) {
 				kls.Extends = baseGen.JavaName;

--- a/tools/generator/Parameter.cs
+++ b/tools/generator/Parameter.cs
@@ -246,7 +246,7 @@ namespace MonoDroid.Generation {
 			if (targetType.EndsWith ("[]")) {
 				return string.Format ("{0}.ToArray<{1}> ()", name, targetType.Replace ("[]",""));
 			}
-			var rgm = SymbolTable.Lookup (targetType) as IRequireGenericMarshal;
+			var rgm = opt.SymbolTable.Lookup (targetType) as IRequireGenericMarshal;
 			return string.Format ("global::Java.Interop.JavaObjectExtensions.JavaCast<{0}>({1})",
 					opt.GetOutputName (rgm != null ? (rgm.GetGenericJavaObjectTypeOverride () ?? targetType) : targetType),
 					name); 
@@ -254,7 +254,7 @@ namespace MonoDroid.Generation {
 
 		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params)
 		{
-			sym = SymbolTable.Lookup (type, type_params);
+			sym = opt.SymbolTable.Lookup (type, type_params);
 			if (sym == null) {
 				Report.Warning (0, Report.WarningParameter + 0, "Unknown parameter type {0} {1}.", type, opt.ContextString);
 				return false;

--- a/tools/generator/Parser.cs
+++ b/tools/generator/Parser.cs
@@ -6,9 +6,16 @@ using System.Xml;
 using System.Xml.Linq;
 using Xamarin.Android.Tools;
 
-namespace MonoDroid.Generation {
+namespace MonoDroid.Generation
+{
+	public class Parser
+	{
+		readonly CodeGenerationOptions opt;
 
-	public class Parser  {
+		public Parser (CodeGenerationOptions opt)
+		{
+			this.opt = opt;
+		}
 
 		public string ApiSource { get; private set; }
 
@@ -68,7 +75,7 @@ namespace MonoDroid.Generation {
 					break;
 				case "enum":
 					ISymbol sym = new EnumSymbol (elem.XGetAttribute ("name"));
-					SymbolTable.AddType (elem.XGetAttribute ("name"), sym);
+					opt.SymbolTable.AddType (elem.XGetAttribute ("name"), sym);
 					continue;
 				default:
 					Report.Warning (0, Report.WarningParser + 2, "Unexpected child node: {0}.", elem.Name);

--- a/tools/generator/ReturnValue.cs
+++ b/tools/generator/ReturnValue.cs
@@ -110,7 +110,7 @@ namespace MonoDroid.Generation {
 				return name;
 			if (targetType == "string")
 				return string.Format ("{0}.ToString ()", name);
-			var rgm = SymbolTable.Lookup (targetType) as IRequireGenericMarshal;
+			var rgm = opt.SymbolTable.Lookup (targetType) as IRequireGenericMarshal;
 			return string.Format ("global::Java.Interop.JavaObjectExtensions.JavaCast<{0}>({1})",
 			                      rgm != null ? (rgm.GetGenericJavaObjectTypeOverride () ?? sym.FullName) : sym.FullName,
 			                      opt.GetSafeIdentifier (rgm != null ? rgm.ToInteroperableJavaObject (name) : name)); 
@@ -118,7 +118,7 @@ namespace MonoDroid.Generation {
 
 		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params)
 		{
-			sym = (IsEnumified ? SymbolTable.Lookup (managed_type, type_params) : null) ?? SymbolTable.Lookup (java_type, type_params);
+			sym = (IsEnumified ? opt.SymbolTable.Lookup (managed_type, type_params) : null) ?? opt.SymbolTable.Lookup (java_type, type_params);
 			if (sym == null) {
 				Report.Warning (0, Report.WarningReturnValue + 0, "Unknown return type {0} {1}.", java_type, opt.ContextString);
 				return false;

--- a/tools/generator/SymbolTable.cs
+++ b/tools/generator/SymbolTable.cs
@@ -5,17 +5,17 @@ using System.Collections.Generic;
 
 namespace MonoDroid.Generation {
 
-	public static class SymbolTable {
+	public class SymbolTable {
 
-		static Dictionary<string, List<ISymbol>> symbols = new Dictionary<string, List<ISymbol>> ();
-		static ISymbol char_seq;
-		static ISymbol fileinstream_sym;
-		static ISymbol fileoutstream_sym;
-		static ISymbol instream_sym;
-		static ISymbol outstream_sym;
-		static ISymbol xmlpullparser_sym;
-		static ISymbol xmlresourceparser_sym;
-		static ISymbol string_sym;
+		Dictionary<string, List<ISymbol>> symbols = new Dictionary<string, List<ISymbol>> ();
+		ISymbol char_seq;
+		ISymbol fileinstream_sym;
+		ISymbol fileoutstream_sym;
+		ISymbol instream_sym;
+		ISymbol outstream_sym;
+		ISymbol xmlpullparser_sym;
+		ISymbol xmlresourceparser_sym;
+		ISymbol string_sym;
 
 		static readonly string[] InvariantSymbols = new string[]{
 			"Android.Graphics.Color",
@@ -30,12 +30,12 @@ namespace MonoDroid.Generation {
 			"void",
 		};
 
-		public static IEnumerable<ISymbol> AllRegisteredSymbols ()
+		public IEnumerable<ISymbol> AllRegisteredSymbols ()
 		{
 			return symbols.Values.SelectMany (v => v);
 		}
 
-		static SymbolTable ()
+		public SymbolTable ()
 		{
 			AddType (new SimpleSymbol ("IntPtr.Zero", "void", "void", "V"));
 			AddType (new SimpleSymbol ("false", "boolean", "bool", "Z"));
@@ -63,7 +63,7 @@ namespace MonoDroid.Generation {
 		//   type_params: "<T1<T2>[]>"
 		//     arrayRank: 2
 		//  has_ellipsis: true
-		public static string GetSymbolInfo (string java_type, out string type_params, out int arrayRank, out bool has_ellipsis)
+		public string GetSymbolInfo (string java_type, out string type_params, out int arrayRank, out bool has_ellipsis)
 		{
 			type_params   = string.Empty;
 			arrayRank     = 0;
@@ -114,7 +114,7 @@ namespace MonoDroid.Generation {
 			return erased.ToString ();
 		}
 
-		public static void AddType (ISymbol symbol)
+		public void AddType (ISymbol symbol)
 		{
 			string dummy;
 			int ar;
@@ -124,7 +124,7 @@ namespace MonoDroid.Generation {
 			AddType (key, symbol);
 		}
 
-		static bool ShouldAddType (string key)
+		bool ShouldAddType (string key)
 		{
 			if (!symbols.ContainsKey (key))
 				return true;
@@ -133,7 +133,7 @@ namespace MonoDroid.Generation {
 			return true;
 		}
 
-		public static void AddType (string key, ISymbol symbol)
+		public void AddType (string key, ISymbol symbol)
 		{
 			if (!ShouldAddType (key))
 				return;
@@ -177,7 +177,7 @@ namespace MonoDroid.Generation {
 			return null;
 		}
 
-		public static ISymbol Lookup (string java_type, GenericParameterDefinitionList in_params)
+		public ISymbol Lookup (string java_type, GenericParameterDefinitionList in_params)
 		{
 			string type_params;
 			int arrayRank;
@@ -239,7 +239,7 @@ namespace MonoDroid.Generation {
 			return CreateArray (result, arrayRank, has_ellipsis);
 		}
 
-		static ISymbol CreateArray (ISymbol symbol, int rank, bool has_ellipsis)
+		ISymbol CreateArray (ISymbol symbol, int rank, bool has_ellipsis)
 		{
 			if (symbol == null)
 				return null;
@@ -252,7 +252,7 @@ namespace MonoDroid.Generation {
 			return symbol;
 		}
 
-		public static ISymbol Lookup (string java_type)
+		public ISymbol Lookup (string java_type)
 		{
 			string type_params;
 			int ar;
@@ -287,7 +287,7 @@ namespace MonoDroid.Generation {
 			return result;
 		}
 		
-		public static void Dump ()
+		public void Dump ()
 		{
 			foreach (var p in symbols) {
 				if (p.Key.StartsWith ("System"))

--- a/tools/generator/Tests/Unit-Tests/SupportTypes.cs
+++ b/tools/generator/Tests/Unit-Tests/SupportTypes.cs
@@ -60,20 +60,12 @@ namespace generatortests
 	{
 		bool isFinal, isStatic, isEnumified, isDeprecated;
 		string type, value, deprecatedComment, visibility = "public";
-		ISymbol managedSymbol;
 		Parameter setterParameter;
 
 		public TestField (string type, string name)
 		{
 			this.type = type;
 			Name = name;
-
-			//HACK: SymbolTable is static, hence problematic for testing
-			//	If running a unit test first, we need to add java.lang.String.
-			//	If an integration test was run, java.lang.String exists already.
-			//	Down the line SymbolTable should be refactored to be non-static, so this could be done in [SetUp]
-			managedSymbol = SymbolTable.Lookup (type) ?? 
-				new SimpleSymbol ("", "java.lang.String", "Ljava/lang/String;", "Java.Lang.String");
 		}
 
 		public TestField SetStatic ()
@@ -131,8 +123,11 @@ namespace generatortests
 
 		protected override Parameter SetterParameter {
 			get {
-				if (setterParameter == null)
-					setterParameter = new Parameter ("value", type, managedSymbol.FullName, isEnumified);
+				if (setterParameter == null) {
+					//NOTE: passing `type` for `managedType`, required since `SymbolTable` is no longer static
+					//	This currently isn't causing any test failures
+					setterParameter = new Parameter ("value", type, type, isEnumified);
+				}
 				return setterParameter;
 			}
 		}


### PR DESCRIPTION
While refactoring/writing tests for `generator` some issues arise
because `SymbolTable` is `static`.

At the begin and end of each test, we would like to begin with a clean
state. Unfortunately if `SymbolTable` is static, symbols are leftover
from any previous tests. This both introduces different behavior
depending on the ordering of tests, as well as potential interference
between tests.

Changes:
- `SymbolTable` is non-static, several helper methods that were
"stateless" were left to be static
- Added a property to `CodeGenerationOptions` to hold an instance of
`SymbolTable` since this object is already passed through most of
`generator`
- There were a few places I had to add additional parameters to pass the
instance of `CodeGenerationOptions` through
- The constructor for `ManagedGenBaseSupport` was hitting the
`SymbolTable` to get the full name of the type. This did not seem to be
needed at all, we can call `FullNameCorrected` from the `TypeDefinition`
to get this value. No test failures occurred from this change.
- I was able to remove some initial hacks I added to the unit tests to
workaround `SymbolTable` being static
- I could also remove the `ISymbol managedSymbol` from `TestField`
completely.
- Since tests now start at a clean state, we can add to the
`SymbolTable` as needed during unit tests.
- I noticed that we weren't setting up `java.lang.Object` and
`java.lang.String` in both `XmlTests` and `ManagedTests`