### PR TITLE
[Java.Interop.BootstrapTasks] <JdkInfo/> requires `include` dir

### DIFF
--- a/build-tools/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks/JdkInfo.cs
+++ b/build-tools/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks/JdkInfo.cs
@@ -42,6 +42,7 @@ namespace Java.Interop.BootstrapTasks
 
 			XATInfo jdk         = XATInfo.GetKnownSystemJdkInfos (CreateLogger ())
 				.Where (j => maxVersion != null ? j.Version <= maxVersion : true)
+				.Where (j => j.IncludePath.Any ())
 				.FirstOrDefault ();
 
 			if (jdk == null) {


### PR DESCRIPTION
The Microsoft OpenJDK package does *not* contain the `includes`
directory, or `jdk.h`, or anything else needed to build native code.
Consequently, it is not useful for *building* Java.Interop.

Update the `<JdkInfo/>` task to require that `JdkInfo.IncludePath`
includes directories.  (We don't currently check that `jdk.h` exists,
but we could do so in the future if necessary.)  This causes the
Microsoft OpenJDK package to be *skipped* during `make prepare`,
causing the Java.Interop build to instead use a "system" JDK
installation which *does* provide the `include` directories.