### PR TITLE
[JavaCallableWrappers] support split APKs

### DIFF
--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers.csproj
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers.csproj
@@ -60,6 +60,9 @@
     <EmbeddedResource Include="Resources\MonoRuntimeProvider.Bundled.java">
       <LogicalName>MonoRuntimeProvider.Bundled.java</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="Resources\MonoRuntimeProvider.Bundled.20.java">
+      <LogicalName>MonoRuntimeProvider.Bundled.20.java</LogicalName>
+    </EmbeddedResource>
     <EmbeddedResource Include="Resources\MonoRuntimeProvider.Shared.java">
       <LogicalName>MonoRuntimeProvider.Shared.java</LogicalName>
     </EmbeddedResource>

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
@@ -69,6 +69,8 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 
 		public bool GenerateOnCreateOverrides { get; set; }
 
+		public int? TargetSdkVersion { get; set; }
+
 		public bool HasExport { get; private set; }
 
 		public string Name {
@@ -837,11 +839,15 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 			sw.WriteLine ("\t\tandroid.content.Context context = getContext ();");
 			sw.WriteLine ();
 
+			var provider = "MonoRuntimeProvider.Bundled.java";
+			if (UseSharedRuntime) {
+				provider = "MonoRuntimeProvider.Shared.java";
+			} else if (TargetSdkVersion < 21) {
+				provider = "MonoRuntimeProvider.Bundled.20.java";
+			}
+
 			using (var app = new StreamReader (
-						Assembly.GetExecutingAssembly ().GetManifestResourceStream (
-							UseSharedRuntime
-							? "MonoRuntimeProvider.Shared.java"
-							: "MonoRuntimeProvider.Bundled.java"))) {
+						Assembly.GetExecutingAssembly ().GetManifestResourceStream (provider))) {
 				bool copy = false;
 				string line;
 				while ((line = app.ReadLine ()) != null) {

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Resources/MonoRuntimeProvider.Bundled.20.java
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Resources/MonoRuntimeProvider.Bundled.20.java
@@ -19,20 +19,7 @@ public class MonoRuntimeProvider
 	public void attachInfo (android.content.Context context, android.content.pm.ProviderInfo info)
 	{
 		// Mono Runtime Initialization {{{
-		android.content.pm.ApplicationInfo applicationInfo = context.getApplicationInfo ();
-		String[] apks = null;
-		if (android.os.Build.VERSION.SDK_INT >= 21) {
-			String[] splitApks = applicationInfo.splitPublicSourceDirs;
-			if (splitApks != null && splitApks.length > 0) {
-				apks = new String[splitApks.length + 1];
-				apks [0] = applicationInfo.sourceDir;
-				System.arraycopy (splitApks, 0, apks, 1, splitApks.length);
-			}
-		}
-		if (apks == null) {
-			apks = new String[] { applicationInfo.sourceDir };
-		}
-		mono.MonoPackageManager.LoadApplication (context, applicationInfo, apks);
+		mono.MonoPackageManager.LoadApplication (context, context.getApplicationInfo (), new String[]{context.getApplicationInfo ().sourceDir});
 		// }}}
 		super.attachInfo (context, info);
 	}
@@ -67,4 +54,3 @@ public class MonoRuntimeProvider
 		throw new RuntimeException ("This operation is not supported.");
 	}
 }
-

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGeneratorTests.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGeneratorTests.cs
@@ -56,6 +56,12 @@ public class Name
 		mono.MonoPackageManager.setContext (this);
 	}}
 
+	public void onCreate ()
+	{{
+		mono.android.Runtime.register (""Xamarin.Android.ToolsTests.ApplicationName, Java.Interop.Tools.JavaCallableWrappers-Tests"", Name.class, __md_methods);
+		super.onCreate ();
+	}}
+
 	private java.util.ArrayList refList;
 	public void monodroidAddReference (java.lang.Object obj)
 	{{
@@ -74,11 +80,13 @@ public class Name
 			Assert.AreEqual (expected, actual);
 		}
 
-		static string Generate (Type type, string applicationJavaClass = null)
+		static string Generate (Type type, string applicationJavaClass = null, int? targetSdkVersion = null)
 		{
 			var td  = SupportDeclarations.GetTypeDefinition (type);
 			var g   = new JavaCallableWrapperGenerator (td, null) {
 				ApplicationJavaClass        = applicationJavaClass,
+				GenerateOnCreateOverrides   = true,
+				TargetSdkVersion            = targetSdkVersion,
 			};
 			var o   = new StringWriter ();
 			var dir = Path.GetDirectoryName (typeof (JavaCallableWrapperGeneratorTests).Assembly.Location);
@@ -488,6 +496,110 @@ public class ExportsThrowsConstructors
 			refList.clear ();
 	}
 }
