### PR TITLE
[jnimarshalmethod-gen] Update the types traversal

### DIFF
--- a/tools/jnimarshalmethod-gen/App.cs
+++ b/tools/jnimarshalmethod-gen/App.cs
@@ -245,18 +245,20 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 
 			PrepareTypeMap (ad.MainModule);
 
-			IEnumerable<TypeInfo> types = null;
+			Type[] types = null;
 			try {
-				types = assembly.DefinedTypes;
+				types = assembly.GetTypes ();
 			} catch (ReflectionTypeLoadException e) {
-				types = (IEnumerable<TypeInfo>) e.Types;
+				types = e.Types;
 				foreach (var le in e.LoaderExceptions)
 					Warning ($"Type Load exception{Environment.NewLine}{le}");
 			}
 
-			foreach (var type in types) {
-				if (type == null)
+			foreach (var systemType in types) {
+				if (systemType == null)
 					continue;
+
+				var type = systemType.GetTypeInfo ();
 
 				if (matchType) {
 					var matched = false;


### PR DESCRIPTION
The previous try to fix
https://github.com/xamarin/java.interop/issues/381 didn't
work. (https://github.com/xamarin/java.interop/commit/adf4c48531259aa8f555c872df9bb5509f8a4c72)

The reason is that we don't get the exception when calling
`assembly.DefinedTypes`, but later during traversal of the enumerable.

So instead of using the `DefinedTypes`, use `GetTypes ()` directly as
the exception comes from it. That should hopefuly allow us to handle
it here.

Related reflection sources:
https://github.com/mono/mono/blob/ab3c897d6851ccf75e840d8b767aafa0d0a32d53/mcs/class/corlib/System.Reflection/Assembly.cs#L1023-L1029