### PR TITLE
[jnimarshalmethod-gen] Use absolute path when loading assemblies

### DIFF
--- a/tools/jnimarshalmethod-gen/App.cs
+++ b/tools/jnimarshalmethod-gen/App.cs
@@ -223,7 +223,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 
 		void CreateMarshalMethodAssembly (string path)
 		{
-			var assembly        = Assembly.LoadFile (path);
+			var assembly        = Assembly.LoadFile (Path.GetFullPath (path));
 
 			var baseName        = Path.GetFileNameWithoutExtension (path);
 			var assemblyName    = new AssemblyName (baseName + "-JniMarshalMethods");


### PR DESCRIPTION
We should use absolute path when loading assemblies through
`System.Reflection.Assembly:LoadFile`.

The documentation of the `LoadFile` method
indeed lists the `ArgumentException` with *The path argument is not an
absolute path.* message. So it looks like mono got more strict after
the latest 2018-06 bump.

The exception we get after mono-2018-06 bump in XA:

    Absolute path information is required. (TaskId:3132)
    Parameter name: assemblyFile (TaskId:3132)
    System.ArgumentException: Absolute path information is required. (TaskId:3132)
    Parameter name: assemblyFile (TaskId:3132)
      at (wrapper managed-to-native) System.Reflection.Assembly.LoadFile_internal(string) (TaskId:3132)
      at System.Reflection.Assembly.LoadFile (System.String path, System.Security.Policy.Evidence securityEvidence) [0x0002b] in <62cb6427b15944208d28cba011a5bb1a>:0  (TaskId:3132)
      at System.Reflection.Assembly.LoadFile (System.String path) [0x00000] in <62cb6427b15944208d28cba011a5bb1a>:0  (TaskId:3132)
      at Xamarin.Android.Tools.JniMarshalMethodGenerator.App.CreateMarshalMethodAssembly (System.String path) [0x00000] in <a2ae64d118584c46aead2fae423791fb>:0  (TaskId:3132)
      at Xamarin.Android.Tools.JniMarshalMethodGenerator.App.ProcessAssemblies (System.Collections.Generic.List`1[T] assemblies) [0x0010a] in <a2ae64d118584c46aead2fae423791fb>:0  (TaskId:3132)