+";
+			Assert.AreEqual (expected, actual);
+		}
+
+		[Test]
+		public void GenerateActivity ()
+		{
+			var actual = Generate (typeof (ExampleActivity));
+			var expected = @"package my;
+
+
+public class ExampleActivity
+	extends android.app.Activity
+	implements
+		mono.android.IGCUserPeer
+{
+/** @hide */
+	public static final String __md_methods;
+	static {
+		__md_methods = 
+			"""";
+		mono.android.Runtime.register (""Xamarin.Android.ToolsTests.ExampleActivity, Java.Interop.Tools.JavaCallableWrappers-Tests"", ExampleActivity.class, __md_methods);
+	}
+
+	private java.util.ArrayList refList;
+	public void monodroidAddReference (java.lang.Object obj)
+	{
+		if (refList == null)
+			refList = new java.util.ArrayList ();
+		refList.add (obj);
+	}
+
+	public void monodroidClearReferences ()
+	{
+		if (refList != null)
+			refList.clear ();
+	}
+}
+";
+			Assert.AreEqual (expected, actual);
+		}
+
+		[Test]
+		public void GenerateInstrumentation ([Values (28, 20)] int targetSdkVersion)
+		{
+			var onCreate = "mono.MonoPackageManager.LoadApplication (context, context.getApplicationInfo (), new String[]{context.getApplicationInfo ().sourceDir});";
+			if (targetSdkVersion >= 21) {
+				onCreate = @"android.content.pm.ApplicationInfo applicationInfo = context.getApplicationInfo ();
+		String[] apks = null;
+		if (android.os.Build.VERSION.SDK_INT >= 21) {
+			String[] splitApks = applicationInfo.splitPublicSourceDirs;
+			if (splitApks != null && splitApks.length > 0) {
+				apks = new String[splitApks.length + 1];
+				apks [0] = applicationInfo.sourceDir;
+				System.arraycopy (splitApks, 0, apks, 1, splitApks.length);
+			}
+		}
+		if (apks == null) {
+			apks = new String[] { applicationInfo.sourceDir };
+		}
+		mono.MonoPackageManager.LoadApplication (context, applicationInfo, apks);";
+			}
+
+			var actual = Generate (typeof (ExampleInstrumentation), targetSdkVersion: targetSdkVersion);
+			var expected = $@"package my;
+
+
+public class ExampleInstrumentation
+	extends android.app.Instrumentation
+	implements
+		mono.android.IGCUserPeer
+{{
+/** @hide */
+	public static final String __md_methods;
+	static {{
+		__md_methods = 
+			"""";
+	}}
+
+	public void onCreate (android.os.Bundle arguments)
+	{{
+		android.content.Context context = getContext ();
+
+		// Mono Runtime Initialization {{{{{{
+		{onCreate}
+		// }}}}}}
+		mono.android.Runtime.register (""Xamarin.Android.ToolsTests.ExampleInstrumentation, Java.Interop.Tools.JavaCallableWrappers-Tests"", ExampleInstrumentation.class, __md_methods);
+		super.onCreate (arguments);
+	}}
+
+	private java.util.ArrayList refList;
+	public void monodroidAddReference (java.lang.Object obj)
+	{{
+		if (refList == null)
+			refList = new java.util.ArrayList ();
+		refList.add (obj);
+	}}
+
+	public void monodroidClearReferences ()
+	{{
+		if (refList != null)
+			refList.clear ();
+	}}
+}}
 ";
 			Assert.AreEqual (expected, actual);
 		}

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers/SupportDeclarations.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers/SupportDeclarations.cs
@@ -23,6 +23,24 @@ namespace Android.App {
 		{
 		}
 	}
