### PR TITLE
[generator] Cache finding descendants of a GenBase.

### DIFF
--- a/tools/generator/CodeGenerationOptions.cs
+++ b/tools/generator/CodeGenerationOptions.cs
@@ -68,7 +68,6 @@ namespace MonoDroid.Generation
 		public bool IgnoreNonPublicType { get; set; }
 		public string AssemblyName { get; set; }
 		public bool UseShortFileNames { get; set; }
-		public IList<GenBase> Gens {get;set;}
 		public int ProductVersion { get; set; }
 
 		bool? buildingCoreAssembly;

--- a/tools/generator/CodeGenerator.cs
+++ b/tools/generator/CodeGenerator.cs
@@ -11,6 +11,7 @@ using Xamarin.Android.Tools.ApiXmlAdjuster;
 using Java.Interop.Tools.Cecil;
 using Java.Interop.Tools.Diagnostics;
 using Java.Interop.Tools.TypeNameMappings;
+using MonoDroid.Generation.Utilities;
 
 namespace Xamarin.Android.Binder
 {
@@ -129,7 +130,6 @@ namespace Xamarin.Android.Binder
 				return;
 			}
 			apiSource = p.ApiSource;
-			opt.Gens = gens;
 
 			// disable interface default methods here, especially before validation.
 			gens = gens.Where (g => !g.IsObfuscated && g.Visibility != "private").ToList ();
@@ -147,8 +147,10 @@ namespace Xamarin.Android.Binder
 			foreach (GenBase gen in gens)
 				gen.FillProperties ();
 
+			var cache = new AncestorDescendantCache (gens);
+
 			foreach (var gen in gens)
-				gen.UpdateEnums (opt);
+				gen.UpdateEnums (opt, cache);
 
 			foreach (GenBase gen in gens)
 				gen.FixupMethodOverrides (opt);

--- a/tools/generator/Utilities/AncestorDescendantCache.cs
+++ b/tools/generator/Utilities/AncestorDescendantCache.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MonoDroid.Generation.Utilities
+{
+	// Finding all descendants of a type is expensive, so we cache the results here
+	public class AncestorDescendantCache
+	{
+		readonly List<GenBase> gens;
+		readonly Dictionary<GenBase, IEnumerable<GenBase>> cache = new Dictionary<GenBase, IEnumerable<GenBase>> ();
+
+		public AncestorDescendantCache (List<GenBase> gens)
+		{
+			this.gens = gens;
+		}
+
+		public IEnumerable<GenBase> GetAncestorsAndDescendants (GenBase gen)
+		{
+			if (cache.TryGetValue (gen, out var value))
+				return value;
+
+			var new_value = GetAncestors (gen).Concat (GetDescendants (gen)).ToList ();
+
+			cache [gen] = new_value;
+
+			return new_value;
+		}
+
+		IEnumerable<GenBase> GetAncestors (GenBase gen)
+		{
+			for (var g = gen.BaseGen; g != null; g = g.BaseGen)
+				yield return g;
+		}
+
+		IEnumerable<GenBase> GetDescendants (GenBase gen)
+		{
+			foreach (var directDescendants in gens.Where (x => x.BaseGen == gen)) {
+				yield return directDescendants;
+
+				foreach (var indirectDescendants in GetDescendants (directDescendants))
+					yield return indirectDescendants;
+			}
+		}
+	}
+}

--- a/tools/generator/generator.csproj
+++ b/tools/generator/generator.csproj
@@ -105,6 +105,7 @@
     <Compile Include="Java.Interop.Tools.Generator.ObjectModel\Parameter.cs" />
     <Compile Include="Java.Interop.Tools.Generator.ObjectModel\ParameterList.cs" />
     <Compile Include="Java.Interop.Tools.Generator.Transformation\Parser.cs" />
+    <Compile Include="Utilities\AncestorDescendantCache.cs" />
     <Compile Include="Utilities\ProcessRocks.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Java.Interop.Tools.Generator.ObjectModel\Property.cs" />


### PR DESCRIPTION
Finding the descendants of a GenBase is relatively expensive.  Caching the results causes the `UpdateEnums` step to drop from ~9.5s generating `Mono.Android.dll` to ~1s.