### PR TITLE
Revert "[generator] fix NRE encountered when binding AndroidX (#396)"

### DIFF
--- a/tools/generator/Parameter.cs
+++ b/tools/generator/Parameter.cs
@@ -16,7 +16,7 @@ namespace MonoDroid.Generation {
 		string name;
 		string type, managed_type, rawtype;
 		ISymbol sym;
-		bool is_enumified, validated, is_valid;
+		bool is_enumified;
 
 		internal Parameter (string name, string type, string managedType, bool isEnumified, string rawtype = null)
 		{
@@ -254,20 +254,16 @@ namespace MonoDroid.Generation {
 
 		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params)
 		{
-			if (validated)
-				return is_valid;
-			validated = true;
-
 			sym = opt.SymbolTable.Lookup (type, type_params);
 			if (sym == null) {
 				Report.Warning (0, Report.WarningParameter + 0, "Unknown parameter type {0} {1}.", type, opt.ContextString);
-				return (is_valid = false);
+				return false;
 			}
 			if (!sym.Validate (opt, type_params)) {
 				Report.Warning (0, Report.WarningParameter + 1, "Invalid parameter type {0} {1}.", type, opt.ContextString);
-				return (is_valid = false);
+				return false;
 			}
-			return (is_valid = true);
+			return true;
 		}
 
 		public static Parameter FromElement (XElement elem)


### PR DESCRIPTION
This reverts commit 2e682251c3942f2323ec39b21830b39fd74bbf67.

I neglected to test this change in `Mono.Android.csproj`!

```
obj\Debug\android-28\mcw\Java.Time.Temporal.ChronoUnit.cs(284,50): error CS0234: The type or namespace name 'ITemporal' does not exist in the namespace 'Java.Time.Temporal' (are you missing an assembly reference?) [C:\Users\jopepper\Desktop\Git\xamarin-android\src\Mono.Android\Mono.Android.csproj]
obj\Debug\android-28\mcw\Java.Time.Temporal.ChronoUnit.cs(284,99): error CS0234: The type or namespace name 'ITemporal' does not exist in the namespace 'Java.Time.Temporal' (are you missing an assembly reference?) [C:\Users\jopepper\Desktop\Git\xamarin-android\src\Mono.Android\Mono.Android.csproj]
obj\Debug\android-28\mcw\Java.Time.Temporal.ChronoUnit.cs(299,56): error CS0234: The type or namespace name 'ITemporal' does not exist in the namespace 'Java.Time.Temporal' (are you missing an assembly reference?) [C:\Users\jopepper\Desktop\Git\xamarin-android\src\Mono.Android\Mono.Android.csproj]
obj\Debug\android-28\mcw\Java.Time.Temporal.ValueRange.cs(113,72): error CS0234: The type or namespace name 'ITemporalField' does not exist in the namespace 'Java.Time.Temporal' (are you missing an assembly reference?) [C:\Users\jopepper\Desktop\Git\xamarin-android\src\Mono.Android\Mono.Android.csproj]
obj\Debug\android-28\mcw\Java.Time.Temporal.ValueRange.cs(128,70): error CS0234: The type or namespace name 'ITemporalField' does not exist in the namespace 'Java.Time.Temporal' (are you missing an assembly reference?) [C:\Users\jopepper\Desktop\Git\xamarin-android\src\Mono.Android\Mono.Android.csproj]
```

Let's revert this change, and I will look into another fix for the
AndroidX problem. It will likely happen *after* we branch.