### PR TITLE
[Java.Runtime.Environment] Allow injection of dllmap's to config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,9 +70,16 @@ include build-tools/scripts/msbuild.mk
 $(PACKAGES) $(NUNIT_CONSOLE):
 	nuget restore
 
+JAVA_RUNTIME_ENVIRONMENT_DLLMAP_OVERRIDE = Java.Runtime.Environment.Override.dllmap
+ifeq ($(wildcard $(JAVA_RUNTIME_ENVIRONMENT_DLLMAP_OVERRIDE)),)
+	JAVA_RUNTIME_ENVIRONMENT_DLLMAP_OVERRIDE_CMD = '/@JAVA_RUNTIME_ENVIRONMENT_DLLMAP@/d'
+else
+	JAVA_RUNTIME_ENVIRONMENT_DLLMAP_OVERRIDE_CMD = '/@JAVA_RUNTIME_ENVIRONMENT_DLLMAP@/ {' -e 'r $(JAVA_RUNTIME_ENVIRONMENT_DLLMAP_OVERRIDE)' -e 'd' -e '}'
+endif
+
 src/Java.Runtime.Environment/Java.Runtime.Environment.dll.config: src/Java.Runtime.Environment/Java.Runtime.Environment.dll.config.in \
 		bin/Build$(CONFIGURATION)/JdkInfo.props
-	sed -e 's#@JI_JVM_PATH@#$(JI_JVM_PATH)#g' -e 's#@OS_NAME@#$(DLLMAP_OS_NAME)#g' < $< > $@
+	sed -e 's#@JI_JVM_PATH@#$(JI_JVM_PATH)#g' -e 's#@OS_NAME@#$(DLLMAP_OS_NAME)#g' -e $(JAVA_RUNTIME_ENVIRONMENT_DLLMAP_OVERRIDE_CMD) < $< > $@
 
 xa-fxcop: lib/gendarme-2.10/gendarme.exe bin/$(XA_CONFIGURATION)/Java.Interop.dll
 	$(RUNTIME) $< --html xa-gendarme.html $(if @(GENDARME_XML),--xml xa-gendarme.xml) --ignore gendarme-ignore.txt bin/$(XA_CONFIGURATION)/Java.Interop.dll

--- a/src/Java.Runtime.Environment/Java.Runtime.Environment.dll.config.in
+++ b/src/Java.Runtime.Environment/Java.Runtime.Environment.dll.config.in
@@ -1,3 +1,4 @@
 <configuration>
   <dllmap dll="jvm.dll" os="@OS_NAME@" target="@JI_JVM_PATH@"/>
+@JAVA_RUNTIME_ENVIRONMENT_DLLMAP@
 </configuration>


### PR DESCRIPTION
Make it possible to inject *dllmap*'s into
`src/Java.Runtime.Environment/Java.Runtime.Environment.dll.config` by
providing `Java.Runtime.Environment.Override.dllmap` file in
Java.Interop root directory

In case the file is missing, the line containing
`@JAVA_RUNTIME_ENVIRONMENT_DLLMAP@` is removed.