### PR TITLE
[Java.Interop] Do not dispose live references on return to JNI

### DIFF
--- a/src/Java.Interop.Export/Tests/Java.Interop/MarshalMemberBuilderTest.cs
+++ b/src/Java.Interop.Export/Tests/Java.Interop/MarshalMemberBuilderTest.cs
@@ -477,14 +477,6 @@ namespace Java.InteropTests
 	}
 	finally
 	{
-		if (null != __mret)
-		{
-			__mret.DisposeUnlessReferenced();
-		}
-		else
-		{
-			default(void);
-		}
 		__envp.Dispose();
 	}
 }");

--- a/src/Java.Interop.Export/Tests/Java.Interop/MarshalMemberBuilderTest.cs
+++ b/src/Java.Interop.Export/Tests/Java.Interop/MarshalMemberBuilderTest.cs
@@ -449,7 +449,6 @@ namespace Java.InteropTests
 	JavaObject __mret;
 	ExportTest __this_val;
 	JniObjectReference __mret_ref;
-	IntPtr __mret_handle;
 	IntPtr __mret_rtn;
 
 	__envp = new JniTransition(__jnienv);
@@ -468,7 +467,6 @@ namespace Java.InteropTests
 		{
 			return __mret_ref = __mret.PeerReference;
 		}
-		__mret_handle = __mret_ref.Handle;
 		__mret_rtn = References.NewReturnToJniRef(__mret_ref);
 		return __mret_rtn;
 	}
@@ -479,7 +477,14 @@ namespace Java.InteropTests
 	}
 	finally
 	{
-		JniObjectReference.Dispose(__mret_ref);
+		if (null != __mret)
+		{
+			__mret.DisposeUnlessReferenced();
+		}
+		else
+		{
+			default(void);
+		}
 		__envp.Dispose();
 	}
 }");

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -593,7 +593,7 @@ namespace Java.Interop
 		{
 			var r = CreateIntermediaryExpressionFromManagedExpression (context, sourceValue);
 
-			var h = Expression.Variable (typeof (IntPtr), sourceValue + "_handle");
+			var h = Expression.Variable (typeof (IntPtr), sourceValue.Name + "_handle");
 			context.LocalVariables.Add (h);
 			context.CreationStatements.Add (Expression.Assign (h, Expression.Property (r, "Handle")));
 
@@ -609,12 +609,9 @@ namespace Java.Interop
 						test:       Expression.Equal (Expression.Constant (null), sourceValue),
 						ifTrue:     Expression.Assign (r, Expression.New (typeof (JniObjectReference))),
 						ifFalse:    Expression.Assign (r, Expression.Property (sourceValue, "PeerReference"))));
-
-			if (typeof (IJavaPeerable).GetTypeInfo ().IsAssignableFrom (sourceValue.Type.GetTypeInfo ())) {
-				context.CleanupStatements.Add (Expression.IfThen (
-							test:       Expression.NotEqual (Expression.Constant (null), sourceValue),
-							ifTrue:     Expression.Call (sourceValue, typeof (IJavaPeerable).GetTypeInfo ().GetDeclaredMethod ("DisposeUnlessReferenced"))));
-			}
+			context.CleanupStatements.Add (Expression.IfThen (
+						test:       Expression.NotEqual (Expression.Constant (null), sourceValue),
+						ifTrue:     Expression.Call (sourceValue, typeof (IJavaPeerable).GetTypeInfo ().GetDeclaredMethod ("DisposeUnlessReferenced"))));
 
 			return r;
 		}
@@ -626,7 +623,7 @@ namespace Java.Interop
 
 		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type targetType)
 		{
-			var r   = Expression.Variable (targetType, sourceValue + "_val");
+			var r   = Expression.Variable (targetType, sourceValue.Name + "_val");
 			context.LocalVariables.Add (r);
 			context.CreationStatements.Add (
 					Expression.Assign (r,

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -592,8 +592,6 @@ namespace Java.Interop
 		public override Expression CreateParameterFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize)
 		{
 			var r = CreateIntermediaryExpressionFromManagedExpression (context, sourceValue);
-			context.CleanupStatements.Add (DisposeObjectReference (r));
-
 			var h = Expression.Variable (typeof (IntPtr), sourceValue.Name + "_handle");
 			context.LocalVariables.Add (h);
 			context.CreationStatements.Add (Expression.Assign (h, Expression.Property (r, "Handle")));

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -592,6 +592,7 @@ namespace Java.Interop
 		public override Expression CreateParameterFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize)
 		{
 			var r = CreateIntermediaryExpressionFromManagedExpression (context, sourceValue);
+			context.CleanupStatements.Add (DisposeObjectReference (r));
 
 			var h = Expression.Variable (typeof (IntPtr), sourceValue.Name + "_handle");
 			context.LocalVariables.Add (h);
@@ -609,9 +610,6 @@ namespace Java.Interop
 						test:       Expression.Equal (Expression.Constant (null), sourceValue),
 						ifTrue:     Expression.Assign (r, Expression.New (typeof (JniObjectReference))),
 						ifFalse:    Expression.Assign (r, Expression.Property (sourceValue, "PeerReference"))));
-			context.CleanupStatements.Add (Expression.IfThen (
-						test:       Expression.NotEqual (Expression.Constant (null), sourceValue),
-						ifTrue:     Expression.Call (sourceValue, typeof (IJavaPeerable).GetTypeInfo ().GetDeclaredMethod ("DisposeUnlessReferenced"))));
 
 			return r;
 		}

