### PR TITLE
[build] option for Java.Interop to be built as non-PCL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ packages
 *.userprefs
 *.user
 Resource.designer.cs
+*.binlog

--- a/src/Java.Interop/Java.Interop.Net45.props
+++ b/src/Java.Interop/Java.Interop.Net45.props
@@ -1,0 +1,20 @@
+<Project>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <NoStdLib>true</NoStdLib>
+  </PropertyGroup>
+  <ItemGroup Condition=" '$(XAInstallPrefix)' != '' ">
+    <Reference Include="mscorlib">
+      <HintPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\v1.0\mscorlib.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System">
+      <HintPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\v1.0\System.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System.Core">
+      <HintPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\v1.0\System.Core.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+  </ItemGroup>
+</Project>

--- a/src/Java.Interop/Java.Interop.Net45.props
+++ b/src/Java.Interop/Java.Interop.Net45.props
@@ -1,8 +1,9 @@
 <Project>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <NoStdLib>true</NoStdLib>
+    <NoStdLib Condition=" '$(XAInstallPrefix)' != '' ">true</NoStdLib>
+    <OutputPath>..\..\bin\$(Configuration)Net45</OutputPath>
   </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup Condition=" '$(XAInstallPrefix)' != '' ">
     <Reference Include="mscorlib">
       <HintPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\v1.0\mscorlib.dll</HintPath>
@@ -16,5 +17,10 @@
       <HintPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\v1.0\System.Core.dll</HintPath>
       <Private>False</Private>
     </Reference>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(XAInstallPrefix)' == '' ">
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
   </ItemGroup>
 </Project>

--- a/src/Java.Interop/Java.Interop.Net45.props
+++ b/src/Java.Interop/Java.Interop.Net45.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <NoStdLib Condition=" '$(XAInstallPrefix)' != '' ">true</NoStdLib>
     <OutputPath>..\..\bin\$(Configuration)Net45</OutputPath>
+    <DocumentationFile>$(OutputPath)\Java.Interop.xml</DocumentationFile>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup Condition=" '$(XAInstallPrefix)' != '' ">

--- a/src/Java.Interop/Java.Interop.PCL.props
+++ b/src/Java.Interop/Java.Interop.PCL.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+</Project>

--- a/src/Java.Interop/Java.Interop.csproj
+++ b/src/Java.Interop/Java.Interop.csproj
@@ -129,7 +129,6 @@
     <CompileJavaInteropJar Include="java\com\xamarin\java_interop\ManagedPeer.java" />
   </ItemGroup>
   <Import Project="..\..\Configuration.props" />
-  <Import Project="$(JNIEnvGenPath)\JdkInfo.props" />
   <Import Project="Java.Interop.PCL.props"   Condition=" '$(JavaInteropProfile)' != 'net45' " />
   <Import Project="Java.Interop.Net45.props" Condition=" '$(JavaInteropProfile)' == 'net45' " />
   <Import Project="Java.Interop.targets" />

--- a/src/Java.Interop/Java.Interop.csproj
+++ b/src/Java.Interop/Java.Interop.csproj
@@ -10,7 +10,6 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Java.Interop</RootNamespace>
     <AssemblyName>Java.Interop</AssemblyName>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <NoWarn>1591</NoWarn>
     <SignAssembly>true</SignAssembly>
@@ -129,7 +128,10 @@
     <CompileJavaInteropJar Include="java\com\xamarin\java_interop\GCUserPeerable.java" />
     <CompileJavaInteropJar Include="java\com\xamarin\java_interop\ManagedPeer.java" />
   </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+  <Import Project="..\..\Configuration.props" />
+  <Import Project="$(JNIEnvGenPath)\JdkInfo.props" />
+  <Import Project="Java.Interop.PCL.props"   Condition=" '$(JavaInteropProfile)' != 'net45' " />
+  <Import Project="Java.Interop.Net45.props" Condition=" '$(JavaInteropProfile)' == 'net45' " />
   <Import Project="Java.Interop.targets" />
   <PropertyGroup>
     <BuildDependsOn>

--- a/src/Java.Interop/Java.Interop.targets
+++ b/src/Java.Interop/Java.Interop.targets
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <Runtime Condition="'$(OS)' != 'Windows_NT'">mono</Runtime>
   </PropertyGroup>
-  <Import Project="$(JNIEnvGenPath)\JdkInfo.props" />
   <Target Name="BuildJnienvGen"
       Inputs="..\..\build-tools\jnienv-gen\jnienv-gen.csproj"
       Outputs="$(JNIEnvGenPath)\jnienv-gen.exe">


### PR DESCRIPTION
Fixes: http://work.devdiv.io/667174

When building a "Hello World" Xamarin.Android app, I noticed the
following in the build log:

    Adding assembly reference for Java.Interop, Version=0.1.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065, recursively...
        Adding assembly reference for System.Runtime, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
        Adding assembly reference for System.ComponentModel.Composition, Version=2.0.5.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, recursively...
        Adding assembly reference for System.Diagnostics.Debug, Version=4.0.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
        Adding assembly reference for System.Threading, Version=4.0.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
        Adding assembly reference for System.Collections, Version=4.0.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
        Adding assembly reference for System.Collections.Concurrent, Version=4.0.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
        Adding assembly reference for System.Reflection, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
        Adding assembly reference for System.Linq.Expressions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
        Adding assembly reference for System.Reflection.Primitives, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
        Adding assembly reference for System.Dynamic.Runtime, Version=4.0.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
        Adding assembly reference for System.ObjectModel, Version=4.0.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
        Adding assembly reference for System.Linq, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
        Adding assembly reference for System.Runtime.InteropServices, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
        Adding assembly reference for System.Runtime.Extensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
        Adding assembly reference for System.Reflection.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, recursively...
    Adding assembly reference for Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065, recursively...

It appears that Java.Interop is a PCL, and we end up having to work
with lots of facade assemblies during our build!

My thought is that we should build `Java.Interop.dll` the same as
`Mono.Android.dll`:

    <PropertyGroup>
        <NoStdLib>true</NoStdLib>
    </PropertyGroup>
    <ItemGroup>
        <Reference Include="mscorlib">
            <HintPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\v1.0\mscorlib.dll</HintPath>
            <Private>False</Private>
        </Reference>
        <Reference Include="System">
            <HintPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\v1.0\System.dll</HintPath>
            <Private>False</Private>
        </Reference>
        <Reference Include="System.Core">
            <HintPath>$(XAInstallPrefix)xbuild-frameworks\MonoAndroid\v1.0\System.Core.dll</HintPath>
            <Private>False</Private>
        </Reference>
    </ItemGroup>

I added a new property, `$(JavaInteropProfile)` we can set downstream
in Xamarin.Android. We can set this with a
`Configuration.Override.props` file that is already used in
Xamarin.Android's build process.

After doing this, the log now reads:

     Adding assembly reference for Java.Interop, Version=0.1.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065, recursively...
     Adding assembly reference for Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065, recursively...

And the savings in build times for "Hello World", this is the
`Rebuild` target:
- `Debug` + PCL - 8.424s
- `Release` + PCL - 13.651s
- `Debug` + *not* PCL - 4.258s
- `Release` + *not* PCL - 9.487s

That does bring up a big question, however...

### Why are facade assemblies adding so much build time???

This change is good: making `Java.Interop` have fewer dependencies.
But I suspect there is more work to be done downstream in
Xamarin.Android. I have a feeling referencing `netstandard` libraries
cause the same problem to occur.