### PR TITLE
[jcwgen] perf improvements

### DIFF
--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/CustomAttributeProviderRocks.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/CustomAttributeProviderRocks.cs
@@ -15,9 +15,6 @@ namespace Java.Interop.Tools.Cecil {
 
 		public static IEnumerable<CustomAttribute> GetCustomAttributes (this ICustomAttributeProvider item, string attribute_fullname)
 		{
-			if (!item.HasCustomAttributes)
-				yield break;
-
 			foreach (CustomAttribute custom_attribute in item.CustomAttributes) {
 				if (custom_attribute.Constructor.DeclaringType.FullName != attribute_fullname)
 					continue;

--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/MethodDefinitionRocks.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/MethodDefinitionRocks.cs
@@ -17,9 +17,9 @@ namespace Java.Interop.Tools.Cecil {
 			foreach (var baseType in method.DeclaringType.GetBaseTypes ()) {
 				foreach (var m in baseType.Methods) {
 					if (!m.IsConstructor &&
-						m.Name == method.Name &&
-						(m.IsVirtual || m.IsAbstract) &&
-						AreParametersCompatibleWith (m.Parameters, method.Parameters)) {
+							m.Name == method.Name &&
+							(m.IsVirtual || m.IsAbstract) &&
+							AreParametersCompatibleWith (m.Parameters, method.Parameters)) {
 						return m;
 					}
 				}

--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/MethodDefinitionRocks.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/MethodDefinitionRocks.cs
@@ -13,17 +13,18 @@ namespace Java.Interop.Tools.Cecil {
 		{
 			if (method.IsStatic || method.IsNewSlot || !method.IsVirtual)
 				return method;
-			var baseMethod = method.DeclaringType.GetBaseTypes ()
-				.SelectMany (t => t.Methods)
-				.Where (m => !m.IsConstructor &&
+
+			foreach (var baseType in method.DeclaringType.GetBaseTypes ()) {
+				foreach (var m in baseType.Methods) {
+					if (!m.IsConstructor &&
 						m.Name == method.Name &&
 						(m.IsVirtual || m.IsAbstract) &&
-						m.HasParameters == method.HasParameters &&
-						(!m.HasParameters
-							? true
-							: AreParametersCompatibleWith (m.Parameters, method.Parameters)))
-				.FirstOrDefault ();
-			return baseMethod ?? method;
+						AreParametersCompatibleWith (m.Parameters, method.Parameters)) {
+						return m;
+					}
+				}
+			}
+			return method;
 		}
 
 		public static IEnumerable<MethodDefinition> GetOverriddenMethods (MethodDefinition method, bool inherit)

--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/TypeDefinitionRocks.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/TypeDefinitionRocks.cs
@@ -39,8 +39,6 @@ namespace Java.Interop.Tools.Cecil {
 			foreach (var t in d.GetTypeAndBaseTypes ()) {
 				if (type.FullName == t.FullName)
 					return true;
-				if (!t.HasInterfaces)
-					continue;
 				foreach (var ifaceImpl in t.Interfaces) {
 					var i   = ifaceImpl.InterfaceType;
 					if (IsAssignableFrom (type, i))
@@ -57,8 +55,7 @@ namespace Java.Interop.Tools.Cecil {
 
 		public static bool ImplementsInterface (this TypeDefinition type, string interfaceName)
 		{
-			return type.GetTypeAndBaseTypes ().Any (t => t.HasInterfaces &&
-					t.Interfaces.Any (i => i.InterfaceType.FullName == interfaceName));
+			return type.GetTypeAndBaseTypes ().Any (t => t.Interfaces.Any (i => i.InterfaceType.FullName == interfaceName));
 		}
 
 		public static string GetPartialAssemblyName (this TypeReference type)

--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/TypeDefinitionRocks.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/TypeDefinitionRocks.cs
@@ -55,7 +55,14 @@ namespace Java.Interop.Tools.Cecil {
 
 		public static bool ImplementsInterface (this TypeDefinition type, string interfaceName)
 		{
-			return type.GetTypeAndBaseTypes ().Any (t => t.Interfaces.Any (i => i.InterfaceType.FullName == interfaceName));
+			foreach (var t in type.GetTypeAndBaseTypes ()) {
+				foreach (var i in t.Interfaces) {
+					if (i.InterfaceType.FullName == interfaceName) {
+						return true;
+					}
+				}
+			}
+			return false;
 		}
 
 		public static string GetPartialAssemblyName (this TypeReference type)


### PR DESCRIPTION
Context: https://docs.microsoft.com/en-us/visualstudio/profiling/beginners-guide-to-performance-profiling

Using the CPU usage tool in Visual Studio (profiler), I could see the
percentage of time spent in various methods during the
`<GenerateJavaStubs/>` task.

The first "hot spot" I found was this `FirstOrDefault` call in
`JavaCallableWrapperGenerator`:

    var baseMethods = GetBaseMethods (minfo);
    var baseRegiteredMethod = baseMethods.FirstOrDefault (m => GetRegisterAttributes (m).Any ());

`GetBaseMethods` was another method in this class:

    static IEnumerable<MethodDefinition> GetBaseMethods (MethodDefinition method)
    {
        MethodDefinition bmethod;
        while ((bmethod = method.GetBaseDefinition ()) != method) {
            method = bmethod;
            yield return method;
        }
    }

I was able to flatten out the LINQ usage here, by switching this to a
`GetBaseRegisteredMethod` method. It is now basically a while-loop,
but it calls `GetCustomAttributes` directly. Extra work was done in
`GetRegisterAttributes` that we don't need to call here.

*I fixed the `baseRegiteredMethod` typo, too.

Through looking at this, I found another general "hot spot" in
`Java.Interop.Tools.Cecil`. For example, I was finding that calling
`HasCustomAttributes` prior to iterating over a list of
`CustomAttributes` is actually slower. It appears that Mono.Cecil goes
and reads for attributes, and so this work is done twice when
attributes exist. I went through and removed any checks for `Has*` in
`Java.Interop.Tools.Cecil`, as I could see a benefit in Visual
Studio's profiler: the % time taken went down in these methods when
`Has*` was removed.

Another instance I found `MethodDefinitionRocks.GetBaseDefinition` had
a lot of LINQ:

    var baseMethod = method.DeclaringType.GetBaseTypes ()
        .SelectMany (t => t.Methods)
        .Where (m => !m.IsConstructor &&
                m.Name == method.Name &&
                (m.IsVirtual || m.IsAbstract) &&
                m.HasParameters == method.HasParameters &&
                (!m.HasParameters
                    ? true
                    : AreParametersCompatibleWith (m.Parameters, method.Parameters)))
        .FirstOrDefault ();

I switched this to a `foreach` loop, and removed the `HasParameters`
checks.

When testing these changes in xamarin-android, there was a noticeable
improvement to `GenerateJavaStubs`:

    Before
    1414 ms  GenerateJavaStubs                          1 calls
    After
    1355 ms  GenerateJavaStubs                          1 calls

So ~59ms improvement for the Xamarin.Forms integration project, I ran
it a few times and consistently got a faster result.