### PR TITLE
[build] `make prepare` creates `MonoInfo.props`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,14 +44,13 @@ NUNIT_CONSOLE = packages/NUnit.ConsoleRunner.3.7.0/tools/nunit3-console.exe
 
 BUILD_PROPS = bin/Build$(CONFIGURATION)/JdkInfo.props bin/Build$(CONFIGURATION)/MonoInfo.props
 
-all: $(BUILD_PROPS)  src/Java.Runtime.Environment/Java.Runtime.Environment.dll.config \
-		$(PACKAGES) $(DEPENDENCIES) $(TESTS)
+all: $(DEPENDENCIES) $(TESTS)
 
 run-all-tests: run-tests run-test-jnimarshal run-test-generator-core run-ptests
 
 include build-tools/scripts/msbuild.mk
 
-prepare:: src/Java.Runtime.Environment/Java.Runtime.Environment.dll.config
+prepare:: $(BUILD_PROPS) src/Java.Runtime.Environment/Java.Runtime.Environment.dll.config
 
 prepare:: prepare-bootstrap
 	$(MSBUILD) $(MSBUILD_FLAGS) /t:Restore Java.Interop.sln


### PR DESCRIPTION
With enough finagling, Visual Studio for Mac 8.0 (build 2479) is able
to build `Java.Interop.sln`.  (And there was much rejoicing!)

Now, about that finagling...

This process doesn't work:

 1. Run `make prepare`
 2. Open `Java.Interop.sln` within Visual Studio for Mac.
 3. Press Command+B or click Build > Build All

Step (3) fails:

	src/java-interop/java-interop.targets(5,5): Error MSB3073:
	The command "gcc -g -shared -m64 -std=c99 -o "../../bin/Debug/libjava-interop.dylib" …" exited with code 1.

The problem is that `java-interop.targets` "requires" that
`bin/BuildDebug/MonoInfo.props` exist, otherwise `@(MonoIncludePath)`,
`$(MonoFrameworkPath)`, and `$(MonoLibs)` won't be defined, which is
why the above `gcc` command fails.

Fix the `make prepare` target so that `MonoInfo.props` is created.
This allows Visual Studio for Mac 8.0 to build `Java.Interop.sln` once
`make prepare` has been executed.