### PR TITLE
[libjava-interop] Use own DylibMono instance

### DIFF
--- a/src/java-interop/java-interop-gc-bridge-mono.c
+++ b/src/java-interop/java-interop-gc-bridge-mono.c
@@ -262,6 +262,13 @@ java_interop_gc_bridge_new (JavaVM *jvm)
 	if (jvm == NULL)
 		return NULL;
 
+#if defined (ANDROID) || defined (DYLIB_MONO)
+	if (!monodroid_dylib_mono_init (monodroid_get_dylib (), NULL)) {
+		log_fatal (LOG_DEFAULT, "mono runtime initialization error: %s", dlerror ());
+		exit (FATAL_EXIT_CANNOT_FIND_MONO);
+	}
+#endif  /* defined (ANDROID) || defined (DYLIB_MONO) */
+
 	lookup_optional_mono_thread_functions ();
 
 	JavaInteropGCBridge bridge = {0};


### PR DESCRIPTION
The monodroid's DylibMono is initialized in
[`Java_mono_android_Runtime_init`][1] and thus not avaiable for
standalone Java.Interop consumers, like `jnimarshalmethod-gen.exe`.

Let `libjava-interop` have its own DylibMono instance and initialize
it on first call to mono functions.

We might rethink that once we start using libjava-interop's GC bridge
in monodroid.

[1]: https://github.com/xamarin/xamarin-android/blob/master/src/monodroid/jni/monodroid-glue.c#L3703