### PR TITLE
[generator] fix regression for types from assemblies, take 2!

### DIFF
--- a/tools/generator/ClassGen.cs
+++ b/tools/generator/ClassGen.cs
@@ -20,8 +20,8 @@ namespace MonoDroid.Generation {
 		TypeDefinition t;
 		TypeReference nominal_base_type;
 		
-		public ManagedClassGen (TypeDefinition t)
-			: base (new ManagedGenBaseSupport (t))
+		public ManagedClassGen (TypeDefinition t, CodeGenerationOptions opt)
+			: base (new ManagedGenBaseSupport (t, opt))
 		{
 			this.t = t;
 			foreach (var ifaceImpl in t.Interfaces) {

--- a/tools/generator/CodeGenerator.cs
+++ b/tools/generator/CodeGenerator.cs
@@ -442,18 +442,7 @@ namespace Xamarin.Android.Binder {
 				//Console.Error.WriteLine ("WARNING: " + td.FullName + " survived");
 			}
 
-			ISymbol gb;
-			if (td.IsEnum) {
-				gb = new EnumSymbol (td.FullNameCorrected ());
-			} else if (td.IsInterface) {
-				var iface = new ManagedInterfaceGen (td);
-				iface.Validate (opt, null); //This will initialize the type, using opt.SymbolTable
-				gb = iface;
-			} else {
-				var @class = new ManagedClassGen (td);
-				@class.Validate (opt, null); //This will initialize the type, using opt.SymbolTable
-				gb = @class;
-			}
+			ISymbol gb = td.IsEnum ? (ISymbol)new EnumSymbol (td.FullNameCorrected ()) : td.IsInterface ? (ISymbol)new ManagedInterfaceGen (td, opt) : new ManagedClassGen (td, opt);
 			opt.SymbolTable.AddType (gb);
 
 			foreach (var nt in td.NestedTypes)

--- a/tools/generator/GenBaseSupport.cs
+++ b/tools/generator/GenBaseSupport.cs
@@ -59,13 +59,9 @@ namespace MonoDroid.Generation
 		bool deprecated, is_acw;
 		string deprecatedComment;
 
-		public ManagedGenBaseSupport (TypeDefinition t)
+		public ManagedGenBaseSupport (TypeDefinition t, CodeGenerationOptions opt)
 		{
 			this.t = t;
-		}
-
-		public override bool OnValidate (CodeGenerationOptions opt)
-		{
 			var regatt = t.CustomAttributes.FirstOrDefault (a => a.AttributeType.FullNameCorrected () == "Android.Runtime.RegisterAttribute");
 			is_acw = regatt != null;
 			string jn = regatt != null ? ((string) regatt.ConstructorArguments [0].Value).Replace ('/', '.') : t.FullNameCorrected ();
@@ -89,8 +85,6 @@ namespace MonoDroid.Generation
 					? obsolete.ConstructorArguments [0].Value.ToString ()
 					: "This class is obsoleted in this android platform";
 			}
-
-			return base.OnValidate (opt);
 		}
 
 		public override bool IsAcw {

--- a/tools/generator/InterfaceGen.cs
+++ b/tools/generator/InterfaceGen.cs
@@ -13,8 +13,8 @@ using Xamarin.Android.Tools;
 namespace MonoDroid.Generation {
 #if HAVE_CECIL
 	public class ManagedInterfaceGen : InterfaceGen {
-		public ManagedInterfaceGen (TypeDefinition t)
-			: base (new ManagedGenBaseSupport (t))
+		public ManagedInterfaceGen (TypeDefinition t, CodeGenerationOptions opt)
+			: base (new ManagedGenBaseSupport (t, opt))
 		{
 			foreach (var ifaceImpl in t.Interfaces) {
 				AddInterface (ifaceImpl.InterfaceType.FullNameCorrected ());

--- a/tools/generator/Tests/Unit-Tests/ManagedTests.cs
+++ b/tools/generator/Tests/Unit-Tests/ManagedTests.cs
@@ -60,7 +60,7 @@ namespace generatortests
 			options = new CodeGenerationOptions ();
 
 			foreach (var type in module.Types.Where(t => t.IsClass && t.Namespace == "Java.Lang")) {
-				var @class = new ManagedClassGen (type);
+				var @class = new ManagedClassGen (type, options);
 				Assert.IsTrue (@class.Validate (options, new GenericParameterDefinitionList ()), "@class.Validate failed!");
 				options.SymbolTable.AddType (@class);
 			}
@@ -76,7 +76,7 @@ namespace generatortests
 		[Test]
 		public void Class ()
 		{
-			var @class = new ManagedClassGen (module.GetType ("Com.Mypackage.Foo"));
+			var @class = new ManagedClassGen (module.GetType ("Com.Mypackage.Foo"), options);
 			Assert.IsTrue (@class.Validate (options, new GenericParameterDefinitionList ()), "@class.Validate failed!");
 
 			Assert.AreEqual ("public", @class.Visibility);
@@ -93,7 +93,7 @@ namespace generatortests
 		public void Method ()
 		{
 			var type = module.GetType ("Com.Mypackage.Foo");
-			var @class = new ManagedClassGen (type);
+			var @class = new ManagedClassGen (type, options);
 			var method = new ManagedMethod (@class, type.Methods.First (m => m.Name == "Bar"));
 			Assert.IsTrue (method.Validate (new CodeGenerationOptions (), new GenericParameterDefinitionList ()), "method.Validate failed!");
 
@@ -113,7 +113,7 @@ namespace generatortests
 		public void Method_Matches_True ()
 		{
 			var type = module.GetType ("Com.Mypackage.Foo");
-			var @class = new ManagedClassGen (type);
+			var @class = new ManagedClassGen (type, options);
 			var unknownTypes = type.Methods.First (m => m.Name == "UnknownTypes");
 			var methodA = new ManagedMethod (@class, unknownTypes);
 			var methodB = new ManagedMethod (@class, unknownTypes);
@@ -124,7 +124,7 @@ namespace generatortests
 		public void Method_Matches_False ()
 		{
 			var type = module.GetType ("Com.Mypackage.Foo");
-			var @class = new ManagedClassGen (type);
+			var @class = new ManagedClassGen (type, options);
 			var unknownTypesA = type.Methods.First (m => m.Name == "UnknownTypes");
 			var unknownTypesB = type.Methods.First (m => m.Name == "UnknownTypesReturn");
 			unknownTypesB.Name = "UnknownTypes";
@@ -138,7 +138,7 @@ namespace generatortests
 		public void MethodWithParameters ()
 		{
 			var type = module.GetType ("Com.Mypackage.Foo");
-			var @class = new ManagedClassGen (type);
+			var @class = new ManagedClassGen (type, options);
 			var method = new ManagedMethod (@class, type.Methods.First (m => m.Name == "BarWithParams"));
 			Assert.IsTrue (method.Validate (new CodeGenerationOptions (), new GenericParameterDefinitionList ()), "method.Validate failed!");
 			Assert.AreEqual ("(ZID)Ljava/lang/String;", method.JniSignature);
@@ -168,7 +168,7 @@ namespace generatortests
 		public void Ctor ()
 		{
 			var type = module.GetType ("Com.Mypackage.Foo");
-			var @class = new ManagedClassGen (type);
+			var @class = new ManagedClassGen (type, options);
 			var ctor = new ManagedCtor (@class, type.Methods.First (m => m.IsConstructor && !m.IsStatic));
 			Assert.IsTrue (ctor.Validate (new CodeGenerationOptions (), new GenericParameterDefinitionList ()), "ctor.Validate failed!");
 
@@ -182,7 +182,7 @@ namespace generatortests
 		public void Field ()
 		{
 			var type = module.GetType ("Com.Mypackage.Foo");
-			var @class = new ManagedClassGen (type);
+			var @class = new ManagedClassGen (type, options);
 			var field = new ManagedField (type.Fields.First (f => f.Name == "Value"));
 			Assert.IsTrue (field.Validate (new CodeGenerationOptions (), new GenericParameterDefinitionList ()), "field.Validate failed!");
 
@@ -198,7 +198,7 @@ namespace generatortests
 		public void Interface ()
 		{
 			var type = module.GetType ("Com.Mypackage.IService");
-			var @interface = new ManagedInterfaceGen (type);
+			var @interface = new ManagedInterfaceGen (type, options);
 			Assert.IsTrue (@interface.Validate (new CodeGenerationOptions (), new GenericParameterDefinitionList ()), "interface.Validate failed!");
 
 			Assert.AreEqual ("public", @interface.Visibility);


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/commit/84014f4a735f65c3aa666597f05ce6de7d984bb6
Context: https://github.com/xamarin/java.interop/commit/19bcca50934ff7a2464e8d6170eadbba10c2b266

In trying to make the `SymbolTable` class non-static, there was one
place in the `GenBaseSupport` class that needed to use the
`SymbolTable`. My first attempt to workaround this was to move some of
the logic in `GenBaseSupport`'s constructor to an `OnValidate` method.
Unfortunately this breaks alot of things, since it requires `Validate`
to be called for any `ManagedClassGen` or `ManagedInterfaceGen`.

Things are further complicated when you try a large set of input, such
as what happens during `xamarin-android`'s build. Calling `Validate`
was getting exceptions such as:

    Unhandled Exception:
    System.NullReferenceException: Object reference not set to an instance of an object
        at Xamarin.Android.Tools.ApiXmlAdjuster.JavaTypeName.Parse (System.String dottedFullName)
        at Xamarin.Android.Tools.ApiXmlAdjuster.JavaApiTypeResolverExtensions.Parse (Xamarin.Android.Tools.ApiXmlAdjuster.JavaApi api, System.String name, Xamarin.Android.Tools.ApiXmlAdjuster.JavaTypeParameters[] contextTypeParameters)
        at Xamarin.Android.Tools.ApiXmlAdjuster.JavaApiTypeResolverExtensions.ResolveType (Xamarin.Android.Tools.ApiXmlAdjuster.JavaType type)
        at Xamarin.Android.Tools.ApiXmlAdjuster.JavaApiTypeResolverExtensions.Resolve (Xamarin.Android.Tools.ApiXmlAdjuster.JavaInterface i)
        at Xamarin.Android.Tools.ApiXmlAdjuster.JavaApiTypeResolverExtensions.Resolve (Xamarin.Android.Tools.ApiXmlAdjuster.JavaApi api)
        at Xamarin.Android.Tools.ApiXmlAdjuster.Adjuster.Process (System.String inputXmlFile, MonoDroid.Generation.GenBase[] gens, System.String outputXmlFile, System.Int32 reportVerbosity)
        at Xamarin.Android.Binder.CodeGenerator.Run (Xamarin.Android.Binder.CodeGeneratorOptions options, Java.Interop.Tools.Cecil.DirectoryAssemblyResolver resolver)
        at Xamarin.Android.Binder.CodeGenerator.Run (Xamarin.Android.Binder.CodeGeneratorOptions options)
        at Xamarin.Android.Binder.CodeGenerator.Main (System.String[] args)

Since reordering initialization in `generator` is causing failures, I
thought it best to put the initialization of the `GenBaseSupport` type
the way it was:

- Pass in `CodeGenerationOptions` to `ManagedClassGen` and
  `ManagedInterfaceGen`, so they have an instance of `SymbolTable`
- Move all the logic from `GenBaseSupport` `OnValidate` to its
  constructor
- We don't need to call `Validate` as early in `CodeGenerator`

Sadly this gets us a little further away from POCOs, but gets things
working again. We can revisit this later when we have more tests. I
think adding support for multiple assemblies in `generator`'s
integration tests would help catch these failures earlier.