### PR TITLE
[generator] fix NRE encountered when binding AndroidX

### DIFF
--- a/tools/generator/Parameter.cs
+++ b/tools/generator/Parameter.cs
@@ -16,7 +16,7 @@ namespace MonoDroid.Generation {
 		string name;
 		string type, managed_type, rawtype;
 		ISymbol sym;
-		bool is_enumified;
+		bool is_enumified, validated, is_valid;
 
 		internal Parameter (string name, string type, string managedType, bool isEnumified, string rawtype = null)
 		{
@@ -254,16 +254,20 @@ namespace MonoDroid.Generation {
 
 		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params)
 		{
+			if (validated)
+				return is_valid;
+			validated = true;
+
 			sym = opt.SymbolTable.Lookup (type, type_params);
 			if (sym == null) {
 				Report.Warning (0, Report.WarningParameter + 0, "Unknown parameter type {0} {1}.", type, opt.ContextString);
-				return false;
+				return (is_valid = false);
 			}
 			if (!sym.Validate (opt, type_params)) {
 				Report.Warning (0, Report.WarningParameter + 1, "Invalid parameter type {0} {1}.", type, opt.ContextString);
-				return false;
+				return (is_valid = false);
 			}
-			return true;
+			return (is_valid = true);
 		}
 
 		public static Parameter FromElement (XElement elem)


### PR DESCRIPTION
Context: https://github.com/xamarin/AndroidSupportComponents/tree/AndroidX

When binding AndroidX, the components team are hitting a
`NullReferenceException` from `generator.exe`:

    Unhandled Exception: System.NullReferenceException: Object reference not set to an instance of an object.
        at MonoDroid.Generation.Parameter.get_IsGeneric() in java.interop\tools\generator\Parameter.cs:line 68
        at MonoDroid.Generation.Parameter.Equals(Parameter other) in java.interop\tools\generator\Parameter.cs:line 164
        at MonoDroid.Generation.ParameterList.Equals(ParameterList l1, ParameterList l2) in java.interop\tools\generator\ParameterList.cs:line 19
        at MonoDroid.Generation.GenBase.<>c__DisplayClass148_0.<FixupMethodOverrides>b__1(Method mm) in java.interop\tools\generator\GenBase.cs:line 814
        at System.Linq.Enumerable.FirstOrDefault[TSource](IEnumerable`1 source, Func`2 predicate)
        at MonoDroid.Generation.GenBase.FixupMethodOverrides(CodeGenerationOptions opt) in java.interop\tools\generator\GenBase.cs:line 814
        at MonoDroid.Generation.GenBase.FixupMethodOverrides(CodeGenerationOptions opt) in java.interop\tools\generator\GenBase.cs:line 841
        at Xamarin.Android.Binder.CodeGenerator.Run(CodeGeneratorOptions options, DirectoryAssemblyResolver resolver) in java.interop\tools\generator\CodeGenerator.cs:line 343
        at Xamarin.Android.Binder.CodeGenerator.Run(CodeGeneratorOptions options) in java.interop\tools\generator\CodeGenerator.cs:line 218
        at Xamarin.Android.Binder.CodeGenerator.Main(String[] args) in java.interop\tools\generator\CodeGenerator.cs:line 208

Happening on this block of XML:

    <method abstract="false" deprecated="not deprecated" final="false" name="layoutChild" jni-signature="(Landroidx/coordinatorlayout/widget/CoordinatorLayout;Landroid/view/View;I)V" bridge="false" native="false" return="void" jni-return="V" static="false" synchronized="false" synthetic="false" visibility="protected">
        <parameter name="parent" type="androidx.coordinatorlayout.widget.CoordinatorLayout" jni-type="Landroidx/coordinatorlayout/widget/CoordinatorLayout;"></parameter>
        <parameter name="child" type="V" jni-type="TV;"></parameter>
        <parameter name="layoutDirection" type="int" jni-type="I"></parameter>
    </method>

Which resides within a generic type that declares `V`:

    <typeParameters>
      <typeParameter name="V" classBound="android.view.View">
        <genericConstraints>
          <genericConstraint type="android.view.View"></genericConstraint>
        </genericConstraints>
      </typeParameter>
    </typeParameters>

However, I could not reproduce the problem in `generator-Tests`! It
must be the huge tree of types in AndroidX causing it!

I was able to send a workaround, so they could continue their binding
work. This fixup gets past the issue:

    <attr path="//parameter[@type='V']" name="type">android.view.View</attr>

I pressed on...

To reproduce the problem I could:

1. Generate a `*.binlog` of the
   `com.google.android.material.material.csproj`.
2. Copy the `generator.exe` command line arguments.
3. Add a `Console.ReadLine ()` call to `generator.csproj`, so that I
   had time to attach a debugger.
4. Run a locally built `generator.exe` with the args.
5. Attach the Visual Studio debugger to a running process.

After banging my head on the desk for a while, I realized
`Parameter.Validate` was getting called more than once. I believe that
the way generator is traversing types recursively, sometimes it goes
in the method and returns `true` and sometimes `false`... This would
make a `Method` instance go from `IsValid=True` to `IsValid=False`
throughout the binding process!

Other places in `generator.exe` we have the pattern of:

    protected override bool OnValidate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params)
    {
        if (validated)
            return is_valid;
        validated = true;
        //Do stuff, might need to return (is_valid = false)
        return (is_valid = true);
    }

When I applied the same pattern to `Parameter` the problem went away!

For now, I think this is a good solution, since it should also improve
performance when binding huge Java libraries.