### PR TITLE
[build] Remove warnings

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -24,6 +24,12 @@
     <XamarinAndroidToolsDirectory   Condition=" '$(XamarinAndroidToolsDirectory)' == '' ">$(MSBuildThisFileDirectory)external\xamarin-android-tools</XamarinAndroidToolsDirectory>
   </PropertyGroup>
   <PropertyGroup>
+    <JavacSourceVersion Condition=" '$(JavacSourceVersion)' == '' ">1.6</JavacSourceVersion>
+    <JavacTargetVersion Condition=" '$(JavacTargetVersion)' == '' ">1.6</JavacTargetVersion>
+    <JreRtJarPath Condition=" '$(JreRtJarPath)' == '' And '$(JavaCPath)' != '' ">$([System.IO.Path]::GetDirectoryName('$(JavaCPath)'))\..\jre\lib\rt.jar</JreRtJarPath>
+    <_JavacSourceOptions>-source $(JavacSourceVersion) -target $(JavacTargetVersion) -bootclasspath "$(JreRtJarPath)"</_JavacSourceOptions>
+  </PropertyGroup>
+  <PropertyGroup>
     <CecilFullPath>$([System.IO.Path]::GetFullPath ('$(CecilSourceDirectory)'))</CecilFullPath>
     <XamarinAndroidToolsFullPath>$([System.IO.Path]::GetFullPath ('$(XamarinAndroidToolsDirectory)'))</XamarinAndroidToolsFullPath>
   </PropertyGroup>

--- a/src/Java.Interop.Export/Tests/Export-Tests.projitems
+++ b/src/Java.Interop.Export/Tests/Export-Tests.projitems
@@ -13,12 +13,5 @@
     <Compile Include="$(MSBuildThisFileDirectory)Java.Interop\ExportTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Java.Interop\MarshalMemberBuilderTest.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <JavaExportTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\export\ExportType.java" />
-  </ItemGroup>
-  <Target Name="BuildExportTestJar" Inputs="@(JavaExportTestJar)" Outputs="$(OutputPath)export-test.jar">
-    <MakeDir Directories="$(IntermediateOutputPath)et-classes" />
-    <Exec Command="&quot;$(JavaCPath)&quot; -classpath &quot;$(OutputPath)..\$(Configuration)\java-interop.jar&quot; -source 1.5 -target 1.6 -d &quot;$(IntermediateOutputPath)et-classes&quot; @(JavaExportTestJar -&gt; '%(Identity)', ' ')" />
-    <Exec Command="&quot;$(JarPath)&quot; cf &quot;$(OutputPath)export-test.jar&quot; -C &quot;$(IntermediateOutputPath)et-classes&quot; ." />
-  </Target>
+  <Import Project="$(MSBuildThisFileDirectory)Export-Tests.targets" />
 </Project>

--- a/src/Java.Interop.Export/Tests/Export-Tests.targets
+++ b/src/Java.Interop.Export/Tests/Export-Tests.targets
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <JavaExportTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\export\ExportType.java" />
+  </ItemGroup>
+  <Target Name="BuildExportTestJar"
+      Inputs="@(JavaExportTestJar)"
+      Outputs="$(OutputPath)export-test.jar">
+    <MakeDir Directories="$(IntermediateOutputPath)et-classes" />
+    <Exec
+        Command="&quot;$(JavaCPath)&quot; -classpath &quot;$(OutputPath)..\$(Configuration)\java-interop.jar&quot; $(_JavacSourceOptions) -d &quot;$(IntermediateOutputPath)et-classes&quot; @(JavaExportTestJar->'%(Identity)', ' ')"
+    />
+    <Exec
+        Command="&quot;$(JarPath)&quot; cf &quot;$(OutputPath)export-test.jar&quot; -C &quot;$(IntermediateOutputPath)et-classes&quot; ."
+    />
+  </Target>
+</Project>

