### PR TITLE
[java-interop] Added missing logger implementation

### DIFF
--- a/src/java-interop/java-interop-logger.c
+++ b/src/java-interop/java-interop-logger.c
@@ -1,39 +1,26 @@
-#include <stdlib.h>
+#include <stdio.h>
 #include <stdarg.h>
-#include <strings.h>
-#include <string.h>
-#include <unistd.h>
-#include <errno.h>
-
-#ifdef ANDROID
-#include <android/log.h>
-#endif
 
 #include "java-interop-logger.h"
 
-#include "monodroid.h"
-#include "monodroid-glue.h"
-#include "debug.h"
-#include "util.h"
-
-#define DO_LOG(_level_,_category_,_format_,_args_)						                        \
+#define DO_LOG(_kind_,_category_,_format_,_args_)			\
 	va_start ((_args_), (_format_));									                        \
-	__android_log_vprint ((_level_), CATEGORY_NAME((_category_)), (_format_), (_args_)); \
+	log_vprint (_kind_, CATEGORY_NAME((_category_)), (_format_), (_args_)); \
 	va_end ((_args_));
 
 // Must match the same ordering as LogCategories
 static const char* log_names[] = {
 	"*none*",
-	"monodroid",
-	"monodroid-assembly",
-	"monodroid-debug",
-	"monodroid-gc",
-	"monodroid-gref",
-	"monodroid-lref",
-	"monodroid-timing",
-	"monodroid-bundle",
-	"monodroid-network",
-	"monodroid-netlink",
+	"javainterop",
+	"javainterop-assembly",
+	"javainterop-debug",
+	"javainterop-gc",
+	"javainterop-gref",
+	"javainterop-lref",
+	"javainterop-timing",
+	"javainterop-bundle",
+	"javainterop-network",
+	"javainterop-netlink",
 	"*error*",
 };
 
@@ -46,147 +33,23 @@ static const char* log_names[] = {
 // ffs(value) returns index of lowest bit set in `value`
 #define CATEGORY_NAME(value) (value == 0 ? log_names [0] : log_names [ffs (value)])
 
-#ifndef ANDROID
 static void
-__android_log_vprint (int prio, const char* tag, const char* fmt, va_list ap)
+log_vprint (const char* kind, const char* tag, const char* fmt, va_list ap)
 {
-  printf ("%d [%s] ", prio, tag);
+  printf ("%s: [%s] ", kind, tag);
   vprintf (fmt, ap);
   putchar ('\n');
   fflush (stdout);
 }
-#endif
 
-unsigned int log_categories;
-int gc_spew_enabled;
-
-static FILE*
-open_file (LogCategories category, const char *path, const char *override_dir, const char *filename)
-{
-	char *p = NULL;
-	FILE *f;
-
-	if (path && access (path, W_OK) < 0) {
-		log_warn (category, "Could not open path '%s' for logging (\"%s\"). Using '%s/%s' instead.",
-				path, strerror (errno), override_dir, filename);
-		path  = NULL;
-	}
-
-	if (!path) {
-		create_public_directory (override_dir);
-		p     = path_combine (override_dir, filename);
-		path  = p;
-	}
-
-	unlink (path);
-
-	f = monodroid_fopen (path, "a");
-
-	if (f) {
-		set_world_accessable (path);
-	} else {
-		log_warn (category, "Could not open path '%s' for logging: %s",
-				path, strerror (errno));
-	}
-
-	free (p);
-
-	return f;
-}
-
-static const char *gref_file = NULL;
-static const char *lref_file = NULL;
-static int light_gref  = 0;
-static int light_lref  = 0;
-
-void
-init_reference_logging (const char *override_dir)
-{
-	if ((log_categories & LOG_GREF) != 0 && !light_gref) {
-		gref_log  = open_file (LOG_GREF, gref_file, override_dir, "grefs.txt");
-	}
-
-	if ((log_categories & LOG_LREF) != 0 && !light_lref) {
-		// if both lref & gref have files specified, and they're the same path, reuse the FILE*.
-		if (lref_file != NULL && strcmp (lref_file, gref_file != NULL ? gref_file : "") == 0) {
-			lref_log  = gref_log;
-		} else {
-			lref_log  = open_file (LOG_LREF, lref_file, override_dir, "lrefs.txt");
-		}
-	}
-}
-
-void
-init_logging_categories ()
-{
-	char *value;
-	char **args, **ptr;
-
-#if !ANDROID
-	log_categories = LOG_DEFAULT;
-#endif
-	if (monodroid_get_namespaced_system_property (DEBUG_MONO_LOG_PROPERTY, &value) == 0)
-		return;
-
-	args = monodroid_strsplit (value, ",", -1);
-	free (value);
-	value = NULL;
-
-	for (ptr = args; ptr && *ptr; ptr++) {
-		const char *arg = *ptr;
-
-		if (!strcmp (arg, "all")) {
-			log_categories = 0xFFFFFFFF;
-			break;
-		}
-
-#define CATEGORY(name,entry) do { \
-		if (!strncmp (arg, name, sizeof(name)-1)) \
-			log_categories |= entry; \
-	} while (0)
-
-		CATEGORY ("assembly", LOG_ASSEMBLY);
-		CATEGORY ("default",  LOG_DEFAULT);
-		CATEGORY ("debugger", LOG_DEBUGGER);
-		CATEGORY ("gc",       LOG_GC);
-		CATEGORY ("gref",     LOG_GREF);
-		CATEGORY ("lref",     LOG_LREF);
-		CATEGORY ("timing",   LOG_TIMING);
-		CATEGORY ("bundle",   LOG_BUNDLE);
-		CATEGORY ("network",  LOG_NET);
-		CATEGORY ("netlink",  LOG_NETLINK);
-
-#undef CATEGORY
-
-		if (!strncmp (arg, "gref=", 5)) {
-			log_categories  |= LOG_GREF;
-			gref_file        = arg + 5;
-		} else if (!strncmp (arg, "gref-", 5)) {
-			log_categories  |= LOG_GREF;
-			light_gref       = 1;
-		} else if (!strncmp (arg, "lref=", 5)) {
-			log_categories  |= LOG_LREF;
-			lref_file        = arg + 5;
-		} else if (!strncmp (arg, "lref-", 5)) {
-			log_categories  |= LOG_LREF;
-			light_lref       = 1;
-		}
-	}
-
-	monodroid_strfreev (args);
-
-#if DEBUG
-	if ((log_categories & LOG_GC) != 0)
-		gc_spew_enabled = 1;
-#endif  /* DEBUG */
-}
+unsigned int log_categories = 0xFFFFFFFF;
 
 void
 log_error (LogCategories category, const char *format, ...)
 {
 	va_list args;
 
-	DO_LOG (ANDROID_LOG_ERROR, category, format, args);
+	DO_LOG ("error", category, format, args);
 }
 
 void
