### PR TITLE
[Java.Interop] Lazy initialization of JniRuntime static array fields

### DIFF
--- a/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.cs
+++ b/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.cs
@@ -10,59 +10,69 @@ using System.Linq.Expressions;
 namespace Java.Interop {
 
 	partial class JniRuntime {
-		static readonly KeyValuePair<Type, JniTypeSignature>[] JniBuiltinArrayMappings = new[]{
-			new KeyValuePair<Type, JniTypeSignature>(typeof (JavaPrimitiveArray<Boolean>),  new JniTypeSignature ("Z", arrayRank: 1, keyword: true)),
-			new KeyValuePair<Type, JniTypeSignature>(typeof (JavaArray<Boolean>),           new JniTypeSignature ("Z", arrayRank: 1, keyword: true)),
-			new KeyValuePair<Type, JniTypeSignature>(typeof (JavaPrimitiveArray<SByte>),  new JniTypeSignature ("B", arrayRank: 1, keyword: true)),
-			new KeyValuePair<Type, JniTypeSignature>(typeof (JavaArray<SByte>),           new JniTypeSignature ("B", arrayRank: 1, keyword: true)),
-			new KeyValuePair<Type, JniTypeSignature>(typeof (JavaPrimitiveArray<Char>),  new JniTypeSignature ("C", arrayRank: 1, keyword: true)),
-			new KeyValuePair<Type, JniTypeSignature>(typeof (JavaArray<Char>),           new JniTypeSignature ("C", arrayRank: 1, keyword: true)),
-			new KeyValuePair<Type, JniTypeSignature>(typeof (JavaPrimitiveArray<Int16>),  new JniTypeSignature ("S", arrayRank: 1, keyword: true)),
-			new KeyValuePair<Type, JniTypeSignature>(typeof (JavaArray<Int16>),           new JniTypeSignature ("S", arrayRank: 1, keyword: true)),
-			new KeyValuePair<Type, JniTypeSignature>(typeof (JavaPrimitiveArray<Int32>),  new JniTypeSignature ("I", arrayRank: 1, keyword: true)),
-			new KeyValuePair<Type, JniTypeSignature>(typeof (JavaArray<Int32>),           new JniTypeSignature ("I", arrayRank: 1, keyword: true)),
-			new KeyValuePair<Type, JniTypeSignature>(typeof (JavaPrimitiveArray<Int64>),  new JniTypeSignature ("J", arrayRank: 1, keyword: true)),
-			new KeyValuePair<Type, JniTypeSignature>(typeof (JavaArray<Int64>),           new JniTypeSignature ("J", arrayRank: 1, keyword: true)),
-			new KeyValuePair<Type, JniTypeSignature>(typeof (JavaPrimitiveArray<Single>),  new JniTypeSignature ("F", arrayRank: 1, keyword: true)),
-			new KeyValuePair<Type, JniTypeSignature>(typeof (JavaArray<Single>),           new JniTypeSignature ("F", arrayRank: 1, keyword: true)),
-			new KeyValuePair<Type, JniTypeSignature>(typeof (JavaPrimitiveArray<Double>),  new JniTypeSignature ("D", arrayRank: 1, keyword: true)),
-			new KeyValuePair<Type, JniTypeSignature>(typeof (JavaArray<Double>),           new JniTypeSignature ("D", arrayRank: 1, keyword: true)),
-		};
+		static readonly Lazy<KeyValuePair<Type, JniTypeSignature>[]> JniBuiltinArrayMappings = new Lazy<KeyValuePair<Type, JniTypeSignature>[]> (InitJniBuiltinArrayMappings);
 
-		static readonly KeyValuePair<Type, JniValueMarshaler>[] JniPrimitiveArrayMarshalers = new []{
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (Boolean[]),                   JavaBooleanArray.ArrayMarshaler),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaArray<Boolean>),          JavaBooleanArray.ArrayMarshaler),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaPrimitiveArray<Boolean>), JavaBooleanArray.ArrayMarshaler),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaBooleanArray),            JavaBooleanArray.ArrayMarshaler),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (SByte[]),                   JavaSByteArray.ArrayMarshaler),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaArray<SByte>),          JavaSByteArray.ArrayMarshaler),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaPrimitiveArray<SByte>), JavaSByteArray.ArrayMarshaler),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaSByteArray),            JavaSByteArray.ArrayMarshaler),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (Char[]),                   JavaCharArray.ArrayMarshaler),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaArray<Char>),          JavaCharArray.ArrayMarshaler),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaPrimitiveArray<Char>), JavaCharArray.ArrayMarshaler),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaCharArray),            JavaCharArray.ArrayMarshaler),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (Int16[]),                   JavaInt16Array.ArrayMarshaler),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaArray<Int16>),          JavaInt16Array.ArrayMarshaler),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaPrimitiveArray<Int16>), JavaInt16Array.ArrayMarshaler),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaInt16Array),            JavaInt16Array.ArrayMarshaler),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (Int32[]),                   JavaInt32Array.ArrayMarshaler),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaArray<Int32>),          JavaInt32Array.ArrayMarshaler),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaPrimitiveArray<Int32>), JavaInt32Array.ArrayMarshaler),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaInt32Array),            JavaInt32Array.ArrayMarshaler),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (Int64[]),                   JavaInt64Array.ArrayMarshaler),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaArray<Int64>),          JavaInt64Array.ArrayMarshaler),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaPrimitiveArray<Int64>), JavaInt64Array.ArrayMarshaler),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaInt64Array),            JavaInt64Array.ArrayMarshaler),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (Single[]),                   JavaSingleArray.ArrayMarshaler),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaArray<Single>),          JavaSingleArray.ArrayMarshaler),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaPrimitiveArray<Single>), JavaSingleArray.ArrayMarshaler),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaSingleArray),            JavaSingleArray.ArrayMarshaler),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (Double[]),                   JavaDoubleArray.ArrayMarshaler),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaArray<Double>),          JavaDoubleArray.ArrayMarshaler),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaPrimitiveArray<Double>), JavaDoubleArray.ArrayMarshaler),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaDoubleArray),            JavaDoubleArray.ArrayMarshaler),
-		};
+		static KeyValuePair<Type, JniTypeSignature>[] InitJniBuiltinArrayMappings ()
+		{
+			return new[] {
+				new KeyValuePair<Type, JniTypeSignature>(typeof (JavaPrimitiveArray<Boolean>),  new JniTypeSignature ("Z", arrayRank: 1, keyword: true)),
+				new KeyValuePair<Type, JniTypeSignature>(typeof (JavaArray<Boolean>),           new JniTypeSignature ("Z", arrayRank: 1, keyword: true)),
+				new KeyValuePair<Type, JniTypeSignature>(typeof (JavaPrimitiveArray<SByte>),  new JniTypeSignature ("B", arrayRank: 1, keyword: true)),
+				new KeyValuePair<Type, JniTypeSignature>(typeof (JavaArray<SByte>),           new JniTypeSignature ("B", arrayRank: 1, keyword: true)),
+				new KeyValuePair<Type, JniTypeSignature>(typeof (JavaPrimitiveArray<Char>),  new JniTypeSignature ("C", arrayRank: 1, keyword: true)),
+				new KeyValuePair<Type, JniTypeSignature>(typeof (JavaArray<Char>),           new JniTypeSignature ("C", arrayRank: 1, keyword: true)),
+				new KeyValuePair<Type, JniTypeSignature>(typeof (JavaPrimitiveArray<Int16>),  new JniTypeSignature ("S", arrayRank: 1, keyword: true)),
+				new KeyValuePair<Type, JniTypeSignature>(typeof (JavaArray<Int16>),           new JniTypeSignature ("S", arrayRank: 1, keyword: true)),
+				new KeyValuePair<Type, JniTypeSignature>(typeof (JavaPrimitiveArray<Int32>),  new JniTypeSignature ("I", arrayRank: 1, keyword: true)),
+				new KeyValuePair<Type, JniTypeSignature>(typeof (JavaArray<Int32>),           new JniTypeSignature ("I", arrayRank: 1, keyword: true)),
+				new KeyValuePair<Type, JniTypeSignature>(typeof (JavaPrimitiveArray<Int64>),  new JniTypeSignature ("J", arrayRank: 1, keyword: true)),
+				new KeyValuePair<Type, JniTypeSignature>(typeof (JavaArray<Int64>),           new JniTypeSignature ("J", arrayRank: 1, keyword: true)),
+				new KeyValuePair<Type, JniTypeSignature>(typeof (JavaPrimitiveArray<Single>),  new JniTypeSignature ("F", arrayRank: 1, keyword: true)),
+				new KeyValuePair<Type, JniTypeSignature>(typeof (JavaArray<Single>),           new JniTypeSignature ("F", arrayRank: 1, keyword: true)),
+				new KeyValuePair<Type, JniTypeSignature>(typeof (JavaPrimitiveArray<Double>),  new JniTypeSignature ("D", arrayRank: 1, keyword: true)),
+				new KeyValuePair<Type, JniTypeSignature>(typeof (JavaArray<Double>),           new JniTypeSignature ("D", arrayRank: 1, keyword: true)),
+			};
+		}
+
+		static readonly Lazy<KeyValuePair<Type, JniValueMarshaler>[]> JniPrimitiveArrayMarshalers = new Lazy<KeyValuePair<Type, JniValueMarshaler>[]> (InitJniPrimitiveArrayMarshalers);
+
+		static KeyValuePair<Type, JniValueMarshaler>[] InitJniPrimitiveArrayMarshalers ()
+		{
+			return new [] {
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (Boolean[]),                   JavaBooleanArray.ArrayMarshaler),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaArray<Boolean>),          JavaBooleanArray.ArrayMarshaler),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaPrimitiveArray<Boolean>), JavaBooleanArray.ArrayMarshaler),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaBooleanArray),            JavaBooleanArray.ArrayMarshaler),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (SByte[]),                   JavaSByteArray.ArrayMarshaler),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaArray<SByte>),          JavaSByteArray.ArrayMarshaler),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaPrimitiveArray<SByte>), JavaSByteArray.ArrayMarshaler),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaSByteArray),            JavaSByteArray.ArrayMarshaler),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (Char[]),                   JavaCharArray.ArrayMarshaler),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaArray<Char>),          JavaCharArray.ArrayMarshaler),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaPrimitiveArray<Char>), JavaCharArray.ArrayMarshaler),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaCharArray),            JavaCharArray.ArrayMarshaler),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (Int16[]),                   JavaInt16Array.ArrayMarshaler),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaArray<Int16>),          JavaInt16Array.ArrayMarshaler),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaPrimitiveArray<Int16>), JavaInt16Array.ArrayMarshaler),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaInt16Array),            JavaInt16Array.ArrayMarshaler),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (Int32[]),                   JavaInt32Array.ArrayMarshaler),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaArray<Int32>),          JavaInt32Array.ArrayMarshaler),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaPrimitiveArray<Int32>), JavaInt32Array.ArrayMarshaler),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaInt32Array),            JavaInt32Array.ArrayMarshaler),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (Int64[]),                   JavaInt64Array.ArrayMarshaler),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaArray<Int64>),          JavaInt64Array.ArrayMarshaler),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaPrimitiveArray<Int64>), JavaInt64Array.ArrayMarshaler),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaInt64Array),            JavaInt64Array.ArrayMarshaler),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (Single[]),                   JavaSingleArray.ArrayMarshaler),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaArray<Single>),          JavaSingleArray.ArrayMarshaler),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaPrimitiveArray<Single>), JavaSingleArray.ArrayMarshaler),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaSingleArray),            JavaSingleArray.ArrayMarshaler),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (Double[]),                   JavaDoubleArray.ArrayMarshaler),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaArray<Double>),          JavaDoubleArray.ArrayMarshaler),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaPrimitiveArray<Double>), JavaDoubleArray.ArrayMarshaler),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaDoubleArray),            JavaDoubleArray.ArrayMarshaler),
+			};
+		}
 	}
 
 	public sealed class JniBooleanArrayElements : JniArrayElements {

--- a/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.tt
+++ b/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.tt
@@ -27,29 +27,39 @@ namespace Java.Interop {
 	};
 #>
 	partial class JniRuntime {
-		static readonly KeyValuePair<Type, JniTypeSignature>[] JniBuiltinArrayMappings = new[]{
-<#
-	foreach (var info in arrayTypeInfo) {
-#>
-			new KeyValuePair<Type, JniTypeSignature>(typeof (JavaPrimitiveArray<<#= info.ManagedType #>>),  new JniTypeSignature ("<#= info.JniType #>", arrayRank: 1, keyword: true)),
-			new KeyValuePair<Type, JniTypeSignature>(typeof (JavaArray<<#= info.ManagedType #>>),           new JniTypeSignature ("<#= info.JniType #>", arrayRank: 1, keyword: true)),
-<#
-	}
-#>
-		};
+		static readonly Lazy<KeyValuePair<Type, JniTypeSignature>[]> JniBuiltinArrayMappings = new Lazy<KeyValuePair<Type, JniTypeSignature>[]> (InitJniBuiltinArrayMappings);
 
-		static readonly KeyValuePair<Type, JniValueMarshaler>[] JniPrimitiveArrayMarshalers = new []{
+		static KeyValuePair<Type, JniTypeSignature>[] InitJniBuiltinArrayMappings ()
+		{
+			return new[] {
 <#
 	foreach (var info in arrayTypeInfo) {
 #>
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (<#= info.ManagedType #>[]),                   Java<#= info.TypeModifier #>Array.ArrayMarshaler),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaArray<<#= info.ManagedType #>>),          Java<#= info.TypeModifier #>Array.ArrayMarshaler),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaPrimitiveArray<<#= info.ManagedType #>>), Java<#= info.TypeModifier #>Array.ArrayMarshaler),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (Java<#= info.TypeModifier #>Array),            Java<#= info.TypeModifier #>Array.ArrayMarshaler),
+				new KeyValuePair<Type, JniTypeSignature>(typeof (JavaPrimitiveArray<<#= info.ManagedType #>>),  new JniTypeSignature ("<#= info.JniType #>", arrayRank: 1, keyword: true)),
+				new KeyValuePair<Type, JniTypeSignature>(typeof (JavaArray<<#= info.ManagedType #>>),           new JniTypeSignature ("<#= info.JniType #>", arrayRank: 1, keyword: true)),
 <#
 	}
 #>
-		};
+			};
+		}
+
+		static readonly Lazy<KeyValuePair<Type, JniValueMarshaler>[]> JniPrimitiveArrayMarshalers = new Lazy<KeyValuePair<Type, JniValueMarshaler>[]> (InitJniPrimitiveArrayMarshalers);
+
+		static KeyValuePair<Type, JniValueMarshaler>[] InitJniPrimitiveArrayMarshalers ()
+		{
+			return new [] {
+<#
+	foreach (var info in arrayTypeInfo) {
+#>
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (<#= info.ManagedType #>[]),                   Java<#= info.TypeModifier #>Array.ArrayMarshaler),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaArray<<#= info.ManagedType #>>),          Java<#= info.TypeModifier #>Array.ArrayMarshaler),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaPrimitiveArray<<#= info.ManagedType #>>), Java<#= info.TypeModifier #>Array.ArrayMarshaler),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (Java<#= info.TypeModifier #>Array),            Java<#= info.TypeModifier #>Array.ArrayMarshaler),
+<#
+	}
+#>
+			};
+		}
 	}
 
 <#

--- a/src/Java.Interop/Java.Interop/JniBuiltinMarshalers.cs
+++ b/src/Java.Interop/Java.Interop/JniBuiltinMarshalers.cs
@@ -10,49 +10,59 @@ namespace Java.Interop {
 
 	partial class JniRuntime {
 
-		static readonly KeyValuePair<Type, JniTypeSignature>[] JniBuiltinTypeNameMappings = new []{
-			new KeyValuePair<Type, JniTypeSignature>(typeof (string),    new JniTypeSignature ("java/lang/String")),
+		static readonly Lazy<KeyValuePair<Type, JniTypeSignature>[]> JniBuiltinTypeNameMappings = new Lazy<KeyValuePair<Type, JniTypeSignature>[]> (InitJniBuiltinTypeNameMappings);
 
-			new KeyValuePair<Type, JniTypeSignature>(typeof (void),      new JniTypeSignature ("V", arrayRank: 0, keyword: true)),
-			new KeyValuePair<Type, JniTypeSignature>(typeof (void),      new JniTypeSignature ("java/lang/Void")),
+		static KeyValuePair<Type, JniTypeSignature>[] InitJniBuiltinTypeNameMappings ()
+		{
+			return new []{
+				new KeyValuePair<Type, JniTypeSignature>(typeof (string),    new JniTypeSignature ("java/lang/String")),
 
-			new KeyValuePair<Type, JniTypeSignature>(typeof (Boolean),     new JniTypeSignature ("Z", 0, keyword: true)),
-			new KeyValuePair<Type, JniTypeSignature>(typeof (Boolean?),    new JniTypeSignature ("java/lang/Boolean")),
-			new KeyValuePair<Type, JniTypeSignature>(typeof (SByte),     new JniTypeSignature ("B", 0, keyword: true)),
-			new KeyValuePair<Type, JniTypeSignature>(typeof (SByte?),    new JniTypeSignature ("java/lang/Byte")),
-			new KeyValuePair<Type, JniTypeSignature>(typeof (Char),     new JniTypeSignature ("C", 0, keyword: true)),
-			new KeyValuePair<Type, JniTypeSignature>(typeof (Char?),    new JniTypeSignature ("java/lang/Character")),
-			new KeyValuePair<Type, JniTypeSignature>(typeof (Int16),     new JniTypeSignature ("S", 0, keyword: true)),
-			new KeyValuePair<Type, JniTypeSignature>(typeof (Int16?),    new JniTypeSignature ("java/lang/Short")),
-			new KeyValuePair<Type, JniTypeSignature>(typeof (Int32),     new JniTypeSignature ("I", 0, keyword: true)),
-			new KeyValuePair<Type, JniTypeSignature>(typeof (Int32?),    new JniTypeSignature ("java/lang/Integer")),
-			new KeyValuePair<Type, JniTypeSignature>(typeof (Int64),     new JniTypeSignature ("J", 0, keyword: true)),
-			new KeyValuePair<Type, JniTypeSignature>(typeof (Int64?),    new JniTypeSignature ("java/lang/Long")),
-			new KeyValuePair<Type, JniTypeSignature>(typeof (Single),     new JniTypeSignature ("F", 0, keyword: true)),
-			new KeyValuePair<Type, JniTypeSignature>(typeof (Single?),    new JniTypeSignature ("java/lang/Float")),
-			new KeyValuePair<Type, JniTypeSignature>(typeof (Double),     new JniTypeSignature ("D", 0, keyword: true)),
-			new KeyValuePair<Type, JniTypeSignature>(typeof (Double?),    new JniTypeSignature ("java/lang/Double")),
-		};
+				new KeyValuePair<Type, JniTypeSignature>(typeof (void),      new JniTypeSignature ("V", arrayRank: 0, keyword: true)),
+				new KeyValuePair<Type, JniTypeSignature>(typeof (void),      new JniTypeSignature ("java/lang/Void")),
 
-		static readonly KeyValuePair<Type, JniValueMarshaler>[] JniBuiltinMarshalers = new []{
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (string), JniStringValueMarshaler.Instance),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (Boolean),   JniBooleanValueMarshaler.Instance),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (Boolean?),  JniNullableBooleanValueMarshaler.Instance),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (SByte),   JniSByteValueMarshaler.Instance),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (SByte?),  JniNullableSByteValueMarshaler.Instance),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (Char),   JniCharValueMarshaler.Instance),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (Char?),  JniNullableCharValueMarshaler.Instance),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (Int16),   JniInt16ValueMarshaler.Instance),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (Int16?),  JniNullableInt16ValueMarshaler.Instance),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (Int32),   JniInt32ValueMarshaler.Instance),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (Int32?),  JniNullableInt32ValueMarshaler.Instance),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (Int64),   JniInt64ValueMarshaler.Instance),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (Int64?),  JniNullableInt64ValueMarshaler.Instance),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (Single),   JniSingleValueMarshaler.Instance),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (Single?),  JniNullableSingleValueMarshaler.Instance),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (Double),   JniDoubleValueMarshaler.Instance),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (Double?),  JniNullableDoubleValueMarshaler.Instance),
-		};
+				new KeyValuePair<Type, JniTypeSignature>(typeof (Boolean),     new JniTypeSignature ("Z", 0, keyword: true)),
+				new KeyValuePair<Type, JniTypeSignature>(typeof (Boolean?),    new JniTypeSignature ("java/lang/Boolean")),
+				new KeyValuePair<Type, JniTypeSignature>(typeof (SByte),     new JniTypeSignature ("B", 0, keyword: true)),
+				new KeyValuePair<Type, JniTypeSignature>(typeof (SByte?),    new JniTypeSignature ("java/lang/Byte")),
+				new KeyValuePair<Type, JniTypeSignature>(typeof (Char),     new JniTypeSignature ("C", 0, keyword: true)),
+				new KeyValuePair<Type, JniTypeSignature>(typeof (Char?),    new JniTypeSignature ("java/lang/Character")),
+				new KeyValuePair<Type, JniTypeSignature>(typeof (Int16),     new JniTypeSignature ("S", 0, keyword: true)),
+				new KeyValuePair<Type, JniTypeSignature>(typeof (Int16?),    new JniTypeSignature ("java/lang/Short")),
+				new KeyValuePair<Type, JniTypeSignature>(typeof (Int32),     new JniTypeSignature ("I", 0, keyword: true)),
+				new KeyValuePair<Type, JniTypeSignature>(typeof (Int32?),    new JniTypeSignature ("java/lang/Integer")),
+				new KeyValuePair<Type, JniTypeSignature>(typeof (Int64),     new JniTypeSignature ("J", 0, keyword: true)),
+				new KeyValuePair<Type, JniTypeSignature>(typeof (Int64?),    new JniTypeSignature ("java/lang/Long")),
+				new KeyValuePair<Type, JniTypeSignature>(typeof (Single),     new JniTypeSignature ("F", 0, keyword: true)),
+				new KeyValuePair<Type, JniTypeSignature>(typeof (Single?),    new JniTypeSignature ("java/lang/Float")),
+				new KeyValuePair<Type, JniTypeSignature>(typeof (Double),     new JniTypeSignature ("D", 0, keyword: true)),
+				new KeyValuePair<Type, JniTypeSignature>(typeof (Double?),    new JniTypeSignature ("java/lang/Double")),
+			};
+		}
+
+		static readonly Lazy<KeyValuePair<Type, JniValueMarshaler>[]> JniBuiltinMarshalers = new Lazy<KeyValuePair<Type, JniValueMarshaler>[]> (InitJniBuiltinMarshalers);
+
+		static KeyValuePair<Type, JniValueMarshaler>[] InitJniBuiltinMarshalers ()
+		{
+			return new []{
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (string), JniStringValueMarshaler.Instance),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (Boolean),   JniBooleanValueMarshaler.Instance),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (Boolean?),  JniNullableBooleanValueMarshaler.Instance),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (SByte),   JniSByteValueMarshaler.Instance),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (SByte?),  JniNullableSByteValueMarshaler.Instance),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (Char),   JniCharValueMarshaler.Instance),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (Char?),  JniNullableCharValueMarshaler.Instance),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (Int16),   JniInt16ValueMarshaler.Instance),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (Int16?),  JniNullableInt16ValueMarshaler.Instance),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (Int32),   JniInt32ValueMarshaler.Instance),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (Int32?),  JniNullableInt32ValueMarshaler.Instance),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (Int64),   JniInt64ValueMarshaler.Instance),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (Int64?),  JniNullableInt64ValueMarshaler.Instance),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (Single),   JniSingleValueMarshaler.Instance),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (Single?),  JniNullableSingleValueMarshaler.Instance),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (Double),   JniDoubleValueMarshaler.Instance),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (Double?),  JniNullableDoubleValueMarshaler.Instance),
+			};
+		}
 	}
 
 	static class JniBoolean {

--- a/src/Java.Interop/Java.Interop/JniBuiltinMarshalers.tt
+++ b/src/Java.Interop/Java.Interop/JniBuiltinMarshalers.tt
@@ -27,33 +27,43 @@ namespace Java.Interop {
 
 	partial class JniRuntime {
 
-		static readonly KeyValuePair<Type, JniTypeSignature>[] JniBuiltinTypeNameMappings = new []{
-			new KeyValuePair<Type, JniTypeSignature>(typeof (string),    new JniTypeSignature ("java/lang/String")),
+		static readonly Lazy<KeyValuePair<Type, JniTypeSignature>[]> JniBuiltinTypeNameMappings = new Lazy<KeyValuePair<Type, JniTypeSignature>[]> (InitJniBuiltinTypeNameMappings);
 
-			new KeyValuePair<Type, JniTypeSignature>(typeof (void),      new JniTypeSignature ("V", arrayRank: 0, keyword: true)),
-			new KeyValuePair<Type, JniTypeSignature>(typeof (void),      new JniTypeSignature ("java/lang/Void")),
+		static KeyValuePair<Type, JniTypeSignature>[] InitJniBuiltinTypeNameMappings ()
+		{
+			return new []{
+				new KeyValuePair<Type, JniTypeSignature>(typeof (string),    new JniTypeSignature ("java/lang/String")),
+
+				new KeyValuePair<Type, JniTypeSignature>(typeof (void),      new JniTypeSignature ("V", arrayRank: 0, keyword: true)),
+				new KeyValuePair<Type, JniTypeSignature>(typeof (void),      new JniTypeSignature ("java/lang/Void")),
 
 <#
 	foreach (var type in types) {
 #>
-			new KeyValuePair<Type, JniTypeSignature>(typeof (<#= type.Type #>),     new JniTypeSignature ("<#= type.JniType #>", 0, keyword: true)),
-			new KeyValuePair<Type, JniTypeSignature>(typeof (<#= type.Type #>?),    new JniTypeSignature ("java/lang/<#= type.Name #>")),
+				new KeyValuePair<Type, JniTypeSignature>(typeof (<#= type.Type #>),     new JniTypeSignature ("<#= type.JniType #>", 0, keyword: true)),
+				new KeyValuePair<Type, JniTypeSignature>(typeof (<#= type.Type #>?),    new JniTypeSignature ("java/lang/<#= type.Name #>")),
 <#
 	}
 #>
-		};
+			};
+		}
 
-		static readonly KeyValuePair<Type, JniValueMarshaler>[] JniBuiltinMarshalers = new []{
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (string), JniStringValueMarshaler.Instance),
+		static readonly Lazy<KeyValuePair<Type, JniValueMarshaler>[]> JniBuiltinMarshalers = new Lazy<KeyValuePair<Type, JniValueMarshaler>[]> (InitJniBuiltinMarshalers);
+
+		static KeyValuePair<Type, JniValueMarshaler>[] InitJniBuiltinMarshalers ()
+		{
+			return new []{
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (string), JniStringValueMarshaler.Instance),
 <#
 	foreach (var type in types) {
 #>
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (<#= type.Type #>),   Jni<#= type.Type #>ValueMarshaler.Instance),
-			new KeyValuePair<Type, JniValueMarshaler>(typeof (<#= type.Type #>?),  JniNullable<#= type.Type #>ValueMarshaler.Instance),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (<#= type.Type #>),   Jni<#= type.Type #>ValueMarshaler.Instance),
+				new KeyValuePair<Type, JniValueMarshaler>(typeof (<#= type.Type #>?),  JniNullable<#= type.Type #>ValueMarshaler.Instance),
 <#
 	}
 #>
-		};
+			};
+		}
 	}
 <#
 	foreach (var type in types) {

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
@@ -74,14 +74,14 @@ namespace Java.Interop {
 					type = Enum.GetUnderlyingType (type);
 
 #if !XA_INTEGRATION
-				foreach (var mapping in JniBuiltinTypeNameMappings) {
+				foreach (var mapping in JniBuiltinTypeNameMappings.Value) {
 					if (mapping.Key == type) {
 						var r = mapping.Value;
 						yield return r.AddArrayRank (rank);
 					}
 				}
 
-				foreach (var mapping in JniBuiltinArrayMappings) {
+				foreach (var mapping in JniBuiltinArrayMappings.Value) {
 					if (mapping.Key == type) {
 						var r = mapping.Value;
 						yield return r.AddArrayRank (rank);
@@ -202,7 +202,7 @@ namespace Java.Interop {
 			IEnumerable<Type> CreateGetTypesForSimpleReferenceEnumerator (string jniSimpleReference)
 			{
 #if !XA_INTEGRATION
-				foreach (var mapping in JniBuiltinTypeNameMappings) {
+				foreach (var mapping in JniBuiltinTypeNameMappings.Value) {
 					if (mapping.Value.SimpleReference == jniSimpleReference)
 						yield return mapping.Key;
 				}

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -500,7 +500,7 @@ namespace Java.Interop
 				if (typeof (void) == type)
 					return VoidValueMarshaler.Instance;
 
-				foreach (var marshaler in JniBuiltinMarshalers) {
+				foreach (var marshaler in JniBuiltinMarshalers.Value) {
 					if (marshaler.Key == type)
 						return marshaler.Value;
 				}
@@ -515,7 +515,7 @@ namespace Java.Interop
 				if (listType != null) {
 					var elementType = listType.GenericTypeArguments [0];
 					if (elementType.GetTypeInfo ().IsValueType) {
-						foreach (var marshaler in JniPrimitiveArrayMarshalers) {
+						foreach (var marshaler in JniPrimitiveArrayMarshalers.Value) {
 							if (info.IsAssignableFrom (marshaler.Key.GetTypeInfo ()))
 								return marshaler.Value;
 						}


### PR DESCRIPTION
The static constructor of JniRuntime class took relatively long to
JIT. It also initializes bunch of static arrays, while some of them
are not used during the startup.

So using the lazy initialization we save time in array creation and
also in less code to JIT.

The lazy initialization helps improve the startup time.

XA template times on Pixel XL 2

Before:

    Time:    321ms Message: Runtime.init: end, total time; elapsed: 0s:224::473824
    Time:    316ms Message: Runtime.init: end, total time; elapsed: 0s:224::390855
    Time:    305ms Message: Runtime.init: end, total time; elapsed: 0s:223::397210
    Time:    313ms Message: Runtime.init: end, total time; elapsed: 0s:229::617471
    Time:    304ms Message: Runtime.init: end, total time; elapsed: 0s:221::623355

After:

    Time:    315ms Message: Runtime.init: end, total time; elapsed: 0s:217::304293
    Time:    298ms Message: Runtime.init: end, total time; elapsed: 0s:217::385334
    Time:    308ms Message: Runtime.init: end, total time; elapsed: 0s:215::707209
    Time:    302ms Message: Runtime.init: end, total time; elapsed: 0s:215::524865
    Time:    315ms Message: Runtime.init: end, total time; elapsed: 0s:215::715438

Measured improvement in `Runtime.init` is 8.4ms in average.

The JIT times.

Before:

    Total (ms) |  Self (ms) | Method
         13.15 |       9.92 | Java.Interop.JniRuntime:.cctor ()

After:

    Total (ms) |  Self (ms) | Method
          0.58 |       0.58 | Java.Interop.JniRuntime:.cctor ()
          1.68 |       1.68 | Java.Interop.JniRuntime:InitJniBuiltinTypeNameMappings ()
          2.26 |       2.26 | Java.Interop.JniRuntime:InitJniBuiltinArrayMappings ()