### PR TITLE
[generator] prevent generation of `new override` properties

### DIFF
--- a/tools/generator/Property.cs
+++ b/tools/generator/Property.cs
@@ -259,7 +259,7 @@ namespace MonoDroid.Generation {
 				virtual_override = " static";
 			// It should be using AdjustedName instead of Name, but ICharSequence ("Formatted") properties are not caught by this...
 			else if (gen.BaseSymbol != null && gen.BaseSymbol.GetPropertyByName (Name, true) != null)
-				virtual_override = needNew + " override";
+				virtual_override = " override";
 
 			opt.CodeGenerator.WriteMethodIdField (Getter, sw, indent, opt);
 			if (Setter != null)

--- a/tools/generator/Tests/Unit-Tests/SupportTypes.cs
+++ b/tools/generator/Tests/Unit-Tests/SupportTypes.cs
@@ -7,7 +7,7 @@ namespace generatortests
 	{
 		public TestClass (string baseType, string javaName) : base (new TestBaseSupport (javaName))
 		{
-			this.BaseType = BaseType;
+			this.BaseType = baseType;
 		}
 
 		public override bool IsAbstract => false;


### PR DESCRIPTION
Context: https://jenkins.mono-project.com/job/xamarin-android-pr-builder/3070/testReport/junit/Xamarin.Android.Build.Tests/BindingBuildTest/MergeAndroidManifest___Debug/

Upstream in xamarin-android, `generator` created a property such as:

    public new override unsafe string Message {

This is not valid C#, so we shouldn't emit `new override` in any case.

I also noticed a mistake in `TestClass`, it should be setting
`this.BaseType` to `baseType`.