### PR TITLE
[Xamarin.Android.Cecil] fix assembly names if using $(CecilSourceDirectory)

### DIFF
--- a/src/Xamarin.Android.Cecil/Xamarin.Android.Cecil.targets
+++ b/src/Xamarin.Android.Cecil/Xamarin.Android.Cecil.targets
@@ -20,6 +20,10 @@
         Targets="Clean;Build"
         StopOnFirstFailure="True"
         Properties="Configuration=net_4_0_Debug;OutputPath=$(CecilOutputPath);BuildingSolutionFile=false" />
+    <ItemGroup>
+      <_MonoCecilAssemblies Include="$(OutputPath)\Mono.Cecil.*" />
+    </ItemGroup>
+    <Move SourceFiles="@(_MonoCecilAssemblies)" DestinationFiles="@(_MonoCecilAssemblies->'%(Identity)'->Replace('Mono.Cecil.', 'Xamarin.Android.Cecil.'))" />
     <Touch Files="$(CecilAssemblies)" />
   </Target>
   <Target Name="Build" DependsOnTargets="BuildCecil" Returns="$(CecilOutputPath)\$(AssemblyName).dll">


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/1747

Downstream in xamarin-android, I started getting a build failure on
Windows such as:

    xamarin-android\external\Java.Interop\src\Xamarin.Android.Cecil\Xamarin.Android.Cecil.targets(23,5): error MSB3375: The file "..\..\bin\Debug\\Xamarin.Android.Cecil.dll" does not exist.
    xamarin-android\external\Java.Interop\src\Xamarin.Android.Cecil\Xamarin.Android.Cecil.targets(23,5): error MSB3375: The file "..\..\bin\Debug\\Xamarin.Android.Cecil.Mdb.dll" does not exist.

Looking in my `external\Java.Interop\bin\Debug` directory, the
`Mono.Cecil` assemblies were named `Mono.Cecil.*` instead of
`Xamarin.Android.*`.

I think this was an oversight, but I don't know how the builds were
green...

Looking at `Mono.Cecil.csproj` in
`xamarin-android/external/mono/external/cecil` there was no way to
override `AssemblyName`. But we can use the `<Move />` task instead.

To fix this:
- Added a `_MonoCecilAssemblies` to check for any files named
  `Mono.Cecil.*`
- `<Move />` the files to start with `Xamarin.Android.*` instead.