### PR TITLE
[build] Use `msbuild` by default, not `xbuild`

### DIFF
--- a/build-tools/scripts/msbuild.mk
+++ b/build-tools/scripts/msbuild.mk
@@ -21,7 +21,7 @@
 #   $(MSBUILD): The MSBuild program to use. Defaults to `xbuild` unless overridden.
 #   $(MSBUILD_FLAGS): Additional MSBuild flags; contains $(CONFIGURATION), $(V), $(MSBUILD_ARGS).
 
-MSBUILD       = xbuild
+MSBUILD       = msbuild
 MSBUILD_FLAGS = /p:Configuration=$(CONFIGURATION) $(MSBUILD_ARGS)
 
 ifneq ($(V),0)


### PR DESCRIPTION
[`xbuild` is deprecated][0], and has been deprecated for over a year.

[0]: https://www.mono-project.com/docs/about-mono/releases/5.0.0/#xbuild

Update `$(MSBUILD)` so that we build with `msbuild` by default,
not `xbuild`.