### PR TITLE
[build] Allow overriding Cecil location

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -14,6 +14,10 @@
       Condition="Exists('$(MSBuildThisFileDirectory)bin\Build$(Configuration)\MonoInfo.props')"
   />
   <PropertyGroup>
+    <CecilSourceDirectory   Condition=" '$(CecilSourceDirectory)' == '' ">$(MSBuildThisFileDirectory)external\cecil</CecilSourceDirectory>
     <UtilityOutputFullPath  Condition=" '$(UtilityOutputFullPath)' == '' ">$(MSBuildThisFileDirectory)bin\$(Configuration)\</UtilityOutputFullPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <CecilFullPath>$([System.IO.Path]::GetFullPath ('$(CecilSourceDirectory)'))</CecilFullPath>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ it within other project files.
 
 Overridable MSBuild properties include:
 
+* `$(CecilSourceDirectory)`: Directory for the `cecil` sources.
+    Defaults to `external/cecil`.
 * `$(JdkJvmPath)`: Full path name to the JVM native library to link
     [`java-interop`](src/java-interop) against. By default this is
     probed for from numerious locations within

--- a/src/Xamarin.Android.Cecil/Xamarin.Android.Cecil.targets
+++ b/src/Xamarin.Android.Cecil/Xamarin.Android.Cecil.targets
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <CecilDirectory>$(MSBuildThisFileDirectory)\..\..\external\cecil</CecilDirectory>
     <CecilPreparedFlag>prepared.flag</CecilPreparedFlag>
     <OutputPath Condition=" '$(OutputPath)' == '' ">..\..\bin\$(Configuration)</OutputPath>
     <CecilOutputPath>$([System.IO.Path]::Combine ($(MSBuildThisFileDirectory), $(OutputPath)))</CecilOutputPath>
@@ -9,9 +8,9 @@
     <CecilAssemblies>$(OutputPath)\Xamarin.Android.Cecil.dll;$(OutputPath)\Xamarin.Android.Cecil.Mdb.dll</CecilAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <_CecilProject  Include="$(CecilDirectory)\Mono.Cecil.csproj" />
-    <_CecilProject  Include="$(CecilDirectory)\symbols\mdb\Mono.Cecil.Mdb.csproj" />
-    <_CecilSource   Include="$(CecilDirectory)\**\*.cs" />
+    <_CecilProject  Include="$(CecilFullPath)\Mono.Cecil.csproj" />
+    <_CecilProject  Include="$(CecilFullPath)\symbols\mdb\Mono.Cecil.Mdb.csproj" />
+    <_CecilSource   Include="$(CecilFullPath)\**\*.cs" />
   </ItemGroup>
   <Target Name="BuildCecil"
       Inputs="@(_CecilSource)"


### PR DESCRIPTION
There is a philosophically confusing question due to the interaction
between the Java.Interop, xamarin-android, and mono repos:

Which repo "owns" Cecil?

The Java.Interop repo has a Cecil submodule.

The mono repo has a Cecil submodule. (*Two*, if you count the indirect
one from the Linker submodule, but that shouldn't be used.)

The xamarin-android repo references both Java.Interop & mono.

If we have a fix in Cecil, what all needs bumping?

A present, the answer is *everything*, because the mono reference is
included into a variety of mono-built utilities (*as source*, not an
assembly), while the Java.Interop reference built into
`Xamarin.Android.Cecil.dll` and used by the Xamarin.Android build
process.

This is somewhat confusing, and means that more work needs to be done
to apply fixes everywhere.

Try to simplify things by adding a new `$(CecilSourceDirectory)`
MSBuild property to `Configuration.props`.  The intent is to allow a
xamarin-android checkout to *override* `$(CecilSourceDirectory)` so
that the Java.Interop build will the *mono* reference, thus permitting
a degree of consistency and understanding not previously available.

Thus, which repo "owns" Cecil?  The mono repo will; the Java.Interop
reference will be ignored *when building from xamarin-android*.