### PR TITLE
[tests] Export JI_JVM_PATH in NUnit tests

### DIFF
--- a/build-tools/scripts/RunNUnitTests.targets
+++ b/build-tools/scripts/RunNUnitTests.targets
@@ -8,6 +8,10 @@
     <_NUnit>$(_Runtime) packages\NUnit.ConsoleRunner.3.7.0\tools\nunit3-console.exe</_NUnit>
     <_Run Condition=" '$(RUN)' != '' ">--run=&quot;$(RUN)&quot;</_Run>
   </PropertyGroup>
+  <Import
+      Condition=" Exists('..\..\bin\Build$(Configuration)\JdkInfo.props') "
+      Project="..\..\bin\Build$(Configuration)\JdkInfo.props"
+  />
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Java.Interop.BootstrapTasks.dll" TaskName="Java.Interop.BootstrapTasks.SetEnvironmentVariable" />
   <ItemGroup>
     <_TestAssembly Include="$(_TopDir)\bin\Test$(Configuration)\*-*Tests.dll" Condition=" '$(TestAssembly)' == '' " />
@@ -27,6 +31,7 @@
     <SetEnvironmentVariable Name="MONO_TRACE_LISTENER"   Value="Console.Out" />
     <SetEnvironmentVariable Name="JAVA_INTEROP_GREF_LOG" Value="bin\Test$(Configuration)\g-%(_TestAssembly.Filename).txt" />
     <SetEnvironmentVariable Name="JAVA_INTEROP_LREF_LOG" Value="bin\Test$(Configuration)\l-%(_TestAssembly.Filename).txt" />
+    <SetEnvironmentVariable Name="JI_JVM_PATH"           Value="$(JdkJvmPath)" />
     <Exec
         Command="$(_NUnit) $(NUNIT_EXTRA) %(_TestAssembly.Identity) $(_Run) --result=&quot;TestResult-%(Filename).xml;format=nunit2&quot; --output=&quot;bin\Test$(Configuration)\TestOutput-%(Filename).txt&quot;"
         WorkingDirectory="$(_TopDir)"


### PR DESCRIPTION
Context: https://jenkins.mono-project.com/job/xamarin-android-pr-builder/3640/

Commit d1cce190 broke unit test execution within xamarin-android,
as d1cce190 requires that the path to `jvm.dll` be specified within
the `$JI_JVM_PATH` environment variable, but `RunNUnitTests.targets`
never set or exported that environment variable.

The result is that `$JI_JVM_PATH` wasn't set, causing tests to fail:

	OneTimeSetUp: System.TypeInitializationException : The type initializer for 'Java.InteropTests.JavaVMFixture' threw an exception.
	----> System.NotSupportedException : The JDK supports creating at most one JVM per process, ever; do you have a JVM running already, or have you already created (and destroyed?) one? (JNI_CreateJavaVM returned -1002).

Code -1002 is `JAVA_INTEROP_JVM_FAILED_NOT_LOADED`, because it wasn't
specified and couldn't be found.

Update `RunNUnitTests.targets` so that `$JI_JVM_PATH` is exported,
allowing `jvm.dll` to be found, in turn allowing unit tests to run.