### PR TITLE
Use right calling convention for JNI calls

### DIFF
--- a/src/Java.Interop/Java.Interop/JniRuntime.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.cs
@@ -79,7 +79,7 @@ namespace Java.Interop
 	partial class NativeMethods {
 		const string JavaInteropLibrary = "java-interop";
 
-		[DllImport (JavaInteropLibrary)]
+		[DllImport (JavaInteropLibrary, CallingConvention=CallingConvention.Cdecl)]
 		internal static extern int java_interop_jvm_list ([Out] IntPtr[] handles, int bufLen, out int nVMs);
 	}
 

--- a/src/Java.Runtime.Environment/Java.Interop/JreRuntime.cs
+++ b/src/Java.Runtime.Environment/Java.Interop/JreRuntime.cs
@@ -153,10 +153,10 @@ namespace Java.Interop {
 	}
 
 	partial class NativeMethods {
-		[DllImport (JavaInteropLib, CharSet=CharSet.Ansi)]
+		[DllImport (JavaInteropLib, CharSet=CharSet.Ansi, CallingConvention=CallingConvention.Cdecl)]
 		internal static extern int java_interop_jvm_load (string path);
 
-		[DllImport (JavaInteropLib, CharSet=CharSet.Ansi)]
+		[DllImport (JavaInteropLib, CharSet=CharSet.Ansi, CallingConvention=CallingConvention.Cdecl)]
 		internal static extern int java_interop_jvm_create (out IntPtr javavm, out IntPtr jnienv, ref JavaVMInitArgs args);
 	}
 }

--- a/src/java-interop/java-interop-jvm.c
+++ b/src/java-interop/java-interop-jvm.c
@@ -6,8 +6,8 @@
 #include "java-interop-util.h"
 
 
-typedef int (*java_interop_JNI_CreateJavaVM_fptr) (JavaVM **p_vm, void **p_env, void *vm_args);
-typedef int (*java_interop_JNI_GetCreatedJavaVMs_fptr) (JavaVM **vmBuf, int bufLen, int *nVMs);
+typedef int (JNICALL *java_interop_JNI_CreateJavaVM_fptr) (JavaVM **p_vm, void **p_env, void *vm_args);
+typedef int (JNICALL *java_interop_JNI_GetCreatedJavaVMs_fptr) (JavaVM **vmBuf, int bufLen, int *nVMs);
 
 struct DylibJVM {
 	void                                       *dl_handle;

--- a/src/java-interop/java-interop-jvm.h
+++ b/src/java-interop/java-interop-jvm.h
@@ -1,9 +1,9 @@
 #ifndef INC_JAVA_INTEROP_JVM_H
 #define INC_JAVA_INTEROP_JVM_H
 
-#include "java-interop.h"
+#include <jni.h>
 
-typedef void JavaVM;
+#include "java-interop.h"
 
 JAVA_INTEROP_BEGIN_DECLS
 

--- a/tests/PerformanceTests/TimingTests.cs
+++ b/tests/PerformanceTests/TimingTests.cs
@@ -17,19 +17,19 @@ namespace Java.Interop.PerformanceTests {
 
 		const string LibName = "NativeTiming";
 
-		[DllImport (LibName)]
+		[DllImport (LibName, CallingConvention=CallingConvention.Cdecl)]
 		static extern void foo_void_timing ();
 
-		[DllImport (LibName)]
+		[DllImport (LibName, CallingConvention=CallingConvention.Cdecl)]
 		static extern int foo_int_timing ();
 
-		[DllImport (LibName)]
+		[DllImport (LibName, CallingConvention=CallingConvention.Cdecl)]
 		static extern IntPtr foo_ptr_timing ();
 
-		[DllImport (LibName)]
+		[DllImport (LibName, CallingConvention=CallingConvention.Cdecl)]
 		static extern void foo_init (IntPtr env);
 
-		[DllImport (LibName)]
+		[DllImport (LibName, CallingConvention=CallingConvention.Cdecl)]
 		static extern void foo_get_native_jni_timings (IntPtr env, int count, IntPtr klass, IntPtr self, long[] jniTimes);
 
 		struct FooMethods {
@@ -46,7 +46,7 @@ namespace Java.Interop.PerformanceTests {
 			public IntPtr void_3_iargs;
 		}
 
-		[DllImport (LibName)]
+		[DllImport (LibName, CallingConvention=CallingConvention.Cdecl)]
 		static extern void foo_get_methods (out FooMethods methods);
 
 


### PR DESCRIPTION
Fixes (partially?) https://github.com/xamarin/java.interop/issues/403

Make sure we use the right calling convention by using JNICALL.

Do not force `CallingConvention.Cdecl` in pinvokes, as these are
different on Windows. Rather stay with the platform defaults.