@@ -194,7 +57,7 @@ log_fatal (LogCategories category, const char *format, ...)
 {
 	va_list args;
 
-	DO_LOG (ANDROID_LOG_FATAL, category, format, args);
+	DO_LOG ("fatal error", category, format, args);
 }
 
 void
@@ -205,7 +68,7 @@ log_info_nocheck (LogCategories category, const char *format, ...)
 	if ((log_categories & category) == 0)
 		return;
 
-	DO_LOG (ANDROID_LOG_INFO, category, format, args);
+	DO_LOG ("info", category, format, args);
 }
 
 void
@@ -213,7 +76,7 @@ log_warn (LogCategories category, const char *format, ...)
 {
 	va_list args;
 
-	DO_LOG (ANDROID_LOG_WARN, category, format, args);
+	DO_LOG ("warning", category, format, args);
 }
 
 void
@@ -224,5 +87,5 @@ log_debug_nocheck (LogCategories category, const char *format, ...)
 	if ((log_categories & category) == 0)
 		return;
 
-	DO_LOG (ANDROID_LOG_DEBUG, category, format, args);
+	DO_LOG ("debug", category, format, args);
 }

--- a/src/java-interop/java-interop-logger.h
+++ b/src/java-interop/java-interop-logger.h
@@ -1,21 +1,7 @@
 #ifndef __JAVA_INTEROP_LOGGER_H__
 #define __JAVA_INTEROP_LOGGER_H__
 
