### PR TITLE
Allow .jar files to be read from a Stream

### DIFF
--- a/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
@@ -46,7 +46,17 @@ namespace Xamarin.Android.Tools.Bytecode {
 			if (!IsJarFile (jarFile))
 				throw new ArgumentException ("'jarFile' is not a valid .jar file.", "jarFile");
 
-			using (var jar = CreateZipArchive (jarFile)) {
+			using (var jarStream = File.OpenRead (jarFile)) { 
+				Load (jarStream);
+			}
+		}
+
+		public void Load (Stream jarStream)
+		{
+			if (jarStream == null)
+				throw new ArgumentNullException (nameof (jarStream));
+
+			using (var jar = CreateZipArchive (jarStream)) {
 				foreach (var entry in jar.Entries) {
 					if (entry.Length == 0)
 						continue;
@@ -67,11 +77,11 @@ namespace Xamarin.Android.Tools.Bytecode {
 			}
 		}
 
-		static ZipArchive CreateZipArchive (string jarFile)
+		static ZipArchive CreateZipArchive (Stream jarStream)
 		{
 			var encoding    = new UTF8Encoding (encoderShouldEmitUTF8Identifier: false);
 
-			return new ZipArchive (File.OpenRead (jarFile), ZipArchiveMode.Read, leaveOpen: false, entryNameEncoding: encoding);
+			return new ZipArchive (jarStream, ZipArchiveMode.Read, leaveOpen: true, entryNameEncoding: encoding);
 		}
 
 		public void Add (ClassFile classFile)

--- a/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
@@ -51,12 +51,12 @@ namespace Xamarin.Android.Tools.Bytecode {
 			}
 		}
 
-		public void Load (Stream jarStream)
+		public void Load (Stream jarStream, bool leaveOpen = false)
 		{
 			if (jarStream == null)
 				throw new ArgumentNullException (nameof (jarStream));
 
-			using (var jar = CreateZipArchive (jarStream)) {
+			using (var jar = CreateZipArchive (jarStream, leaveOpen)) {
 				foreach (var entry in jar.Entries) {
 					if (entry.Length == 0)
 						continue;
@@ -77,11 +77,11 @@ namespace Xamarin.Android.Tools.Bytecode {
 			}
 		}
 
-		static ZipArchive CreateZipArchive (Stream jarStream)
+		static ZipArchive CreateZipArchive (Stream jarStream, bool leaveOpen)
 		{
 			var encoding    = new UTF8Encoding (encoderShouldEmitUTF8Identifier: false);
 
-			return new ZipArchive (jarStream, ZipArchiveMode.Read, leaveOpen: true, entryNameEncoding: encoding);
+			return new ZipArchive (jarStream, ZipArchiveMode.Read, leaveOpen: leaveOpen, entryNameEncoding: encoding);
 		}
 
 		public void Add (ClassFile classFile)


### PR DESCRIPTION
Instead of requiring a path on the filesystem, allow a stream. This will allow direct reading from .aar files without having to extract the .jar first.