### PR TITLE
[generator] Remove CS0108 warning for inherited methods

### DIFF
--- a/tools/generator/CodeGenerator.cs
+++ b/tools/generator/CodeGenerator.cs
@@ -768,6 +768,8 @@ namespace MonoDroid.Generation {
 			string delegate_type = method.GetDelegateType ();
 			writer.WriteLine ("{0}static Delegate {1};", indent, method.EscapedCallbackName);
 			writer.WriteLine ("#pragma warning disable 0169");
+			if (method.Deprecated != null)
+				writer.WriteLine($"{indent}[Obsolete]");
 			writer.WriteLine ("{0}static Delegate {1} ()", indent, method.ConnectorName);
 			writer.WriteLine ("{0}{{", indent);
 			writer.WriteLine ("{0}\tif ({1} == null)", indent, method.EscapedCallbackName);
@@ -775,6 +777,8 @@ namespace MonoDroid.Generation {
 			writer.WriteLine ("{0}\treturn {1};", indent, method.EscapedCallbackName);
 			writer.WriteLine ("{0}}}", indent);
 			writer.WriteLine ();
+			if (method.Deprecated != null)
+				writer.WriteLine($"{indent}[Obsolete]");
 			writer.WriteLine ("{0}static {1} n_{2} (IntPtr jnienv, IntPtr native__this{3})", indent, method.RetVal.NativeType, method.Name + method.IDSignature, method.Parameters.GetCallbackSignature (opt));
 			writer.WriteLine ("{0}{{", indent);
 			writer.WriteLine ("{0}\t{1} __this = global::Java.Lang.Object.GetObject<{1}> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);", indent, opt.GetOutputName (type.FullName));
@@ -852,7 +856,13 @@ namespace MonoDroid.Generation {
 					writer.WriteLine ("{0}// Metadata.xml XPath method reference: path=\"{1}\"", indent, method.GetMetadataXPathReference (method.DeclaringType));
 				writer.WriteLine ("{0}[Register (\"{1}\", \"{2}\", \"{3}\"{4})]", indent, method.JavaName, method.JniSignature, method.ConnectorName, method.AdditionalAttributeString ());
 				WriteMethodCustomAttributes (method, writer, indent);
-				writer.WriteLine ("{0}{1} abstract {2} {3} ({4});", indent, method.Visibility, opt.GetOutputName (method.RetVal.FullName), name, GenBase.GetSignature (method, opt));
+				writer.WriteLine ("{0}{1}{2} abstract {3} {4} ({5});",
+						indent,
+						impl.RequiresNew (method.Name) ? "new " : "",
+						method.Visibility,
+						opt.GetOutputName (method.RetVal.FullName),
+						name,
+						GenBase.GetSignature (method, opt));
 				writer.WriteLine ();
 
 				if (gen_as_formatted || method.Parameters.HasCharSequence)

--- a/tools/generator/Tests/Integration-Tests/GenericArguments.cs
+++ b/tools/generator/Tests/Integration-Tests/GenericArguments.cs
@@ -9,8 +9,6 @@ namespace generatortests
 		[Test]
 		public void GeneratedOK ()
 		{
-			//hides inherited member `Java.Lang.Object.class_ref'
-			AllowWarnings = true;
 			RunAllTargets (
 					outputRelativePath: "GenericArguments",
 					apiDescriptionFile: "expected/GenericArguments/GenericArguments.xml",

--- a/tools/generator/Tests/Integration-Tests/InterfaceMethodsConflict.cs
+++ b/tools/generator/Tests/Integration-Tests/InterfaceMethodsConflict.cs
@@ -9,8 +9,6 @@ namespace generatortests
 		[Test]
 		public void GeneratedOK ()
 		{
-			//hides inherited member `Java.Lang.Object.class_ref'
-			AllowWarnings = true;
 			RunAllTargets (
 					outputRelativePath:     "InterfaceMethodsConflict",
 					apiDescriptionFile:     "expected/InterfaceMethodsConflict/InterfaceMethodsConflict.xml",

--- a/tools/generator/Tests/Integration-Tests/Interfaces.cs
+++ b/tools/generator/Tests/Integration-Tests/Interfaces.cs
@@ -9,8 +9,6 @@ namespace generatortests
 		[Test]
 		public void Generated_OK ()
 		{
-			//hides inherited member `Java.Lang.Object.class_ref'
-			AllowWarnings = true;
 			RunAllTargets (
 					outputRelativePath:     "TestInterface",
 					apiDescriptionFile:     "expected/TestInterface/TestInterface.xml",

--- a/tools/generator/Tests/Integration-Tests/Java_Lang_Enum.cs
+++ b/tools/generator/Tests/Integration-Tests/Java_Lang_Enum.cs
@@ -9,8 +9,6 @@ namespace generatortests
 		[Test]
 		public void Generated_OK ()
 		{
-			//hides inherited member `Java.Lang.Object.class_ref'
-			AllowWarnings = true;
 			RunAllTargets (
 					outputRelativePath:     "java.lang.Enum",
 					apiDescriptionFile:     "expected/java.lang.Enum/Java.Lang.Enum.xml",

--- a/tools/generator/Tests/Integration-Tests/NestedTypes.cs
+++ b/tools/generator/Tests/Integration-Tests/NestedTypes.cs
@@ -9,8 +9,6 @@ namespace generatortests
 		[Test]
 		public void GeneratedOK ()
 		{
-			//hides inherited member `Java.Lang.Object.class_ref'
-			AllowWarnings = true;
 			RunAllTargets (
 					outputRelativePath:     "NestedTypes",
 					apiDescriptionFile:     "expected/NestedTypes/NestedTypes.xml",

--- a/tools/generator/Tests/Integration-Tests/NormalMethods.cs
+++ b/tools/generator/Tests/Integration-Tests/NormalMethods.cs
@@ -9,9 +9,6 @@ namespace generatortests
 		[Test]
 		public void GeneratedOK ()
 		{
-			//`Xamarin.Test.SomeObject.GetType()' hides inherited member `object.GetType()'
-			//`Xamarin.Test.SomeObject.ObsoleteMethod()' is obsolete
-			AllowWarnings = true;
 			RunAllTargets (
 					outputRelativePath:     "NormalMethods",
 					apiDescriptionFile:     "expected/NormalMethods/NormalMethods.xml",

--- a/tools/generator/Tests/expected.ji/NormalMethods/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected.ji/NormalMethods/Xamarin.Test.SomeObject.cs
@@ -68,7 +68,7 @@ namespace Xamarin.Test {
 
 		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/method[@name='getType' and count(parameter)=0]"
 		[Register ("getType", "()[I", "GetGetTypeHandler")]
-		public virtual unsafe int[] GetType ()
+		public new virtual unsafe int[] GetType ()
 		{
 			const string __id = "getType.()[I";
 			try {
@@ -260,6 +260,7 @@ namespace Xamarin.Test {
 
 		static Delegate cb_ObsoleteMethod;
 #pragma warning disable 0169
+		[Obsolete]
 		static Delegate GetObsoleteMethodHandler ()
 		{
 			if (cb_ObsoleteMethod == null)
@@ -267,6 +268,7 @@ namespace Xamarin.Test {
 			return cb_ObsoleteMethod;
 		}
 
+		[Obsolete]
 		static int n_ObsoleteMethod (IntPtr jnienv, IntPtr native__this)
 		{
 			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);

--- a/tools/generator/Tests/expected/NormalMethods/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected/NormalMethods/Xamarin.Test.SomeObject.cs
@@ -74,7 +74,7 @@ namespace Xamarin.Test {
 		static IntPtr id_getType;
 		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/method[@name='getType' and count(parameter)=0]"
 		[Register ("getType", "()[I", "GetGetTypeHandler")]
-		public virtual unsafe int[] GetType ()
+		public new virtual unsafe int[] GetType ()
 		{
 			if (id_getType == IntPtr.Zero)
 				id_getType = JNIEnv.GetMethodID (class_ref, "getType", "()[I");
@@ -304,6 +304,7 @@ namespace Xamarin.Test {
 
 		static Delegate cb_ObsoleteMethod;
 #pragma warning disable 0169
+		[Obsolete]
 		static Delegate GetObsoleteMethodHandler ()
 		{
 			if (cb_ObsoleteMethod == null)
@@ -311,6 +312,7 @@ namespace Xamarin.Test {
 			return cb_ObsoleteMethod;
 		}
 
+		[Obsolete]
 		static int n_ObsoleteMethod (IntPtr jnienv, IntPtr native__this)
 		{
 			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);


### PR DESCRIPTION
When a Java method is declared which has a name matching a method name
from a C# base class, a CS0108 warning is produced:

	Xamarin.Test.SomeObject.cs(77,31): warning CS0108:
	`Xamarin.Test.SomeObject.GetType()' hides inherited member `object.GetType()'.
	Use the new keyword if hiding was intended

Fix this by updating `GenBase.RequiresNew()` to have a more complete
set of member names from `System.Object` and `System.Exception`, and
calling `GenBase.RequiresNew()` from
`CodeGenerator.WriteMethodAbstractDeclaration()` so that `new` is
emitted for `GetType()` and other methods.

Additionally, the `NormalMethods.cs` test also contains obsolete
methods, which results in CS0618 warnings:

	Xamarin.Test.SomeObject.cs(317,18): warning CS0618:
	`Xamarin.Test.SomeObject.ObsoleteMethod()' is obsolete: `Deprecated please use IntegerMethod instead'

This warning was emitted for the "connector methods" which reference
the deprecated Java method.  Update
`CodeGenerator.WriteMethodCallback()` so that the connector-related
methods are *also* `[Obsolete]`, removing this warning.

With this change in place, we no longer need to allow warnings in our
CodeDom-based unit tests.