### PR TITLE
Make logging calls slightly faster for disabled categories

### DIFF
--- a/src/java-interop/java-interop-logger.c
+++ b/src/java-interop/java-interop-logger.c
@@ -198,7 +198,7 @@ log_fatal (LogCategories category, const char *format, ...)
 }
 
 void
-log_info (LogCategories category, const char *format, ...)
+log_info_nocheck (LogCategories category, const char *format, ...)
 {
 	va_list args;
 
@@ -217,7 +217,7 @@ log_warn (LogCategories category, const char *format, ...)
 }
 
 void
-log_debug (LogCategories category, const char *format, ...)
+log_debug_nocheck (LogCategories category, const char *format, ...)
 {
 	va_list args;
 

--- a/src/java-interop/java-interop-logger.h
+++ b/src/java-interop/java-interop-logger.h
@@ -44,10 +44,20 @@ void log_error (LogCategories category, const char *format, ...);
 
 void log_fatal (LogCategories category, const char *format, ...);
 
-void log_info (LogCategories category, const char *format, ...);
+void log_info_nocheck (LogCategories category, const char *format, ...);
 
 void log_warn (LogCategories category, const char *format, ...);
 
-void log_debug (LogCategories category, const char *format, ...);
+void log_debug_nocheck (LogCategories category, const char *format, ...);
+
+#define DO_LOG(_level, _category_, ...)                                           \
+	do {                                                                      \
+		if ((log_categories && ((_category_))) != 0) {                    \
+			::log_ ## _level ## _nocheck ((_category_), __VA_ARGS__); \
+		}                                                                 \
+	} while (0)
+
+#define log_debug(_category_, ...) DO_LOG (debug, (_category_), __VA_ARGS__)
+#define log_info(_category_, ...) DO_LOG (info, (_category_), __VA_ARGS__)
 
 #endif /* __JAVA_INTEROP_LOGGER_H__ */


### PR DESCRIPTION
Calls to `log_{info,debug}` may sometimes take parameters which will have to be
processed (functions called, memory allocated etc) even though the category the
calls use is disabled. This is because the category check is done inside the
`log_*` functions. This commit makes it slightly faster by wrapping the log call
in a macro which performs the check before calling the function, thus saving
some time. In Xamarin.Android native runtime this approach saved between 17 and
21ms (!) of startup time.