### PR TITLE
[Java.Interop.Export] Add GetMarshalMethodName to MarshalMemberBuilder

### DIFF
--- a/src/Java.Interop.Export/Java.Interop/MarshalMemberBuilder.cs
+++ b/src/Java.Interop.Export/Java.Interop/MarshalMemberBuilder.cs
@@ -347,6 +347,24 @@ namespace Java.Interop {
 					s);
 			return Expression.Lambda<Func<ConstructorInfo, JniObjectReference, object[], object>> (b, new []{c, r, p});
 		}
+
+		public static string GetMarshalMethodName (string name, string signature)
+		{
+			if (name == null)
+				throw new ArgumentNullException (nameof (name));
+
+			if (signature == null)
+				throw new ArgumentNullException (nameof (signature));
+
+			var idx1 = signature.IndexOf ('(');
+			var idx2 = signature.IndexOf (')');
+			var arguments = signature;
+
+			if (idx1 >= 0 && idx2 >= idx1)
+				arguments = arguments.Substring (idx1 + 1, idx2 - idx1 - 1);
+
+			return $"n_{name}{(string.IsNullOrEmpty (arguments) ? "" : "_")}{arguments?.Replace ('/', '_')?.Replace (';', '_')}";
+		}
 	}
 
 	static class JniSignature {

--- a/tools/jnimarshalmethod-gen/App.cs
+++ b/tools/jnimarshalmethod-gen/App.cs
@@ -403,18 +403,13 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 
 				}
 
-				var idx1 = signature.IndexOf ('(');
-				var idx2 = signature.IndexOf (')');
-				var arguments = signature;
+				if (string.IsNullOrEmpty (name) || string.IsNullOrEmpty (signature))
+					continue;
 
-				if (idx1 >= 0 && idx2 >= idx1)
-					arguments = arguments.Substring (idx1 + 1, idx2 - idx1 - 1);
-
+				methodName = MarshalMemberBuilder.GetMarshalMethodName (name, signature);
 				name = $"n_{name}";
-				methodName = $"{name}_{arguments?.Replace ('/', '_')?.Replace (';', '_')}";
 
-				if (name != null && signature != null)
-					return true;
+				return true;
 			}
 
 			return false;


### PR DESCRIPTION
We use it in the `jnimarshalmethod-gen` and will also use it from the
XA's Xamarin.Android.Build.Tasks, to avoid code duplication.

It also removes trailing '_' from marshal methods names of java
methods without arguments.