### PR TITLE
Make JI build with current XA/master

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -19,6 +19,7 @@
       Condition="Exists('$(_OutputPath)MonoInfo.props')"
   />
   <PropertyGroup>
+    <CecilRestoreConfiguration Condition=" '$(CecilRestoreConfiguration)' == '' ">$(Configuration)</CecilRestoreConfiguration>
     <CecilSourceDirectory   Condition=" '$(CecilSourceDirectory)' == '' ">$(MSBuildThisFileDirectory)external\cecil</CecilSourceDirectory>
     <UtilityOutputFullPath  Condition=" '$(UtilityOutputFullPath)' == '' ">$(MSBuildThisFileDirectory)bin\$(_Configuration)\</UtilityOutputFullPath>
     <XamarinAndroidToolsDirectory   Condition=" '$(XamarinAndroidToolsDirectory)' == '' ">$(MSBuildThisFileDirectory)external\xamarin-android-tools</XamarinAndroidToolsDirectory>

--- a/src/Xamarin.Android.Cecil/Xamarin.Android.Cecil.targets
+++ b/src/Xamarin.Android.Cecil/Xamarin.Android.Cecil.targets
@@ -19,7 +19,8 @@
     <MSBuild
         Projects="$(_CecilSolution)"
         Targets="Restore"
-        StopOnFirstFailure="True" />
+        StopOnFirstFailure="True"
+        Properties="Configuration=$(CecilRestoreConfiguration);OutputPath=$(CecilOutputPath)" />
     <MSBuild
         Projects="@(_CecilProject)"
         Targets="Clean;Build"


### PR DESCRIPTION
Current XA/master doesn't work with JI/master, because the version of
`mono/external/cecil` doesn't have `Debug` configuration in
`Mono.Cecil.sln`. Unlike the newer cecil used in `mono/2019-06`.

Thus failing with:

    (ValidateSolutionConfiguration target) ->
      /Users/rodo/git/xa3/external/mono/external/cecil/Mono.Cecil.sln.metaproj : error MSB4126: The specified solution configuration "Debug|Any CPU" is invalid. Please specify a valid solution configuration using the Configuration and Platform properties (e.g. MSBuild.exe Solution.sln /p:Configuration=Debug /p:Platform="Any CPU") or leave those properties blank to use the default solution configuration. [/Users/rodo/git/xa3/external/mono/external/cecil/Mono.Cecil.sln]

To overcome that we introduce new `CecilRestoreConfiguration`
property, which can be overriden from XA, so that XA can choose the
configuration, driven by its `XA/external/mono/external/cecil`
requirements.