### PR TITLE
[jnienv-gen] missing TargetFrameworkVersion

### DIFF
--- a/build-tools/jnienv-gen/jnienv-gen.csproj
+++ b/build-tools/jnienv-gen/jnienv-gen.csproj
@@ -9,6 +9,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>jnienvgen</RootNamespace>
     <AssemblyName>jnienv-gen</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Downstream in monodroid, we are getting a build failure such as:

    Generator.cs(4,14): error CS0234: The type or namespace name 'Linq' does not exist in the namespace 'System' (are you missing an assembly reference?)
    Generator.cs(222,10): error CS0246: The type or namespace name 'HashSet<>' could not be found (are you missing a using directive or an assembly reference?)

Looking at `jnienv-gen.csproj` `$(TargetFrameworkVersion)` was
completely missing?

I am not sure how this has been working.