### PR TITLE
[generator] Fix loading broken annotation XML

### DIFF
--- a/src/Xamarin.Android.Tools.AnnotationSupport/AndroidAnnotationsSupport.cs
+++ b/src/Xamarin.Android.Tools.AnnotationSupport/AndroidAnnotationsSupport.cs
@@ -3,7 +3,10 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Text;
 using System.Xml.Linq;
+using System.Xml;
+using HtmlAgilityPack;
 
 namespace Xamarin.AndroidTools.AnnotationSupport
 {
@@ -24,7 +27,63 @@ namespace Xamarin.AndroidTools.AnnotationSupport
 		static IEnumerable<AnnotatedItem> ParseArchiveEntry (ZipArchiveEntry entry)
 		{
 			using (var s = entry.Open ())
-				return XDocument.Load (s).Root.Elements ("item").Select (e => new AnnotatedItem (e));
+				return SafeXmlLoad (s, entry.FullName).Root.Elements ("item").Select (e => new AnnotatedItem (e));
+		}
+
+		static XDocument SafeXmlLoad (Stream s, string fileName)
+		{
+			// We must save to a temporary stream because the stream doesn't support seeking and should the
+			// parsing fail we won't be able to go back to its beginnig to reparse it.
+			using (var ms = new MemoryStream ()) {
+				s.CopyTo (ms);
+				ms.Seek (0, SeekOrigin.Begin);
+
+				try {
+					return XDocument.Load (ms);
+				} catch (XmlException ex) {
+					Console.Error.WriteLine ($"Warning: failed to load annotation document '{fileName}' directly from the annotations archive. {ex.Message}");
+					Console.Error.WriteLine ("Attempting to fix up and reload");
+				}
+
+				try {
+					using (var ns = FixAnnotationXML (ms)) {
+						return XDocument.Load (ns);
+					}
+				} catch (Exception ex) {
+					throw new InvalidOperationException ($"Failed to fix up invalid XML in annotation document '{fileName}'. {ex.Message}", ex);
+				}
+			}
+		}
+
+		static Stream FixAnnotationXML (Stream s)
+		{
+			s.Seek (0, SeekOrigin.Begin);
+
+			//
+			// Context: https://issuetracker.google.com/issues/116182838
+			//
+			// Google ships not well-formed XML files in the platform-tools 28.0.1 package (in the
+			// annotations.zip file), so we need to load the files with a forgiving parser in order to fix
+			// them up before loading with a validating XML parser.
+			var doc = new HtmlDocument ();
+			doc.Load (s);
+			if (doc.DocumentNode.FirstChild.InnerHtml.StartsWith ("<?xml"))
+				doc.DocumentNode.FirstChild.Remove ();
+
+			var ms = new MemoryStream ();
+			var xs = new XmlWriterSettings {
+				Encoding = new UTF8Encoding (false),
+				CloseOutput = false,
+				ConformanceLevel = ConformanceLevel.Fragment,
+			};
+
+			using (var xw = XmlWriter.Create (ms, xs)) {
+				doc.Save (xw);
+				xw.Flush ();
+			}
+
+			ms.Seek (0, SeekOrigin.Begin);
+			return ms;
 		}
 
 		#endregion

--- a/src/Xamarin.Android.Tools.AnnotationSupport/Xamarin.Android.Tools.AnnotationSupport.csproj
+++ b/src/Xamarin.Android.Tools.AnnotationSupport/Xamarin.Android.Tools.AnnotationSupport.csproj
@@ -35,6 +35,9 @@
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
+    <Reference Include="HtmlAgilityPack">
+      <HintPath>..\..\packages\HtmlAgilityPack.1.8.14\lib\Net45\HtmlAgilityPack.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AndroidAnnotationsSupport.cs" />

--- a/src/Xamarin.Android.Tools.AnnotationSupport/packages.config
+++ b/src/Xamarin.Android.Tools.AnnotationSupport/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="HtmlAgilityPack" version="1.8.14" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
Context: https://issuetracker.google.com/issues/116182838

Google shipped invalid (not well-formed) XML annotation documents in
the `platform-tools` 28.0.1 package, with `<` present within element
attributes:

	<item name="android.view.View void addFocusables(java.util.ArrayList<android.view.View>, int) 1">

Note the `java.util.ArrayList<android.view.View>` within the
`//item/@name` attribute value, and that the `<` isn't escaped.

This invalid XML prevents System.Xml from loading the
`annotations.xml` documents, with errors similar to:

	android/view/annotations.xml failed: '<', hexadecimal value 0x3C, is an invalid attribute character. Line 206, position 71

This commit takes advantage of the forgiving nature of the
HtmlAgilityPack HTML parser -- which loads those files fine -- and
makes it possible for us to write them back using `XmlWriter` in
order to generate a well-formed XML document which we can load into
`XDocument`.

Slow, but it works...