### PR TITLE
[jcwgen] add public method for GetDestinationPath

### DIFF
--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
@@ -856,15 +856,18 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 
 		StreamWriter OpenStream (string outputPath)
 		{
-			string path = outputPath;
-			foreach (string dir in package.Split ('.'))
-				path = Path.Combine (path, dir);
+			string destination = GetDestinationPath (outputPath);
+			Directory.CreateDirectory (Path.GetDirectoryName (destination));
+			return new StreamWriter (new FileStream (destination, FileMode.Create, FileAccess.Write));
+		}
 
-			if (!Directory.Exists (path))
-				Directory.CreateDirectory (path);
-
-			path = Path.Combine (path, name + ".java");
-			return new StreamWriter (new FileStream (path, FileMode.Create, FileAccess.Write));
+		/// <summary>
+		/// Returns a destination file path based on the package name of this Java type
+		/// </summary>
+		public string GetDestinationPath (string outputPath)
+		{
+			var dir = package.Replace ('.', Path.DirectorySeparatorChar);
+			return Path.Combine (outputPath, dir, name + ".java");
 		}
 	}
 }


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/2505#issuecomment-445374019

In a world order where we are creating less temp files in
Xamarin.Android, it would be nice to leverage an overload of
`JavaCallableWrapperGenerator` that uses a `TextWriter` in memory.

Currently we are doing:

    //jti is a JavaCallableWrapperGenerator instance
    jti.Generate (outputPath);

    //Then later in our MSBuild task
    foreach (var file in Directory.GetFiles (temp, "*", SearchOption.AllDirectories)) {
        ...
        MonoAndroidHelper.CopyIfChanged (file, dest);
    }

So this is slower than it could be:

1. Writes to a bunch of temp files.
2. Recurses the directory where all these temp files exist.
3. Does a hash comparison of the contents of the source and
   destination.
4. Copies the file if needed.
5. Deletes all the temp files.

Instead, we could do something like:

    using (var memoryStream = new MemoryStream ())
    using (var writer = new StreamWriter (memoryStream)) {
        jti.Generate (writer);
        writer.Flush ();
        var path = jti.GetDestinationPath (outputPath);
        MonoAndroidHelper.CopyIfStreamChanged (memoryStream, path);
    }

This is quite a bit streamlined:

1. Generate the file in-memory.
2. Do a hash comparison of the in-memory file versus the destination.
3. Write to the file if needed.

The change we need in Java.Interop here is to add the
`GetDestinationPath` method. Further changes downstream in
xamarin-android will allow us reap the benefits.