### PR TITLE
Split logging initialization into two functions

### DIFF
--- a/src/java-interop/java-interop-logger.c
+++ b/src/java-interop/java-interop-logger.c
@@ -94,21 +94,37 @@ open_file (LogCategories category, const char *path, const char *override_dir, c
 	return f;
 }
 
+static const char *gref_file = NULL;
+static const char *lref_file = NULL;
+static int light_gref  = 0;
+static int light_lref  = 0;
+
 void
-init_categories (const char *override_dir)
+init_reference_logging (const char *override_dir)
+{
+	if ((log_categories & LOG_GREF) != 0 && !light_gref) {
+		gref_log  = open_file (LOG_GREF, gref_file, override_dir, "grefs.txt");
+	}
+
+	if ((log_categories & LOG_LREF) != 0 && !light_lref) {
+		// if both lref & gref have files specified, and they're the same path, reuse the FILE*.
+		if (lref_file != NULL && strcmp (lref_file, gref_file != NULL ? gref_file : "") == 0) {
+			lref_log  = gref_log;
+		} else {
+			lref_log  = open_file (LOG_LREF, lref_file, override_dir, "lrefs.txt");
+		}
+	}
+}
+
+void
+init_logging_categories ()
 {
 	char *value;
 	char **args, **ptr;
 
-	const char *gref_file = NULL;
-	const char *lref_file = NULL;
-
 #if !ANDROID
 	log_categories = LOG_DEFAULT;
 #endif
-	int light_gref  = 0;
-	int light_lref  = 0;
-
 	if (monodroid_get_namespaced_system_property (DEBUG_MONO_LOG_PROPERTY, &value) == 0)
 		return;
 
@@ -154,19 +170,6 @@ init_categories (const char *override_dir)
 		} else if (!strncmp (arg, "lref-", 5)) {
 			log_categories  |= LOG_LREF;
 			light_lref       = 1;
-		}
-	}
-
-	if ((log_categories & LOG_GREF) != 0 && !light_gref) {
-		gref_log  = open_file (LOG_GREF, gref_file, override_dir, "grefs.txt");
-	}
-
-	if ((log_categories & LOG_LREF) != 0 && !light_lref) {
-		// if both lref & gref have files specified, and they're the same path, reuse the FILE*.
-		if (lref_file != NULL && strcmp (lref_file, gref_file != NULL ? gref_file : "") == 0) {
-			lref_log  = gref_log;
-		} else {
-			lref_log  = open_file (LOG_LREF, lref_file, override_dir, "lrefs.txt");
 		}
 	}
 

--- a/src/java-interop/java-interop-logger.h
+++ b/src/java-interop/java-interop-logger.h
@@ -36,7 +36,9 @@ extern unsigned int log_categories;
 extern int gc_spew_enabled;
 #endif
 
-void init_categories (const char *override_dir);
+void init_logging_categories ();
+
+void init_reference_logging (const char *override_dir);
 
 void log_error (LogCategories category, const char *format, ...);
 


### PR DESCRIPTION
**NOTE: XA bump to use this PR must first make a change to `monodroid-glue.cc` to call `init_logging_categories`**

Logging is currently initialized from within the Xamarin.Android C++ glue by
calling the `init_categories` function and passing it an override directory name
where the logging system can store {L,G}REF log files, if reference logging is
enabled. However, this poses a problem that we can initialize logging (and thus
categories, as configured by the user) only after we know the list of override
directories and so any attempt to log timing information (using the `LOG_TIMING`
category) before that point would yield no output.

To fix it, this commit removes the {L,G}REF logging initialization code to a new
function, `init_reference_logging`, which is called when XA determines the
override directories. The `init_categories` function is renamed to
`init_logging_categories` and all it does is set up the `log_categories` bitmap
according to user settings.