### PR TITLE
[java-interop] Do not redefine MONO_API*

### DIFF
--- a/src/java-interop/java-interop-mono.h
+++ b/src/java-interop/java-interop-mono.h
@@ -27,6 +27,10 @@
 
 #else   /* !defined (ANDROID) && !defined (DYLIB_MONO) */
 
+	#undef MONO_API_EXPORT
+	#undef MONO_API_IMPORT
+	#undef MONO_API
+
 	#include <mono/metadata/assembly.h>
 	#include <mono/metadata/class.h>
 	#include <mono/metadata/object.h>


### PR DESCRIPTION
Do not redefine MONO_API `#define`'s for mono's header files. This fixes the
warnings like this one:

```
  In file included from java-interop-mono.c:2:
  In file included from ./java-interop-mono.h:30:
  In file included from /Library/Frameworks/Mono.framework/Headers/mono-2.0/mono/metadata/assembly.h:8:
  In file included from /Library/Frameworks/Mono.framework/Headers/mono-2.0/mono/utils/mono-error.h:8:
/Library/Frameworks/Mono.framework/Headers/mono-2.0/mono/utils/mono-publib.h(52,9): warning GE1D896A7: 'MONO_API_EXPORT' macro redefined [-Wmacro-redefined] [/Users/rodo/git/java.interop/src/java-interop/java-interop.csproj]
  #define MONO_API_EXPORT __attribute__ ((__visibility__ ("default")))
          ^
  ./java-interop.h:14:11: note: previous definition is here
                  #define MONO_API_EXPORT __attribute__ ((visibility ("default")))
                          ^
  1 warning generated.
```