### PR TITLE
[jnimarshalmethod-gen] Handle ReflectionTypeLoadException

### DIFF
--- a/tools/jnimarshalmethod-gen/App.cs
+++ b/tools/jnimarshalmethod-gen/App.cs
@@ -245,7 +245,19 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 
 			PrepareTypeMap (ad.MainModule);
 
-			foreach (var type in assembly.DefinedTypes) {
+			IEnumerable<TypeInfo> types = null;
+			try {
+				types = assembly.DefinedTypes;
+			} catch (ReflectionTypeLoadException e) {
+				types = (IEnumerable<TypeInfo>) e.Types;
+				foreach (var le in e.LoaderExceptions)
+					Warning ($"Type Load exception{Environment.NewLine}{le}");
+			}
+
+			foreach (var type in types) {
+				if (type == null)
+					continue;
+
 				if (matchType) {
 					var matched = false;
 


### PR DESCRIPTION
Fix https://github.com/xamarin/java.interop/issues/381

I am getting `ReflectionTypeLoadException` when getting
`Assembly:DefinedTypes` property. Looks like it is result of bumping
mono in XA to mono-2018-06 branch.

Unfortunately I am unable to reproduce it locally, so this patch adds
handling code for that exception, processes the loaded types and
reports the load type exceptions as warnings. Let see how it works on
build machines and what are the load exceptions we are getting
nowadays.