--- a/src/Java.Interop/Java.Interop/JniValueMarshaler.cs
+++ b/src/Java.Interop/Java.Interop/JniValueMarshaler.cs
@@ -162,7 +162,7 @@ namespace Java.Interop {
 		public  virtual     Expression              CreateReturnValueFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue)
 		{
 			CreateParameterFromManagedExpression (context, sourceValue, 0);
-			var s   = context.LocalVariables [sourceValue + "_state"];
+			var s   = context.LocalVariables [sourceValue.Name + "_state"];
 			return ReturnObjectReferenceToJni (context, sourceValue.Name, Expression.Property (s, "ReferenceValue"));
 		}
 

--- a/src/Java.Interop/Tests/Java.Interop/JniValueMarshalerContractTests.cs
+++ b/src/Java.Interop/Tests/Java.Interop/JniValueMarshalerContractTests.cs
@@ -608,14 +608,7 @@ namespace Java.InteropTests {
 	}}
 	finally
 	{{
-		if (null != __value)
-		{{
-			__value.DisposeUnlessReferenced();
-		}}
-		else
-		{{
-			default(void);
-		}}
+		default(void);
 	}}
 }}";
 		}

--- a/src/Java.Interop/Tests/Java.Interop/JniValueMarshalerContractTests.cs
+++ b/src/Java.Interop/Tests/Java.Interop/JniValueMarshalerContractTests.cs
@@ -591,7 +591,6 @@ namespace Java.InteropTests {
 	JniRuntime {jvm};
 	IJavaPeerable {value};
 	JniObjectReference {value}_ref;
-	IntPtr {value}_handle;
 	IntPtr {value}_rtn;
 
 	try
@@ -604,13 +603,19 @@ namespace Java.InteropTests {
 		{{
 			return {value}_ref = {value}.PeerReference;
 		}}
-		{value}_handle = {value}_ref.Handle;
 		{value}_rtn = References.NewReturnToJniRef({value}_ref);
 		return {pret.Name};
 	}}
 	finally
 	{{
-		JniObjectReference.Dispose({value}_ref);
+		if (null != __value)
+		{{
+			__value.DisposeUnlessReferenced();
+		}}
+		else
+		{{
+			default(void);
+		}}
 	}}
 }}";
 		}


### PR DESCRIPTION
Fixes https://github.com/xamarin/java.interop/issues/374

Also refactor the code generation to not create `_handle` variable
when returning value to JNI

Example generated marshal method:

    using Android.OS;
    using Android.Views;
    using Java.Interop;
    using System;

    public static IntPtr n_onCreateView_Landroid_view_LayoutInflater_Landroid_view_ViewGroup_Landroid_os_Bundle_ (IntPtr __jnienv, IntPtr __this, IntPtr inflater, IntPtr container, IntPtr savedInstanceState)
    {
    	JniTransition jniTransition = new JniTransition (__jnienv);
    	JniRuntime runtime = default(JniRuntime);
    	global::Android.Views.View view = default(global::Android.Views.View);
    	try {
    		runtime = JniEnvironment.Runtime;
    		JniRuntime.JniValueManager valueManager = runtime.ValueManager;
    		valueManager.WaitForGCBridgeProcessing ();
    		FragmentContainer value = valueManager.GetValue<FragmentContainer> (__this);
    		LayoutInflater value2 = valueManager.GetValue<LayoutInflater> (inflater);
    		ViewGroup value3 = valueManager.GetValue<ViewGroup> (container);
    		Bundle value4 = valueManager.GetValue<Bundle> (savedInstanceState);
    		view = value.OnCreateView (value2, value3, value4);
    		JniObjectReference value5 = (view != null) ? view.PeerReference : default(JniObjectReference);
    		return JniEnvironment.References.NewReturnToJniRef (value5);
    	} catch (Exception ex) when (runtime.ExceptionShouldTransitionToJni (ex)) {
    		jniTransition.SetPendingException (ex);
    		return default(IntPtr);
    	} finally {
    		if (view != null) {
    			((IJavaPeerable)view).DisposeUnlessReferenced ();
    		}
    		jniTransition.Dispose ();
    	}
    	IntPtr intPtr = default(IntPtr);
    	return intPtr;
    }