-#ifndef ANDROID
-typedef enum android_LogPriority {
-    ANDROID_LOG_UNKNOWN = 0,
-    ANDROID_LOG_DEFAULT,    /* only for SetMinPriority() */
-    ANDROID_LOG_VERBOSE,
-    ANDROID_LOG_DEBUG,
-    ANDROID_LOG_INFO,
-    ANDROID_LOG_WARN,
-    ANDROID_LOG_ERROR,
-    ANDROID_LOG_FATAL,
-    ANDROID_LOG_SILENT,     /* only for SetMinPriority(); must be last */
-} android_LogPriority;
-#endif
-
-// Keep in sync with Mono.Android/src/Runtime/Logger.cs!LogCategories enum
+// Keep in sync with java-interop-logger.c's LogCategories enum
 typedef enum _LogCategories {
 	LOG_NONE      = 0,
 	LOG_DEFAULT   = 1 << 0,
@@ -31,14 +17,6 @@ typedef enum _LogCategories {
 } LogCategories;
 
 extern unsigned int log_categories;
-
-#if DEBUG
-extern int gc_spew_enabled;
-#endif
-
-void init_logging_categories ();
-
-void init_reference_logging (const char *override_dir);
 
 void log_error (LogCategories category, const char *format, ...);
 

--- a/src/java-interop/java-interop.csproj
+++ b/src/java-interop/java-interop.csproj
@@ -37,6 +37,7 @@
     <Compile Include="jni.c" />
     <Compile Include="java-interop.c" />
     <Compile Include="java-interop-jvm.c" />
+    <Compile Include="java-interop-logger.c" />
     <Compile Include="java-interop-mono.c" />
     <Compile Include="java-interop-gc-bridge-mono.c" />
   </ItemGroup>


### PR DESCRIPTION
NOTE: XA should be updated before bumping to JI with this change

Implements first part of https://github.com/xamarin/java.interop/issues/397

The `java-interop-logger.c` was not used to build java-interop shared
library. Thus any usage of `log_*` functions led to crash, because the
function was missing. Like:

    dyld: lazy symbol binding failed: Symbol not found: _log_error
      Referenced from: /Users/rodo/git/java.interop/bin/Debug/libjava-interop.dylib
      Expected in: flat namespace

    dyld: Symbol not found: _log_error
      Referenced from: /Users/rodo/git/java.interop/bin/Debug/libjava-interop.dylib
      Expected in: flat namespace

    Stacktrace:

      at <unknown> <0xffffffff>
      at (wrapper managed-to-native) Java.Interop.NativeMethods.java_interop_jvm_load (string) [0x00013] in <ce3946f6ded84ae7a635a712310f3fc9>:0
      at Java.Interop.JreRuntime.CreateJreVM (Java.Interop.JreRuntimeOptions) [0x00045] in /Users/rodo/git/java.interop/src/Java.Runtime.Environment/Java.Interop/JreRuntime.cs:92
      at Java.Interop.JreRuntime..ctor (Java.Interop.JreRuntimeOptions) [0x00000] in /Users/rodo/git/java.interop/src/Java.Runtime.Environment/Java.Interop/JreRuntime.cs:133
      at Java.Interop.JreRuntimeOptions.CreateJreVM () [0x00001] in /Users/rodo/git/java.interop/src/Java.Runtime.Environment/Java.Interop/JreRuntime.cs:72
      at Xamarin.Android.Tools.JniMarshalMethodGenerator.App.CreateJavaVM (string) [0x00010] in /Users/rodo/git/java.interop/tools/jnimarshalmethod-gen/App.cs:194
      at Xamarin.Android.Tools.JniMarshalMethodGenerator.App.ProcessAssemblies (System.Collections.Generic.List`1<string>) [0x00001] in /Users/rodo/git/java.interop/tools/jnimarshalmethod-gen/App.cs:144
      at (wrapper remoting-invoke-with-check) Xamarin.Android.Tools.JniMarshalMethodGenerator.App.ProcessAssemblies (System.Collections.Generic.List`1<string>) [0x00033] in <3425156c0c424f7eadc43572ca191f64>:0
      at (wrapper xdomain-dispatch) Xamarin.Android.Tools.JniMarshalMethodGenerator.App.ProcessAssemblies (object,byte[]&,byte[]&) [0x00043] in <3425156c0c424f7eadc43572ca191f64>:0
      at (wrapper xdomain-invoke) Xamarin.Android.Tools.JniMarshalMethodGenerator.App.ProcessAssemblies (System.Collections.Generic.List`1<string>) <0x001c0>
      at (wrapper remoting-invoke-with-check) Xamarin.Android.Tools.JniMarshalMethodGenerator.App.ProcessAssemblies (System.Collections.Generic.List`1<string>) [0x00027] in <3425156c0c424f7eadc43572ca191f64>:0
      at Xamarin.Android.Tools.JniMarshalMethodGenerator.App.Main (string[]) <0x001e2>
      at (wrapper runtime-invoke) <Module>.runtime_invoke_int_object (object,intptr,intptr,intptr) <0x0010c>

The existing `java-interop-logger.c` was only used in XA to build
`monoandroid` shared library. The new implementation replaces it and
the original `java-interop-logger.c` will move back to XA.