### PR TITLE
[Java.Interop.Tools.JavaCallableWrappers] Fix Exception in GenerateJavaStubs

### DIFF
--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/TypeNameMapGenerator.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/TypeNameMapGenerator.cs
@@ -190,8 +190,8 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 			var encoding    = Encoding.UTF8;
 			var binary      = ToBinary (mapping, encoding);
 
-			var keyLen      = binary.Keys.Max (v => v.Length);
-			var valueLen    = binary.Values.Max (v => v.Length);
+			var keyLen      = binary.Keys.Max (v => v?.Length) ?? 0;
+			var valueLen    = binary.Values.Max (v => v?.Length) ?? 0;
 
 			WriteHeader (o, binary.Count, keyLen, valueLen, encoding);
 

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers/TypeNameMapGeneratorTests.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers/TypeNameMapGeneratorTests.cs
@@ -107,6 +107,16 @@ namespace Xamarin.Android.ToolsTests
 		}
 
 		[Test]
+		public void WriteManagedToJavaWithNoTypes ()
+		{
+			var v = new TypeNameMapGenerator (new string[0], logger: Diagnostic.CreateConsoleLogger ());
+			var o = new MemoryStream ();
+			v.WriteManagedToJava (o);
+			var a = ToArray (o);
+			Assert.AreEqual (52, a.Length);
+		}
+
+		[Test]
 		public void WriteManagedToJava ()
 		{
 			var v = new TypeNameMapGenerator (SupportDeclarations.GetTestTypeDefinitions (), logger: Diagnostic.CreateConsoleLogger ());


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-android/issues/1431

If we end up with an empty mapping dictionary the following
exception is thrown.

	System.InvalidOperationException: Sequence contains no elements
          at System.Linq.Enumerable.Max(IEnumerable`1 source)
          at Java.Interop.Tools.JavaCallableWrappers.TypeNameMapGenerator.WriteBinaryMapping(Stream o, Dictionary`2 mapping)
          at Java.Interop.Tools.JavaCallableWrappers.TypeNameMapGenerator.WriteJavaToManaged(Stream output)
          at Xamarin.Android.Tasks.GenerateJavaStubs.UpdateWhenChanged(String path, Action`1 generator)
          at Xamarin.Android.Tasks.GenerateJavaStubs.WriteTypeMappings(List`1 types)
          at Xamarin.Android.Tasks.GenerateJavaStubs.Run(DirectoryAssemblyResolver res)
          at Xamarin.Android.Tasks.GenerateJavaStubs.Execute()
          at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
          at Microsoft.Build.BackEnd.TaskBuilder.<ExecuteInstantiatedTask>d__26.MoveNext()

We should be able to handle an empty dictionary.