### PR TITLE
[jnimarshalmethod-gen] Do not miss ldc.i4

### DIFF
--- a/tools/jnimarshalmethod-gen/TypeMover.cs
+++ b/tools/jnimarshalmethod-gen/TypeMover.cs
@@ -317,7 +317,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator
 
 			if (il.OpCode == OpCodes.Dup && instructions.Count > idxStart + 10) {
 				il = instructions [idx++];
-				if (!il.OpCode.ToString ().StartsWith ("ldc.i4.", StringComparison.InvariantCulture))
+				if (!il.OpCode.ToString ().StartsWith ("ldc.i4", StringComparison.InvariantCulture))
 					return false;
 
 				il = instructions [idx++];


### PR DESCRIPTION
When looking for matching instructions pattern in
`__RegisterNativeMembers` method, we want to also allow `ldc.i4`
instructions here. So that we update the methods with more than 128
method registrations correctly.

Until now we were only matching instructions like `ldc.i4.[0-8]`,
`ldc.i4.s` and missed the `ldc.i4` which are used for integer values
greater than 127.