### PR TITLE
[jcw-gen] List assembly names for managed type conflicts

### DIFF
--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/TypeDefinitionRocks.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/TypeDefinitionRocks.cs
@@ -61,14 +61,19 @@ namespace Java.Interop.Tools.Cecil {
 					t.Interfaces.Any (i => i.InterfaceType.FullName == interfaceName));
 		}
 
-		public static string GetPartialAssemblyQualifiedName (this TypeReference type)
+		public static string GetPartialAssemblyName (this TypeReference type)
 		{
 			TypeDefinition def = type.Resolve ();
+			return (def ?? type).Module.Assembly.Name.Name;
+		}
+
+		public static string GetPartialAssemblyQualifiedName (this TypeReference type)
+		{
 			return string.Format ("{0}, {1}",
 					// Cecil likes to use '/' as the nested type separator, while
 					// Reflection uses '+' as the nested type separator. Use Reflection.
 					type.FullName.Replace ('/', '+'),
-					(def ?? type).Module.Assembly.Name.Name);
+					type.GetPartialAssemblyName ());
 		}
 
 		public static string GetAssemblyQualifiedName (this TypeReference type)

--- a/src/Java.Interop.Tools.TypeNameMappings/Java.Interop.Tools.TypeNameMappings/JavaNativeTypeManager.cs
+++ b/src/Java.Interop.Tools.TypeNameMappings/Java.Interop.Tools.TypeNameMappings/JavaNativeTypeManager.cs
@@ -508,15 +508,15 @@ namespace Java.Interop.Tools.TypeNameMappings
 
 		public static string GetPackageName (TypeDefinition type)
 		{
-			if (IsPackageNamePreservedForAssembly (type.Module.Assembly.Name.Name))
+			if (IsPackageNamePreservedForAssembly (type.GetPartialAssemblyName ()))
 				return type.Namespace.ToLowerInvariant ();
 			switch (PackageNamingPolicy) {
 			case PackageNamingPolicy.Lowercase:
 				return type.Namespace.ToLowerInvariant ();
 			case PackageNamingPolicy.LowercaseWithAssemblyName:
-				return "assembly_" + (type.Module.Assembly.Name.Name.Replace ('.', '_') + "." + type.Namespace).ToLowerInvariant ();
+				return "assembly_" + (type.GetPartialAssemblyName ().Replace ('.', '_') + "." + type.Namespace).ToLowerInvariant ();
 			default:
-				return "md5" + ToMd5 (type.Namespace + ":" + type.Module.Assembly.Name.Name);
+				return "md5" + ToMd5 (type.Namespace + ":" + type.GetPartialAssemblyName ());
 			}
 		}
 #endif


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/2349

This commit introduces a new extension method `GetAssemblyName()` that
provides the assembly name portion of
`GetPartialAssemblyQualifiedName()` so that `GenerateJavaStubs` doesn't
have to do any string splitting to get the assembly name for warning
XA4214.