### PR TITLE
[java-interop] Fix casing of <fileapi.h>

### DIFF
--- a/src/java-interop/java-interop-gc-bridge-mono.c
+++ b/src/java-interop/java-interop-gc-bridge-mono.c
@@ -10,7 +10,7 @@
 #include "java-interop-util.h"
 
 #ifdef WINDOWS
-#include <FileAPI.h>
+#include <fileapi.h>
 #endif
 
 #ifdef __linux__


### PR DESCRIPTION
Case sensitivity rears its head, in the form of building
xamarin-android under Linux with MXE enabled:

	$ "/usr/bin/x86_64-w64-mingw32-gcc" ...
	…/xamarin-android/external/Java.Interop/src/java-interop/java-interop-gc-bridge-mono.c:13:10: fatal error: FileAPI.h: No such file or directory
	 #include <FileAPI.h> (TaskId:1199)
	          ^~~~~~~~~~~ (TaskId:1199)
	compilation terminated. (TaskId:1199)

Change the `<FileAPI.h>` into a platform-neutral `<fileapi.h>` so that
the header can be found when building under Linux.