### PR TITLE
[Java.Interop] allow $(TargetFrameworkVersion) to be passed in

### DIFF
--- a/src/Java.Interop/Java.Interop.csproj
+++ b/src/Java.Interop/Java.Interop.csproj
@@ -10,7 +10,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Java.Interop</RootNamespace>
     <AssemblyName>Java.Interop</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition=" '$(TargetFrameworkVersion)' == '' ">v4.5</TargetFrameworkVersion>
     <NoWarn>1591</NoWarn>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/2105#issuecomment-416582929

To build `Java.Interop.csproj` as `MonoAndroid,v1.0`, we need to set
the following properties:

    <PropertyGroup>
        <TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
        <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
        <TargetFrameworkRootPath>$(XAInstallPrefix)xbuild-frameworks</TargetFrameworkRootPath>
    </PropertyGroup>

Currently it looks like `$(TargetFrameworkVersion)` is the only one we
can't modify downstream in `xamarin-android`.