### PR TITLE
[generator] Encapsulate and parallelize enum generation.

### DIFF
--- a/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/EnumGenerator.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/EnumGenerator.cs
@@ -22,15 +22,15 @@ namespace MonoDroid.Generation
 
 			sw.WriteLine ("namespace {0} {{", ns);
 			if (enu.Value.BitField)
-				sw.WriteLine ("  [System.Flags]");
-			sw.WriteLine ("  public enum {0} {{", enoom);
+				sw.WriteLine ("\t[System.Flags]");
+			sw.WriteLine ("\tpublic enum {0} {{", enoom);
 
 			foreach (var member in enu.Value.Members) {
 				var managedMember = FindManagedMember (enu.Value, member.Key, gens);
-				sw.WriteLine ("    [global::Android.Runtime.IntDefinition (" + (managedMember != null ? "\"" + managedMember + "\"" : "null") + ", JniField = \"" + StripExtraInterfaceSpec (enu.Value.JniNames [member.Key]) + "\")]");
-				sw.WriteLine ("    {0} = {1},", member.Key.Trim (), member.Value.Trim ());
+				sw.WriteLine ("\t\t[global::Android.Runtime.IntDefinition (" + (managedMember != null ? "\"" + managedMember + "\"" : "null") + ", JniField = \"" + StripExtraInterfaceSpec (enu.Value.JniNames [member.Key]) + "\")]");
+				sw.WriteLine ("\t\t{0} = {1},", member.Key.Trim (), member.Value.Trim ());
 			}
-			sw.WriteLine ("  }");
+			sw.WriteLine ("\t}");
 			sw.WriteLine ("}");
 		}
 

--- a/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/EnumGenerator.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/EnumGenerator.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using static MonoDroid.Generation.EnumMappings;
+
+namespace MonoDroid.Generation
+{
+	class EnumGenerator
+	{
+		protected TextWriter sw;
+
+		public EnumGenerator (TextWriter writer)
+		{
+			sw = writer;
+		}
+
+		public void WriteEnumeration (KeyValuePair<string, EnumDescription> enu, GenBase [] gens)
+		{
+			string ns = enu.Key.Substring (0, enu.Key.LastIndexOf ('.')).Trim ();
+			string enoom = enu.Key.Substring (enu.Key.LastIndexOf ('.') + 1).Trim ();
+
+			sw.WriteLine ("namespace {0} {{", ns);
+			if (enu.Value.BitField)
+				sw.WriteLine ("  [System.Flags]");
+			sw.WriteLine ("  public enum {0} {{", enoom);
+
+			foreach (var member in enu.Value.Members) {
+				var managedMember = FindManagedMember (enu.Value, member.Key, gens);
+				sw.WriteLine ("    [global::Android.Runtime.IntDefinition (" + (managedMember != null ? "\"" + managedMember + "\"" : "null") + ", JniField = \"" + StripExtraInterfaceSpec (enu.Value.JniNames [member.Key]) + "\")]");
+				sw.WriteLine ("    {0} = {1},", member.Key.Trim (), member.Value.Trim ());
+			}
+			sw.WriteLine ("  }");
+			sw.WriteLine ("}");
+		}
+
+		string FindManagedMember (EnumDescription desc, string enumFieldName, IEnumerable<GenBase> gens)
+		{
+			if (desc.FieldsRemoved)
+				return null;
+
+			var jniMember = desc.JniNames [enumFieldName];
+			if (string.IsNullOrWhiteSpace (jniMember)) {
+				// enum values like "None" falls here.
+				return null;
+			}
+			return FindManagedMember (jniMember, gens);
+		}
+
+		WeakReference cache_found_class;
+
+		string FindManagedMember (string jniMember, IEnumerable<GenBase> gens)
+		{
+			string package, type, member;
+			ParseJniMember (jniMember, out package, out type, out member);
+			var fullJavaType = (string.IsNullOrEmpty (package) ? "" : package + ".") + type;
+
+			var cls = cache_found_class != null ? cache_found_class.Target as GenBase : null;
+			if (cls == null || cls.JniName != fullJavaType) {
+				cls = gens.FirstOrDefault (g => g.JavaName == fullJavaType);
+				if (cls == null) {
+					// The class was not found e.g. removed by metadata fixup.
+					return null;
+				}
+				cache_found_class = new WeakReference (cls);
+			}
+			var fld = cls.Fields.FirstOrDefault (f => f.JavaName == member);
+			if (fld == null) {
+				// The field was not found e.g. removed by metadata fixup.
+				return null;
+			}
+			return cls.FullName + "." + fld.Name;
+		}
+
+		internal void ParseJniMember (string jniMember, out string package, out string type, out string member)
+		{
+			try {
+				DoParseJniMember (jniMember, out package, out type, out member);
+			} catch (Exception ex) {
+				throw new Exception (string.Format ("failed to parse enum mapping: JNI member: {0}", jniMember, ex));
+			}
+		}
+
+		static void DoParseJniMember (string jniMember, out string package, out string type, out string member)
+		{
+			int endPackage = jniMember.LastIndexOf ('/');
+			int endClass = jniMember.LastIndexOf ('.');
+
+			package = jniMember.Substring (0, endPackage).Replace ('/', '.');
+			if (package.StartsWith ("I:"))
+				package = package.Substring (2);
+
+			if (endClass >= 0) {
+				type = jniMember.Substring (endPackage + 1, endClass - endPackage - 1).Replace ('$', '.');
+				member = jniMember.Substring (endClass + 1);
+			} else {
+				type = jniMember.Substring (endPackage + 1).Replace ('$', '.');
+				member = "";
+			}
+		}
+
+		string StripExtraInterfaceSpec (string jniFieldSpec)
+		{
+			return jniFieldSpec.StartsWith ("I:", StringComparison.Ordinal) ? jniFieldSpec.Substring (2) : jniFieldSpec;
+		}
+	}
+}

