### PR TITLE
Remove armeabi from build.

### DIFF
--- a/src/Android.Interop/Tests/Android.Interop-Tests.csproj
+++ b/src/Android.Interop/Tests/Android.Interop-Tests.csproj
@@ -122,7 +122,6 @@
     </AndroidJavaLibrary>
   </ItemGroup>
   <ItemGroup>
-    <AndroidNativeLibrary Include="libs\armeabi\libNativeTiming.so" />
     <AndroidNativeLibrary Include="libs\armeabi-v7a\libNativeTiming.so" />
     <AndroidNativeLibrary Include="libs\x86\libNativeTiming.so" />
   </ItemGroup>

--- a/src/Android.Interop/Tests/jni/Application.mk
+++ b/src/Android.Interop/Tests/jni/Application.mk
@@ -1,2 +1,2 @@
 # Build both ARMv5TE and ARMv7-A machine code.
-APP_ABI := arm64-v8a armeabi armeabi-v7a x86 x86_64
+APP_ABI := arm64-v8a armeabi-v7a x86 x86_64


### PR DESCRIPTION
Starting with Android NDK r17, armeabi is *removed*, meaning that we
cannot build anything with armeabi anymore.

xamarin-android changes will follow.