### PR TITLE
[Xamarin.Android.Tools.ApiXmlAdjuster] Attributes are optional

### DIFF
--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiXmlGeneratorExtensions.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiXmlGeneratorExtensions.cs
@@ -29,7 +29,9 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 					continue;
 				writer.WriteStartElement ("package");
 				writer.WriteAttributeString ("name", pkg.Name);
-				writer.WriteAttributeString ("jni-name", pkg.JniName);
+				if (!string.IsNullOrEmpty (pkg.JniName)) {
+					writer.WriteAttributeString ("jni-name", pkg.JniName);
+				}
 				foreach (var type in pkg.Types) {
 					if (type.IsReferenceOnly)
 						continue; // skip reference only types
@@ -69,13 +71,17 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			writer.WriteAttributeString ("name", cls.Name);
 			writer.WriteAttributeString ("static", XmlConvert.ToString (cls.Static));
 			writer.WriteAttributeString ("visibility", cls.Visibility);
-			writer.WriteAttributeString ("jni-signature", cls.ExtendedJniSignature);
-			
+			if (!string.IsNullOrEmpty (cls.ExtendedJniSignature)) {
+				writer.WriteAttributeString ("jni-signature", cls.ExtendedJniSignature);
+			}
+
 			foreach (var imp in cls.Implements.OrderBy (i => i.Name, StringComparer.Ordinal)) {
 				writer.WriteStartElement ("implements");
 				writer.WriteAttributeString ("name", imp.Name);
 				writer.WriteAttributeString ("name-generic-aware", imp.NameGeneric);
-				writer.WriteAttributeString ("jni-type", imp.ExtendedJniType);
+				if (!string.IsNullOrEmpty (imp.ExtendedJniType)) {
+					writer.WriteAttributeString ("jni-type", imp.ExtendedJniType);
+				}
 				writer.WriteString ("\n      ");
 				writer.WriteFullEndElement ();
 			}
@@ -99,10 +105,18 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			foreach (var tp in typeParameters.TypeParameters) {
 				writer.WriteStartElement ("typeParameter");
 				writer.WriteAttributeString ("name", tp.Name);
-				writer.WriteAttributeString ("classBound", tp.ExtendedClassBound);
-				writer.WriteAttributeString ("jni-classBound", tp.ExtendedJniClassBound);
-				writer.WriteAttributeString ("interfaceBounds", tp.ExtendedInterfaceBounds);
-				writer.WriteAttributeString ("jni-interfaceBounds", tp.ExtendedJniInterfaceBounds);
+				if (!string.IsNullOrEmpty (tp.ExtendedClassBound)) {
+					writer.WriteAttributeString ("classBound", tp.ExtendedClassBound);
+				}
+				if (!string.IsNullOrEmpty (tp.ExtendedJniClassBound)) {
+					writer.WriteAttributeString ("jni-classBound", tp.ExtendedJniClassBound);
+				}
+				if (!string.IsNullOrEmpty (tp.ExtendedInterfaceBounds)) {
+					writer.WriteAttributeString ("interfaceBounds", tp.ExtendedInterfaceBounds);
+				}
+				if (!string.IsNullOrEmpty (tp.ExtendedJniInterfaceBounds)) {
+					writer.WriteAttributeString ("jni-interfaceBounds", tp.ExtendedJniInterfaceBounds);
+				}
 
 				if (tp.GenericConstraints != null) {
 					// If there is only one generic constraint that specifies java.lang.Object,
@@ -259,7 +273,9 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 					writer.WriteStartElement ("parameter");
 					writer.WriteAttributeString ("name", p.Name);
 					writer.WriteAttributeString ("type", p.GetVisibleTypeName ());
-					writer.WriteAttributeString ("jni-type", p.JniType);
+					if (!string.IsNullOrEmpty (p.JniType)) {
+						writer.WriteAttributeString ("jni-type", p.JniType);
+					}
 					writer.WriteString ("\n        ");
 					writer.WriteFullEndElement ();
 				}
@@ -270,7 +286,9 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 					writer.WriteStartElement ("exception");
 					writer.WriteAttributeString ("name", e.Name.Substring (e.Name.LastIndexOf ('/') + 1).Replace ('$', '.'));
 					writer.WriteAttributeString ("type", e.Type);
-					writer.WriteAttributeString ("type-generic-aware", e.TypeGenericAware);
+					if (!string.IsNullOrEmpty (e.TypeGenericAware)) {
+						writer.WriteAttributeString ("type-generic-aware", e.TypeGenericAware);
+					}
 					writer.WriteString ("\n        ");
 					writer.WriteFullEndElement ();
 				}

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiXmlLoaderExtensions.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiXmlLoaderExtensions.cs
@@ -204,7 +204,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			member.Name = XmlUtil.GetRequiredAttribute (reader, "name");
 			member.Static = XmlConvert.ToBoolean (XmlUtil.GetRequiredAttribute (reader, "static"));
 			member.Visibility = XmlUtil.GetRequiredAttribute (reader, "visibility");
-			member.ExtendedJniSignature = XmlUtil.GetRequiredAttribute (reader, "jni-signature");
+			member.ExtendedJniSignature = reader.GetAttribute ("jni-signature");
 		}
 
 		public static void Load (this JavaField field, XmlReader reader)
@@ -283,7 +283,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		{
 			p.Name = XmlUtil.GetRequiredAttribute (reader, "name");
 			p.Type = XmlUtil.GetRequiredAttribute (reader, "type");
-			p.JniType = XmlUtil.GetRequiredAttribute (reader, "jni-type");
+			p.JniType = reader.GetAttribute ("jni-type");
 			reader.Skip ();
 		}
 
@@ -291,7 +291,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		{
 			e.Name = XmlUtil.GetRequiredAttribute (reader, "name");
 			e.Type = XmlUtil.GetRequiredAttribute (reader, "type");
-			e.Type = XmlUtil.GetRequiredAttribute (reader, "type-generic-aware");
+			e.Type = reader.GetAttribute ("type-generic-aware");
 			reader.Skip ();
 		}
 		


### PR DESCRIPTION
Commit 0881accd [broke][0] the [build][1] via unit test failure:

	System.Exception : /var/folders/l8/73t5whsx7dj5v5gh_bn7zxlr0000gn/T/tmp28cf44e7.tmp (5,5): Element 'constructor' requires attribute 'jni-signature'
	  at Xamarin.Android.Tools.ApiXmlAdjuster.XmlUtil.GetRequiredAttribute (System.Xml.XmlReader reader, System.String name)
	  at Xamarin.Android.Tools.ApiXmlAdjuster.JavaApiLoaderExtensions.LoadMemberAttributes (Xamarin.Android.Tools.ApiXmlAdjuster.JavaMember member, System.Xml.XmlReader reader)
	  ...

This was generated from e.g. `make run-test-generator-core` and
processing a "legacy" file in the form of
`tools/generator/Tests-Core/api-cp.xml` (whereby "legacy" means
"didn't contain the newly required `//constructor/@jni-signature`
XML attribute).

There are two plausible fixes:

 1. Update `api-cp.xml` so that it provides the attribute that
    0881accd requires, or
 2. Make the attributes *not* required attributes.

Since I don't know what the larger ecosystem may be doing with
these API XML files, I chose the conservative approach (2).

[0]: https://jenkins.mono-project.com/view/Xamarin.Android/job/Java.Interop/261/testReport/junit/generatortests/AdjusterTests/Process/
[1]: https://jenkins.mono-project.com/view/Xamarin.Android/job/Java.Interop/261/