### PR TITLE
[jnimarshalmethod-gen] Add -p|--profile option

### DIFF
--- a/tools/jnimarshalmethod-gen/App.cs
+++ b/tools/jnimarshalmethod-gen/App.cs
@@ -132,7 +132,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 					typeNameRegexes.Add (new Regex (line));
 				}
 			} catch (Exception e) {
-				Error ($"Unable to read profile '{profilePath}'.\n{e}");
+				Error ($"Unable to read profile '{profilePath}'.{Environment.NewLine}{e}");
 				Environment.Exit (4);
 			}
 		}
@@ -174,7 +174,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 				try {
 					CreateMarshalMethodAssembly (assembly);
 				} catch (Exception e) {
-					Error ($"Unable to process assembly '{assembly}'\n{e.Message}\n{e}");
+					Error ($"Unable to process assembly '{assembly}'{Environment.NewLine}{e.Message}{Environment.NewLine}{e}");
 					Environment.Exit (1);
 				}
 			}
@@ -189,7 +189,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 			try {
 				builder.CreateJreVM ();
 			} catch (Exception e) {
-				Error ($"Unable to create Java VM\n{e}");
+				Error ($"Unable to create Java VM{Environment.NewLine}{e}");
 				Environment.Exit (3);
 			}
 		}

--- a/tools/jnimarshalmethod-gen/App.cs
+++ b/tools/jnimarshalmethod-gen/App.cs
@@ -94,7 +94,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 				  "Show this message and exit",
 				  v => help = v != null },
 				{ "p|profile=",
-					"Generate marshaling methods only for types whose names match regex patterns listed in the {PROFILE} file. One pattern per line. Empty lines and lines starting with '#' character are ignored (comments).",
+				  "Generate marshaling methods only for types whose names match regex patterns listed in the {PROFILE} file. One pattern per line. Empty lines and lines starting with '#' character are ignored (comments).",
 				  v => LoadProfile (v) },
 				{ "t|type=",
 				  "Generate marshaling methods only for types whose names match {TYPE-REGEX}.",

--- a/tools/jnimarshalmethod-gen/App.cs
+++ b/tools/jnimarshalmethod-gen/App.cs
@@ -93,9 +93,11 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 				{ "h|help|?",
 				  "Show this message and exit",
 				  v => help = v != null },
-				{ "p|profile=",
-				  "Generate marshaling methods only for types whose names match regex patterns listed in the {PROFILE} file. One pattern per line. Empty lines and lines starting with '#' character are ignored (comments).",
-				  v => LoadProfile (v) },
+				{ "types=",
+				  "Generate marshaling methods only for types whose names match regex patterns listed {FILE}.\n" +
+				  "One regex pattern per line.\n" +
+				  "Empty lines and lines starting with '#' character are ignored as comments.",
+				  v => LoadTypes (v) },
 				{ "t|type=",
 				  "Generate marshaling methods only for types whose names match {TYPE-REGEX}.",
 				  v => typeNameRegexes.Add (new Regex (v)) },
@@ -119,10 +121,10 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 			return assemblies;
 		}
 
-		void LoadProfile (string profilePath)
+		void LoadTypes (string typesPath)
 		{
 			try {
-				foreach (var line in File.ReadLines (profilePath)) {
+				foreach (var line in File.ReadLines (typesPath)) {
 					if (string.IsNullOrWhiteSpace (line))
 						continue;
 
@@ -132,7 +134,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 					typeNameRegexes.Add (new Regex (line));
 				}
 			} catch (Exception e) {
-				Error ($"Unable to read profile '{profilePath}'.{Environment.NewLine}{e}");
+				Error ($"Unable to read profile '{typesPath}'.{Environment.NewLine}{e}");
 				Environment.Exit (4);
 			}
 		}

--- a/tools/jnimarshalmethod-gen/App.cs
+++ b/tools/jnimarshalmethod-gen/App.cs
@@ -93,6 +93,9 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 				{ "h|help|?",
 				  "Show this message and exit",
 				  v => help = v != null },
+				{ "p|profile=",
+					"Generate marshaling methods only for types whose names match regex patterns listed in the {PROFILE} file. One pattern per line. Empty lines and lines starting with '#' character are ignored (comments).",
+				  v => LoadProfile (v) },
 				{ "t|type=",
 				  "Generate marshaling methods only for types whose names match {TYPE-REGEX}.",
 				  v => typeNameRegexes.Add (new Regex (v)) },
@@ -114,6 +117,24 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 			}
 
 			return assemblies;
+		}
+
+		void LoadProfile (string profilePath)
+		{
+			try {
+				foreach (var line in File.ReadLines (profilePath)) {
+					if (string.IsNullOrWhiteSpace (line))
+						continue;
+
+					if (line [0] == '#')
+						continue;
+
+					typeNameRegexes.Add (new Regex (line));
+				}
+			} catch (Exception e) {
+				Error ($"Unable to read profile '{profilePath}'.\n{e}");
+				Environment.Exit (4);
+			}
 		}
 
 		void ProcessAssemblies (List<string> assemblies)


### PR DESCRIPTION
The new option allows to specify which types are processed by a
*profile* with the list of types (regex patterns) to process.

It is similar to specify multiple `-t` options.