### PR TITLE
[libjava-interop] Allow building of it from XA

### DIFF
--- a/src/java-interop/java-interop-mono.c
+++ b/src/java-interop/java-interop-mono.c
@@ -1,3 +1,4 @@
-﻿#include "java-interop-mono.h"
+﻿#include <stdio.h>
+#include "java-interop-mono.h"
 
 

--- a/src/java-interop/java-interop-mono.h
+++ b/src/java-interop/java-interop-mono.h
@@ -3,29 +3,29 @@
 
 #include "java-interop.h"
 
-#if defined (ANDROID)
+#if defined (ANDROID) || defined (DYLIB_MONO)
 
 	#include "dylib-mono.h"
 	#include "monodroid-glue.h"
 
-	#define mono_class_from_mono_type               (mono.mono_class_from_mono_type)
-	#define mono_class_from_name                    (mono.mono_class_from_name)
-	#define mono_class_get_field_from_name          (mono.mono_class_get_field_from_name)
-	#define mono_class_get_name                     (mono.mono_class_get_name)
-	#define mono_class_get_namespace                (mono.mono_class_get_namespace)
-	#define mono_class_is_subclass_of               (mono.mono_class_is_subclass_of)
-	#define mono_class_vtable                       (mono.mono_class_vtable)
-	#define mono_domain_get                         (mono.mono_domain_get)
-	#define mono_field_get_value                    (mono.mono_field_get_value)
-	#define mono_field_set_value                    (mono.mono_field_set_value)
-	#define mono_field_static_set_value             (mono.mono_field_static_set_value)
-	#define mono_object_get_class                   (mono.mono_object_get_class)
-	#define mono_thread_attach                      (mono.mono_thread_attach)
-	#define mono_thread_current                     (mono.mono_thread_current)
-	#define mono_gc_register_bridge_callbacks       (mono.mono_gc_register_bridge_callbacks)
-	#define mono_gc_wait_for_bridge_processing      (mono.mono_gc_wait_for_bridge_processing)
+	#define mono_class_from_mono_type               (monodroid_get_dylib ()->mono_class_from_mono_type)
+	#define mono_class_from_name                    (monodroid_get_dylib ()->mono_class_from_name)
+	#define mono_class_get_field_from_name          (monodroid_get_dylib ()->mono_class_get_field_from_name)
+	#define mono_class_get_name                     (monodroid_get_dylib ()->mono_class_get_name)
+	#define mono_class_get_namespace                (monodroid_get_dylib ()->mono_class_get_namespace)
+	#define mono_class_is_subclass_of               (monodroid_get_dylib ()->mono_class_is_subclass_of)
+	#define mono_class_vtable                       (monodroid_get_dylib ()->mono_class_vtable)
+	#define mono_domain_get                         (monodroid_get_dylib ()->mono_domain_get)
+	#define mono_field_get_value                    (monodroid_get_dylib ()->mono_field_get_value)
+	#define mono_field_set_value                    (monodroid_get_dylib ()->mono_field_set_value)
+	#define mono_field_static_set_value             (monodroid_get_dylib ()->mono_field_static_set_value)
+	#define mono_object_get_class                   (monodroid_get_dylib ()->mono_object_get_class)
+	#define mono_thread_attach                      (monodroid_get_dylib ()->mono_thread_attach)
+	#define mono_thread_current                     (monodroid_get_dylib ()->mono_thread_current)
+	#define mono_gc_register_bridge_callbacks       (monodroid_get_dylib ()->mono_gc_register_bridge_callbacks)
+	#define mono_gc_wait_for_bridge_processing      (monodroid_get_dylib ()->mono_gc_wait_for_bridge_processing)
 
-#else   /* !defined (ANDROID) */
+#else   /* !defined (ANDROID) && !defined (DYLIB_MONO) */
 
 	#include <mono/metadata/assembly.h>
 	#include <mono/metadata/class.h>
@@ -35,7 +35,7 @@
 	#include <mono/utils/mono-counters.h>
 	#include <mono/utils/mono-dl-fallback.h>
 
-#endif  /* !defined (ANDROID) */
+#endif  /* !defined (ANDROID) && !defined (DYLIB_MONO) */
 
 JAVA_INTEROP_BEGIN_DECLS
 


### PR DESCRIPTION
Allow building content of libjava-interop as part of host android
runtime lib in XA.

Use `monodroid_get_dylib ()->` instead of `mono.` as `mono` declared
in
https://github.com/xamarin/xamarin-android/blob/master/src/monodroid/jni/monodroid-glue.c#L452
is static.

Enable using `dylib-mono.*` when `DYLIB_MONO` is defined.