### PR TITLE
[generator] Ensure all intended ctors get generated.

### DIFF
--- a/tools/generator/ClassGen.cs
+++ b/tools/generator/ClassGen.cs
@@ -313,7 +313,7 @@ namespace MonoDroid.Generation {
 
 			foreach (Ctor ctor in ctors) {
 				if (IsFinal && ctor.Visibility == "protected")
-					return;
+					continue;
 				ctor.Name = Name;
 				ctor.Generate (sw, indent, opt, inherits_object, this);
 			}

--- a/tools/generator/Tests/expected.ji/Constructors/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/Constructors/Mono.Android.projitems
@@ -8,6 +8,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.SomeObject.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.SomeObject2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
   </ItemGroup>
   <!-- Enums -->

--- a/tools/generator/Tests/expected/Constructors/Constructors.xml
+++ b/tools/generator/Tests/expected/Constructors/Constructors.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <api>
 	<package name="java.lang">
 	    <class abstract="false" deprecated="not deprecated" final="false" name="Object" static="false" visibility="public">
@@ -8,6 +8,15 @@
 	  <class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" 
 	  		final="false" name="SomeObject" static="false" visibility="public">
 	  		<constructor deprecated="deprecated" final="false" name="SomeObject" static="false" type="xamarin.test.SomeObject" visibility="public">
+	      	</constructor>
+	      	<constructor deprecated="not deprecated" final="false" name="SomeObject" static="false" type="xamarin.test.SomeObject" visibility="public">
+		      	<parameter name="aint" type="int">
+	       		</parameter>
+	      	</constructor>
+	    </class>
+	  <class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" 
+	  		final="true" name="SomeObject2" static="false" visibility="public">
+	  		<constructor deprecated="not deprecated" final="false" name="SomeObject" static="false" type="xamarin.test.SomeObject" visibility="protected">
 	      	</constructor>
 	      	<constructor deprecated="not deprecated" final="false" name="SomeObject" static="false" type="xamarin.test.SomeObject" visibility="public">
 		      	<parameter name="aint" type="int">

--- a/tools/generator/Tests/expected/Constructors/Xamarin.Test.SomeObject2.cs
+++ b/tools/generator/Tests/expected/Constructors/Xamarin.Test.SomeObject2.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Xamarin.Test {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject2']"
+	[global::Android.Runtime.Register ("xamarin/test/SomeObject2", DoNotGenerateAcw=true)]
+	public sealed partial class SomeObject2 : global::Java.Lang.Object {
+
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("xamarin/test/SomeObject2", ref java_class_handle);
+			}
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (SomeObject2); }
+		}
+
+		internal SomeObject2 (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		static IntPtr id_ctor_I;
+		// Metadata.xml XPath constructor reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject2']/constructor[@name='SomeObject2' and count(parameter)=1 and parameter[1][@type='int']]"
+		[Register (".ctor", "(I)V", "")]
+		public unsafe SomeObject2 (int aint)
+			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		{
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+				return;
+
+			try {
+				JValue* __args = stackalloc JValue [1];
+				__args [0] = new JValue (aint);
+				if (((object) this).GetType () != typeof (SomeObject2)) {
+					SetHandle (
+							global::Android.Runtime.JNIEnv.StartCreateInstance (((object) this).GetType (), "(I)V", __args),
+							JniHandleOwnership.TransferLocalRef);
+					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "(I)V", __args);
+					return;
+				}
+
+				if (id_ctor_I == IntPtr.Zero)
+					id_ctor_I = JNIEnv.GetMethodID (class_ref, "<init>", "(I)V");
+				SetHandle (
+						global::Android.Runtime.JNIEnv.StartCreateInstance (class_ref, id_ctor_I, __args),
+						JniHandleOwnership.TransferLocalRef);
+				JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, class_ref, id_ctor_I, __args);
+			} finally {
+			}
+		}
+
+	}
+}


### PR DESCRIPTION
We are mistakenly `return`ing when we want to skip generating a `ctor` instead of `continue`ing.  This causes an ordering issue where desired constructors may or may not be generated based on their position in the xml file.