### PR TITLE
[build] Java.Interop-MonoAndroid wildcards too much

### DIFF
--- a/src/Java.Interop/Java.Interop-MonoAndroid.csproj
+++ b/src/Java.Interop/Java.Interop-MonoAndroid.csproj
@@ -50,6 +50,7 @@
   <ItemGroup>
     <Compile Include="**\*.cs" />
     <Compile Remove="Tests\**\*.cs" />
+    <Compile Remove="obj*\**\*.cs" />
     <Compile Remove="Java.Interop\JniLocationException.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/src/Java.Interop/Java.Interop.csproj
+++ b/src/Java.Interop/Java.Interop.csproj
@@ -8,10 +8,7 @@
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
     <DefineConstants>INTEROP;FEATURE_JNIENVIRONMENT_JI_PINVOKES;FEATURE_JNIOBJECTREFERENCE_INTPTRS</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <AssemblyTitle>Java.Interop</AssemblyTitle>
-    <Company>Microsoft Corporation</Company>
-    <Copyright>Microsoft Corporation</Copyright>
-    <AssemblyVersion>0.1.0.0</AssemblyVersion>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>..\..\bin\Debug</OutputPath>

--- a/src/Java.Interop/Properties/AssemblyInfo.cs
+++ b/src/Java.Interop/Properties/AssemblyInfo.cs
@@ -1,6 +1,16 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
+[assembly: AssemblyTitle ("Java.Interop")]
+[assembly: AssemblyDescription ("")]
+[assembly: AssemblyConfiguration ("")]
+[assembly: AssemblyCompany ("Microsoft Corporation")]
+[assembly: AssemblyProduct ("")]
+[assembly: AssemblyCopyright ("Microsoft Corporation")]
+[assembly: AssemblyTrademark ("Microsoft Corporation")]
+[assembly: AssemblyCulture ("")]
+[assembly: AssemblyVersion ("0.1.0.0")]
+
 [assembly: InternalsVisibleTo (
 	"Java.Interop.GenericMarshaler, PublicKey=" +
 	"0024000004800000940000000602000000240000525341310004000011000000438ac2a5acfbf1" +

--- a/src/Java.Interop/Properties/AssemblyInfo.cs
+++ b/src/Java.Interop/Properties/AssemblyInfo.cs
@@ -3,12 +3,12 @@ using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle ("Java.Interop")]
 [assembly: AssemblyDescription ("")]
+[assembly: AssemblyCulture ("")]
 [assembly: AssemblyConfiguration ("")]
 [assembly: AssemblyCompany ("Microsoft Corporation")]
-[assembly: AssemblyProduct ("")]
 [assembly: AssemblyCopyright ("Microsoft Corporation")]
+[assembly: AssemblyProduct ("")]
 [assembly: AssemblyTrademark ("Microsoft Corporation")]
-[assembly: AssemblyCulture ("")]
 [assembly: AssemblyVersion ("0.1.0.0")]
 
 [assembly: InternalsVisibleTo (


### PR DESCRIPTION
Downstream in xamarin/xamarin-android, running:

    msbuild Xamarin.Android.sln
    msbuild Xamarin.Android.sln /p:Configuration=Release

You run into an odd build error:

    (CoreCompile target) ->
        obj\Release\netstandard2.0\Java.Interop.AssemblyInfo.cs(14,12): error CS0579: Duplicate 'System.Reflection.AssemblyCompanyAttribute' attribute
        obj\Release\netstandard2.0\Java.Interop.AssemblyInfo.cs(15,12): error CS0579: Duplicate 'System.Reflection.AssemblyConfigurationAttribute' attribute
        obj\Release\netstandard2.0\Java.Interop.AssemblyInfo.cs(16,12): error CS0579: Duplicate 'System.Reflection.AssemblyCopyrightAttribute' attribute
        obj\Release\netstandard2.0\Java.Interop.AssemblyInfo.cs(17,12): error CS0579: Duplicate 'System.Reflection.AssemblyFileVersionAttribute' attribute
        obj\Release\netstandard2.0\Java.Interop.AssemblyInfo.cs(18,12): error CS0579: Duplicate 'System.Reflection.AssemblyInformationalVersionAttribute' attribute
        obj\Release\netstandard2.0\Java.Interop.AssemblyInfo.cs(19,12): error CS0579: Duplicate 'System.Reflection.AssemblyProductAttribute' attribute
        obj\Release\netstandard2.0\Java.Interop.AssemblyInfo.cs(20,12): error CS0579: Duplicate 'System.Reflection.AssemblyTitleAttribute' attribute
        obj\Release\netstandard2.0\Java.Interop.AssemblyInfo.cs(21,12): error CS0579: Duplicate 'System.Reflection.AssemblyVersionAttribute' attribute

The `@(Compile)` item group included:

    obj\Debug\netstandard2.0\Java.Interop.AssemblyInfo.cs
    obj\Release\netstandard2.0\Java.Interop.AssemblyInfo.cs

We have a wildcard in this project to emulate SDK-style projects:

    <Compile Include="**\*.cs" />

We need to exclude `obj` and `obj-MonoAndroid` from this wildcard.