### PR TITLE
[Java.Interop] JniMethodInfo.ToString() shouldn't throw

### DIFF
--- a/src/Java.Interop/Java.Interop/JniFieldInfo.cs
+++ b/src/Java.Interop/Java.Interop/JniFieldInfo.cs
@@ -52,8 +52,13 @@ namespace Java.Interop
 
 		public override string ToString ()
 		{
+#if DEBUG
 			bool haveName   = !string.IsNullOrEmpty (Name);
 			bool haveSig    = !string.IsNullOrEmpty (Signature);
+#else   // DEBUG
+			bool haveName   = false;
+			bool haveSig    = false;
+#endif  // DEBUG
 			return string.Format ("JniFieldInfo({0}{1}{2}{3}ID=0x{4})",
 					haveName ? "Name=" + Name : string.Empty,
 					haveName ? ", " : string.Empty,

--- a/src/Java.Interop/Java.Interop/JniMethodInfo.cs
+++ b/src/Java.Interop/Java.Interop/JniMethodInfo.cs
@@ -52,8 +52,13 @@ namespace Java.Interop
 
 		public override string ToString ()
 		{
+#if DEBUG
 			bool haveName   = !string.IsNullOrEmpty (Name);
 			bool haveSig    = !string.IsNullOrEmpty (Signature);
+#else   // DEBUG
+			bool haveName   = false;
+			bool haveSig    = false;
+#endif  // DEBUG
 			return string.Format ("JniMethodInfo({0}{1}{2}{3}ID=0x{4})",
 					haveName ? "Name=" + Name : string.Empty,
 					haveName ? ", " : string.Empty,


### PR DESCRIPTION
Commit 69d2c998 contained an oversight: in a Release build, in which
`DEBUG` isn't defined, `JniFieldInfo.ToString()` and
`JniMethodInfo.ToString()` will throw a `NotSupportedException`
because they use the `Name` and `Signature` properties, which always
throw `NotSupportedException` in the Release configuration.

This renders `.ToString()` useless.  Doh!

Fix `JniFieldInfo.ToString()` and `JniMethodInfo.ToString()` so that
in Release configurations they don't access the `Name` or `Signature`
properties, preventing `.ToString()` from throwing.