### PR TITLE
[JavaCallableWrappers] Parallel.ForEach per assembly

### DIFF
--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/DirectoryAssemblyResolver.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/DirectoryAssemblyResolver.cs
@@ -29,7 +29,7 @@
 
 using System;
 using System.Diagnostics;
-using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -61,7 +61,7 @@ namespace Java.Interop.Tools.Cecil {
 
 		public ICollection<string> SearchDirectories {get; private set;}
 
-		Dictionary<string, AssemblyDefinition> cache;
+		ConcurrentDictionary<string, AssemblyDefinition> cache;
 		bool loadDebugSymbols;
 		Action<TraceLevel, string>              logger;
 
@@ -82,7 +82,7 @@ namespace Java.Interop.Tools.Cecil {
 		{
 			if (logger == null)
 				throw new ArgumentNullException (nameof (logger));
-			cache = new Dictionary<string, AssemblyDefinition> ();
+			cache = new ConcurrentDictionary<string, AssemblyDefinition> ();
 			this.loadDebugSymbols = loadDebugSymbols;
 			this.logger       = logger;
 			SearchDirectories = new List<string> ();

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers-Tests.csproj
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers-Tests.csproj
@@ -34,6 +34,8 @@
       <HintPath>..\..\..\packages\NUnit.3.7.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression.FileSystem" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Java.Interop.Tools.JavaCallableWrappers\JavaCallableWrapperGeneratorTests.cs" />
@@ -47,6 +49,9 @@
     <Compile Include="Android.Content\ContentProviderAttribute.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="Data\Assemblies.zip">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Since we are looking at every type in each assembly, we can
parallelize this work to make things a bit faster.

However, there are a few concerns when doing this:
- Made sure to add a *new* method `GetJavaTypesInParallel` so the
  caller can opt-in to this
- The `cache` in `DirectoryAssemblyResolver` needs to now be a
  `ConcurrentDictionary`
- The list of `javaTypes` returned by `JavaTypeScanner` needs to also
  use a `BlockingCollection`
- Downstream in `xamarin-android`, we need to make sure
  `GenerateJavaStubs` is now an `AsyncTask`, so the "thread safe"
  logger methods are used.

To time the improvements, I used this project in Xamarin.Forms:
https://github.com/xamarin/Xamarin.Forms/tree/master/Xamarin.Forms.ControlGallery.Android

Before I did anything, the times were:

    2594 ms  GenerateJavaStubs                          2 calls

After making things parallel:

    2143 ms  GenerateJavaStubs                          2 calls

And then after a few more LINQ improvements in the `GenerateJavaStubs`
MSBuild task:

    2104 ms  GenerateJavaStubs                          2 calls

So we have close to a 500ms improvement for `GenerateJavaStubs` in
this project, that will build a library project + application project.

To see the full changes required downstream in `xamarin-android`:
https://github.com/xamarin/xamarin-android/compare/master...jonathanpeppers:generatejavastubs-perf