### PR TITLE
[java-interop] Implemented Windows version of ji_realpath

### DIFF
--- a/src/java-interop/java-interop-gc-bridge-mono.c
+++ b/src/java-interop/java-interop-gc-bridge-mono.c
@@ -183,9 +183,7 @@ ji_realpath (const char *path)
 			break;
 		}
 
-		wchar_t *allocated_buffer = malloc (sizeof (wchar_t)*retval);
-		if (allocated_buffer == NULL)
-			break;
+		wchar_t *allocated_buffer = xmalloc (sizeof (wchar_t)*retval);
 
 		retval = GetFullPathNameW (wpath, retval, allocated_buffer, NULL);
 

--- a/src/java-interop/java-interop-logger.c
+++ b/src/java-interop/java-interop-logger.c
@@ -1,0 +1,225 @@
+#include <stdlib.h>
+#include <stdarg.h>
+#include <strings.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+
+#ifdef ANDROID
+#include <android/log.h>
+#endif
+
+#include "java-interop-logger.h"
+
+#include "monodroid.h"
+#include "monodroid-glue.h"
+#include "debug.h"
+#include "util.h"
+
+#define DO_LOG(_level_,_category_,_format_,_args_)						                        \
+	va_start ((_args_), (_format_));									                        \
+	__android_log_vprint ((_level_), CATEGORY_NAME((_category_)), (_format_), (_args_)); \
+	va_end ((_args_));
+
+// Must match the same ordering as LogCategories
+static const char* log_names[] = {
+	"*none*",
+	"monodroid",
+	"monodroid-assembly",
+	"monodroid-debug",
+	"monodroid-gc",
+	"monodroid-gref",
+	"monodroid-lref",
+	"monodroid-timing",
+	"monodroid-bundle",
+	"monodroid-network",
+	"monodroid-netlink",
+	"*error*",
+};
+
+#if defined(__i386__) && defined(__GNUC__)
+#define ffs(__value__) __builtin_ffs ((__value__))
+#elif defined(__x86_64__) && defined(__GNUC__)
+#define ffs(__value__) __builtin_ffsll ((__value__))
+#endif
+
+// ffs(value) returns index of lowest bit set in `value`
+#define CATEGORY_NAME(value) (value == 0 ? log_names [0] : log_names [ffs (value)])
+
+#ifndef ANDROID
+static void
+__android_log_vprint (int prio, const char* tag, const char* fmt, va_list ap)
+{
+  printf ("%d [%s] ", prio, tag);
+  vprintf (fmt, ap);
+  putchar ('\n');
+  fflush (stdout);
+}
+#endif
+
+unsigned int log_categories;
+int gc_spew_enabled;
+
+static FILE*
+open_file (LogCategories category, const char *path, const char *override_dir, const char *filename)
+{
+	char *p = NULL;
+	FILE *f;
+
+	if (path && access (path, W_OK) < 0) {
+		log_warn (category, "Could not open path '%s' for logging (\"%s\"). Using '%s/%s' instead.",
+				path, strerror (errno), override_dir, filename);
+		path  = NULL;
+	}
+
+	if (!path) {
+		create_public_directory (override_dir);
+		p     = path_combine (override_dir, filename);
+		path  = p;
+	}
+
+	unlink (path);
+
+	f = monodroid_fopen (path, "a");
+
+	if (f) {
+		set_world_accessable (path);
+	} else {
+		log_warn (category, "Could not open path '%s' for logging: %s",
+				path, strerror (errno));
+	}
+
+	free (p);
+
+	return f;
+}
+
+void
+init_categories (const char *override_dir)
+{
+	char *value;
+	char **args, **ptr;
+
+	const char *gref_file = NULL;
+	const char *lref_file = NULL;
+
+#if !ANDROID
+	log_categories = LOG_DEFAULT;
+#endif
+	int light_gref  = 0;
+	int light_lref  = 0;
+
+	if (monodroid_get_namespaced_system_property (DEBUG_MONO_LOG_PROPERTY, &value) == 0)
+		return;
+
+	args = monodroid_strsplit (value, ",", -1);
+	free (value);
+	value = NULL;
+
+	for (ptr = args; ptr && *ptr; ptr++) {
+		const char *arg = *ptr;
+
+		if (!strcmp (arg, "all")) {
+			log_categories = 0xFFFFFFFF;
+			break;
+		}
+
+#define CATEGORY(name,entry) do { \
+		if (!strncmp (arg, name, sizeof(name)-1)) \
+			log_categories |= entry; \
+	} while (0)
+
+		CATEGORY ("assembly", LOG_ASSEMBLY);
+		CATEGORY ("default",  LOG_DEFAULT);
+		CATEGORY ("debugger", LOG_DEBUGGER);
+		CATEGORY ("gc",       LOG_GC);
+		CATEGORY ("gref",     LOG_GREF);
+		CATEGORY ("lref",     LOG_LREF);
+		CATEGORY ("timing",   LOG_TIMING);
+		CATEGORY ("bundle",   LOG_BUNDLE);
+		CATEGORY ("network",  LOG_NET);
+		CATEGORY ("netlink",  LOG_NETLINK);
+
+#undef CATEGORY
+
+		if (!strncmp (arg, "gref=", 5)) {
+			log_categories  |= LOG_GREF;
+			gref_file        = arg + 5;
+		} else if (!strncmp (arg, "gref-", 5)) {
+			log_categories  |= LOG_GREF;
+			light_gref       = 1;
+		} else if (!strncmp (arg, "lref=", 5)) {
+			log_categories  |= LOG_LREF;
+			lref_file        = arg + 5;
+		} else if (!strncmp (arg, "lref-", 5)) {
+			log_categories  |= LOG_LREF;
+			light_lref       = 1;
+		}
+	}
+
+	if ((log_categories & LOG_GREF) != 0 && !light_gref) {
+		gref_log  = open_file (LOG_GREF, gref_file, override_dir, "grefs.txt");
+	}
+
+	if ((log_categories & LOG_LREF) != 0 && !light_lref) {
+		// if both lref & gref have files specified, and they're the same path, reuse the FILE*.
+		if (lref_file != NULL && strcmp (lref_file, gref_file != NULL ? gref_file : "") == 0) {
+			lref_log  = gref_log;
+		} else {
+			lref_log  = open_file (LOG_LREF, lref_file, override_dir, "lrefs.txt");
+		}
+	}
+
+	monodroid_strfreev (args);
+
+#if DEBUG
+	if ((log_categories & LOG_GC) != 0)
+		gc_spew_enabled = 1;
+#endif  /* DEBUG */
+}
+
+void
+log_error (LogCategories category, const char *format, ...)
+{
+	va_list args;
+
+	DO_LOG (ANDROID_LOG_ERROR, category, format, args);
+}
+
+void
+log_fatal (LogCategories category, const char *format, ...)
+{
+	va_list args;
+
+	DO_LOG (ANDROID_LOG_FATAL, category, format, args);
+}
+
+void
+log_info (LogCategories category, const char *format, ...)
+{
+	va_list args;
+
+	if ((log_categories & category) == 0)
+		return;
+
+	DO_LOG (ANDROID_LOG_INFO, category, format, args);
+}
+
+void
+log_warn (LogCategories category, const char *format, ...)
+{
+	va_list args;
+
+	DO_LOG (ANDROID_LOG_WARN, category, format, args);
+}
+
+void
+log_debug (LogCategories category, const char *format, ...)
+{
+	va_list args;
+
+	if ((log_categories & category) == 0)
+		return;
+
+	DO_LOG (ANDROID_LOG_DEBUG, category, format, args);
+}