--- a/src/Java.Interop.NamingCustomAttributes/Java.Interop/IJniNameProviderAttribute.cs
+++ b/src/Java.Interop.NamingCustomAttributes/Java.Interop/IJniNameProviderAttribute.cs
@@ -1,7 +1,10 @@
 ﻿using System;
 namespace Java.Interop
 {
-	public interface IJniNameProviderAttribute
+#if !JCW_ONLY_TYPE_NAMES
+	public
+#endif  // !JCW_ONLY_TYPE_NAMES
+	interface IJniNameProviderAttribute
 	{
 		string Name { get; }
 	}

--- a/src/Java.Interop/Java.Interop.targets
+++ b/src/Java.Interop/Java.Interop.targets
@@ -22,7 +22,7 @@
       Inputs="@(CompileJavaInteropJar)"
       Outputs="$(OutputPath)java-interop.jar">
     <MakeDir Directories="$(OutputPath);$(IntermediateOutputPath)ji-classes" />
-    <Exec Command="&quot;$(JavaCPath)&quot; -source 1.5 -target 1.6 -d &quot;$(IntermediateOutputPath)ji-classes&quot; @(CompileJavaInteropJar -&gt; '%(Identity)', ' ')" />
+    <Exec Command="&quot;$(JavaCPath)&quot; $(_JavacSourceOptions) -d &quot;$(IntermediateOutputPath)ji-classes&quot; @(CompileJavaInteropJar -&gt; '%(Identity)', ' ')" />
     <Exec Command="&quot;$(JarPath)&quot; cf &quot;$(OutputPath)java-interop.jar&quot; -C &quot;$(IntermediateOutputPath)ji-classes&quot; ." />
   </Target>
 </Project>

--- a/src/Java.Interop/Tests/Interop-Tests.projitems
+++ b/src/Java.Interop/Tests/Interop-Tests.projitems
@@ -53,19 +53,5 @@
     <Compile Include="$(MSBuildThisFileDirectory)Java.Interop\JniValueMarshalerAttributeTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Java.Interop\JniValueMarshalerContractTests.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\CrossReferenceBridge.java" />
-    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\CallNonvirtualBase.java" />
-    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\CallNonvirtualDerived.java" />
-    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\CallNonvirtualDerived2.java" />
-    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\CallVirtualFromConstructorBase.java" />
-    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\CallVirtualFromConstructorDerived.java" />
-    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\SelfRegistration.java" />
-    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\TestType.java" />
-  </ItemGroup>
-  <Target Name="BuildInteropTestJar" Inputs="@(JavaInteropTestJar)" Outputs="$(OutputPath)interop-test.jar">
-    <MakeDir Directories="$(IntermediateOutputPath)it-classes" />
-    <Exec Command="&quot;$(JavaCPath)&quot; -source 1.5 -target 1.6 -d &quot;$(IntermediateOutputPath)it-classes&quot; -classpath &quot;$(OutputPath)..\$(Configuration)\java-interop.jar&quot; @(JavaInteropTestJar -&gt; '%(Identity)', ' ')" />
-    <Exec Command="&quot;$(JarPath)&quot; cf &quot;$(OutputPath)interop-test.jar&quot; -C &quot;$(IntermediateOutputPath)it-classes&quot; ." />
-  </Target>
+  <Import Project="$(MSBuildThisFileDirectory)Interop-Tests.targets" />
 </Project>

--- a/src/Java.Interop/Tests/Interop-Tests.targets
+++ b/src/Java.Interop/Tests/Interop-Tests.targets
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\CrossReferenceBridge.java" />
+    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\CallNonvirtualBase.java" />
+    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\CallNonvirtualDerived.java" />
+    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\CallNonvirtualDerived2.java" />
+    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\CallVirtualFromConstructorBase.java" />
+    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\CallVirtualFromConstructorDerived.java" />
+    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\SelfRegistration.java" />
+    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\TestType.java" />
+  </ItemGroup>
+  <Target Name="BuildInteropTestJar"
+      Inputs="@(JavaInteropTestJar)"
+      Outputs="$(OutputPath)interop-test.jar">
+    <MakeDir Directories="$(IntermediateOutputPath)it-classes" />
+    <Exec
+        Command="&quot;$(JavaCPath)&quot; $(_JavacSourceOptions) -d &quot;$(IntermediateOutputPath)it-classes&quot; -classpath &quot;$(OutputPath)..\$(Configuration)\java-interop.jar&quot; @(JavaInteropTestJar->'%(Identity)', ' ')"
+    />
+    <Exec
+        Command="&quot;$(JarPath)&quot; cf &quot;$(OutputPath)interop-test.jar&quot; -C &quot;$(IntermediateOutputPath)it-classes&quot; ."
+    />
+  </Target>
+</Project>

--- a/src/Java.Interop/Tests/Java.Interop/JavaArrayContract.cs
+++ b/src/Java.Interop/Tests/Java.Interop/JavaArrayContract.cs
@@ -12,13 +12,13 @@ namespace Java.InteropTests
 	{
 		int lrefStartCount;
 
-		[TestFixtureSetUp]
+		[OneTimeSetUp]
 		public void StartArrayTests ()
 		{
 			lrefStartCount  = JniEnvironment.LocalReferenceCount;
 		}
 
-		[TestFixtureTearDown]
+		[OneTimeTearDown]
 		public void EndArrayTests ()
 		{
 			int lref    = JniEnvironment.LocalReferenceCount;

--- a/src/Java.Interop/Tests/Java.Interop/JavaObjectArrayTest.cs
+++ b/src/Java.Interop/Tests/Java.Interop/JavaObjectArrayTest.cs
@@ -130,7 +130,7 @@ namespace Java.InteropTests
 
 		int grefStartCount;
 
-		[TestFixtureSetUp]
+		[OneTimeSetUp]
 		public void BeginCheckGlobalRefCount ()
 		{
 			// So that the JavaProxyObject.TypeRef GREF isn't counted.
@@ -139,7 +139,7 @@ namespace Java.InteropTests
 			grefStartCount  = JniEnvironment.Runtime.GlobalReferenceCount;
 		}
 
-		[TestFixtureTearDown]
+		[OneTimeTearDown]
 		public void EndCheckGlobalRefCount ()
 		{
 			int gref    = JniEnvironment.Runtime.GlobalReferenceCount;

--- a/src/Java.Interop/Tests/Java.Interop/TestTypeTests.cs
+++ b/src/Java.Interop/Tests/Java.Interop/TestTypeTests.cs
@@ -12,13 +12,13 @@ namespace Java.InteropTests
 	{
 		int lrefStartCount;
 
-		[TestFixtureSetUp]
+		[OneTimeSetUp]
 		public void StartArrayTests ()
 		{
 			lrefStartCount  = JniEnvironment.LocalReferenceCount;
 		}
 
-		[TestFixtureTearDown]
+		[OneTimeTearDown]
 		public void EndArrayTests ()
 		{
 			int lref    = JniEnvironment.LocalReferenceCount;

--- a/src/Java.Runtime.Environment/Java.Interop/JreRuntime.cs
+++ b/src/Java.Runtime.Environment/Java.Interop/JreRuntime.cs
@@ -26,9 +26,6 @@ namespace Java.Interop {
 
 		internal    List<string>    Options = new List<string> ();
 
-		public  string      JvmLibraryPath              {get; set;}
-
-		public  JniVersion  JniVersion                  {get; set;}
 		public  bool        IgnoreUnrecognizedOptions   {get; set;}
 
 		public  Collection<string>  ClassPath           {get; private set;}

--- a/src/Java.Runtime.Environment/Java.Runtime.Environment.csproj
+++ b/src/Java.Runtime.Environment/Java.Runtime.Environment.csproj
@@ -10,6 +10,8 @@
     <RootNamespace>Java.Interop</RootNamespace>
     <AssemblyName>Java.Runtime.Environment</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/Tests/GenericInheritanceMappingTest.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/Tests/GenericInheritanceMappingTest.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster.Tests
 	{
 		JavaApi api;
 		
-		[TestFixtureSetUp]
+		[OneTimeSetUp]
 		public void SetupFixture ()
 		{
 			api = JavaApiTestHelper.GetLoadedApi ();

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/Tests/JavaApiTest.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/Tests/JavaApiTest.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster.Tests
 	{
 		JavaApi api;
 		
-		[TestFixtureSetUp]
+		[OneTimeSetUp]
 		public void SetupFixture ()
 		{
 			api = JavaApiTestHelper.GetLoadedApi ();

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/Tests/OverrideMarkerTest.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/Tests/OverrideMarkerTest.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster.Tests
 	{
 		JavaApi api;
 		
-		[TestFixtureSetUp]
+		[OneTimeSetUp]
 		public void SetupFixture ()
 		{
 			api = JavaApiTestHelper.GetLoadedApi ();

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/Tests/TypeResolverTest.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/Tests/TypeResolverTest.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster.Tests
 	{
 		JavaApi api;
 		
-		[TestFixtureSetUp]
+		[OneTimeSetUp]
 		public void SetupFixture ()
 		{
 			api = JavaApiTestHelper.GetLoadedApi ();

--- a/src/Xamarin.Android.Tools.Bytecode/AttributeInfo.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/AttributeInfo.cs
@@ -114,7 +114,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 	// http://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.7.3
 	public sealed class CodeAttribute : AttributeInfo {
 
-		public byte[]       Code;
+		public byte[]       ByteCode;
 		public ushort       MaxStack;
 		public ushort       MaxLocals;
 
@@ -133,7 +133,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 			var code        = new byte[code_length];
 			for (int i = 0; i < code.Length; ++i)
 				code [i] = stream.ReadNetworkByte ();
-			Code = code;
+			ByteCode = code;
 
 			var exception_table_length  = stream.ReadNetworkUInt16 ();
 			for (int i = 0; i < exception_table_length; ++i) {
@@ -152,7 +152,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 		public override string ToString ()
 		{
 			var sb = new StringBuilder ("Code(")
-				.Append (Code.Length);
+				.Append (ByteCode.Length);
 			foreach (var attr in Attributes) {
 				sb.Append (", ").Append (attr);
 			}
@@ -236,7 +236,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 			}
 		}
 
-		public IEnumerable<ConstantPoolClassItem> Exceptions {
+		public IEnumerable<ConstantPoolClassItem> CheckedExceptions {
 			get {return exceptions.Select (c => (ConstantPoolClassItem) ConstantPool [c]);}
 		}
 
@@ -244,7 +244,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 		{
 			var sb = new StringBuilder ("Exceptions(");
 			bool first = true;
-			foreach (var e in Exceptions) {
+			foreach (var e in CheckedExceptions) {
 				if (!first)
 					sb.Append (", ");
 				first = false;
@@ -473,13 +473,13 @@ namespace Xamarin.Android.Tools.Bytecode {
 			signatureIndex  = stream.ReadNetworkUInt16 ();
 		}
 
-		public string Signature {
+		public string Value {
 			get {return ((ConstantPoolUtf8Item) ConstantPool [signatureIndex]).Value;}
 		}
 
 		public override string ToString ()
 		{
-			return string.Format ("Signature({0})", Signature);
+			return string.Format ("Signature({0})", Value);
 		}
 	}
 

--- a/src/Xamarin.Android.Tools.Bytecode/ClassFile.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/ClassFile.cs
@@ -104,7 +104,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 				return this.signature;
 			var sig = Attributes.Get<SignatureAttribute> ();
 			return sig != null
-				? (this.signature = new ClassSignature (sig.Signature))
+				? (this.signature = new ClassSignature (sig.Value))
 				: null;
 		}
 

--- a/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
@@ -98,7 +98,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 					return true;
 				}
 			}
-			catch (Exception e) {
+			catch (Exception) {
 				return false;
 			}
 		}

--- a/src/Xamarin.Android.Tools.Bytecode/Fields.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/Fields.cs
@@ -58,7 +58,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 		public string GetSignature ()
 		{
 			var signature   = Attributes.Get<SignatureAttribute> ();
-			return signature != null ? signature.Signature : null;
+			return signature != null ? signature.Value : null;
 		}
 	}
 

--- a/src/Xamarin.Android.Tools.Bytecode/Methods.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/Methods.cs
@@ -180,7 +180,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 			var throws  = new List<TypeInfo> ();
 			foreach (var exceptions in Attributes.Where (a => a.Name == "Exceptions")) {
 				var ex = (ExceptionsAttribute) exceptions;
-				foreach (var t in ex.Exceptions) {
+				foreach (var t in ex.CheckedExceptions) {
 					throws.Add (new TypeInfo (t.Name.Value));
 				}
 			}
@@ -202,7 +202,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 		{
 			var signature = (SignatureAttribute) Attributes.SingleOrDefault (a => a.Name == "Signature");
 			return signature != null
-				? new MethodTypeSignature (signature.Signature)
+				? new MethodTypeSignature (signature.Value)
 				: null;
 		}
 

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj
@@ -56,10 +56,6 @@
     <Compile Include="ExpectedInnerClassInfo.cs" />
     <Compile Include="ParameterFixupTests.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <TestJar Include="java\**\*.java" Exclude="java\java\util\Collection.java" />
-    <TestJarNoParameters Include="java\java\util\Collection.java" />
-  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <BuildDependsOn>
@@ -67,11 +63,7 @@
       $(BuildDependsOn)
     </BuildDependsOn>
   </PropertyGroup>
-  <Target Name="BuildClasses" Inputs="@(TestJar)" Outputs="@(TestJar-&gt;'$(IntermediateOutputPath)classes\%(RecursiveDir)%(Filename).class')">
-    <MakeDir Directories="$(IntermediateOutputPath)classes" />
-    <Exec Command="&quot;$(JavaCPath)&quot; -parameters -source 1.5 -target 1.6 -g -d &quot;$(IntermediateOutputPath)classes&quot; @(TestJar-&gt;'%(Identity)', ' ')" />
-    <Exec Command="&quot;$(JavaCPath)&quot; -source 1.5 -target 1.6 -g -d &quot;$(IntermediateOutputPath)classes&quot; @(TestJarNoParameters-&gt;'%(Identity)', ' ')" />
-  </Target>
+  <Import Project="Xamarin.Android.Tools.Bytecode-Tests.targets" />
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Android.Tools.Bytecode.csproj">
       <Project>{B17475BC-45A2-47A3-B8FC-62F3A0959EE0}</Project>

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/Xamarin.Android.Tools.Bytecode-Tests.targets
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/Xamarin.Android.Tools.Bytecode-Tests.targets
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <TestJar Include="java\**\*.java" Exclude="java\java\util\Collection.java" />
+    <TestJarNoParameters Include="java\java\util\Collection.java" />
+  </ItemGroup>
+  <Target Name="BuildClasses"
+      Inputs="@(TestJar)"
+      Outputs="@(TestJar->'$(IntermediateOutputPath)classes\%(RecursiveDir)%(Filename).class')">
+    <MakeDir Directories="$(IntermediateOutputPath)classes" />
+    <Exec
+        Command="&quot;$(JavaCPath)&quot; -parameters $(_JavacSourceOptions) -g -d &quot;$(IntermediateOutputPath)classes&quot; @(TestJar->'%(Identity)', ' ')"
+    />
+    <Exec
+        Command="&quot;$(JavaCPath)&quot; $(_JavacSourceOptions) -g -d &quot;$(IntermediateOutputPath)classes&quot; @(TestJarNoParameters->'%(Identity)', ' ')"
+    />
+  </Target>
+</Project>

--- a/tests/PerformanceTests/PerformanceTests.projitems
+++ b/tests/PerformanceTests/PerformanceTests.projitems
@@ -13,12 +13,5 @@
     <Compile Include="$(MSBuildThisFileDirectory)JavaTiming.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TimingTests.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <JavaPerformanceTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\performance\JavaTiming.java" />
-  </ItemGroup>
-  <Target Name="BuildPerformanceTestJar" Inputs="@(JavaPerformanceTestJar)" Outputs="$(OutputPath)performance-test.jar">
-    <MakeDir Directories="$(IntermediateOutputPath)pt-classes" />
-    <Exec Command="&quot;$(JavaCPath)&quot; -source 1.5 -target 1.6 -d &quot;$(IntermediateOutputPath)pt-classes&quot; @(JavaPerformanceTestJar -&gt; '%(Identity)', ' ')" />
-    <Exec Command="&quot;$(JarPath)&quot; cf &quot;$(OutputPath)performance-test.jar&quot; -C &quot;$(IntermediateOutputPath)pt-classes&quot; ." />
-  </Target>
+  <Import Project="$(MSBuildThisFileDirectory)PerformanceTests.targets" />
 </Project>

--- a/tests/PerformanceTests/PerformanceTests.targets
+++ b/tests/PerformanceTests/PerformanceTests.targets
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <JavaPerformanceTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\performance\JavaTiming.java" />
+  </ItemGroup>
+  <Target Name="BuildPerformanceTestJar"
+      Inputs="@(JavaPerformanceTestJar)"
+      Outputs="$(OutputPath)performance-test.jar">
+    <MakeDir Directories="$(IntermediateOutputPath)pt-classes" />
+    <Exec
+        Command="&quot;$(JavaCPath)&quot; $(_JavacSourceOptions) -d &quot;$(IntermediateOutputPath)pt-classes&quot; @(JavaPerformanceTestJar->'%(Identity)', ' ')"
+    />
+    <Exec
+        Command="&quot;$(JarPath)&quot; cf &quot;$(OutputPath)performance-test.jar&quot; -C &quot;$(IntermediateOutputPath)pt-classes&quot; ."
+    />
+  </Target>
+</Project>

--- a/tests/PerformanceTests/TimingTests.cs
+++ b/tests/PerformanceTests/TimingTests.cs
@@ -448,8 +448,6 @@ namespace Java.Interop.PerformanceTests {
 		[Test]
 		public void ObjectArrayEnumerationTiming ()
 		{
-			const int C = 100;
-
 			var total   = Stopwatch.StartNew ();
 
 			JniMethodInfo Class_getMethods;

--- a/tests/TestJVM/TestJVM.csproj
+++ b/tests/TestJVM/TestJVM.csproj
@@ -10,6 +10,8 @@
     <RootNamespace>TestJVM</RootNamespace>
     <AssemblyName>TestJVM</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tools/generator/ApiFixup.cs
+++ b/tools/generator/ApiFixup.cs
@@ -96,14 +96,12 @@ namespace MonoDroid.Generation
 				case "add-node":
 					try {
 						var nodes = api_doc.XPathSelectElements (path);
-						bool matched = false;
 						if (!nodes.Any ())
 							// BG8A01
 							Report.Warning (0, Report.WarningApiFixup + 1, null, metaitem, "<add-node path=\"{0}\"/> matched no nodes.", path);
 						else {
 							foreach (var node in nodes)
 								node.Add (metaitem.Nodes ());
-							matched = true;
 						}
 					} catch (XPathException e) {
 						// BG4A02

--- a/tools/generator/ApiVersionsProvider.cs
+++ b/tools/generator/ApiVersionsProvider.cs
@@ -63,7 +63,9 @@ namespace Xamarin.AndroidTools.AnnotationSupport
 			public int Deprecated;
 
 			string method;
+#if !GENERATOR
 			string [] args;
+#endif  // !GENERATOR
 
 			public string MethodName {
 				get {
@@ -76,8 +78,9 @@ namespace Xamarin.AndroidTools.AnnotationSupport
 					EnsureParsed ();
 #if GENERATOR
 						throw new NotSupportedException ("Not supported as embedded in generator.");
-#endif
+#else   // !GENERATOR
 					return args;
+#endif  // !GENERATOR
 				}
 			}
 

--- a/tools/generator/CodeGenerator.cs
+++ b/tools/generator/CodeGenerator.cs
@@ -14,6 +14,7 @@ using Xamarin.AndroidTools.AnnotationSupport;
 using Xamarin.Android.Tools.ApiXmlAdjuster;
 
 using Java.Interop.Tools.Cecil;
+using Java.Interop.Tools.Diagnostics;
 using Java.Interop.Tools.TypeNameMappings;
 
 namespace Xamarin.Android.Binder {
@@ -210,7 +211,7 @@ namespace Xamarin.Android.Binder {
 			if (options == null)
 				throw new ArgumentNullException ("options");
 
-			using (var resolver = new DirectoryAssemblyResolver (Console.WriteLine, loadDebugSymbols: false)) {
+			using (var resolver = new DirectoryAssemblyResolver (Diagnostic.CreateConsoleLogger (), loadDebugSymbols: false)) {
 				Run (options, resolver);
 			}
 		}

--- a/tools/jcw-gen/App.cs
+++ b/tools/jcw-gen/App.cs
@@ -16,7 +16,7 @@ namespace Java.Interop.Tools
 	{
 		public static int Main (string [] args)
 		{
-			var     resolver    = new DirectoryAssemblyResolver (logWarnings: Console.WriteLine, loadDebugSymbols: false);
+			var     resolver    = new DirectoryAssemblyResolver (logger: Diagnostic.CreateConsoleLogger (), loadDebugSymbols: false);
 
 			bool    help        = false;
 			string  outputPath  = null;


### PR DESCRIPTION
Context: https://jenkins.mono-project.com/view/Xamarin.Android/job/Java.Interop/287/consoleText

There are 50 warnings as part of the Java.Interop build:

	    50 Warning(s)
	    0 Error(s)

Let's fix that as much as possible, shall we?

The various warnings are as follows:

**`javac`-related warnings**:

	EXEC : warning : [options] bootstrap class path not set in conjunction with -source 1.5
	EXEC : warning : [options] source value 1.5 is obsolete and will be removed in a future release
	EXEC : warning : [options] To suppress warnings about obsolete options, use -Xlint:-options.

These are fixed by introducing the new `$(JavacSourceVersion)` and
`$(JavacTargetVersion)` MSBuild properties, defaulting
`$(JavacSourceVersion)` to 1.6 (up from 1.5), and providing a
`javac -bootclasspath PATH` option.

**C# Member Removals**:

	Java.Interop/JreRuntime.cs(29,23): warning CS0108: 'JreRuntimeOptions.JvmLibraryPath' hides inherited member 'JniRuntime.CreationOptions.JvmLibraryPath'. Use the new keyword if hiding was intended.
	Java.Interop/JreRuntime.cs(31,23): warning CS0108: 'JreRuntimeOptions.JniVersion' hides inherited member 'JniRuntime.CreationOptions.JniVersion'. Use the new keyword if hiding was intended.

These were fixed by removing the members.  The are not necessary.

**C# Member Renames**:

	AttributeInfo.cs(117,23): warning CS0108: 'CodeAttribute.Code' hides inherited member 'AttributeInfo.Code'. Use the new keyword if hiding was intended.
	AttributeInfo.cs(239,45): warning CS0108: 'ExceptionsAttribute.Exceptions' hides inherited member 'AttributeInfo.Exceptions'. Use the new keyword if hiding was intended.
	AttributeInfo.cs(476,17): warning CS0108: 'SignatureAttribute.Signature' hides inherited member 'AttributeInfo.Signature'. Use the new keyword if hiding was intended.

These were fixed by renaming the offending members.
`CodeAttribute.Code` is now `CodeAttribute.ByteCode`.
`ExceptionsAttribute.Exceptions` is now
`ExceptionsAttribute.CheckedExceptions`.
`SignatureAttribute.Signature` is now `SignatureAttribute.Value`.

**C# Appeasement**:

	ClassPath.cs(101,21): warning CS0168: The variable 'e' is declared but never used
	ApiVersionsProvider.cs(80,6): warning CS0162: Unreachable code detected
	ApiFixup.cs(99,12): warning CS0219: The variable 'matched' is assigned but its value is never used
	ApiVersionsProvider.cs(66,14): warning CS0649: Field 'ApiVersionsProvider.Definition.args' is never assigned to, and will always have its default value null
	TimingTests.cs(451,14): warning CS0219: The variable 'C' is assigned but its value is never used

Appease the C# compiler: remove the offending variables, remove the
unreachable code.

	RegisterAttribute.cs(9,59): warning CS0436: The type 'IJniNameProviderAttribute' in '/Users/builder/jenkins/workspace/Java.Interop/src/Java.Interop.NamingCustomAttributes/Java.Interop/IJniNameProviderAttribute.cs' conflicts with the imported type 'IJniNameProviderAttribute' in 'Java.Interop.Tools.JavaCallableWrappers, Version=1.0.6857.11402, Culture=neutral, PublicKeyToken=null'. Using the type defined in '/Users/builder/jenkins/workspace/Java.Interop/src/Java.Interop.NamingCustomAttributes/Java.Interop/IJniNameProviderAttribute.cs'.

This was slightly different: the problem was that
`IJniNameProviderAttribute` was always public, while other related
attributes such as `RegisterAttribute` were public *only if*
`JCW_ONLY_TYPE_NAMES` was not set.  Update `IJniNameProviderAttribute`
so that it has the same semantics.

**C# Obsoletes**:

	CodeGenerator.cs(213,26): warning CS0618: 'DirectoryAssemblyResolver.DirectoryAssemblyResolver(Action<string, object[]>, bool, ReaderParameters)' is obsolete: 'Use DirectoryAssemblyResolver(Action<TraceLevel, string>, bool, ReaderParameters)'
	JavaObjectArrayTest.cs(133,4): warning CS0618: 'TestFixtureSetUpAttribute' is obsolete: 'Use OneTimeSetUpAttribute'
	JavaObjectArrayTest.cs(142,4): warning CS0618: 'TestFixtureTearDownAttribute' is obsolete: 'Use OneTimeTearDownAttribute'
	TestTypeTests.cs(15,4): warning CS0618: 'TestFixtureSetUpAttribute' is obsolete: 'Use OneTimeSetUpAttribute'
	TestTypeTests.cs(21,4): warning CS0618: 'TestFixtureTearDownAttribute' is obsolete: 'Use OneTimeTearDownAttribute'
	JavaArrayContract.cs(15,4): warning CS0618: 'TestFixtureSetUpAttribute' is obsolete: 'Use OneTimeSetUpAttribute'
	JavaArrayContract.cs(21,4): warning CS0618: 'TestFixtureTearDownAttribute' is obsolete: 'Use OneTimeTearDownAttribute'
	GenericInheritanceMappingTest.cs(12,4): warning CS0618: 'TestFixtureSetUpAttribute' is obsolete: 'Use OneTimeSetUpAttribute'
	JavaApiTest.cs(13,4): warning CS0618: 'TestFixtureSetUpAttribute' is obsolete: 'Use OneTimeSetUpAttribute'
	OverrideMarkerTest.cs(14,4): warning CS0618: 'TestFixtureSetUpAttribute' is obsolete: 'Use OneTimeSetUpAttribute'
	TypeResolverTest.cs(12,4): warning CS0618: 'TestFixtureSetUpAttribute' is obsolete: 'Use OneTimeSetUpAttribute'
	App.cs(19,26): warning CS0618: 'DirectoryAssemblyResolver.DirectoryAssemblyResolver(Action<string, object[]>, bool, ReaderParameters)' is obsolete: 'Use DirectoryAssemblyResolver(Action<TraceLevel, string>, bool, ReaderParameters)'

Stop using `[Obsolete]` members. :-)

**Assembly Signing**:

	CSC : warning CS8002: Referenced assembly 'TestJVM, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' does not have a strong name.
	CSC : warning CS8002: Referenced assembly 'Java.Runtime.Environment, Version=1.0.6857.11395, Culture=neutral, PublicKeyToken=null' does not have a strong name.

This was caused because `Java.Interop-Tests.dll` was strong named but
referenced `TestJVM.dll` and `Java.Runtime.Environment.dll`.  Fix this
by strong-naming `TestJVM.dll` and `Java.Runtime.Environment.dll`.

With all that done, we're now down to one warning, which I'm not sure
how to fix:

	/Library/Frameworks/Mono.framework/Versions/5.12.0/lib/mono/msbuild/15.0/bin/Microsoft.CSharp.CurrentVersion.targets(141,9):
	warning MSB3884: Could not find rule set file "AllRules.ruleset". […/Java.Interop/lib/mono.linq.expressions/Mono.Linq.Expressions.csproj]