### PR TITLE
[generator] Copy ClassGen into JavaClass

### DIFF
--- a/tools/generator/ApiXmlAdjuster.cs
+++ b/tools/generator/ApiXmlAdjuster.cs
@@ -5,7 +5,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 {
 	public class Adjuster
 	{
-		public void Process (string inputXmlFile, GenBase [] gens, string outputXmlFile, int reportVerbosity)
+		public void Process (string inputXmlFile, CodeGenerationOptions opt, GenBase [] gens, string outputXmlFile, int reportVerbosity)
 		{
 			switch (reportVerbosity) {
 			case 0:
@@ -21,7 +21,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 				break;
 			}
 			var api = new JavaApi ();
-			api.LoadReferences (gens);
+			api.LoadReferences (opt, gens);
 			api.Load (inputXmlFile);
 			api.StripNonBindables ();
 			api.Resolve ();

--- a/tools/generator/CodeGenerator.cs
+++ b/tools/generator/CodeGenerator.cs
@@ -285,7 +285,7 @@ namespace Xamarin.Android.Binder {
 			}
 			if (apiSourceAttr == "class-parse") {
 				apiXmlFile = api_xml_adjuster_output ?? Path.Combine (Path.GetDirectoryName (filename), Path.GetFileName (filename) + ".adjusted");
-				new Adjuster ().Process (filename, opt.SymbolTable.AllRegisteredSymbols ().OfType<GenBase> ().ToArray (), apiXmlFile, Report.Verbosity ?? 0);
+				new Adjuster ().Process (filename, opt, opt.SymbolTable.AllRegisteredSymbols ().OfType<GenBase> ().ToArray (), apiXmlFile, Report.Verbosity ?? 0);
 			}
 			if (only_xml_adjuster)
 				return;

--- a/tools/generator/JavaApiDllLoaderExtensions.cs
+++ b/tools/generator/JavaApiDllLoaderExtensions.cs
@@ -8,7 +8,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 {
 	public static class JavaApiDllLoaderExtensions
 	{
-		public static void LoadReferences (this JavaApi api, IEnumerable<GenBase> gens)
+		public static void LoadReferences (this JavaApi api, CodeGenerationOptions opt, IEnumerable<GenBase> gens)
 		{
 			JavaPackage pkg = null;
 			foreach (var gen in gens.Where (_ => _.IsAcw)) {
@@ -21,14 +21,14 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 					var iface = new JavaInterface (pkg);
 					pkg.Types.Add (iface);
 					iface.Load ((InterfaceGen) gen);
-				} else if (gen is ClassGen) {
+				} else if (gen is ClassGen c) {
 					var kls = new JavaClass (pkg);
 					pkg.Types.Add (kls);
-					kls.Load ((ClassGen) gen);
+					kls.Load (opt, c);
 				}
 				else
 					throw new InvalidOperationException ();
-				api.LoadReferences (gen.NestedTypes);
+				api.LoadReferences (opt, gen.NestedTypes);
 			}
 		}
 

--- a/tools/generator/Tests/Unit-Tests/AdjusterTests.cs
+++ b/tools/generator/Tests/Unit-Tests/AdjusterTests.cs
@@ -67,7 +67,7 @@ namespace generatortests
 				Xamarin.Android.Binder.CodeGenerator.ProcessReferencedType (type, options);
 			}
 
-			adjuster.Process (inputFile, options.SymbolTable.AllRegisteredSymbols ().OfType<GenBase> ().ToArray (), outputFile, (int)Log.LoggingLevel.Debug);
+			adjuster.Process (inputFile, options, options.SymbolTable.AllRegisteredSymbols ().OfType<GenBase> ().ToArray (), outputFile, (int)Log.LoggingLevel.Debug);
 
 			FileAssert.Exists (outputFile);
 		}


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/1633#issuecomment-387069574

Turning `SymbolTable` into a non-`static` class (19bcca50) broke all
manner of things when trying to integrate with xamarin-android --
partially fixed by 84014f4a, 2004ef86, and b19bc60f -- yet we *still*
can't bump, because Java.Interop/b19bc60f causes the
[`BindingBuildTest/RemoveEventHandlerResolution()` unit test fails][0].

[0]: https://jenkins.mono-project.com/job/xamarin-android-pr-builder/3075/testReport/junit/Xamarin.Android.Build.Tests/BindingBuildTest/RemoveEventHandlerResolution___Debug/

	error CS0115: 'SherlockPreferenceActivity.OnTitleChanged(ICharSequence, int)': no suitable method found to override

Further investigation determined that the CS0115 occurred because
during the binding project build `generator.exe --only-xml-adjuster`
is executed. In a pre-19bcca50 world, the result of
`generator.exe --only-xml-adjuster` resulted in *no* methods with the
name `onTitleChanged`; in b19bc60f, there are *many*.

`generator.exe --only-xml-adjuster` in turn started emitting the
`onTitleChanged` methods because
`JavaApiOverrideMarkerExtensions.MarkBaseMethod()` wasn't able to
resolve the base class to `android.preference.PreferenceActivity`,
which meant it thought that `onTitleChanged()` was a *new* method,
thus keeping it within the resulting `api.xml` file.

`JavaApiOverrideMarkerExtensions.MarkBaseMethod()` couldn't resolve a
base class for `android.preference.PreferenceActivity` because
`JavaApiDllLoaderExtensions.LoadReferences()` *no longer set base
class information*.

And *here* we have the problem, an error of omission: Commit 19bcca50
changed `JavaApiDllLoaderExtensions.Load(JavaClass, ClassGen)` to
`JavaApiDllLoaderExtensions.Load(JavaClass, CodeGenerationOptions, ClassGen)`,
but *the call site didn't change* to provide the new parameter.
Additionally, there was an applicable overload. Consequently, the
"offending" line:

	kls.Load ((ClassGen) gen);

*changed semantic meaning* in 19bcca50: instead of calling
`JavaApiDllLoaderExtensions.Load(JavaClass, ClassGen)`, it now called
`JavaApiDllLoaderExtensions.Load(JavaClass, GenBase)`,
*which doesn't set the base class*.

(Even "better", the offending line -- the line which needed changing
-- doesn't even *appear* within 19bcca50.)

Fix this oversight: Update
`JavaApiDllLoaderExtensions.LoadReferences()` so that a
`CodeGenerationOptions` is now required, and update callers
accordingly.  Additionally, make `Adjuster` an internal `static`
class, because there's no need to instantiate an empty object, and the
type isn't used anywhere else anyway.