### PR TITLE
[jnimarshalmethod-gen] Do not use method cache for generic types

### DIFF
--- a/src/Java.Interop.Export/Tests/Java.Interop/ExportTest.cs
+++ b/src/Java.Interop.Export/Tests/Java.Interop/ExportTest.cs
@@ -73,6 +73,16 @@ namespace Java.InteropTests
 		public static void StaticActionIJavaObject (JavaObject test)
 		{
 		}
+
+		[JavaCallable ("staticActionInt", Signature="(I)V")]
+		public static void StaticActionInt (int i)
+		{
+		}
+
+		[JavaCallable ("staticActionFloat", Signature="(F)V")]
+		public static void StaticActionFloat (float f)
+		{
+		}
 	}
 
 	[JniValueMarshaler (typeof (MyColorValueMarshaler))]

--- a/src/Java.Interop.Export/Tests/Java.Interop/MarshalMemberBuilderTest.cs
+++ b/src/Java.Interop.Export/Tests/Java.Interop/MarshalMemberBuilderTest.cs
@@ -22,7 +22,7 @@ namespace Java.InteropTests
 				var methods = CreateBuilder ()
 					.GetExportedMemberRegistrations (typeof (ExportTest))
 					.ToList ();
-				Assert.AreEqual (8, methods.Count);
+				Assert.AreEqual (10, methods.Count);
 
 				Assert.AreEqual ("action",  methods [0].Name);
 				Assert.AreEqual ("()V",     methods [0].Signature);

--- a/src/Java.Interop.Export/Tests/java/com/xamarin/interop/export/ExportType.java
+++ b/src/Java.Interop.Export/Tests/java/com/xamarin/interop/export/ExportType.java
@@ -40,14 +40,19 @@ public class ExportType
 	        throw new Error ("funcInt64() should return 42!");
 
 	    Object o = funcIJavaObject ();
-		if (o != this)
-			throw new Error ("funcIJavaObject() should return `this`!");
+	    if (o != this)
+	        throw new Error ("funcIJavaObject() should return `this`!");
+
+	    staticActionInt (1);
+	    staticActionFloat (2.0f);
 	}
 
 	public native void action ();
 	public native void actionIJavaObject (Object test);
 	public native long funcInt64 ();
 	public native Object funcIJavaObject ();
+	public native void staticActionInt (int i);
+	public native void staticActionFloat (float f);
 
 	ArrayList<Object>       managedReferences     = new ArrayList<Object>();
 

--- a/tools/jnimarshalmethod-gen/TypeMover.cs
+++ b/tools/jnimarshalmethod-gen/TypeMover.cs
@@ -268,7 +268,8 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator
 			foreach (var p in mr.Parameters)
 				p.ParameterType = GetUpdatedType (p.ParameterType, module);
 
-			methodMap [method] = mr;
+			if (method.DeclaringType != null && !method.DeclaringType.HasGenericParameters)
+				methodMap [method] = mr;
 
 			return mr;
 		}


### PR DESCRIPTION
Sometimes we ask for updated method declared in type without
generic parameters set and that led to issue where we ended with
different generic type than we wanted.

So for example in the registration methods we sometime ended with
wrong Action constructor. `Action<IntPtr, IntPtr, IntPtr, Single>`
instead of `Action<IntPtr, IntPtr, int, int>`.

The fixed registration method:

    [JniAddNativeMethodRegistration]
    public static void __RegisterNativeMembers (JniNativeMethodRegistrationArguments args)
    {
    	Console.WriteLine ("Registering JNI marshal methods in Xamarin.Forms.Platform.Android.PlatformRenderer");
    	args.AddRegistrations (new JniNativeMethodRegistration[3] {
    		new JniNativeMethodRegistration ("n_dispatchTouchEvent", "(Landroid/view/MotionEvent;)Z", new Func<IntPtr, IntPtr, IntPtr, bool> (__<$>_jni_marshal_methods.n_dispatchTouchEvent_Landroid_view_MotionEvent_)),
    		new JniNativeMethodRegistration ("n_onLayout", "(ZIIII)V", new Action<IntPtr, IntPtr, bool, int, int, int, int> (__<$>_jni_marshal_methods.n_onLayout_ZIIII)),
    		new JniNativeMethodRegistration ("n_onMeasure", "(II)V", new Action<IntPtr, IntPtr, int, int> (__<$>_jni_marshal_methods.n_onMeasure_II))
    	});
    }