--- a/src/java-interop/java-interop-logger.h
+++ b/src/java-interop/java-interop-logger.h
@@ -1,0 +1,51 @@
+#ifndef __JAVA_INTEROP_LOGGER_H__
+#define __JAVA_INTEROP_LOGGER_H__
+
+#ifndef ANDROID
+typedef enum android_LogPriority {
+    ANDROID_LOG_UNKNOWN = 0,
+    ANDROID_LOG_DEFAULT,    /* only for SetMinPriority() */
+    ANDROID_LOG_VERBOSE,
+    ANDROID_LOG_DEBUG,
+    ANDROID_LOG_INFO,
+    ANDROID_LOG_WARN,
+    ANDROID_LOG_ERROR,
+    ANDROID_LOG_FATAL,
+    ANDROID_LOG_SILENT,     /* only for SetMinPriority(); must be last */
+} android_LogPriority;
+#endif
+
+// Keep in sync with Mono.Android/src/Runtime/Logger.cs!LogCategories enum
+typedef enum _LogCategories {
+	LOG_NONE      = 0,
+	LOG_DEFAULT   = 1 << 0,
+	LOG_ASSEMBLY  = 1 << 1,
+	LOG_DEBUGGER  = 1 << 2,
+	LOG_GC        = 1 << 3,
+	LOG_GREF      = 1 << 4,
+	LOG_LREF      = 1 << 5,
+	LOG_TIMING    = 1 << 6,
+	LOG_BUNDLE    = 1 << 7,
+	LOG_NET       = 1 << 8,
+	LOG_NETLINK   = 1 << 9,
+} LogCategories;
+
+extern unsigned int log_categories;
+
+#if DEBUG
+extern int gc_spew_enabled;
+#endif
+
+void init_categories (const char *override_dir);
+
+void log_error (LogCategories category, const char *format, ...);
+
+void log_fatal (LogCategories category, const char *format, ...);
+
+void log_info (LogCategories category, const char *format, ...);
+
+void log_warn (LogCategories category, const char *format, ...);
+
+void log_debug (LogCategories category, const char *format, ...);
+
+#endif /* __JAVA_INTEROP_LOGGER_H__ */

