### PR TITLE
[jnimarshalmethod-gen] Ask cecil to read assemblies to the memory

### DIFF
--- a/tools/jnimarshalmethod-gen/App.cs
+++ b/tools/jnimarshalmethod-gen/App.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 	{
 
 		internal const string Name = "jnimarshalmethod-gen";
-		static DirectoryAssemblyResolver resolver = new DirectoryAssemblyResolver (logger: (l, v) => { Console.WriteLine (v); }, loadDebugSymbols: true, loadReaderParameters: new ReaderParameters () { ReadSymbols = true });
+		static DirectoryAssemblyResolver resolver = new DirectoryAssemblyResolver (logger: (l, v) => { Console.WriteLine (v); }, loadDebugSymbols: true, loadReaderParameters: new ReaderParameters () { ReadSymbols = true, InMemory = true });
 		static Dictionary<string, TypeBuilder> definedTypes = new Dictionary<string, TypeBuilder> ();
 		static Dictionary<string, TypeDefinition> typeMap = new Dictionary<string, TypeDefinition> ();
 		static public bool Debug;
@@ -145,11 +145,13 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 
 			var readWriteParameters    = new ReaderParameters {
 				AssemblyResolver   = resolver,
+				InMemory           = true,
 				ReadSymbols        = true,
 				ReadWrite          = true,
 			};
 			var readWriteParametersNoSymbols    = new ReaderParameters {
 				AssemblyResolver   = resolver,
+				InMemory           = true,
 				ReadSymbols        = false,
 				ReadWrite          = true,
 			};
@@ -347,7 +349,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 				ColorWriteLine ($"Marshal method assembly '{assemblyName}' created", ConsoleColor.Cyan);
 
 			var dstAssembly = resolver.GetAssembly (destPath);
-			var mover = new TypeMover (dstAssembly, ad, definedTypes, resolver);
+			var mover = new TypeMover (dstAssembly, ad, path, definedTypes, resolver);
 			mover.Move ();
 
 			if (!keepTemporary)

--- a/tools/jnimarshalmethod-gen/TypeMover.cs
+++ b/tools/jnimarshalmethod-gen/TypeMover.cs
@@ -13,14 +13,16 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator
 	{
 		AssemblyDefinition Source { get; }
 		AssemblyDefinition Destination { get; }
+		string DestinationPath { get; }
 		Dictionary<string, System.Reflection.Emit.TypeBuilder> Types { get; }
 
 		MethodReference consoleWriteLine;
 
-		public TypeMover (AssemblyDefinition source, AssemblyDefinition destination, Dictionary<string, System.Reflection.Emit.TypeBuilder> types, DirectoryAssemblyResolver resolver)
+		public TypeMover (AssemblyDefinition source, AssemblyDefinition destination, string destinationPath, Dictionary<string, System.Reflection.Emit.TypeBuilder> types, DirectoryAssemblyResolver resolver)
 		{
 			Source = source;
 			Destination = destination;
+			DestinationPath = destinationPath;
 			Types = types;
 
 			if (App.Debug) {
@@ -49,7 +51,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator
 				return;
 			}
 
-			Destination.Write (new WriterParameters () { WriteSymbols = Destination.MainModule.HasSymbols });
+			Destination.Write (DestinationPath, new WriterParameters () { WriteSymbols = Destination.MainModule.HasSymbols });
 
 			if (App.Verbose)
 				App.ColorWriteLine ($"Wrote updated {Destination.MainModule.FileName} assembly", ConsoleColor.Cyan);


### PR DESCRIPTION
That helps to process the assembly faster.

Process `Mono.Android.dll` times:

Before:

    whole       37.34 real        37.29 user         2.04 sys
    types        7.02 real         6.54 user         1.17 sys

After:

    whole       33.84 real        34.99 user         1.01 sys
    types        4.41 real         4.76 user         0.36 sys

Where *whole* means process all types in the assembly and *types*
means use the `--types` option to process only listed types.

The listed types:

    # XA template startup, Mono.Android
    #
    Android.Runtime.UncaughtExceptionHandler
    Java.Interop.TypeManager\+JavaTypeManager
    Android.Views.View\+IOnClickListenerImplementor

    # XForms template, Mono.Android
    #
    Android.Animation.ValueAnimator\+IAnimatorUpdateListenerImplementor
    Java.Lang.Thread\+RunnableImplementor