### PR TITLE
[jnimarshalmethod-gen] Add -f option

### DIFF
--- a/tools/jnimarshalmethod-gen/App.cs
+++ b/tools/jnimarshalmethod-gen/App.cs
@@ -24,6 +24,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 		static public bool Debug;
 		static public bool Verbose;
 		static bool keepTemporary;
+		static bool forceRegeneration;
 		static List<Regex> typeNameRegexes = new List<Regex> ();
 		List<string> FilesToDelete = new List<string> ();
 
@@ -58,6 +59,9 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 				{ "d|debug",
 				  "Inject debug messages",
 				  v => Debug = true },
+				{ "f",
+				  "Force regeneration of marshal methods",
+				  v => forceRegeneration = true },
 				{ "keeptemp",
 				  "Keep temporary *-JniMarshalMethod.dll files.",
 				  v => keepTemporary = true },
@@ -193,6 +197,13 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 				}
 				if (!td.ImplementsInterface ("Java.Interop.IJavaPeerable"))
 					continue;
+
+				var existingMarshalMethodsType = td.GetNestedType (TypeMover.NestedName);
+				if (existingMarshalMethodsType != null && !forceRegeneration) {
+					Warning ($"Marshal methods type '{existingMarshalMethodsType.GetAssemblyQualifiedName ()}' already exists. Skipped generation of marshal methods. Use -f to force regeneration when desired.");
+
+					continue;
+				}
 
 				var registrationElements    = new List<Expression> ();
 				var targetType              = Expression.Variable (typeof(Type), "targetType");

--- a/tools/jnimarshalmethod-gen/TypeMover.cs
+++ b/tools/jnimarshalmethod-gen/TypeMover.cs
@@ -76,11 +76,12 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator
 				}
 			}
 
-			if (toRemove != null)
+			if (toRemove != null) {
 				foreach (var t in toRemove) {
 					App.ColorWriteLine ($"Removing original '{t.GetAssemblyQualifiedName ()}' type. (forced)", ConsoleColor.Cyan);
 					typeDst.NestedTypes.Remove (t);
 				}
+			}
 
 			var jniType = new TypeDefinition ("", NestedName, TypeAttributes.NestedPrivate | TypeAttributes.Sealed);
 

--- a/tools/jnimarshalmethod-gen/TypeMover.cs
+++ b/tools/jnimarshalmethod-gen/TypeMover.cs
@@ -52,7 +52,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator
 				App.ColorWriteLine ($"Wrote updated {Destination.MainModule.FileName} assembly", ConsoleColor.Cyan);
 		}
 
-		static readonly string nestedName = "__<$>_jni_marshal_methods";
+		public static readonly string NestedName = "__<$>_jni_marshal_methods";
 
 		Dictionary<string, MethodReference> newHelperMethods;
 
@@ -65,7 +65,24 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator
 		{
 			var typeSrc = Source.MainModule.GetType (type.GetCecilName ());
 			var typeDst = Destination.MainModule.GetType (type.GetCecilName ());
-			var jniType = new TypeDefinition ("", nestedName, TypeAttributes.NestedPrivate | TypeAttributes.Sealed);
+
+			List<TypeDefinition> toRemove = null;
+			foreach (var nestedType in typeDst.NestedTypes) {
+				if (nestedType.Name == NestedName) {
+					if (toRemove == null)
+						toRemove = new List<TypeDefinition> ();
+
+					toRemove.Add (nestedType);
+				}
+			}
+
+			if (toRemove != null)
+				foreach (var t in toRemove) {
+					App.ColorWriteLine ($"Removing original '{t.GetAssemblyQualifiedName ()}' type. (forced)", ConsoleColor.Cyan);
+					typeDst.NestedTypes.Remove (t);
+				}
+
+			var jniType = new TypeDefinition ("", NestedName, TypeAttributes.NestedPrivate | TypeAttributes.Sealed);
 
 			if (TypeIsEmptyOrHasOnlyDefaultConstructor (typeSrc))
 				return;


### PR DESCRIPTION
Do not add new `__<$>_jni_marshal_methods` nested classes in case they
already exists.

Added `-f` option to force regeneration when desired. In that case,
remove existing `__<$>_jni_marshal_methods` classes and generate new
ones.