--- a/src/java-interop/java-interop-util.c
+++ b/src/java-interop/java-interop-util.c
@@ -1,0 +1,29 @@
+#ifdef WINDOWS
+#include <assert.h>
+#include <direct.h>
+#include <stringapiset.h>
+
+char*
+utf16_to_utf8 (const wchar_t *widestr)
+{
+	int required_size = WideCharToMultiByte (CP_UTF8, 0, widestr, -1, NULL, 0, NULL, NULL);
+	char *mbstr = calloc (required_size, sizeof (char));
+	int converted_size = WideCharToMultiByte (CP_UTF8, 0, widestr, -1, mbstr, required_size, NULL, NULL);
+
+	assert (converted_size == required_size);
+
+	return mbstr;
+}
+
+wchar_t*
+utf8_to_utf16 (const char *mbstr)
+{
+	int required_chars = MultiByteToWideChar (CP_UTF8, 0, mbstr, -1, NULL, 0);
+	wchar_t *widestr = calloc (required_chars, sizeof (wchar_t));
+	int converted_chars = MultiByteToWideChar (CP_UTF8, 0, mbstr, -1, widestr, required_chars);
+
+	assert (converted_chars == required_chars);
+
+	return widestr;
+}
+#endif // def WINDOWS

--- a/src/java-interop/java-interop-util.h
+++ b/src/java-interop/java-interop-util.h
@@ -1,3 +1,6 @@
+#ifndef __JAVA_INTEROP_UTIL_H__
+#define __JAVA_INTEROP_UTIL_H__
+
 #ifdef WINDOWS
 /* Those two conversion functions are only properly implemented on Windows
  * because that's the only place where they should be useful.
@@ -5,3 +8,63 @@
 char* utf16_to_utf8 (const wchar_t *widestr);
 wchar_t* utf8_to_utf16 (const char *mbstr);
 #endif // def WINDOWS
+
+#include "java-interop-logger.h"
+
+enum FatalExitCodes {
+	FATAL_EXIT_CANNOT_FIND_MONO           =  1,
+	FATAL_EXIT_ATTACH_JVM_FAILED          =  2,
+	FATAL_EXIT_DEBUGGER_CONNECT           =  3,
+	FATAL_EXIT_CANNOT_FIND_JNIENV         =  4,
+	FATAL_EXIT_CANNOT_FIND_APK            = 10,
+	FATAL_EXIT_TRIAL_EXPIRED              = 11,
+	FATAL_EXIT_PTHREAD_FAILED             = 12,
+	FATAL_EXIT_MISSING_ASSEMBLY           = 13,
+	FATAL_EXIT_CANNOT_LOAD_BUNDLE         = 14,
+	FATAL_EXIT_CANNOT_FIND_LIBMONOSGEN    = 15,
+	FATAL_EXIT_NO_ASSEMBLIES              = 'A',
+	FATAL_EXIT_MONO_MISSING_SYMBOLS       = 'B',
+	FATAL_EXIT_FORK_FAILED                = 'F',
+	FATAL_EXIT_MISSING_INIT               = 'I',
+	FATAL_EXIT_MISSING_TIMEZONE_MEMBERS   = 'T',
+	FATAL_EXIT_MISSING_ZIPALIGN           = 'Z',
+	FATAL_EXIT_OUT_OF_MEMORY              = 'M',
+};
+
+static inline void*
+_assert_valid_pointer (void *p, size_t size)
+{
+	if (!p) {
+		if (size == 0) {
+			/* In this case it's "ok" to return NULL, although a malloc
+			 * implementation may choose to do something else
+			 */
+			return p;
+		}
+
+		log_fatal (LOG_DEFAULT, "Out of memory!");
+		exit (FATAL_EXIT_OUT_OF_MEMORY);
+	}
+
+	return p;
+}
+
+static inline void*
+xmalloc (size_t size)
+{
+	return _assert_valid_pointer (malloc (size), size);
+}
+
+static inline void*
+xrealloc (void *ptr, size_t size)
+{
+	return _assert_valid_pointer (realloc (ptr, size), size);
+}
+
+static inline void*
+xcalloc (size_t nmemb, size_t size)
+{
+	return _assert_valid_pointer (calloc (nmemb, size), nmemb * size);
+}
+
+#endif /* __JAVA_INTEROP_UTIL_H__ */

--- a/src/java-interop/java-interop-util.h
+++ b/src/java-interop/java-interop-util.h
@@ -1,0 +1,7 @@
+#ifdef WINDOWS
+/* Those two conversion functions are only properly implemented on Windows
+ * because that's the only place where they should be useful.
+ */
+char* utf16_to_utf8 (const wchar_t *widestr);
+wchar_t* utf8_to_utf16 (const char *mbstr);
+#endif // def WINDOWS


### PR DESCRIPTION
It makes it possible to build it in XA for `mxe-Win32:mxe-Win64` host
ABI's.

Also moved utf8/16 helper functions from XA to
`java-interop-util.[ch]`