--- a/tools/generator/Java.Interop.Tools.Generator.Transformation/EnumMappings.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Transformation/EnumMappings.cs
@@ -1,8 +1,10 @@
-﻿using System;
+using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
 using System.Xml.XPath;
@@ -139,75 +141,22 @@ namespace MonoDroid.Generation {
 			if (!Directory.Exists (output_dir))
 				Directory.CreateDirectory (output_dir);
 
-			var files   = new List<string> ();
-			foreach (var enu in enums) {
-				var path    = Path.Combine (output_dir, GetFileName (enu.Key, useShortFileNames) + ".cs");
+			var files = new ConcurrentBag<string> ();
+
+			Parallel.ForEach (enums, enu => {
+				var path = Path.Combine (output_dir, GetFileName (enu.Key, useShortFileNames) + ".cs");
 				files.Add (path);
-				using (StreamWriter sw = new StreamWriter (path, append: false)) {
-					string ns = enu.Key.Substring (0, enu.Key.LastIndexOf ('.')).Trim ();
-					string enoom = enu.Key.Substring (enu.Key.LastIndexOf ('.') + 1).Trim ();
 
-					sw.WriteLine ("namespace {0} {{", ns);
-					if (enu.Value.BitField)
-						sw.WriteLine ("  [System.Flags]");
-					sw.WriteLine ("  public enum {0} {{", enoom);
-
-					foreach (var member in enu.Value.Members) {
-						var managedMember = FindManagedMember (ns, enoom, enu.Value, member.Key, gens);
-						sw.WriteLine ("    [global::Android.Runtime.IntDefinition (" + (managedMember != null? "\"" + managedMember + "\"" : "null") + ", JniField = \"" + StripExtraInterfaceSpec (enu.Value.JniNames [member.Key]) + "\")]");
-						sw.WriteLine ("    {0} = {1},", member.Key.Trim (), member.Value.Trim ());
-					}
-					sw.WriteLine ("  }");
-					sw.WriteLine ("}");
+				using (var sw = File.CreateText (path)) {
+					var generator = new EnumGenerator (sw);
+					generator.WriteEnumeration (enu, gens);
 				}
-			}
-			return files;
+			});
+
+			return files.ToList ();
 		}
 
-		string StripExtraInterfaceSpec (string jniFieldSpec)
-		{
-			return jniFieldSpec.StartsWith ("I:", StringComparison.Ordinal) ? jniFieldSpec.Substring (2) : jniFieldSpec;
-		}
-
-		string FindManagedMember (string ns, string enumName, EnumDescription desc, string enumFieldName, IEnumerable<GenBase> gens)
-		{
-			if (desc.FieldsRemoved)
-				return null;
-
-			var jniMember = desc.JniNames [enumFieldName];
-			if (string.IsNullOrWhiteSpace (jniMember)) {
-				// enum values like "None" falls here.
-				return null;
-			}
-			return FindManagedMember (jniMember, gens);
-		}
-
-		WeakReference cache_found_class;
-
-		string FindManagedMember (string jniMember, IEnumerable<GenBase> gens)
-		{
-			string package, type, member;
-			ParseJniMember (jniMember, out package, out type, out member);
-			var fullJavaType = (string.IsNullOrEmpty (package) ? "" : package + ".") + type;
-
-			var cls = cache_found_class != null ? cache_found_class.Target as GenBase : null;
-			if (cls == null || cls.JniName != fullJavaType) {
-				cls = gens.FirstOrDefault (g => g.JavaName == fullJavaType);
-				if (cls == null) {
-					// The class was not found e.g. removed by metadata fixup.
-					return null;
-				}
-				cache_found_class = new WeakReference (cls);
-			}
-			var fld = cls.Fields.FirstOrDefault (f => f.JavaName == member);
-			if (fld == null) {
-				// The field was not found e.g. removed by metadata fixup.
-                                return null;
-			}
-			return cls.FullName + "." + fld.Name;
-		}
-
-		Dictionary<string,string> file_name_map = new Dictionary<string, string> ();
+		ConcurrentDictionary<string,string> file_name_map = new ConcurrentDictionary<string, string> ();
 
 		string GetFileName (string file, bool useShortFileNames)
 		{

--- a/tools/generator/Java.Interop.Tools.Generator.Transformation/EnumMappings.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Transformation/EnumMappings.cs
@@ -156,17 +156,21 @@ namespace MonoDroid.Generation {
 			return files.ToList ();
 		}
 
-		ConcurrentDictionary<string,string> file_name_map = new ConcurrentDictionary<string, string> ();
+		readonly Dictionary<string,string> file_name_map = new Dictionary<string, string> ();
 
 		string GetFileName (string file, bool useShortFileNames)
 		{
 			if (!useShortFileNames)
 				return file;
 			string s;
-			if (file_name_map.TryGetValue (file, out s))
-				return s;
-			s = file_name_map.Count.ToString ();
-			file_name_map [file] = s;
+
+			lock (file_name_map) {
+				if (file_name_map.TryGetValue (file, out s))
+					return s;
+				s = file_name_map.Count.ToString ();
+				file_name_map [file] = s;
+			}
+
 			return s;
 		}
 

--- a/tools/generator/Tests-Core/expected.ji/Android.Text.SpanTypes.cs
+++ b/tools/generator/Tests-Core/expected.ji/Android.Text.SpanTypes.cs
@@ -1,6 +1,6 @@
 namespace Android.Text {
-  public enum SpanTypes {
-    [global::Android.Runtime.IntDefinition (null, JniField = "android/text/Spanned.SPAN_COMPOSING")]
-    Composing = 256,
-  }
+	public enum SpanTypes {
+		[global::Android.Runtime.IntDefinition (null, JniField = "android/text/Spanned.SPAN_COMPOSING")]
+		Composing = 256,
+	}
 }

--- a/tools/generator/Tests-Core/expected/Android.Text.SpanTypes.cs
+++ b/tools/generator/Tests-Core/expected/Android.Text.SpanTypes.cs
@@ -1,6 +1,6 @@
 namespace Android.Text {
-  public enum SpanTypes {
-    [global::Android.Runtime.IntDefinition (null, JniField = "android/text/Spanned.SPAN_COMPOSING")]
-    Composing = 256,
-  }
+	public enum SpanTypes {
+		[global::Android.Runtime.IntDefinition (null, JniField = "android/text/Spanned.SPAN_COMPOSING")]
+		Composing = 256,
+	}
 }

--- a/tools/generator/Tests/Unit-Tests/EnumGeneratorExpectedResults/WriteBasicEnum.txt
+++ b/tools/generator/Tests/Unit-Tests/EnumGeneratorExpectedResults/WriteBasicEnum.txt
@@ -1,0 +1,8 @@
+namespace Android.App {
+  public enum RecentTaskFlags {
+    [global::Android.Runtime.IntDefinition (null, JniField = "android/app/ActivityManager.RECENT_IGNORE_UNAVAILABLE")]
+    WithExcluded = 1,
+    [global::Android.Runtime.IntDefinition (null, JniField = "android/app/ActivityManager.RECENT_WITH_EXCLUDED")]
+    IgnoreUnavailable = 2,
+  }
+}

--- a/tools/generator/Tests/Unit-Tests/EnumGeneratorExpectedResults/WriteBasicEnum.txt
+++ b/tools/generator/Tests/Unit-Tests/EnumGeneratorExpectedResults/WriteBasicEnum.txt
@@ -1,8 +1,8 @@
 namespace Android.App {
-  public enum RecentTaskFlags {
-    [global::Android.Runtime.IntDefinition (null, JniField = "android/app/ActivityManager.RECENT_IGNORE_UNAVAILABLE")]
-    WithExcluded = 1,
-    [global::Android.Runtime.IntDefinition (null, JniField = "android/app/ActivityManager.RECENT_WITH_EXCLUDED")]
-    IgnoreUnavailable = 2,
-  }
+	public enum RecentTaskFlags {
+		[global::Android.Runtime.IntDefinition (null, JniField = "android/app/ActivityManager.RECENT_IGNORE_UNAVAILABLE")]
+		WithExcluded = 1,
+		[global::Android.Runtime.IntDefinition (null, JniField = "android/app/ActivityManager.RECENT_WITH_EXCLUDED")]
+		IgnoreUnavailable = 2,
+	}
 }

--- a/tools/generator/Tests/Unit-Tests/EnumGeneratorExpectedResults/WriteEnumWithGens.txt
+++ b/tools/generator/Tests/Unit-Tests/EnumGeneratorExpectedResults/WriteEnumWithGens.txt
@@ -1,0 +1,8 @@
+namespace Android.App {
+  public enum RecentTaskFlags {
+    [global::Android.Runtime.IntDefinition ("android.app.ActivityManager.RECENT_IGNORE_UNAVAILABLE", JniField = "android/app/ActivityManager.RECENT_IGNORE_UNAVAILABLE")]
+    WithExcluded = 1,
+    [global::Android.Runtime.IntDefinition (null, JniField = "android/app/ActivityManager.RECENT_WITH_EXCLUDED")]
+    IgnoreUnavailable = 2,
+  }
+}

--- a/tools/generator/Tests/Unit-Tests/EnumGeneratorExpectedResults/WriteEnumWithGens.txt
+++ b/tools/generator/Tests/Unit-Tests/EnumGeneratorExpectedResults/WriteEnumWithGens.txt
@@ -1,8 +1,8 @@
 namespace Android.App {
-  public enum RecentTaskFlags {
-    [global::Android.Runtime.IntDefinition ("android.app.ActivityManager.RECENT_IGNORE_UNAVAILABLE", JniField = "android/app/ActivityManager.RECENT_IGNORE_UNAVAILABLE")]
-    WithExcluded = 1,
-    [global::Android.Runtime.IntDefinition (null, JniField = "android/app/ActivityManager.RECENT_WITH_EXCLUDED")]
-    IgnoreUnavailable = 2,
-  }
+	public enum RecentTaskFlags {
+		[global::Android.Runtime.IntDefinition ("android.app.ActivityManager.RECENT_IGNORE_UNAVAILABLE", JniField = "android/app/ActivityManager.RECENT_IGNORE_UNAVAILABLE")]
+		WithExcluded = 1,
+		[global::Android.Runtime.IntDefinition (null, JniField = "android/app/ActivityManager.RECENT_WITH_EXCLUDED")]
+		IgnoreUnavailable = 2,
+	}
 }

--- a/tools/generator/Tests/Unit-Tests/EnumGeneratorExpectedResults/WriteFlagsEnum.txt
+++ b/tools/generator/Tests/Unit-Tests/EnumGeneratorExpectedResults/WriteFlagsEnum.txt
@@ -1,9 +1,9 @@
 namespace Android.App {
-  [System.Flags]
-  public enum RecentTaskFlags {
-    [global::Android.Runtime.IntDefinition (null, JniField = "android/app/ActivityManager.RECENT_IGNORE_UNAVAILABLE")]
-    WithExcluded = 1,
-    [global::Android.Runtime.IntDefinition (null, JniField = "android/app/ActivityManager.RECENT_WITH_EXCLUDED")]
-    IgnoreUnavailable = 2,
-  }
+	[System.Flags]
+	public enum RecentTaskFlags {
+		[global::Android.Runtime.IntDefinition (null, JniField = "android/app/ActivityManager.RECENT_IGNORE_UNAVAILABLE")]
+		WithExcluded = 1,
+		[global::Android.Runtime.IntDefinition (null, JniField = "android/app/ActivityManager.RECENT_WITH_EXCLUDED")]
+		IgnoreUnavailable = 2,
+	}
 }

--- a/tools/generator/Tests/Unit-Tests/EnumGeneratorExpectedResults/WriteFlagsEnum.txt
+++ b/tools/generator/Tests/Unit-Tests/EnumGeneratorExpectedResults/WriteFlagsEnum.txt
@@ -1,0 +1,9 @@
+namespace Android.App {
+  [System.Flags]
+  public enum RecentTaskFlags {
+    [global::Android.Runtime.IntDefinition (null, JniField = "android/app/ActivityManager.RECENT_IGNORE_UNAVAILABLE")]
+    WithExcluded = 1,
+    [global::Android.Runtime.IntDefinition (null, JniField = "android/app/ActivityManager.RECENT_WITH_EXCLUDED")]
+    IgnoreUnavailable = 2,
+  }
+}

--- a/tools/generator/Tests/Unit-Tests/EnumGeneratorTests.cs
+++ b/tools/generator/Tests/Unit-Tests/EnumGeneratorTests.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Text;
+using MonoDroid.Generation;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+
+namespace generatortests.Unit_Tests
+{
+	[TestFixture]
+	class EnumGeneratorTests
+	{
+		protected EnumGenerator generator;
+		protected StringBuilder builder;
+		protected StringWriter writer;
+
+		[SetUp]
+		public void SetUp ()
+		{
+			builder = new StringBuilder ();
+			writer = new StringWriter (builder);
+
+			generator = new EnumGenerator (writer);
+		}
+
+		[Test]
+		public void WriteBasicEnum ()
+		{
+			var enu = CreateEnum ();
+			enu.Value.FieldsRemoved = true;
+
+			generator.WriteEnumeration (enu, null);
+
+			Assert.AreEqual (GetExpected (nameof (WriteBasicEnum)), writer.ToString ().NormalizeLineEndings ());
+		}
+
+		[Test]
+		public void WriteFlagsEnum ()
+		{
+			var enu = CreateEnum ();
+			enu.Value.BitField = true;
+			enu.Value.FieldsRemoved = true;
+
+			generator.WriteEnumeration (enu, null);
+
+			Assert.AreEqual (GetExpected (nameof (WriteFlagsEnum)), writer.ToString ().NormalizeLineEndings ());
+		}
+
+		[Test]
+		public void WriteEnumWithGens ()
+		{
+			var enu = CreateEnum ();
+			var gens = CreateGens ();
+
+			generator.WriteEnumeration (enu, gens);
+			
+			Assert.AreEqual (GetExpected (nameof (WriteEnumWithGens)), writer.ToString ().NormalizeLineEndings ());
+		}
+
+		protected string GetExpected (string testName)
+		{
+			var root = Path.GetDirectoryName (Assembly.GetExecutingAssembly ().Location);
+
+			return File.ReadAllText (Path.Combine (root, "Unit-Tests", "EnumGeneratorExpectedResults", $"{testName}.txt")).NormalizeLineEndings ();
+		}
+
+		KeyValuePair<string, EnumMappings.EnumDescription> CreateEnum ()
+		{
+			var enu = new EnumMappings.EnumDescription {
+				Members = new Dictionary<string, string> {
+					{ "WithExcluded", "1" },
+					{ "IgnoreUnavailable", "2" }
+				},
+				JniNames = new Dictionary<string, string> {
+					{ "WithExcluded", "android/app/ActivityManager.RECENT_IGNORE_UNAVAILABLE" },
+					{ "IgnoreUnavailable", "android/app/ActivityManager.RECENT_WITH_EXCLUDED" }
+				},
+				BitField = false,
+				FieldsRemoved = false
+			};
+
+			return new KeyValuePair<string, EnumMappings.EnumDescription> ("Android.App.RecentTaskFlags", enu);
+		}
+
+		GenBase[] CreateGens ()
+		{
+			var klass = new TestClass (string.Empty, "android.app.ActivityManager");
+
+			klass.Fields.Add (new TestField ("int", "RECENT_IGNORE_UNAVAILABLE"));
+
+			return new [] { klass };
+		}
+	}
+}

--- a/tools/generator/Tests/expected/EnumerationFixup/Xamarin.Test.SomeValues.cs
+++ b/tools/generator/Tests/expected/EnumerationFixup/Xamarin.Test.SomeValues.cs
@@ -1,8 +1,8 @@
 namespace Xamarin.Test {
-  public enum SomeValues {
-    [global::Android.Runtime.IntDefinition (null, JniField = "xamarin/test/SomeObject.SOME_VALUE")]
-    SomeValue = 0,
-    [global::Android.Runtime.IntDefinition (null, JniField = "xamarin/test/SomeObject.SOME_VALUE2")]
-    SomeValue2 = 1,
-  }
+	public enum SomeValues {
+		[global::Android.Runtime.IntDefinition (null, JniField = "xamarin/test/SomeObject.SOME_VALUE")]
+		SomeValue = 0,
+		[global::Android.Runtime.IntDefinition (null, JniField = "xamarin/test/SomeObject.SOME_VALUE2")]
+		SomeValue2 = 1,
+	}
 }

--- a/tools/generator/Tests/generator-Tests.csproj
+++ b/tools/generator/Tests/generator-Tests.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Unit-Tests\CodeGeneratorTests.cs" />
     <Compile Include="Unit-Tests\AdjusterTests.cs" />
     <Compile Include="Unit-Tests\DefaultInterfaceMethodsTests.cs" />
+    <Compile Include="Unit-Tests\EnumGeneratorTests.cs" />
     <Compile Include="Unit-Tests\ManagedTests.cs" />
     <Compile Include="Unit-Tests\SupportTypes.cs" />
     <Compile Include="Unit-Tests\TestExtensions.cs" />
@@ -479,6 +480,15 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XamarinAndroid\WriteCtor.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\EnumGeneratorExpectedResults\WriteBasicEnum.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\EnumGeneratorExpectedResults\WriteEnumWithGens.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\EnumGeneratorExpectedResults\WriteFlagsEnum.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/tools/generator/generator.csproj
+++ b/tools/generator/generator.csproj
@@ -59,6 +59,7 @@
     </Compile>
     <Compile Include="CodeGenerationTarget.cs" />
     <Compile Include="CodeGeneratorOptions.cs" />
+    <Compile Include="Java.Interop.Tools.Generator.CodeGeneration\EnumGenerator.cs" />
     <Compile Include="Java.Interop.Tools.Generator.ObjectModel\InterfaceExtensionInfo.cs" />
     <Compile Include="Java.Interop.Tools.Generator.Importers\Xml\InterfaceXmlGenBaseSupport.cs" />
     <Compile Include="Java.Interop.Tools.Generator.Transformation\ApiFixup.cs" />


### PR DESCRIPTION
Encapsulate the generation of the enum files to `EnumGenerator`.  This helps make it testable and easier to ensure it is thread-safe.  With it being thread-safe we can now generate these files in parallel.  On my 6 core machine, this reduces the time taken from ~5.5s to ~1.1s.