### PR TITLE
[Xamarin.Android.Tools.Bytecode-Tests] Fix BuildClasses

### DIFF
--- a/src/Xamarin.Android.Tools.Bytecode/Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj
@@ -59,7 +59,6 @@
   <ItemGroup>
     <TestJar Include="java\**\*.java" Exclude="java\java\util\Collection.java" />
     <TestJarNoParameters Include="java\java\util\Collection.java" />
-    <TestJar Include="java\com\xamarin\NestedInterface.java" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>


### PR DESCRIPTION
The `BuildClasses` target constantly executes:

	$ msbuild /v:diag
	$ msbuild /v:diag
	...
	Building target "BuildClasses" partially, because some output files are out of date with respect to their input files.
	[TestJar: Input=java/com/xamarin/NestedInterface.java, Output=obj/Debug/classes/NestedInterface.class] Output file does not exist.

The *cause* of the above message is because the `Outputs` attribute
used `%(RecursiveDir)`, which was *empty* for `NestedInterface.java`,
as the full path was explicitly provided.  (No wildcards were used.)

As it happens, that `@(TestJar)` entry wasn't required *anyway*, as
`NestedInterface.java` was also pulled in via the wild-card include.

Remove the `java\com\xamarin\NestedInterface.java` entry, which allows
`BuildClasses` Inputs & Outputs to behave as expected:

	$ msbuild
	$ msbuild /v:diag
	...
	Skipping target "BuildClasses" because all output files are up-to-date with respect to the input files.