### PR TITLE
[java-interop] Few more fixes for mxe-Win[32|64] builds in XA

### DIFF
--- a/src/java-interop/java-interop-gc-bridge-mono.cc
+++ b/src/java-interop/java-interop-gc-bridge-mono.cc
@@ -1,3 +1,5 @@
+#define __STDC_FORMAT_MACROS
+
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
@@ -164,7 +166,7 @@ _ji_realpath_win_loop (wchar_t* wpath, DWORD len)
 {
 	DWORD retval;
 	char* fullpath = NULL;
-	wchar_t *allocated_buffer = xmalloc (sizeof (wchar_t)*len);;
+	wchar_t *allocated_buffer = static_cast<wchar_t*> (xmalloc (sizeof (wchar_t)*len));
 
 	while (1) {
 		retval = GetFullPathNameW (wpath, len, allocated_buffer, NULL);
@@ -180,7 +182,7 @@ _ji_realpath_win_loop (wchar_t* wpath, DWORD len)
 		// other thread probably called chdir ()
 		// be on the safe side and allocate more space in case it will happen again
 		len = retval*2;
-		allocated_buffer = xrealloc (allocated_buffer, sizeof (wchar_t)*len);
+		allocated_buffer = static_cast<wchar_t*> (xrealloc (allocated_buffer, sizeof (wchar_t)*len));
 	}
 
 	free (allocated_buffer);

--- a/src/java-interop/java-interop-util.cc
+++ b/src/java-interop/java-interop-util.cc
@@ -7,7 +7,7 @@ char*
 utf16_to_utf8 (const wchar_t *widestr)
 {
 	int required_size = WideCharToMultiByte (CP_UTF8, 0, widestr, -1, NULL, 0, NULL, NULL);
-	char *mbstr = calloc (required_size, sizeof (char));
+	char *mbstr = static_cast<char*> (calloc (required_size, sizeof (char)));
 	int converted_size = WideCharToMultiByte (CP_UTF8, 0, widestr, -1, mbstr, required_size, NULL, NULL);
 
 	assert (converted_size == required_size);
@@ -19,7 +19,7 @@ wchar_t*
 utf8_to_utf16 (const char *mbstr)
 {
 	int required_chars = MultiByteToWideChar (CP_UTF8, 0, mbstr, -1, NULL, 0);
-	wchar_t *widestr = calloc (required_chars, sizeof (wchar_t));
+	wchar_t *widestr = static_cast<wchar_t*> (calloc (required_chars, sizeof (wchar_t)));
 	int converted_chars = MultiByteToWideChar (CP_UTF8, 0, mbstr, -1, widestr, required_chars);
 
 	assert (converted_chars == required_chars);


### PR DESCRIPTION
The `__STDC_FORMAT_MACROS` define is to have `PRId64` defined by `inttypes.h`.

Few more casts when allocating memory.
