### PR TITLE
[jnimarshalmethod-gen] Avoid creating duplicate marshal methods

### DIFF
--- a/tools/jnimarshalmethod-gen/App.cs
+++ b/tools/jnimarshalmethod-gen/App.cs
@@ -556,8 +556,8 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 
 		public static MethodDefinition GetMethodDefinition (this TypeDefinition td, MethodInfo method)
 		{
-			if (MethodMap.ContainsKey (method))
-				return MethodMap [method];
+			if (MethodMap.TryGetValue (method, out var md))
+				return md;
 
 			foreach (var m in td.Methods)
 				if (MethodsAreEqual (method, m)) {


### PR DESCRIPTION
Fixes https://github.com/xamarin/java.interop/issues/384

Sort the methods before generating marshal methods. Sort them so that
methods with name containing the interface name are at the end.

During processing check whether we already have a marshal method with
the same name. (note that the name contains parameter types)

When sorting methods so that interface implementation methods are
last, use `MethodDefinition:HasOverrides` to identify interface
implementations.

Introduce new cache to map reflection methods to cecil method
definitions. Example cache hit ratio:

        ~ 92% (1210/1318)

when generating marshal methods for
`Mono.Android.dll:Java.Nio.CharBuffer*` types.