### PR TITLE
[jnimarshalmethod-gen] Do not generate in already processed assemblies

### DIFF
--- a/tools/jnimarshalmethod-gen/App.cs
+++ b/tools/jnimarshalmethod-gen/App.cs
@@ -183,6 +183,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 			foreach (var assembly in assemblies) {
 				try {
 					CreateMarshalMethodAssembly (assembly);
+					definedTypes.Clear ();
 				} catch (Exception e) {
 					Error ($"Unable to process assembly '{assembly}'{Environment.NewLine}{e.Message}{Environment.NewLine}{e}");
 					Environment.Exit (1);
@@ -327,9 +328,9 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 
 				var existingMarshalMethodsType = td.GetNestedType (TypeMover.NestedName);
 				if (existingMarshalMethodsType != null && !forceRegeneration) {
-					Warning ($"Marshal methods type '{existingMarshalMethodsType.GetAssemblyQualifiedName ()}' already exists. Skipped generation of marshal methods. Use -f to force regeneration when desired.");
+					Warning ($"Marshal methods type '{existingMarshalMethodsType.GetAssemblyQualifiedName ()}' already exists. Skipped generation of marshal methods in assembly '{assemblyName}'. Use -f to force regeneration when desired.");
 
-					continue;
+					return;
 				}
 
 				if (Verbose)
@@ -425,8 +426,6 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 
 			if (!keepTemporary)
 				FilesToDelete.Add (dstAssembly.MainModule.FileName);
-
-			definedTypes.Clear ();
 		}
 
 		static  readonly    MethodInfo          Delegate_CreateDelegate             = typeof (Delegate).GetMethod ("CreateDelegate", new[] {


### PR DESCRIPTION
Improves https://github.com/xamarin/xamarin-android/issues/2419

Change the behavior in case we find an existing
`__<$>_jni_marshal_methods` class. Skip the whole assembly instead of
just the type.

Updated the warning message to report the assembly name. This can be
still overriden by using `-f`.

This also means the number of these warnings is significanly reduced
to one per assembly, instead one per type in case we try to generate
the methods for assemblies which were already processed and thus
contain the marshaling classes.