### PR TITLE
[Java.Interop] Additional marshaler lookup

### DIFF
--- a/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -527,6 +527,14 @@ namespace Java.Interop
 				if (typeof (IJavaPeerable).GetTypeInfo ().IsAssignableFrom (info)) {
 					return JavaPeerableValueMarshaler.Instance;
 				}
+
+				foreach (var iface in info.ImplementedInterfaces) {
+					var ifaceInfo = iface.GetTypeInfo ();
+					marshalerAttr   = ifaceInfo.GetCustomAttribute<JniValueMarshalerAttribute> ();
+					if (marshalerAttr != null)
+						return (JniValueMarshaler) Activator.CreateInstance (marshalerAttr.MarshalerType);
+				}
+
 				return GetValueMarshalerCore (type);
 			}
 

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -528,12 +528,18 @@ namespace Java.Interop
 					return JavaPeerableValueMarshaler.Instance;
 				}
 
+				JniValueMarshalerAttribute ifaceAttribute = null;
 				foreach (var iface in info.ImplementedInterfaces) {
-					var ifaceInfo = iface.GetTypeInfo ();
-					marshalerAttr   = ifaceInfo.GetCustomAttribute<JniValueMarshalerAttribute> ();
-					if (marshalerAttr != null)
-						return (JniValueMarshaler) Activator.CreateInstance (marshalerAttr.MarshalerType);
+					marshalerAttr = iface.GetTypeInfo ().GetCustomAttribute<JniValueMarshalerAttribute> ();
+					if (marshalerAttr != null) {
+						if (ifaceAttribute != null)
+							throw new NotSupportedException ($"There is more than one interface with custom marshaler for type {type}.");
+
+						ifaceAttribute = marshalerAttr;
+					}
 				}
+				if (ifaceAttribute != null)
+					return (JniValueMarshaler) Activator.CreateInstance (ifaceAttribute.MarshalerType);
 
 				return GetValueMarshalerCore (type);
 			}


### PR DESCRIPTION
Before going to use the proxy object marshaler, try to check the
implemented interfaces for custom marshaler.

It will be used in XA to marshal IJavaObject based objects, which do
not implement IJavaPeerable.

That will make it possible to fix
https://github.com/xamarin/java.interop/issues/388