### PR TITLE
[build] use NuGet 4.7.1

### DIFF
--- a/build-tools/scripts/PrepareWindows.targets
+++ b/build-tools/scripts/PrepareWindows.targets
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <_TopDir>$(MSBuildThisFileDirectory)..\..</_TopDir>
-    <_NuGetUri>https://dist.nuget.org/win-x86-commandline/latest/nuget.exe</_NuGetUri>
+    <_NuGetUri>https://dist.nuget.org/win-x86-commandline/v4.7.1/nuget.exe</_NuGetUri>
     <_NuGetPath>$(_TopDir)\.nuget</_NuGetPath>
     <_NuGet>$(_NuGetPath)\NuGet.exe</_NuGet>
   </PropertyGroup>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/2463

When running:

    msbuild Java.Interop.sln /t:Prepare

We are hitting a similar error on the latest version of NuGet that we
saw in Xamarin.Android:

    src\java-interop\java-interop.csproj(29,3): error MSB4019:
        The imported project "bin\BuildDebug\JdkInfo.props" was not found. Confirm that the path in the <Import> declaration is correct, and that the file exists on disk.

It seems the latest version of NuGet will fail if it encounters an
`<Import/>` on a file that does not yet exist.

Pinning our build to use NuGet 4.7.1 solves this problem, and we
should be able to update NuGet deliberately in the future.