### PR TITLE
[generator] Remove CS0108 warning for `*Invoker.class_ref`

### DIFF
--- a/tools/generator/CodeGenerator.cs
+++ b/tools/generator/CodeGenerator.cs
@@ -626,6 +626,13 @@ namespace MonoDroid.Generation {
 		public IList<GenBase> Gens {get;set;}
 		public int ProductVersion { get; set; }
 
+		bool? buildingCoreAssembly;
+		public bool BuildingCoreAssembly {
+			get {
+				return buildingCoreAssembly ?? (buildingCoreAssembly = (SymbolTable.Lookup ("java.lang.Object") is XmlClassGen)).Value;
+			}
+		}
+
 		public string GetOutputName (string s)
 		{
 			if (s == "System.Void")

--- a/tools/generator/InterfaceGen.cs
+++ b/tools/generator/InterfaceGen.cs
@@ -223,7 +223,7 @@ namespace MonoDroid.Generation {
 			sw.WriteLine ("{0}internal class {1}Invoker : global::Java.Lang.Object, {1} {{", indent, Name);
 			sw.WriteLine ();
 			opt.CodeGenerator.WriteInterfaceInvokerHandle (this, sw, indent + "\t", opt, Name + "Invoker");
-			sw.WriteLine ("{0}\tIntPtr class_ref;", indent);
+			sw.WriteLine ("{0}\t{1}IntPtr class_ref;", indent, opt.BuildingCoreAssembly ? "new " : "");
 			sw.WriteLine ();
 			sw.WriteLine ("{0}\tpublic static {1} GetObject (IntPtr handle, JniHandleOwnership transfer)", indent, Name);
 			sw.WriteLine ("{0}\t{{", indent);

--- a/tools/generator/Tests-Core/expected.ji/Android.Text.ISpannable.cs
+++ b/tools/generator/Tests-Core/expected.ji/Android.Text.ISpannable.cs
@@ -32,7 +32,7 @@ namespace Android.Text {
 			get { return _members.ManagedPeerType; }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static ISpannable GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests-Core/expected.ji/Android.Text.ISpanned.cs
+++ b/tools/generator/Tests-Core/expected.ji/Android.Text.ISpanned.cs
@@ -37,7 +37,7 @@ namespace Android.Text {
 			get { return _members.ManagedPeerType; }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static ISpanned GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests-Core/expected.ji/Android.Views.View.cs
+++ b/tools/generator/Tests-Core/expected.ji/Android.Views.View.cs
@@ -40,7 +40,7 @@ namespace Android.Views {
 				get { return _members.ManagedPeerType; }
 			}
 
-			IntPtr class_ref;
+			new IntPtr class_ref;
 
 			public static IOnClickListener GetObject (IntPtr handle, JniHandleOwnership transfer)
 			{

--- a/tools/generator/Tests-Core/expected/Android.Text.ISpannable.cs
+++ b/tools/generator/Tests-Core/expected/Android.Text.ISpannable.cs
@@ -23,7 +23,7 @@ namespace Android.Text {
 			get { return typeof (ISpannableInvoker); }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static ISpannable GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests-Core/expected/Android.Text.ISpanned.cs
+++ b/tools/generator/Tests-Core/expected/Android.Text.ISpanned.cs
@@ -28,7 +28,7 @@ namespace Android.Text {
 			get { return typeof (ISpannedInvoker); }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static ISpanned GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests-Core/expected/Android.Views.View.cs
+++ b/tools/generator/Tests-Core/expected/Android.Views.View.cs
@@ -31,7 +31,7 @@ namespace Android.Views {
 				get { return typeof (IOnClickListenerInvoker); }
 			}
 
-			IntPtr class_ref;
+			new IntPtr class_ref;
 
 			public static IOnClickListener GetObject (IntPtr handle, JniHandleOwnership transfer)
 			{

--- a/tools/generator/Tests/Integration-Tests/Adapters.cs
+++ b/tools/generator/Tests/Integration-Tests/Adapters.cs
@@ -9,8 +9,6 @@ namespace generatortests
 		[Test]
 		public void GeneratedOK ()
 		{
-			//hides inherited member `Java.Lang.Object.class_ref'
-			AllowWarnings = true;
 			RunAllTargets (
 					outputRelativePath:     "Adapters",
 					apiDescriptionFile:     "expected/Adapters/Adapters.xml",

--- a/tools/generator/Tests/expected.ji/Adapters/Xamarin.Test.IAdapter.cs
+++ b/tools/generator/Tests/expected.ji/Adapters/Xamarin.Test.IAdapter.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Test {
 			get { return _members.ManagedPeerType; }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static IAdapter GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected.ji/Adapters/Xamarin.Test.ISpinnerAdapter.cs
+++ b/tools/generator/Tests/expected.ji/Adapters/Xamarin.Test.ISpinnerAdapter.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Test {
 			get { return _members.ManagedPeerType; }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static ISpinnerAdapter GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected.ji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
+++ b/tools/generator/Tests/expected.ji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
@@ -37,7 +37,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 			get { return _members.ManagedPeerType; }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static IExoMediaDrmOnEventListener GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{
@@ -218,7 +218,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 			get { return _members.ManagedPeerType; }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static IExoMediaDrm GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.II1.cs
+++ b/tools/generator/Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.II1.cs
@@ -36,7 +36,7 @@ namespace Xamarin.Test {
 			get { return _members.ManagedPeerType; }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static II1 GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.II2.cs
+++ b/tools/generator/Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.II2.cs
@@ -36,7 +36,7 @@ namespace Xamarin.Test {
 			get { return _members.ManagedPeerType; }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static II2 GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected.ji/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
+++ b/tools/generator/Tests/expected.ji/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
@@ -44,7 +44,7 @@ namespace Xamarin.Test {
 					get { return _members.ManagedPeerType; }
 				}
 
-				IntPtr class_ref;
+				new IntPtr class_ref;
 
 				public static IFactory GetObject (IntPtr handle, JniHandleOwnership transfer)
 				{

--- a/tools/generator/Tests/expected.ji/TestInterface/Test.ME.IGenericInterface.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Test.ME.IGenericInterface.cs
@@ -37,7 +37,7 @@ namespace Test.ME {
 			get { return _members.ManagedPeerType; }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static IGenericInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected.ji/TestInterface/Test.ME.IGenericPropertyInterface.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Test.ME.IGenericPropertyInterface.cs
@@ -40,7 +40,7 @@ namespace Test.ME {
 			get { return _members.ManagedPeerType; }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static IGenericPropertyInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected.ji/TestInterface/Test.ME.ITestInterface.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Test.ME.ITestInterface.cs
@@ -98,7 +98,7 @@ namespace Test.ME {
 			get { return _members.ManagedPeerType; }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static ITestInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected.ji/java.lang.Enum/Java.Lang.IComparable.cs
+++ b/tools/generator/Tests/expected.ji/java.lang.Enum/Java.Lang.IComparable.cs
@@ -37,7 +37,7 @@ namespace Java.Lang {
 			get { return _members.ManagedPeerType; }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static IComparable GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected/Adapters/Xamarin.Test.IAdapter.cs
+++ b/tools/generator/Tests/expected/Adapters/Xamarin.Test.IAdapter.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Test {
 			get { return typeof (IAdapterInvoker); }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static IAdapter GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected/Adapters/Xamarin.Test.ISpinnerAdapter.cs
+++ b/tools/generator/Tests/expected/Adapters/Xamarin.Test.ISpinnerAdapter.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Test {
 			get { return typeof (ISpinnerAdapterInvoker); }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static ISpinnerAdapter GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
+++ b/tools/generator/Tests/expected/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
@@ -28,7 +28,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 			get { return typeof (IExoMediaDrmOnEventListenerInvoker); }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static IExoMediaDrmOnEventListener GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{
@@ -201,7 +201,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 			get { return typeof (IExoMediaDrmInvoker); }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static IExoMediaDrm GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected/InterfaceMethodsConflict/Xamarin.Test.II1.cs
+++ b/tools/generator/Tests/expected/InterfaceMethodsConflict/Xamarin.Test.II1.cs
@@ -27,7 +27,7 @@ namespace Xamarin.Test {
 			get { return typeof (II1Invoker); }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static II1 GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected/InterfaceMethodsConflict/Xamarin.Test.II2.cs
+++ b/tools/generator/Tests/expected/InterfaceMethodsConflict/Xamarin.Test.II2.cs
@@ -27,7 +27,7 @@ namespace Xamarin.Test {
 			get { return typeof (II2Invoker); }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static II2 GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
+++ b/tools/generator/Tests/expected/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
@@ -35,7 +35,7 @@ namespace Xamarin.Test {
 					get { return typeof (IFactoryInvoker); }
 				}
 
-				IntPtr class_ref;
+				new IntPtr class_ref;
 
 				public static IFactory GetObject (IntPtr handle, JniHandleOwnership transfer)
 				{

--- a/tools/generator/Tests/expected/TestInterface/Test.ME.IGenericInterface.cs
+++ b/tools/generator/Tests/expected/TestInterface/Test.ME.IGenericInterface.cs
@@ -28,7 +28,7 @@ namespace Test.ME {
 			get { return typeof (IGenericInterfaceInvoker); }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static IGenericInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected/TestInterface/Test.ME.IGenericPropertyInterface.cs
+++ b/tools/generator/Tests/expected/TestInterface/Test.ME.IGenericPropertyInterface.cs
@@ -31,7 +31,7 @@ namespace Test.ME {
 			get { return typeof (IGenericPropertyInterfaceInvoker); }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static IGenericPropertyInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected/TestInterface/Test.ME.ITestInterface.cs
+++ b/tools/generator/Tests/expected/TestInterface/Test.ME.ITestInterface.cs
@@ -90,7 +90,7 @@ namespace Test.ME {
 			get { return typeof (ITestInterfaceInvoker); }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static ITestInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{

--- a/tools/generator/Tests/expected/java.lang.Enum/Java.Lang.IComparable.cs
+++ b/tools/generator/Tests/expected/java.lang.Enum/Java.Lang.IComparable.cs
@@ -28,7 +28,7 @@ namespace Java.Lang {
 			get { return typeof (IComparableInvoker); }
 		}
 
-		IntPtr class_ref;
+		new IntPtr class_ref;
 
 		public static IComparable GetObject (IntPtr handle, JniHandleOwnership transfer)
 		{


### PR DESCRIPTION
The code for interface `Invoker` types elicits a CS0108 warning on the
`class_ref` field, e.g.

	Xamarin.Test.IAdapter.cs(26,10): warning CS0108:
	`Xamarin.Test.IAdapterInvoker.class_ref' hides inherited member `Java.Lang.Object.class_ref'.
	Use the new keyword if hiding was intended.

This happens because `Java.Lang.Object` has a `class_ref` field, and
the `Invoker` type also has one:

	namespace Java.Lang {
	  partial class Object {
	    internal static IntPtr class_ref {get;}
	  }
	}

	namespace Xamarin.Test {
	  partial class IAdapterInvoker : Java.Lang.Object, IAdapter {
	    IntPtr class_ref;
	  }
	}

Simple enough, right?  Just always always emit `new IntPtr class_ref`
and the warning is removed.

There's a problem with this simple solution: there are *two ways* that
`generator`-emitted source code is used:

 1. When `Java.Lang.Object` is part of the same assembly.
    This is the case when building `Mono.Android.dll` and running some
    of the `generator-Tests.dll` unit tests

 2. When `Java.Lang.Object` is referenced from a *different* assembly.
    This is the case for *new* binding assemblies.

We need `new IntPtr class_ref` for (1), but doing so for (2) will
introduce a CS0109 warning:

	Xamarin.Test.IAdapter.cs(26,10): warning CS0109:
	The member 'Xamarin.Test.IAdapterInvoker.class_ref' does not hide an accessible member.
	The new keyword is not required.

Can we have our cake and eat it too?

Introduce a new `CodeGenerationOptions.BuildingCoreAssembly` property,
which is true when we're building an assembly that binds
`java.lang.Object` (e.g. `Mono.Android.dll` or unit tests).

Update `InterfaceGen.GenerateInvoker()` so that when
`CodeGenerationOptions.BuildingCoreAssembly` is true, we emit the
`new` keyword, silencing the CS0108 warning, and otherwise we *don't*
emit `new`, thus avoiding the CS0109 warning.