### PR TITLE
[generator] fix regression for types from assemblies

### DIFF
--- a/tools/generator/Tests/Unit-Tests/AdjusterTests.cs
+++ b/tools/generator/Tests/Unit-Tests/AdjusterTests.cs
@@ -1,0 +1,75 @@
+﻿using Mono.Cecil;
+using MonoDroid.Generation;
+using NUnit.Framework;
+using System.IO;
+using System.Linq;
+using Xamarin.Android.Tools.ApiXmlAdjuster;
+
+namespace generatortests
+{
+	//For now this is a basic smoke test to validate the `generator --only-xml-adjuster` option
+	//	In the future, it should be expanded to fully test the Adjuster class
+	[TestFixture]
+	public class AdjusterTests
+	{
+		Adjuster adjuster;
+		CodeGenerationOptions options;
+		string inputFile, outputFile, temporaryAssembly;
+		ModuleDefinition module;
+
+		[SetUp]
+		public void SetUp ()
+		{
+			temporaryAssembly = Path.GetTempFileName ();
+			File.Copy (GetType ().Assembly.Location, temporaryAssembly, true);
+			module = ModuleDefinition.ReadModule (temporaryAssembly);
+
+			adjuster = new Adjuster ();
+			options = new CodeGenerationOptions ();
+			inputFile = Path.GetTempFileName ();
+			outputFile = inputFile + ".adjusted";
+
+			//We should fail on warnings & errors, and just log debug
+			Log.LogDebugAction = TestContext.Out.WriteLine;
+			Log.LogWarningAction =
+				Log.LogErrorAction = Assert.Fail;
+
+			File.WriteAllText (inputFile, @"
+<api>
+	<package name=""com.mypackage"">
+		<class abstract=""false"" deprecated=""not deprecated"" extends=""java.lang.Object"" extends-generic-aware=""java.lang.Object"" final=""false"" name=""foo"" static=""false"" visibility=""public"">
+			<constructor deprecated=""not deprecated"" final=""false"" name=""foo"" static=""false"" visibility=""public"" />
+			<method abstract=""false"" deprecated=""not deprecated"" final=""false"" name=""bar"" native=""false"" return=""void"" static=""false"" synchronized=""false"" visibility=""public"" />
+		</class>
+	</package>
+</api>");
+		}
+
+		[TearDown]
+		public void TearDown ()
+		{
+			//HACK: put the Log callbacks back the way they were
+			Log.LogDebugAction = null;
+			Log.LogWarningAction = null;
+			Log.LogErrorAction = null;
+
+			module.Dispose ();
+			File.Delete (temporaryAssembly);
+			File.Delete (inputFile);
+			File.Delete (outputFile);
+		}
+
+		[Test]
+		public void Process ()
+		{
+			foreach (var type in module.Types.Where (t => t.IsClass && t.Namespace == "Java.Lang")) {
+				//Make sure we use this method instead of SymbolTable directly, to match what happens in generator.exe
+				Xamarin.Android.Binder.CodeGenerator.ProcessReferencedType (type, options);
+			}
+
+			adjuster.Process (inputFile, options.SymbolTable.AllRegisteredSymbols ().OfType<GenBase> ().ToArray (), outputFile, (int)Log.LoggingLevel.Debug);
+
+			FileAssert.Exists (outputFile);
+		}
+	}
+}

--- a/tools/generator/Tests/Unit-Tests/ManagedTests.cs
+++ b/tools/generator/Tests/Unit-Tests/ManagedTests.cs
@@ -70,8 +70,7 @@ namespace generatortests
 		public void TearDown ()
 		{
 			module.Dispose ();
-			if (File.Exists (tempFile))
-				File.Delete (tempFile);
+			File.Delete (tempFile);
 		}
 
 		[Test]

--- a/tools/generator/Tests/generator-Tests.csproj
+++ b/tools/generator/Tests/generator-Tests.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Integration-Tests\InterfaceMethodsConflict.cs" />
     <Compile Include="SupportFiles\RegisterAttribute.cs" />
     <Compile Include="Unit-Tests\CodeGeneratorTests.cs" />
+    <Compile Include="Unit-Tests\AdjusterTests.cs" />
     <Compile Include="Unit-Tests\JavaInteropCodeGeneratorTests.cs" />
     <Compile Include="Unit-Tests\ManagedTests.cs" />
     <Compile Include="Unit-Tests\SupportTypes.cs" />


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/commit/19bcca50934ff7a2464e8d6170eadbba10c2b266

One of the side-effects of 19bcca5 was that `Validate` *has* to be
called in order for `ManagedClassGen` and `ManagedInterfaceGen` to be
initialized properly. Otherwise, properties such as `JavaName` are
going to return `null`.

I added a call to `Validate` in `CodeGenerator.ProcessReferencedType`,
and additionally added a new test class for the `Adjuster` class. For
now, it is verifying this regression is fixed, but should be expanded
down the road to get better test coverage around the `Adjuster` class.