### PR TITLE
[jnimarshalmethod-gen] Fix multiple assemblies processing

### DIFF
--- a/tools/jnimarshalmethod-gen/TypeMover.cs
+++ b/tools/jnimarshalmethod-gen/TypeMover.cs
@@ -36,6 +36,9 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator
 		{
 			int movedTypesCount = 0;
 
+			typeMap.Clear ();
+			resolvedTypeMap.Clear ();
+
 			foreach (var type in Types.Values) {
 				Move (type);
 				movedTypesCount++;
@@ -327,7 +330,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator
 
 				if (App.Debug) {
 					newInstructions.Add (Instruction.Create (OpCodes.Ldstr, $"Registering JNI marshal methods in {opStr}"));
-					newInstructions.Add (Instruction.Create (OpCodes.Call, consoleWriteLine));
+					newInstructions.Add (Instruction.Create (OpCodes.Call, module.ImportReference (consoleWriteLine)));
 				}
 
 				return true;


### PR DESCRIPTION
Clear the type caches between moving types in multiple
assemblies. (note to myself, in case we want to process and move
multiple assemblies in parallel, we would need to make the caches per
TypeMover instance)

Also fix debug prints, where `Console::WriteLine (...)` reference
needs to be imported.