### PR TITLE
[build] use <ProjectReference /> instead of <MSBuild />

### DIFF
--- a/build-tools/jnienv-gen/jnienv-gen.csproj
+++ b/build-tools/jnienv-gen/jnienv-gen.csproj
@@ -20,6 +20,16 @@
     <WarningLevel>4</WarningLevel>
     <Externalconsole>true</Externalconsole>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Gendarme|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\..\bin\BuildDebug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Externalconsole>true</Externalconsole>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>full</DebugType>
     <Optimize>true</Optimize>

--- a/build-tools/jnienv-gen/jnienv-gen.csproj
+++ b/build-tools/jnienv-gen/jnienv-gen.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\BuildDebug</OutputPath>
     <DefineConstants>DEBUG;</DefineConstants>
@@ -22,7 +22,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Gendarme|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\BuildDebug</OutputPath>
     <DefineConstants>DEBUG;</DefineConstants>
@@ -31,7 +31,7 @@
     <Externalconsole>true</Externalconsole>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\BuildRelease</OutputPath>
     <ErrorReport>prompt</ErrorReport>

--- a/src/Java.Interop/Java.Interop.PCL.props
+++ b/src/Java.Interop/Java.Interop.PCL.props
@@ -2,5 +2,12 @@
   <PropertyGroup>
     <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
   </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\build-tools\jnienv-gen\jnienv-gen.csproj">
+      <Project>{6410DA0F-5E14-4FC0-9AEE-F4C542C96C7A}</Project>
+      <Name>jnienv-gen</Name>
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
 </Project>

--- a/src/Java.Interop/Java.Interop.csproj
+++ b/src/Java.Interop/Java.Interop.csproj
@@ -132,7 +132,7 @@
   <Import Project="Java.Interop.targets" />
   <PropertyGroup>
     <BuildDependsOn>
-      BuildJnienvGen;
+      ResolveReferences;
       BuildJniEnvironment_g_cs;
       BuildInteropJar;
       $(BuildDependsOn)

--- a/src/Java.Interop/Java.Interop.targets
+++ b/src/Java.Interop/Java.Interop.targets
@@ -3,13 +3,6 @@
   <PropertyGroup>
     <Runtime Condition="'$(OS)' != 'Windows_NT'">mono</Runtime>
   </PropertyGroup>
-  <Target Name="BuildJnienvGen"
-      Inputs="..\..\build-tools\jnienv-gen\jnienv-gen.csproj"
-      Outputs="$(JNIEnvGenPath)\jnienv-gen.exe">
-    <MSBuild
-        Projects="..\..\build-tools\jnienv-gen\jnienv-gen.csproj"
-    />
-  </Target>
   <Target Name="BuildJniEnvironment_g_cs"
       Inputs="$(JNIEnvGenPath)\jnienv-gen.exe"
       Outputs="Java.Interop\JniEnvironment.g.cs;$(IntermediateOutputPath)\jni.c">


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/compare/master...jonathanpeppers:fix-xa-build

`Java.Interop.targets` was manually invoking the `<MSBuild />` task to
build a dependent project:

    <MSBuild Projects="..\..\build-tools\jnienv-gen\jnienv-gen.csproj" />

This is *ok* in some cases, like if you are creating a top-level
MSBuild script that orchestrates other builds.

However, this cause should just use `<ProjectReference />`, such as:

    <ItemGroup>
      <ProjectReference Include="..\..\build-tools\jnienv-gen\jnienv-gen.csproj">
        <Project>{6410DA0F-5E14-4FC0-9AEE-F4C542C96C7A}</Project>
        <Name>jnienv-gen</Name>
        <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
      </ProjectReference>
    </ItemGroup>

The kicker here, is that the `ResolveReferences` target has to run
*before* the `BuildJniEnvironment_g_cs` and `BuildInteropJar` custom
targets. So I setup `$(BuildDependsOn)` appropriately.

Downstream in xamarin-android, this is one of the problems that
induces projects to always build when they shouldn't. Using
`<ProjectReference />` allows things to build properly.

Once I get this change downstream in `xamarin-android`, I can finish
up the changes in my `jonathanpeppers/xamarin-android/fix-xa-build`
branch.