Weird exception we were running into during Xamarin.Forms app runtime:

    System.InvalidProgramException: Invalid IL code in (wrapper native-to-managed) Xamarin.Forms.Platform.Android.PlatformRenderer/__<$>_jni_marshal_methods:n_onMeasure_II (intptr,intptr,intptr,single): IL_0023: call      0x00000004
      at (wrapper managed-to-native) System.Object.__icall_wrapper_mono_delegate_to_ftnptr(object)
      at (wrapper managed-to-native) Java.Interop.NativeMethods.java_interop_jnienv_register_natives(intptr,intptr&,intptr,Java.Interop.JniNativeMethodRegistration[],int)
      at Java.Interop.JniEnvironment+Types._RegisterNatives (Java.Interop.JniObjectReference type, Java.Interop.JniNativeMethodRegistration[] methods, System.Int32 numMethods) [0x00027] in <b12c3733cbeb4ac09055ec1fd016b201>:0 
      at Java.Interop.JniEnvironment+Types.RegisterNatives (Java.Interop.JniObjectReference type, Java.Interop.JniNativeMethodRegistration[] methods, System.Int32 numMethods) [0x00000] in <b12c3733cbeb4ac09055ec1fd016b201>:0 
      at Java.Interop.JniType.RegisterNativeMethods (Java.Interop.JniNativeMethodRegistration[] methods) [0x0001a] in <b12c3733cbeb4ac09055ec1fd016b201>:0 
      at Android.Runtime.AndroidTypeManager.FastRegisterNativeMembers (Java.Interop.JniType nativeClass, System.Type type, System.String methods) [0x0005a] in <bd52f0ac5c8f48f2adce67d8c85501dd>:0 
      at Android.Runtime.AndroidTypeManager.RegisterNativeMembers (Java.Interop.JniType jniType, System.Type type, System.String methods) [0x00000] in <bd52f0ac5c8f48f2adce67d8c85501dd>:0 
      at Android.Runtime.JNIEnv.RegisterJniNatives (System.IntPtr typeName_ptr, System.Int32 typeName_len, System.IntPtr jniClass, System.IntPtr methods_ptr, System.Int32 methods_len) [0x00115] in <bd52f0ac5c8f48f2adce67d8c85501dd>:0 
      at (wrapper managed-to-native) Java.Interop.NativeMethods.java_interop_jnienv_alloc_object(intptr,intptr&,intptr)
      at Java.Interop.JniEnvironment+Object.AllocObject (Java.Interop.JniObjectReference type) [0x00027] in <b12c3733cbeb4ac09055ec1fd016b201>:0 
      at Java.Interop.JniType.AllocObject () [0x0000c] in <b12c3733cbeb4ac09055ec1fd016b201>:0 
      at Java.Interop.JniPeerMembers+JniInstanceMethods.StartCreateInstance (System.String constructorSignature, System.Type declaringType, Java.Interop.JniArgumentValue* parameters) [0x00044] in <b12c3733cbeb4ac09055ec1fd016b201>:0 
      at Android.Views.ViewGroup..ctor (Android.Content.Context context) [0x0005b] in <bd52f0ac5c8f48f2adce67d8c85501dd>:0 
      at Xamarin.Forms.Platform.Android.PlatformRenderer..ctor (Android.Content.Context context, Xamarin.Forms.Platform.Android.IPlatformLayout canvas) [0x00000] in <7999cc4bd5664eca8a72469344172ca3>:0 
      at Xamarin.Forms.Platform.Android.AppCompat.Platform..ctor (Android.Content.Context context) [0x00018] in <7999cc4bd5664eca8a72469344172ca3>:0 
      at Xamarin.Forms.Platform.Android.FormsAppCompatActivity.InternalSetPage (Xamarin.Forms.Page page) [0x0002d] in <7999cc4bd5664eca8a72469344172ca3>:0 
      at Xamarin.Forms.Platform.Android.FormsAppCompatActivity.SetMainPage () [0x0000c] in <7999cc4bd5664eca8a72469344172ca3>:0 
      at Xamarin.Forms.Platform.Android.FormsAppCompatActivity.LoadApplication (Xamarin.Forms.Application application) [0x0026f] in <7999cc4bd5664eca8a72469344172ca3>:0 
      at Xamarin.Forms.Performance.Integration.Droid.MainActivity.OnCreate (Android.OS.Bundle bundle) [0x0003a] in <dfbc1ae60774476dbd1bd027d3872ce2>:0 
      at Xamarin.Forms.Performance.Integration.Droid.MainActivity+__<$>_jni_marshal_methods.n_onCreate_Landroid_os_Bundle_ (System.IntPtr __jnienv, System.IntPtr __this, System.IntPtr bundle) [0x0002b] in <dfbc1ae60774476dbd1bd027d3872ce2>:0 
