### PR TITLE
Bump to xamarin/xamarin-android-tools/master@66d445c

### DIFF
--- a/build-tools/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks.csproj
+++ b/build-tools/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Java.Interop.BootstrapTasks</RootNamespace>
     <AssemblyName>Java.Interop.BootstrapTasks</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>


### PR DESCRIPTION
Context: http://build.devdiv.io/2532642
Changes: https://github.com/xamarin/xamarin-android-tools/compare/9e78d6e...66d445c

As part of this change, anything referencing
`Xamarin.Android.Tools.AndroidSdk.csproj` neeeds to be using a
`TargetFrameworkVersion` of `v4.7.1`.

This will solve a build failure currently happening in
xamarin-android:

    warning MSB3274: The primary reference "E:\A\_work\1345\s\external\xamarin-android-tools\bin\Release\Xamarin.Android.Tools.AndroidSdk.dll" could not be resolved because it was built against the ".NETFramework,Version=v4.7.1" framework. This is a higher version than the currently targeted framework ".NETFramework,Version=v4.6.1". [E:\A\_work\1345\s\external\Java.Interop\build-tools\Java.Interop.BootstrapTasks\Java.Interop.BootstrapTasks.csproj]
    ...
    Java.Interop.BootstrapTasks\JdkInfo.cs(14,19): error CS0246: The type or namespace name 'Xamarin' could not be found (are you missing a using directive or an assembly reference?) [E:\A\_work\1345\s\external\Java.Interop\build-tools\Java.Interop.BootstrapTasks\Java.Interop.BootstrapTasks.csproj]
    Java.Interop.BootstrapTasks\JdkInfo.cs(12,7): error CS0246: The type or namespace name 'Xamarin' could not be found (are you missing a using directive or an assembly reference?) [E:\A\_work\1345\s\external\Java.Interop\build-tools\Java.Interop.BootstrapTasks\Java.Interop.BootstrapTasks.csproj]