+
+	[Register ("android/app/Activity", DoNotGenerateAcw = true)]
+	class Activity : Java.Lang.Object
+	{
+		[Register ("onCreate", "(Ljava/lang/Object;)V", "Activity.OnCreate")]
+		public virtual void OnCreate (Java.Lang.Object savedInstanceState)
+		{
+		}
+	}
+
+	[Register ("android/app/Instrumentation", DoNotGenerateAcw = true)]
+	class Instrumentation : Java.Lang.Object
+	{
+		[Register ("onCreate", "(Ljava/lang/Object;)V", "Instrumentation.OnCreate")]
+		public virtual void OnCreate (Java.Lang.Object arguments)
+		{
+		}
+	}
 }
 
 namespace Android.Runtime {
@@ -58,6 +76,8 @@ namespace Xamarin.Android.ToolsTests {
 			typeof (DefaultName.A),
 			typeof (DefaultName.A.B),
 			typeof (DefaultName.C.D),
+			typeof (ExampleActivity),
+			typeof (ExampleInstrumentation),
 			typeof (ExampleOuterClass),
 			typeof (ExampleOuterClass.ExampleInnerClass),
 			typeof (InstrumentationName),
@@ -177,6 +197,16 @@ namespace Xamarin.Android.ToolsTests {
 			{
 			}
 		}
+	}
+
+	[Activity (Name = "my.ExampleActivity")]
+	class ExampleActivity : Activity
+	{
+	}
+
+	[Instrumentation (Name = "my.ExampleInstrumentation")]
+	class ExampleInstrumentation : Instrumentation
+	{
 	}
 
 	[BroadcastReceiver (Name = "receiver.Name")]

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers/TypeNameMapGeneratorTests.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers/TypeNameMapGeneratorTests.cs
@@ -44,7 +44,8 @@ namespace Xamarin.Android.ToolsTests
 		[Test]
 		public void WriteJavaToManaged ()
 		{
-			var v = new TypeNameMapGenerator (SupportDeclarations.GetTestTypeDefinitions (), logger: Diagnostic.CreateConsoleLogger ());
+			var types = SupportDeclarations.GetTestTypeDefinitions ();
+			var v = new TypeNameMapGenerator (types, logger: Diagnostic.CreateConsoleLogger ());
 			var o = new MemoryStream ();
 			v.WriteJavaToManaged (o);
 			var a = ToArray (o);
@@ -53,7 +54,7 @@ namespace Xamarin.Android.ToolsTests
 			var offset = 90;
 			var e =
 				"version=1\u0000" +
-				"entry-count=18\u0000" +
+				$"entry-count={types.Count - 1}\u0000" +
 				"entry-len=" + length + "\u0000" +
 				"value-offset=" + offset + "\u0000" +
 				GetJ2MEntryLine (typeof (ActivityName),                             "activity/Name",                                                                                offset, length) +
@@ -66,6 +67,8 @@ namespace Xamarin.Android.ToolsTests
 				GetJ2MEntryLine (typeof (ExampleOuterClass),                        "md5f43cdfade412ae71b21bb70a5c2841ab/ExampleOuterClass",                                        offset, length) +
 				GetJ2MEntryLine (typeof (ExampleOuterClass.ExampleInnerClass),      "md5f43cdfade412ae71b21bb70a5c2841ab/ExampleOuterClass$ExampleOuterClass_ExampleInnerClass",    offset, length) +
 				GetJ2MEntryLine (typeof (AbstractClass),                            "my/AbstractClass",                                                                             offset, length) +
+				GetJ2MEntryLine (typeof (ExampleActivity),                          "my/ExampleActivity",                                                                           offset, length) +
+				GetJ2MEntryLine (typeof (ExampleInstrumentation),                   "my/ExampleInstrumentation",                                                                    offset, length) +
 				GetJ2MEntryLine (typeof (ProviderName),                             "provider/Name",                                                                                offset, length) +
 				GetJ2MEntryLine (typeof (ReceiverName),                             "receiver/Name",                                                                                offset, length) +
 				GetJ2MEntryLine (typeof (RegisterName),                             "register/Name",                                                                                offset, length) +
@@ -119,7 +122,8 @@ namespace Xamarin.Android.ToolsTests
 		[Test]
 		public void WriteManagedToJava ()
 		{
-			var v = new TypeNameMapGenerator (SupportDeclarations.GetTestTypeDefinitions (), logger: Diagnostic.CreateConsoleLogger ());
+			var types = SupportDeclarations.GetTestTypeDefinitions ();
+			var v = new TypeNameMapGenerator (types, logger: Diagnostic.CreateConsoleLogger ());
 			var o = new MemoryStream ();
 			v.WriteManagedToJava (o);
 			var a = ToArray (o);
@@ -128,7 +132,7 @@ namespace Xamarin.Android.ToolsTests
 			var offset = 114;
 			var e =
 				"version=1\u0000" +
-				"entry-count=19\u0000" +
+				$"entry-count={types.Count}\u0000" +
 				"entry-len=" + length + "\u0000" +
 				"value-offset=" + offset + "\u0000" +
 				GetM2JEntryLine (typeof (AbstractClass),                            "my/AbstractClass",                                                                             offset, length) +
@@ -139,6 +143,8 @@ namespace Xamarin.Android.ToolsTests
 				GetM2JEntryLine (typeof (DefaultName.A),                            "md5f43cdfade412ae71b21bb70a5c2841ab/DefaultName_A",                                            offset, length) +
 				GetM2JEntryLine (typeof (DefaultName.C.D),                          "md5f43cdfade412ae71b21bb70a5c2841ab/DefaultName_C_D",                                          offset, length) +
 				GetM2JEntryLine (typeof (DefaultName),                              "md5f43cdfade412ae71b21bb70a5c2841ab/DefaultName",                                              offset, length) +
+				GetM2JEntryLine (typeof (ExampleActivity),                          "my/ExampleActivity",                                                                           offset, length) +
+				GetM2JEntryLine (typeof (ExampleInstrumentation),                   "my/ExampleInstrumentation",                                                                    offset, length) +
 				GetM2JEntryLine (typeof (ExampleOuterClass.ExampleInnerClass),      "md5f43cdfade412ae71b21bb70a5c2841ab/ExampleOuterClass$ExampleOuterClass_ExampleInnerClass",    offset, length) +
 				GetM2JEntryLine (typeof (ExampleOuterClass),                        "md5f43cdfade412ae71b21bb70a5c2841ab/ExampleOuterClass",                                        offset, length) +
 				GetM2JEntryLine (typeof (InstrumentationName),                      "instrumentation/Name",                                                                         offset, length) +


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/2841

In my initial work to support Android App Bundles in Xamarin.Android,
apps were crashing on startup with an error such as:

    monodroid: Using runtime path: /data/app/UnnamedProject.UnnamedProject-BcBcWREBNkF09eleaCTkuw==/lib/arm64
    monodroid: Trying to load sgen from: /data/app/UnnamedProject.UnnamedProject-BcBcWREBNkF09eleaCTkuw==/lib/arm64/libmonosgen-64bit-2.0.so
    monodroid: Trying to load sgen from: /system/lib64/libmonosgen-2.0.so
    monodroid: Cannot find 'libmonosgen-2.0.so'. Looked in the following locations:
    monodroid:   /data/app/UnnamedProject.UnnamedProject-BcBcWREBNkF09eleaCTkuw==/base.apk!/lib/arm64-v8a
    monodroid: Do you have a shared runtime build of your app with AndroidManifest.xml android:minSdkVersion < 10 while running on a 64-bit Android 5.0 target? This combination is not supported.
    monodroid: Please either set android:minSdkVersion >= 10 or use a build without the shared runtime (like default Release configuration).

Android App Bundles use `android:extractNativeLibs="false"` also known
as "embedded DSOs". The file system showed the app contents are in
multiple APK files:

    $ run-as UnnamedProject.UnnamedProject ls -l /data/app/UnnamedProject.UnnamedProject-BcBcWREBNkF09eleaCTkuw==/
    total 22663
    -rw-r--r-- 1 system system  2994137 2019-03-18 10:37 base.apk
    drwxr-xr-x 3 system system     3488 2019-03-18 10:37 lib
    -rw-r--r-- 1 system system 20161118 2019-03-18 10:37 split_config.arm64_v8a.apk
    -rw-r--r-- 1 system system    23203 2019-03-18 10:37 split_config.xxxhdpi.apk

The paths to these APK files were missing in `LoadApplication`:

https://github.com/xamarin/xamarin-android/blob/f098d9c161a3d602c75f8e866bb22262bf25539e/src/Xamarin.Android.Build.Tasks/Resources/MonoPackageManager.java#L23

The only APK listed was:

    /data/app/UnnamedProject.UnnamedProject-BcBcWREBNkF09eleaCTkuw==/base.apk

It appears we need to use a new API that became available in API 21:

https://developer.android.com/reference/android/content/pm/ApplicationInfo.html#splitPublicSourceDirs

After using the value from `ApplicationInfo.splitPublicSourceDirs`:

    /data/app/UnnamedProject.UnnamedProject-BcBcWREBNkF09eleaCTkuw==/split_config.arm64_v8a.apk
    /data/app/UnnamedProject.UnnamedProject-BcBcWREBNkF09eleaCTkuw==/split_config.xxxhdpi.apk

Xamarin.Android apps deployed as an Android App Bundle were able to
startup properly after this change.

My initial research is showing we probably can't use "Fast Deployment"
in combination with Android App Bundles. So I don't think we should
make any changes to `MonoRuntimeProvider.Shared.java`.

Unfortunately if your `targetSdkVersion` is 20 or less, this code
would not compile! So I included a source file with the original code:
`MonoRuntimeProvider.Bundled.20.java`. We will need to make sure this
file is used in xamarin-android for older `targetSdkVersion`:

https://github.com/xamarin/xamarin-android/blob/5fed357fcfc7c59484fb1eb9b3748bc0545c8a25/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets#L1896-L1899