### PR TITLE
[generator] Remove global state around code generation

### DIFF
--- a/tools/generator/CodeGenerationOptions.cs
+++ b/tools/generator/CodeGenerationOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -111,20 +112,23 @@ namespace MonoDroid.Generation
 			return name.Replace ('$', '_');
 		}
 
-		Dictionary<string,string> short_file_names = new Dictionary<string, string> ();
+		readonly Dictionary<string,string> short_file_names = new Dictionary<string, string> ();
 
 		public string GetFileName (string fullName)
 		{
 			if (!UseShortFileNames)
 				return fullName;
-			string s;
-			if (short_file_names.TryGetValue (fullName, out s))
+
+			lock (short_file_names) {
+				if (short_file_names.TryGetValue (fullName, out var s))
+					return s;
+
+				s = short_file_names.Count.ToString ();
+				short_file_names [fullName] = s;
+
 				return s;
-			s = short_file_names.Count.ToString ();
-			short_file_names [fullName] = s;
-			return s;
+			}
 		}
 	}
-
 }
 

--- a/tools/generator/CodeGenerationOptions.cs
+++ b/tools/generator/CodeGenerationOptions.cs
@@ -10,29 +10,6 @@ namespace MonoDroid.Generation
 {
     public class CodeGenerationOptions
 	{
-		Stack<GenBase> context_types = new Stack<GenBase> ();
-		public Stack<GenBase> ContextTypes {
-			get { return context_types; }
-		}
-		public List<Method> ContextGeneratedMethods { get; set; } = new List<Method> ();
-		public GenBase ContextType {
-			get { return context_types.Any () ? context_types.Peek () : null; }
-		}
-		public Field ContextField { get; set; }
-		string ContextFieldString { 
-			get { return ContextField != null ? "in field " + ContextField.Name + " " : null; }
-		}
-		public MethodBase ContextMethod { get; set; }
-		string ContextMethodString { 
-			get { return ContextMethod != null ? "in method " + ContextMethod.Name + " " : null; }
-		}
-		string ContextTypeString {
-			get { return ContextType != null ? "in managed type " + ContextType.FullName : null; }
-		}
-		public string ContextString {
-			get { return ContextFieldString + ContextMethodString + ContextTypeString; }
-		}
-
 		CodeGenerationTarget    codeGenerationTarget;
 		public      CodeGenerationTarget    CodeGenerationTarget    {
 			get { return codeGenerationTarget; }

--- a/tools/generator/CodeGenerator.cs
+++ b/tools/generator/CodeGenerator.cs
@@ -140,7 +140,7 @@ namespace Xamarin.Android.Binder
 					AddTypeToTable (opt, gen);
 			}
 
-			Validate (gens, opt);
+			Validate (gens, opt, new CodeGeneratorContext ());
 
 			if (api_versions_xml != null)
 				ApiVersionsSupport.AssignApiLevels (gens, api_versions_xml);
@@ -211,7 +211,7 @@ namespace Xamarin.Android.Binder
 			}
 		}
 
-		static void Validate (List<GenBase> gens, CodeGenerationOptions opt)
+		static void Validate (List<GenBase> gens, CodeGenerationOptions opt, CodeGeneratorContext context)
 		{
 			//int cycle = 1;
 			List<GenBase> removed = new List<GenBase> ();
@@ -229,7 +229,7 @@ namespace Xamarin.Android.Binder
 				foreach (GenBase gen in gens)
 					if ((opt.IgnoreNonPublicType &&
 					    (gen.RawVisibility != "public" && gen.RawVisibility != "internal"))
-					    || !gen.Validate (opt, null)) {
+					    || !gen.Validate (opt, null, context)) {
 						foreach (GenBase nest in gen.NestedTypes) {
 							foreach (var nt in nest.Invalidate ())
 								removed.Add (nt);

--- a/tools/generator/CodeGenerator.cs
+++ b/tools/generator/CodeGenerator.cs
@@ -175,6 +175,7 @@ namespace Xamarin.Android.Binder
 				if (gen.IsGeneratable)
 					gen.Generate (opt, gen_info);
 
+
 			ClassGen.GenerateTypeRegistrations (opt, gen_info);
 			ClassGen.GenerateEnumList (gen_info);
 

--- a/tools/generator/CodeGeneratorContext.cs
+++ b/tools/generator/CodeGeneratorContext.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MonoDroid.Generation
+{
+	public class CodeGeneratorContext
+	{
+		public Stack<GenBase> ContextTypes { get; } = new Stack<GenBase> ();
+		public List<Method> ContextGeneratedMethods { get; set; } = new List<Method> ();
+		public Field ContextField { get; set; }
+		public MethodBase ContextMethod { get; set; }
+
+		public GenBase ContextType => ContextTypes.Any () ? ContextTypes.Peek () : null;
+		string ContextFieldString => ContextField != null ? "in field " + ContextField.Name + " " : null;
+		string ContextMethodString => ContextMethod != null ? "in method " + ContextMethod.Name + " " : null;
+		string ContextTypeString => ContextType != null ? "in managed type " + ContextType.FullName : null;
+		public string ContextString => ContextFieldString + ContextMethodString + ContextTypeString;
+	}
+}

--- a/tools/generator/GenerationInfo.cs
+++ b/tools/generator/GenerationInfo.cs
@@ -44,12 +44,6 @@ namespace MonoDroid.Generation {
 			get { return typename; }
 			set { typename = value; }
 		}
-
-		StreamWriter sw;
-		public StreamWriter Writer {
-			get { return sw; }
-			set { sw = value; }
-		}
 		
 		List<string> generated_files = new List<string> ();
 		public IEnumerable<string> GeneratedFiles {
@@ -58,12 +52,12 @@ namespace MonoDroid.Generation {
 
 		public StreamWriter OpenStream (string name) 
 		{
-			if (!Directory.Exists(csdir))
-				Directory.CreateDirectory (csdir);
-			string filename = Path.Combine (csdir, name + ".cs");
+			if (!Directory.Exists (CSharpDir))
+				Directory.CreateDirectory (CSharpDir);
+			string filename = Path.Combine (CSharpDir, name + ".cs");
 			
-			sw = new StreamWriter (File.Create (filename));
 			generated_files.Add (filename);
+			var sw = new StreamWriter (File.Create (filename));
 			return sw;
 		}
 

--- a/tools/generator/GenerationInfo.cs
+++ b/tools/generator/GenerationInfo.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -13,42 +14,17 @@ namespace MonoDroid.Generation {
 
 		public GenerationInfo (string csdir, string javadir, string assembly)
 		{
-			this.csdir = csdir;
-			this.javadir = javadir;
-			this.assembly = assembly;
+			CSharpDir = csdir;
+			JavaDir = javadir;
+			Assembly = assembly;
 		}
 
-		string assembly;
-		public string Assembly {
-			get { return assembly; }
-		}
-
-		string csdir;
-		public string CSharpDir {
-			get { return csdir; }
-		}
-
-		string javadir;
-		public string JavaDir {
-			get { return javadir; }
-		}
-
-		string member;
-		public string CurrentMember {
-			get { return typename + "." + member; }
-			set { member = value; }
-		}
-
-		string typename;
-		public string CurrentType {
-			get { return typename; }
-			set { typename = value; }
-		}
-		
-		List<string> generated_files = new List<string> ();
-		public IEnumerable<string> GeneratedFiles {
-			get { return generated_files; }
-		}
+		public string Assembly { get; }
+		public string CSharpDir { get; }
+		public string JavaDir { get; }
+		public ConcurrentBag<string> GeneratedFiles { get; } = new ConcurrentBag<string> ();
+		public ConcurrentBag<string> Enums { get; } = new ConcurrentBag<string> ();
+		public ConcurrentBag<KeyValuePair<string, string>> TypeRegistrations { get; } = new ConcurrentBag<KeyValuePair<string, string>> ();
 
 		public StreamWriter OpenStream (string name) 
 		{
@@ -56,19 +32,9 @@ namespace MonoDroid.Generation {
 				Directory.CreateDirectory (CSharpDir);
 			string filename = Path.Combine (CSharpDir, name + ".cs");
 			
-			generated_files.Add (filename);
 			var sw = new StreamWriter (File.Create (filename));
+			GeneratedFiles.Add (filename);
 			return sw;
-		}
-
-		List<string> enums = new List<string> ();
-		public ICollection<string> Enums {
-			get { return enums; }
-		}
-
-		List<KeyValuePair<string, string>> type_registrations = new List<KeyValuePair<string, string>> ();
-		public ICollection<KeyValuePair<string, string>> TypeRegistrations {
-			get { return type_registrations; }
 		}
 
 		internal void GenerateLibraryProjectFile (CodeGeneratorOptions options, IEnumerable<string> enumFiles, string path = null)
@@ -77,7 +43,7 @@ namespace MonoDroid.Generation {
 				var     name    = Assembly ?? "GeneratedFiles";
 				int     idx     = name.IndexOf (',');
 				name            = idx < 0 ? name : name.Substring (0, idx);
-				path            = Path.Combine (csdir, name + ".projitems");
+				path            = Path.Combine (CSharpDir, name + ".projitems");
 			}
 
 			var msbuild = XNamespace.Get ("http://schemas.microsoft.com/developer/msbuild/2003");

--- a/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/JavaInteropCodeGenerator.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/JavaInteropCodeGenerator.cs
@@ -120,7 +120,7 @@ namespace MonoDroid.Generation {
 					? "(" + ctor.Parameters.JniNestedDerivedSignature + ")V"
 					: ctor.JniSignature);
 			writer.WriteLine ();
-			writer.WriteLine ("{0}if ({1} != IntPtr.Zero)", indent, opt.ContextType.GetObjectHandleProperty ("this"));
+			writer.WriteLine ("{0}if ({1} != IntPtr.Zero)", indent, Context.ContextType.GetObjectHandleProperty ("this"));
 			writer.WriteLine ("{0}\treturn;", indent);
 			writer.WriteLine ();
 			foreach (string prep in ctor.Parameters.GetCallPrep (opt))

--- a/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/XamarinAndroidCodeGenerator.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/XamarinAndroidCodeGenerator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel.Design;
 using System.IO;
 
 namespace MonoDroid.Generation {
@@ -65,7 +66,7 @@ namespace MonoDroid.Generation {
 
 		internal override void WriteConstructorBody (Ctor ctor, string indent, System.Collections.Specialized.StringCollection call_cleanup)
 		{
-			writer.WriteLine ("{0}if ({1} != IntPtr.Zero)", indent, opt.ContextType.GetObjectHandleProperty ("this"));
+			writer.WriteLine ("{0}if ({1} != IntPtr.Zero)", indent, Context.ContextType.GetObjectHandleProperty ("this"));
 			writer.WriteLine ("{0}\treturn;", indent);
 			writer.WriteLine ();
 			foreach (string prep in ctor.Parameters.GetCallPrep (opt))
@@ -83,7 +84,7 @@ namespace MonoDroid.Generation {
 			writer.WriteLine ("{0}\t\t\tJniHandleOwnership.TransferLocalRef);", indent);
 			writer.WriteLine ("{0}\tglobal::Android.Runtime.JNIEnv.FinishCreateInstance ({1}, \"{2}\"{3});",
 					indent,
-					opt.ContextType.GetObjectHandleProperty ("this"),
+					Context.ContextType.GetObjectHandleProperty ("this"),
 					ctor.IsNonStaticNestedType ? "(" + ctor.Parameters.JniNestedDerivedSignature + ")V" : ctor.JniSignature,
 					ctor.Parameters.GetCallArgs (opt, invoker:false));
 			writer.WriteLine ("{0}\treturn;", indent);
@@ -97,7 +98,7 @@ namespace MonoDroid.Generation {
 			writer.WriteLine ("{0}\t\tJniHandleOwnership.TransferLocalRef);", indent);
 			writer.WriteLine ("{0}JNIEnv.FinishCreateInstance ({1}, class_ref, {2}{3});",
 					indent,
-					opt.ContextType.GetObjectHandleProperty ("this"),
+					Context.ContextType.GetObjectHandleProperty ("this"),
 					ctor.ID,
 					ctor.Parameters.GetCallArgs (opt, invoker:false));
 			indent = oldindent;

--- a/tools/generator/Java.Interop.Tools.Generator.Importers/Xml/XmlCtor.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Importers/Xml/XmlCtor.cs
@@ -68,11 +68,11 @@ namespace MonoDroid.Generation
 			set { name = value; }
 		}
 
-		protected override bool OnValidate (CodeGenerationOptions opt, GenericParameterDefinitionList tps)
+		protected override bool OnValidate (CodeGenerationOptions opt, GenericParameterDefinitionList tps, CodeGeneratorContext context)
 		{
 			if (missing_enclosing_class)
 				return false;
-			return base.OnValidate (opt, tps);
+			return base.OnValidate (opt, tps, context);
 		}
 
 		public override string CustomAttributes {

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ClassGen.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ClassGen.cs
@@ -2,14 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Xml;
-
 using Java.Interop.Tools.TypeNameMappings;
-
 using Xamarin.Android.Binder;
-
-using MonoDroid.Utils;
 
 namespace MonoDroid.Generation
 {
@@ -244,8 +238,6 @@ namespace MonoDroid.Generation
 
 		public override void Generate (CodeGenerationOptions opt, GenerationInfo gen_info)
 		{
-			gen_info.CurrentType = FullName;
-
 			using (var sw = gen_info.OpenStream (opt.GetFileName (FullName))) {
 				sw.WriteLine ("using System;");
 				sw.WriteLine ("using System.Collections.Generic;");
@@ -269,7 +261,7 @@ namespace MonoDroid.Generation
 			using (var sw = gen_info.OpenStream (opt.GetFileName ("Java.Interop.__TypeRegistrations"))) {
 
 				Dictionary<string, List<KeyValuePair<string, string>>> mapping = new Dictionary<string, List<KeyValuePair<string, string>>> ();
-				foreach (KeyValuePair<string, string> reg in gen_info.TypeRegistrations) {
+				foreach (KeyValuePair<string, string> reg in gen_info.TypeRegistrations.OrderBy (p => p.Key, StringComparer.OrdinalIgnoreCase)) {
 					int ls = reg.Key.LastIndexOf ('/');
 					string package = ls >= 0 ? reg.Key.Substring (0, ls) : "";
 
@@ -345,7 +337,7 @@ namespace MonoDroid.Generation
 		public static void GenerateEnumList (GenerationInfo gen_info)
 		{
 			using (var sw = new StreamWriter (File.Create (Path.Combine (gen_info.CSharpDir, "enumlist")))) {
-				foreach (string e in gen_info.Enums)
+				foreach (string e in gen_info.Enums.OrderBy (p => p, StringComparer.OrdinalIgnoreCase))
 					sw.WriteLine (e);
 			}
 		}

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ClassGen.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ClassGen.cs
@@ -93,7 +93,7 @@ namespace MonoDroid.Generation
 			base.ResetValidation ();
 		}
 
-		protected override bool OnValidate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params)
+		protected override bool OnValidate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params, CodeGeneratorContext context)
 		{
 			if (validated)
 				return is_valid;
@@ -106,7 +106,7 @@ namespace MonoDroid.Generation
 			}
 
 			// We're validating this in prior to BaseType.
-			if (TypeParameters != null && !TypeParameters.Validate (opt, type_params)) {
+			if (TypeParameters != null && !TypeParameters.Validate (opt, type_params, context)) {
 				is_valid = false;
 				return false;
 			}
@@ -124,7 +124,7 @@ namespace MonoDroid.Generation
 				return false;
 			}
 
-			if ((base_symbol != null && !base_symbol.Validate (opt, TypeParameters)) || !base.OnValidate (opt, type_params)) {
+			if ((base_symbol != null && !base_symbol.Validate (opt, TypeParameters, context)) || !base.OnValidate (opt, type_params, context)) {
 				Report.Warning (0, Report.WarningClassGen + 3, "Class {0} has invalid base type {1}.", FullName, BaseType);
 				is_valid = false;
 				return false;
@@ -132,7 +132,7 @@ namespace MonoDroid.Generation
 
 			List<Ctor> valid_ctors = new List<Ctor> ();
 			foreach (Ctor c in ctors)
-				if (c.Validate (opt, TypeParameters))
+				if (c.Validate (opt, TypeParameters, context))
 					valid_ctors.Add (c);
 			ctors = valid_ctors;
 

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Ctor.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Ctor.cs
@@ -24,9 +24,9 @@ namespace MonoDroid.Generation
 			get { return "id_ctor" + IDSignature; }
 		}
 
-		protected override bool OnValidate (CodeGenerationOptions opt, GenericParameterDefinitionList tps)
+		protected override bool OnValidate (CodeGenerationOptions opt, GenericParameterDefinitionList tps, CodeGeneratorContext context)
 		{
-			if (!base.OnValidate (opt, tps))
+			if (!base.OnValidate (opt, tps, context))
 				return false;
 			jni_sig = "(" + Parameters.JniSignature + ")V";
 			return true;

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Field.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Field.cs
@@ -83,21 +83,21 @@ namespace MonoDroid.Generation
 
 		public string Annotation { get; internal set; }
 
-		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params)
+		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params, CodeGeneratorContext context)
 		{
 			symbol = opt.SymbolTable.Lookup (TypeName, type_params);
 			
-			if (symbol == null || !symbol.Validate (opt, type_params)) {
-				Report.Warning (0, Report.WarningField + 0, "unexpected field type {0} {1}.", TypeName, opt.ContextString);
+			if (symbol == null || !symbol.Validate (opt, type_params, context)) {
+				Report.Warning (0, Report.WarningField + 0, "unexpected field type {0} {1}.", TypeName, context.ContextString);
 				return false;
 			}
 
 			setParameters = new ParameterList () {
 				SetterParameter,
 			};
-			if (!setParameters.Validate (opt, type_params))
+			if (!setParameters.Validate (opt, type_params, context))
 				throw new NotSupportedException (
-					string.Format ("Unable to generate setter parameter list {0}", opt.ContextString));
+					string.Format ("Unable to generate setter parameter list {0}", context.ContextString));
 
 			return true;
 		}

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
@@ -413,9 +413,9 @@ namespace MonoDroid.Generation {
 			return false;
 		}
 
-		bool ValidateMethod (CodeGenerationOptions opt, Method m)
+		bool ValidateMethod (CodeGenerationOptions opt, Method m, CodeGeneratorContext context)
 		{
-			if (!m.Validate (opt, TypeParameters)) {
+			if (!m.Validate (opt, TypeParameters, context)) {
 				return false;
 			}
 			return true;
@@ -623,17 +623,17 @@ namespace MonoDroid.Generation {
 					nested.FullName = parent.FullName + "." + nested.Name;
 		}
 
-		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params)
+		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params, CodeGeneratorContext context)
 		{
-			opt.ContextTypes.Push (this);
+			context.ContextTypes.Push (this);
 			try {
-				return is_valid = OnValidate (opt, type_params);
+				return is_valid = OnValidate (opt, type_params, context);
 			} finally {
-				opt.ContextTypes.Pop ();
+				context.ContextTypes.Pop ();
 			}
 		}
 
-		protected virtual bool OnValidate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params)
+		protected virtual bool OnValidate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params, CodeGeneratorContext context)
 		{
 			if (Name.Length > TypeNamePrefix.Length &&
 			    (Name [TypeNamePrefix.Length] == '.' || Char.IsDigit (Name [TypeNamePrefix.Length]))) // see bug #5111
@@ -644,7 +644,7 @@ namespace MonoDroid.Generation {
 
 			List<GenBase> valid_nests = new List<GenBase> ();
 			foreach (GenBase gen in nested_types) {
-				if (gen.Validate (opt, TypeParameters))
+				if (gen.Validate (opt, TypeParameters, context))
 					valid_nests.Add (gen);
 			}
 			nested_types = valid_nests;
@@ -653,7 +653,7 @@ namespace MonoDroid.Generation {
 
 			foreach (string iface_name in iface_names) {
 				ISymbol isym = opt.SymbolTable.Lookup (iface_name);
-				if (isym != null && isym.Validate (opt, TypeParameters))
+				if (isym != null && isym.Validate (opt, TypeParameters, context))
 					ifaces.Add (isym);
 				else {
 					if (isym == null)
@@ -666,14 +666,14 @@ namespace MonoDroid.Generation {
 
 			List<Field> valid_fields = new List<Field> ();
 			foreach (Field f in fields) {
-				if (!f.Validate (opt, TypeParameters))
+				if (!f.Validate (opt, TypeParameters, context))
 					continue;
 				valid_fields.Add (f);
 			}
 			fields = valid_fields;
 
 			int method_cnt = methods.Count;
-			methods = methods.Where (m => ValidateMethod (opt, m)).ToList ();
+			methods = methods.Where (m => ValidateMethod (opt, m, context)).ToList ();
 			method_validation_failed = method_cnt != methods.Count;
 			foreach (Method m in methods) {
 				if (m.IsVirtual)

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
@@ -870,27 +870,27 @@ namespace MonoDroid.Generation {
 				var attrClassNameBase = baseName.Substring (TypeNamePrefix.Length) + "Attribute";
 				var localFullName = Namespace + (Namespace.Length > 0 ? "." : string.Empty) + attrClassNameBase;
 				gen_info.CurrentType = localFullName;
-				StreamWriter sw = gen_info.Writer = gen_info.OpenStream (opt.GetFileName (localFullName));
-				sw.WriteLine ("using System;");
-				sw.WriteLine ();
-				sw.WriteLine ("namespace {0} {{", Namespace);
-				sw.WriteLine ();
-				sw.WriteLine ("\t[global::Android.Runtime.Annotation (\"{0}\")]", JavaName);
-				sw.WriteLine ("\t{0} partial class {1} : Attribute", this.Visibility, attrClassNameBase);
-				sw.WriteLine ("\t{");
 
-				// An Annotation attribute property is generated for each applicable annotation method,
-				// where *applicable* means java annotation compatible types. See IsTypeCommensurate().
-				foreach (var method in Methods.Where (m => m.Parameters.Count == 0 &&
-				                                      IsTypeCommensurate (opt, opt.SymbolTable.Lookup (m.RetVal.JavaName)))) {
-					sw.WriteLine ("\t\t[global::Android.Runtime.Register (\"{0}\"{1})]", method.JavaName, method.AdditionalAttributeString ());
-					sw.WriteLine ("\t\tpublic {0} {1} {{ get; set; }}", opt.GetOutputName (method.RetVal.FullName), method.Name);
+				using (var sw = gen_info.OpenStream (opt.GetFileName (localFullName))) {
+					sw.WriteLine ("using System;");
 					sw.WriteLine ();
+					sw.WriteLine ("namespace {0} {{", Namespace);
+					sw.WriteLine ();
+					sw.WriteLine ("\t[global::Android.Runtime.Annotation (\"{0}\")]", JavaName);
+					sw.WriteLine ("\t{0} partial class {1} : Attribute", this.Visibility, attrClassNameBase);
+					sw.WriteLine ("\t{");
+
+					// An Annotation attribute property is generated for each applicable annotation method,
+					// where *applicable* means java annotation compatible types. See IsTypeCommensurate().
+					foreach (var method in Methods.Where (m => m.Parameters.Count == 0 &&
+									      IsTypeCommensurate (opt, opt.SymbolTable.Lookup (m.RetVal.JavaName)))) {
+						sw.WriteLine ("\t\t[global::Android.Runtime.Register (\"{0}\"{1})]", method.JavaName, method.AdditionalAttributeString ());
+						sw.WriteLine ("\t\tpublic {0} {1} {{ get; set; }}", opt.GetOutputName (method.RetVal.FullName), method.Name);
+						sw.WriteLine ();
+					}
+					sw.WriteLine ("\t}");
+					sw.WriteLine ("}");
 				}
-				sw.WriteLine ("\t}");
-				sw.WriteLine ("}");
-				sw.Close ();
-				gen_info.Writer = null;
 			}
 		}
 		

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
@@ -869,7 +869,6 @@ namespace MonoDroid.Generation {
 				var baseName = Namespace.Length > 0 ? FullName.Substring (Namespace.Length + 1) : FullName;
 				var attrClassNameBase = baseName.Substring (TypeNamePrefix.Length) + "Attribute";
 				var localFullName = Namespace + (Namespace.Length > 0 ? "." : string.Empty) + attrClassNameBase;
-				gen_info.CurrentType = localFullName;
 
 				using (var sw = gen_info.OpenStream (opt.GetFileName (localFullName))) {
 					sw.WriteLine ("using System;");

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenericParameterDefinition.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenericParameterDefinition.cs
@@ -28,7 +28,7 @@ namespace MonoDroid.Generation
 
 		bool validated, is_valid;
 
-		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params)
+		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params, CodeGeneratorContext context)
 		{
 			if (ConstraintExpressions == null || ConstraintExpressions.Length == 0)
 				return true;
@@ -38,7 +38,7 @@ namespace MonoDroid.Generation
 			foreach (var c in ConstraintExpressions) {
 				var sym = opt.SymbolTable.Lookup (c, type_params);
 				if (sym == null) {
-					Report.Warning (0, Report.WarningGenericParameterDefinition + 0, "Unknown generic argument constraint type {0} {1}.", c, opt.ContextString);
+					Report.Warning (0, Report.WarningGenericParameterDefinition + 0, "Unknown generic argument constraint type {0} {1}.", c, context.ContextString);
 					validated = true;
 					return false;
 				}
@@ -114,10 +114,10 @@ namespace MonoDroid.Generation
 			return Count == 0 ? null : '<' + String.Join (",", (from p in this select p.Name).ToArray ()) + '>';
 		}
 		
-		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params)
+		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params, CodeGeneratorContext context)
 		{
 			foreach (var pd in this)
-				if (!pd.Validate (opt, type_params))
+				if (!pd.Validate (opt, type_params, context))
 					return false;
 			return true;
 		}

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenericParameterList.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenericParameterList.cs
@@ -64,7 +64,7 @@ namespace MonoDroid.Generation {
 			return managed;
 		}
 
-		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList in_params)
+		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList in_params, CodeGeneratorContext context)
 		{
 			if (validated)
 				return is_valid;
@@ -89,7 +89,7 @@ namespace MonoDroid.Generation {
 				}
 
 				ISymbol psym = opt.SymbolTable.Lookup (tp, in_params);
-				if (psym == null || !psym.Validate (opt, in_params))
+				if (psym == null || !psym.Validate (opt, in_params, context))
 					return false;
 				
 

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/InterfaceGen.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/InterfaceGen.cs
@@ -190,24 +190,22 @@ namespace MonoDroid.Generation
 		{
 			gen_info.CurrentType = FullName;
 
-			StreamWriter sw = gen_info.Writer = gen_info.OpenStream(opt.GetFileName (FullName));
+			using (var sw = gen_info.OpenStream (opt.GetFileName (FullName))) {
+				sw.WriteLine ("using System;");
+				sw.WriteLine ("using System.Collections.Generic;");
+				sw.WriteLine ("using Android.Runtime;");
+				if (opt.CodeGenerationTarget != CodeGenerationTarget.XamarinAndroid) {
+					sw.WriteLine ("using Java.Interop;");
+				}
+				sw.WriteLine ();
+				sw.WriteLine ("namespace {0} {{", Namespace);
+				sw.WriteLine ();
 
-			sw.WriteLine ("using System;");
-			sw.WriteLine ("using System.Collections.Generic;");
-			sw.WriteLine ("using Android.Runtime;");
-			if (opt.CodeGenerationTarget != CodeGenerationTarget.XamarinAndroid) {
-				sw.WriteLine ("using Java.Interop;");
+				var generator = opt.CreateCodeGenerator (sw);
+				generator.WriteInterface (this, "\t", gen_info);
+
+				sw.WriteLine ("}");
 			}
-			sw.WriteLine ();
-			sw.WriteLine ("namespace {0} {{", Namespace);
-			sw.WriteLine ();
-
-			var generator = opt.CreateCodeGenerator (sw);
-			generator.WriteInterface (this, "\t", gen_info);
-
-			sw.WriteLine ("}");
-			sw.Close ();
-			gen_info.Writer = null;
 			
 			GenerateAnnotationAttribute (opt, gen_info);
 		}

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/InterfaceGen.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/InterfaceGen.cs
@@ -188,8 +188,6 @@ namespace MonoDroid.Generation
 
 		public override void Generate (CodeGenerationOptions opt, GenerationInfo gen_info)
 		{
-			gen_info.CurrentType = FullName;
-
 			using (var sw = gen_info.OpenStream (opt.GetFileName (FullName))) {
 				sw.WriteLine ("using System;");
 				sw.WriteLine ("using System.Collections.Generic;");

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/InterfaceGen.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/InterfaceGen.cs
@@ -118,7 +118,7 @@ namespace MonoDroid.Generation
 			base.ResetValidation ();
 		}
 
-		protected override bool OnValidate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params)
+		protected override bool OnValidate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params, CodeGeneratorContext context)
 		{
 			if (validated)
 				return is_valid;
@@ -127,10 +127,10 @@ namespace MonoDroid.Generation
 			
 			// Due to demand to validate in prior to validate ClassGen's BaseType, it is *not* done at
 			// GenBase.
-			if (TypeParameters != null && !TypeParameters.Validate (opt, type_params))
+			if (TypeParameters != null && !TypeParameters.Validate (opt, type_params, context))
 				return false;
 
-			if (!base.OnValidate (opt, type_params) || iface_validation_failed || MethodValidationFailed) {
+			if (!base.OnValidate (opt, type_params, context) || iface_validation_failed || MethodValidationFailed) {
 				if (iface_validation_failed)
 					Report.Warning (0, Report.WarningInterfaceGen + 2, "Invalidating {0} and all nested types because some of its interfaces were invalid.", FullName);
 				else if (MethodValidationFailed)

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Method.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Method.cs
@@ -172,15 +172,15 @@ namespace MonoDroid.Generation
 			return event_name;
 		}
 
-		protected override bool OnValidate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params)
+		protected override bool OnValidate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params, CodeGeneratorContext context)
 		{
 			if (GenericArguments != null)
-				GenericArguments.Validate (opt, type_params);
+				GenericArguments.Validate (opt, type_params, context);
 			var tpl = GenericParameterDefinitionList.Merge (type_params, GenericArguments);
-			if (!retval.Validate (opt, tpl))
+			if (!retval.Validate (opt, tpl, context))
 				return false;
 
-			return base.OnValidate (opt, tpl);
+			return base.OnValidate (opt, tpl, context);
 		}
 
 		string connector_name;

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/MethodBase.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/MethodBase.cs
@@ -79,23 +79,23 @@ namespace MonoDroid.Generation
 			return true;
 		}
 
-		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params)
+		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params, CodeGeneratorContext context)
 		{
-			opt.ContextMethod = this;
+			context.ContextMethod = this;
 			try {
-				return IsValid = OnValidate (opt, type_params);
+				return IsValid = OnValidate (opt, type_params, context);
 			} finally {
-				opt.ContextMethod = null;
+				context.ContextMethod = null;
 			}
 		}
 
-		protected virtual bool OnValidate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params)
+		protected virtual bool OnValidate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params, CodeGeneratorContext context)
 		{
 			var tpl = GenericParameterDefinitionList.Merge (type_params, GenericArguments);
-			if (!parms.Validate (opt, tpl))
+			if (!parms.Validate (opt, tpl, context))
 				return false;
 			if (Parameters.Count > 14) {
-				Report.Warning (0, Report.WarningMethodBase + 0, "More than 16 parameters were found, which goes beyond the maximum number of parameters. ({0})", opt.ContextString);
+				Report.Warning (0, Report.WarningMethodBase + 0, "More than 16 parameters were found, which goes beyond the maximum number of parameters. ({0})", context.ContextString);
 				return false;
 			}
 			return true;

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Parameter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Parameter.cs
@@ -252,15 +252,15 @@ namespace MonoDroid.Generation {
 					name); 
 		}
 
-		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params)
+		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params, CodeGeneratorContext context)
 		{
 			sym = opt.SymbolTable.Lookup (type, type_params);
 			if (sym == null) {
-				Report.Warning (0, Report.WarningParameter + 0, "Unknown parameter type {0} {1}.", type, opt.ContextString);
+				Report.Warning (0, Report.WarningParameter + 0, "Unknown parameter type {0} {1}.", type, context.ContextString);
 				return false;
 			}
-			if (!sym.Validate (opt, type_params)) {
-				Report.Warning (0, Report.WarningParameter + 1, "Invalid parameter type {0} {1}.", type, opt.ContextString);
+			if (!sym.Validate (opt, type_params, context)) {
+				Report.Warning (0, Report.WarningParameter + 1, "Invalid parameter type {0} {1}.", type, context.ContextString);
 				return false;
 			}
 			return true;

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ParameterList.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ParameterList.cs
@@ -278,10 +278,10 @@ namespace MonoDroid.Generation {
 			return sb.ToString ();
 		}
 
-		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params)
+		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params, CodeGeneratorContext context)
 		{
 			foreach (Parameter p in items)
-				if (!p.Validate (opt, type_params))
+				if (!p.Validate (opt, type_params, context))
 					return false;
 			return true;
 		}

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ReturnValue.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ReturnValue.cs
@@ -116,15 +116,15 @@ namespace MonoDroid.Generation {
 			                      opt.GetSafeIdentifier (rgm != null ? rgm.ToInteroperableJavaObject (name) : name)); 
 		}
 
-		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params)
+		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params, CodeGeneratorContext context)
 		{
 			sym = (IsEnumified ? opt.SymbolTable.Lookup (managed_type, type_params) : null) ?? opt.SymbolTable.Lookup (java_type, type_params);
 			if (sym == null) {
-				Report.Warning (0, Report.WarningReturnValue + 0, "Unknown return type {0} {1}.", java_type, opt.ContextString);
+				Report.Warning (0, Report.WarningReturnValue + 0, "Unknown return type {0} {1}.", java_type, context.ContextString);
 				return false;
 			}
-			if (!sym.Validate (opt, type_params)) {
-				Report.Warning (0, Report.WarningReturnValue + 1, "Invalid return type {0} {1}.", java_type, opt.ContextString);
+			if (!sym.Validate (opt, type_params, context)) {
+				Report.Warning (0, Report.WarningReturnValue + 1, "Invalid return type {0} {1}.", java_type, context.ContextString);
 				return false;
 			}
 			return true;

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/ArraySymbol.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/ArraySymbol.cs
@@ -84,9 +84,9 @@ namespace MonoDroid.Generation {
 			return String.Format ("JNIEnv.NewArray ({0})", var_name);
 		}
 
-		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params)
+		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params, CodeGeneratorContext context)
 		{
-			return sym.Validate (opt, type_params);
+			return sym.Validate (opt, type_params, context);
 		}
 
 		public string Call (CodeGenerationOptions opt, string var_name)

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/CharSequenceSymbol.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/CharSequenceSymbol.cs
@@ -61,7 +61,7 @@ namespace MonoDroid.Generation {
 			return String.Format ("CharSequence.ToLocalJniHandle ({0})", var_name);
 		}
 
-		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params)
+		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params, CodeGeneratorContext context)
 		{
 			return true;
 		}

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/CollectionSymbol.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/CollectionSymbol.cs
@@ -89,9 +89,9 @@ namespace MonoDroid.Generation {
 					opt.GetSafeIdentifier (varname));
 		}
 
-		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params)
+		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params, CodeGeneratorContext context)
 		{
-			return parms == null || parms.Validate (opt, type_params);
+			return parms == null || parms.Validate (opt, type_params, context);
 		}
 
 		public string[] PreCallback (CodeGenerationOptions opt, string var_name, bool owned)

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/EnumSymbol.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/EnumSymbol.cs
@@ -66,7 +66,7 @@ namespace MonoDroid.Generation {
 			return "(int) " + varname;
 		}
 
-		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params)
+		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params, CodeGeneratorContext context)
 		{
 			return true;
 		}

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/FormatSymbol.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/FormatSymbol.cs
@@ -81,7 +81,7 @@ namespace MonoDroid.Generation {
 			return String.Format (to_fmt, varname);
 		}
 
-		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params)
+		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params, CodeGeneratorContext context)
 		{
 			return true;
 		}

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/GeneratedEnumSymbol.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/GeneratedEnumSymbol.cs
@@ -40,7 +40,7 @@ namespace MonoDroid.Generation
 				return String.Format ("({0}) {1}", JavaName, var_name);
 		}
 	
-		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params)
+		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params, CodeGeneratorContext context)
 		{
 			return true;
 		}

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/GenericSymbol.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/GenericSymbol.cs
@@ -105,9 +105,9 @@ namespace MonoDroid.Generation {
 			return varname;
 		}
 
-		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList in_params)
+		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList in_params, CodeGeneratorContext context)
 		{
-			if (!gen.Validate (opt, in_params))
+			if (!gen.Validate (opt, in_params, context))
 				return false;
 
 			is_concrete = true;
@@ -129,7 +129,7 @@ namespace MonoDroid.Generation {
 				}
 
 				ISymbol psym = opt.SymbolTable.Lookup (tp, in_params);
-				if (psym == null || !psym.Validate (opt, in_params))
+				if (psym == null || !psym.Validate (opt, in_params, context))
 					return false;
 
 				if (psym is GenericSymbol && !(psym as GenericSymbol).IsConcrete)

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/GenericTypeParameter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/GenericTypeParameter.cs
@@ -88,7 +88,7 @@ namespace MonoDroid.Generation {
 			return varname;
 		}
 
-		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params)
+		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params, CodeGeneratorContext context)
 		{
 			return true;
 		}

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/ISymbol.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/ISymbol.cs
@@ -21,7 +21,7 @@ namespace MonoDroid.Generation {
 		string FromNative (CodeGenerationOptions opt, string var_name, bool owned);
 		string ToNative (CodeGenerationOptions opt, string var_name, Dictionary<string, string> mappings = null);
 
-		bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params);
+		bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params, CodeGeneratorContext context);
 
 		string[] PreCallback (CodeGenerationOptions opt, string var_name, bool owned);
 		string[] PostCallback (CodeGenerationOptions opt, string var_name);

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/StreamSymbol.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/StreamSymbol.cs
@@ -74,7 +74,7 @@ namespace MonoDroid.Generation {
 			return String.Format (opt.GetOutputName ("Android.Runtime.{0}Adapter") + ".ToLocalJniHandle ({1})", base_name, var_name);
 		}
 
-		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params)
+		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params, CodeGeneratorContext context)
 		{
 			return true;
 		}

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/StringSymbol.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/StringSymbol.cs
@@ -64,7 +64,7 @@ namespace MonoDroid.Generation {
 			return String.Format ("JNIEnv.NewString ({0})", var_name);
 		}
 
-		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params)
+		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params, CodeGeneratorContext context)
 		{
 			return true;
 		}

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/XmlPullParserSymbol.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/XmlPullParserSymbol.cs
@@ -61,7 +61,7 @@ namespace MonoDroid.Generation {
 			return String.Format ("global::Android.Runtime.XmlReaderPullParser.ToLocalJniHandle ({0})", var_name);
 		}
 
-		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params)
+		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params, CodeGeneratorContext context)
 		{
 			return true;
 		}

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/XmlResourceParserSymbol.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/XmlResourceParserSymbol.cs
@@ -61,7 +61,7 @@ namespace MonoDroid.Generation {
 			return String.Format ("global::Android.Runtime.XmlReaderResourceParser.ToLocalJniHandle ({0})", var_name);
 		}
 
-		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params)
+		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params, CodeGeneratorContext context)
 		{
 			return true;
 		}

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorTests.cs
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorTests.cs
@@ -35,9 +35,9 @@ namespace generatortests
 		{
 			var @class = SupportTypeBuilder.CreateClass ("java.code.MyClass", options);
 
-			options.ContextTypes.Push (@class);
+			generator.Context.ContextTypes.Push (@class);
 			generator.WriteClass (@class, string.Empty, new GenerationInfo ("", "", "MyAssembly"));
-			options.ContextTypes.Pop ();
+			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteClass)), writer.ToString ().NormalizeLineEndings ());
 		}
@@ -47,9 +47,9 @@ namespace generatortests
 		{
 			var @class = SupportTypeBuilder.CreateClass ("java.code.MyClass", options);
 
-			options.ContextTypes.Push (@class);
+			generator.Context.ContextTypes.Push (@class);
 			generator.WriteClassAbstractMembers (@class, string.Empty);
-			options.ContextTypes.Pop ();
+			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetExpected (nameof (WriteClassAbstractMembers)), writer.ToString ().NormalizeLineEndings ());
 		}
@@ -59,9 +59,9 @@ namespace generatortests
 		{
 			var @class = SupportTypeBuilder.CreateClass ("java.code.MyClass", options);
 
-			options.ContextTypes.Push (@class);
+			generator.Context.ContextTypes.Push (@class);
 			generator.WriteClassConstructors (@class, string.Empty);
-			options.ContextTypes.Pop ();
+			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteClassConstructors)), writer.ToString ().NormalizeLineEndings ());
 		}
@@ -81,9 +81,9 @@ namespace generatortests
 		{
 			var @class = SupportTypeBuilder.CreateClass ("java.code.MyClass", options);
 
-			options.ContextTypes.Push (@class);
+			generator.Context.ContextTypes.Push (@class);
 			generator.WriteClassInvoker (@class, string.Empty);
-			options.ContextTypes.Pop ();
+			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteClassInvoker)), writer.ToString ().NormalizeLineEndings ());
 		}
@@ -105,9 +105,9 @@ namespace generatortests
 			var @class = SupportTypeBuilder.CreateClass ("java.code.MyClass", options);
 			var members = new HashSet<string> ();
 
-			options.ContextTypes.Push (@class);
+			generator.Context.ContextTypes.Push (@class);
 			generator.WriteClassInvokerMembers (@class, string.Empty, members);
-			options.ContextTypes.Pop ();
+			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteClassInvokerMembers)), writer.ToString ().NormalizeLineEndings ());
 		}
@@ -119,9 +119,9 @@ namespace generatortests
 			var @class = SupportTypeBuilder.CreateClass ("java.code.MyClass", options);
 			var members = new HashSet<string> ();
 
-			options.ContextTypes.Push (@class);
+			generator.Context.ContextTypes.Push (@class);
 			generator.WriteClassMethodInvokers (@class, @class.Methods, string.Empty, members, null);
-			options.ContextTypes.Pop ();
+			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteClassMethodInvokers)), writer.ToString ().NormalizeLineEndings ());
 		}
@@ -133,9 +133,9 @@ namespace generatortests
 			var @class = SupportTypeBuilder.CreateClass ("java.code.MyClass", options);
 			var members = new HashSet<string> (new [] { @class.Methods [0].Name });
 
-			options.ContextTypes.Push (@class);
+			generator.Context.ContextTypes.Push (@class);
 			generator.WriteClassMethodInvokers (@class, @class.Methods, string.Empty, members, null);
-			options.ContextTypes.Pop ();
+			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteClassMethodInvokersWithSkips)), writer.ToString ().NormalizeLineEndings ());
 		}
@@ -145,9 +145,9 @@ namespace generatortests
 		{
 			var @class = SupportTypeBuilder.CreateClass ("java.code.MyClass", options);
 
-			options.ContextTypes.Push (@class);
+			generator.Context.ContextTypes.Push (@class);
 			generator.WriteClassMethods (@class, string.Empty);
-			options.ContextTypes.Pop ();
+			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteClassMethods)), writer.ToString ().NormalizeLineEndings ());
 		}
@@ -157,9 +157,9 @@ namespace generatortests
 		{
 			var @class = SupportTypeBuilder.CreateClass ("java.code.MyClass", options);
 
-			options.ContextTypes.Push (@class);
+			generator.Context.ContextTypes.Push (@class);
 			generator.WriteClassProperties (@class, string.Empty);
-			options.ContextTypes.Pop ();
+			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteClassProperties)), writer.ToString ().NormalizeLineEndings ());
 		}
@@ -171,9 +171,9 @@ namespace generatortests
 			var @class = SupportTypeBuilder.CreateClass ("java.code.MyClass", options);
 			var members = new HashSet<string> ();
 
-			options.ContextTypes.Push (@class);
+			generator.Context.ContextTypes.Push (@class);
 			generator.WriteClassPropertyInvokers (@class, @class.Properties, string.Empty, members);
-			options.ContextTypes.Pop ();
+			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteClassPropertyInvokers)), writer.ToString ().NormalizeLineEndings ());
 		}
@@ -185,9 +185,9 @@ namespace generatortests
 			var @class = SupportTypeBuilder.CreateClass ("java.code.MyClass", options);
 			var members = new HashSet<string> (new [] { @class.Properties [0].Name });
 
-			options.ContextTypes.Push (@class);
+			generator.Context.ContextTypes.Push (@class);
 			generator.WriteClassPropertyInvokers (@class, @class.Properties, string.Empty, members);
-			options.ContextTypes.Pop ();
+			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteClassPropertyInvokersWithSkips)), writer.ToString ().NormalizeLineEndings ());
 		}
@@ -198,9 +198,9 @@ namespace generatortests
 			var @class = new TestClass ("java.lang.Object", "com.mypackage.foo");
 			var ctor = new TestCtor (@class, "Object");
 
-			options.ContextTypes.Push (@class);
+			generator.Context.ContextTypes.Push (@class);
 			generator.WriteConstructor (ctor, string.Empty, true, @class);
-			options.ContextTypes.Pop ();
+			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteCtor)), writer.ToString ().NormalizeLineEndings ());
 		}
@@ -214,9 +214,9 @@ namespace generatortests
 				.SetCustomAttributes ("[MyAttribute]")
 				.SetAnnotation ("[global::Android.Runtime.IntDefinition (null, JniField = \"xamarin/test/SomeObject.SOME_VALUE\")]");
 
-			options.ContextTypes.Push (@class);
+			generator.Context.ContextTypes.Push (@class);
 			generator.WriteConstructor (ctor, string.Empty, true, @class);
-			options.ContextTypes.Pop ();
+			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteCtorDeprecated)), writer.ToString ().NormalizeLineEndings ());
 		}
@@ -228,11 +228,11 @@ namespace generatortests
 			var ctor = new TestCtor (@class, "Object");
 
 			ctor.Parameters.Add (new Parameter ("mystring", "java.lang.CharSequence", "Java.Lang.ICharSequence", false));
-			ctor.Validate (options, null);
+			ctor.Validate (options, null, new CodeGeneratorContext ());
 
-			options.ContextTypes.Push (@class);
+			generator.Context.ContextTypes.Push (@class);
 			generator.WriteConstructor (ctor, string.Empty, true, @class);
-			options.ContextTypes.Pop ();
+			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteCtorWithStringOverload)), writer.ToString ().NormalizeLineEndings ());
 		}
@@ -242,7 +242,7 @@ namespace generatortests
 		{
 			var @class = new TestClass ("java.lang.Object", "com.mypackage.foo");
 			var field = new TestField ("int", "bar").SetEnumified ();
-			Assert.IsTrue (field.Validate (options, new GenericParameterDefinitionList ()), "field.Validate failed!");
+			Assert.IsTrue (field.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "field.Validate failed!");
 			generator.WriteField (field, string.Empty, @class);
 
 			StringAssert.Contains ("[global::Android.Runtime.GeneratedEnum]", builder.ToString (), "Should contain GeneratedEnumAttribute!");
@@ -254,7 +254,7 @@ namespace generatortests
 			var comment = "Don't use this!";
 			var @class = new TestClass ("java.lang.Object", "com.mypackage.foo");
 			var field = new TestField ("int", "bar").SetConstant ("1234").SetDeprecated (comment);
-			Assert.IsTrue (field.Validate (options, new GenericParameterDefinitionList ()), "field.Validate failed!");
+			Assert.IsTrue (field.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "field.Validate failed!");
 			generator.WriteField (field, string.Empty, @class);
 
 			StringAssert.Contains ($"[Obsolete (\"{comment}\")]", builder.ToString (), "Should contain ObsoleteAttribute!");
@@ -265,7 +265,7 @@ namespace generatortests
 		{
 			var @class = new TestClass ("java.lang.Object", "com.mypackage.foo");
 			var field = new TestField ("int", "bar").SetVisibility ("protected");
-			Assert.IsTrue (field.Validate (options, new GenericParameterDefinitionList ()), "field.Validate failed!");
+			Assert.IsTrue (field.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "field.Validate failed!");
 			generator.WriteField (field, string.Empty, @class);
 
 			StringAssert.Contains ("protected int bar {", builder.ToString (), "Property should be protected!");
@@ -277,7 +277,7 @@ namespace generatortests
 			var @class = new TestClass ("java.lang.Object", "com.mypackage.foo");
 			var field = new TestField ("java.lang.String", "bar").SetConstant ();
 
-			Assert.IsTrue (field.Validate (options, new GenericParameterDefinitionList ()), "field.Validate failed!");
+			Assert.IsTrue (field.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "field.Validate failed!");
 			generator.WriteField (field, string.Empty, @class);
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteFieldConstant)), writer.ToString ().NormalizeLineEndings ());
@@ -289,7 +289,7 @@ namespace generatortests
 			var @class = new TestClass ("java.lang.Object", "com.mypackage.foo");
 			var field = new TestField ("int", "bar").SetConstant ("1234");
 
-			Assert.IsTrue (field.Validate (options, new GenericParameterDefinitionList ()), "field.Validate failed!");
+			Assert.IsTrue (field.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "field.Validate failed!");
 			generator.WriteField (field, string.Empty, @class);
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteFieldConstantWithIntValue)), writer.ToString ().NormalizeLineEndings ());
@@ -301,7 +301,7 @@ namespace generatortests
 			var @class = new TestClass ("java.lang.Object", "com.mypackage.foo");
 			var field = new TestField ("java.lang.String", "bar").SetConstant ("\"hello\"");
 
-			Assert.IsTrue (field.Validate (options, new GenericParameterDefinitionList ()), "field.Validate failed!");
+			Assert.IsTrue (field.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "field.Validate failed!");
 			generator.WriteField (field, string.Empty, @class);
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteFieldConstantWithStringValue)), writer.ToString ().NormalizeLineEndings ());
@@ -313,7 +313,7 @@ namespace generatortests
 			var @class = new TestClass ("java.lang.Object", "com.mypackage.foo");
 			var field = new TestField ("java.lang.String", "bar");
 
-			Assert.IsTrue (field.Validate (options, new GenericParameterDefinitionList ()), "field.Validate failed!");
+			Assert.IsTrue (field.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "field.Validate failed!");
 			generator.WriteFieldGetBody (field, string.Empty, @class);
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteFieldGetBody)), writer.ToString ().NormalizeLineEndings ());
@@ -335,7 +335,7 @@ namespace generatortests
 			var @class = new TestClass ("java.lang.Object", "com.mypackage.foo");
 			var field = new TestField ("int", "bar");
 
-			Assert.IsTrue (field.Validate (options, new GenericParameterDefinitionList ()), "field.Validate failed!");
+			Assert.IsTrue (field.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "field.Validate failed!");
 			generator.WriteField (field, string.Empty, @class);
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteFieldInt)), writer.ToString ().NormalizeLineEndings ());
@@ -347,7 +347,7 @@ namespace generatortests
 			var @class = new TestClass ("java.lang.Object", "com.mypackage.foo");
 			var field = new TestField ("java.lang.String", "bar");
 
-			Assert.IsTrue (field.Validate (options, new GenericParameterDefinitionList ()), "field.Validate failed!");
+			Assert.IsTrue (field.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "field.Validate failed!");
 			generator.WriteFieldSetBody (field, string.Empty, @class);
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteFieldSetBody)), writer.ToString ().NormalizeLineEndings ());
@@ -359,7 +359,7 @@ namespace generatortests
 			var @class = new TestClass ("java.lang.Object", "com.mypackage.foo");
 			var field = new TestField ("java.lang.String", "bar");
 
-			Assert.IsTrue (field.Validate (options, new GenericParameterDefinitionList ()), "field.Validate failed!");
+			Assert.IsTrue (field.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "field.Validate failed!");
 			generator.WriteField (field, string.Empty, @class);
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteFieldString)), writer.ToString ().NormalizeLineEndings ());
@@ -371,7 +371,7 @@ namespace generatortests
 			var comment = "Don't use this!";
 			var @class = new TestClass ("java.lang.Object", "com.mypackage.foo");
 			var method = new TestMethod (@class, "bar").SetDeprecated (comment);
-			Assert.IsTrue (method.Validate (options, new GenericParameterDefinitionList ()), "method.Validate failed!");
+			Assert.IsTrue (method.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "method.Validate failed!");
 			generator.WriteMethod (method, string.Empty, @class, true);
 
 			StringAssert.Contains ($"[Obsolete (@\"{comment}\")]", builder.ToString (), "Should contain ObsoleteAttribute!");
@@ -382,7 +382,7 @@ namespace generatortests
 		{
 			var @class = new TestClass ("java.lang.Object", "com.mypackage.foo");
 			var method = new TestMethod (@class, "bar", @return: "int").SetManagedReturn ("long");
-			Assert.IsTrue (method.Validate (options, new GenericParameterDefinitionList ()), "method.Validate failed!");
+			Assert.IsTrue (method.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "method.Validate failed!");
 			generator.WriteMethod (method, string.Empty, @class, true);
 
 			StringAssert.Contains ("public virtual unsafe long bar ()", builder.ToString (), "Should contain return long!");
@@ -393,7 +393,7 @@ namespace generatortests
 		{
 			var @class = new TestClass ("java.lang.Object", "com.mypackage.foo");
 			var method = new TestMethod (@class, "bar", @return: "int").SetManagedReturn ("int").SetReturnEnumified ();
-			Assert.IsTrue (method.Validate (options, new GenericParameterDefinitionList ()), "method.Validate failed!");
+			Assert.IsTrue (method.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "method.Validate failed!");
 			generator.WriteMethod (method, string.Empty, @class, true);
 
 			StringAssert.Contains ("[return:global::Android.Runtime.GeneratedEnum]", builder.ToString (), "Should contain GeneratedEnumAttribute!");
@@ -405,9 +405,9 @@ namespace generatortests
 			var iface = SupportTypeBuilder.CreateInterface ("java.code.IMyInterface", options);
 			var gen_info = new GenerationInfo (null, null, null);
 
-			options.ContextTypes.Push (iface);
+			generator.Context.ContextTypes.Push (iface);
 			generator.WriteInterface (iface, string.Empty, gen_info);
-			options.ContextTypes.Pop ();
+			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteInterface)), writer.ToString ().NormalizeLineEndings ());
 		}
@@ -417,9 +417,9 @@ namespace generatortests
 		{
 			var iface = SupportTypeBuilder.CreateInterface ("java.code.IMyInterface", options);
 
-			options.ContextTypes.Push (iface);
+			generator.Context.ContextTypes.Push (iface);
 			generator.WriteInterfaceDeclaration (iface, string.Empty);
-			options.ContextTypes.Pop ();
+			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetExpected (nameof (WriteInterfaceDeclaration)), writer.ToString ().NormalizeLineEndings ());
 		}
@@ -429,9 +429,9 @@ namespace generatortests
 		{
 			var iface = SupportTypeBuilder.CreateInterface ("java.code.IMyInterface", options);
 
-			options.ContextTypes.Push (iface);
+			generator.Context.ContextTypes.Push (iface);
 			generator.WriteInterfaceExtensionMethods (iface, string.Empty);
-			options.ContextTypes.Pop ();
+			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetExpected (nameof (WriteInterfaceExtensionMethods)), writer.ToString ().NormalizeLineEndings ());
 		}
@@ -441,9 +441,9 @@ namespace generatortests
 		{
 			var iface = SupportTypeBuilder.CreateInterface ("java.code.IMyInterface", options);
 
-			options.ContextTypes.Push (iface);
+			generator.Context.ContextTypes.Push (iface);
 			generator.WriteInterfaceEventArgs (iface, iface.Methods[0], string.Empty);
-			options.ContextTypes.Pop ();
+			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetExpected (nameof (WriteInterfaceEventArgs)), writer.ToString ().NormalizeLineEndings ());
 		}
@@ -453,9 +453,9 @@ namespace generatortests
 		{
 			var iface = SupportTypeBuilder.CreateInterface ("java.code.IMyInterface", options);
 
-			options.ContextTypes.Push (iface);
+			generator.Context.ContextTypes.Push (iface);
 			generator.WriteInterfaceEventHandler (iface, string.Empty);
-			options.ContextTypes.Pop ();
+			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetExpected (nameof (WriteInterfaceEventHandler)), writer.ToString ().NormalizeLineEndings ());
 		}
@@ -465,9 +465,9 @@ namespace generatortests
 		{
 			var iface = SupportTypeBuilder.CreateInterface ("java.code.IMyInterface", options);
 
-			options.ContextTypes.Push (iface);
+			generator.Context.ContextTypes.Push (iface);
 			generator.WriteInterfaceEventHandlerImpl (iface, string.Empty);
-			options.ContextTypes.Pop ();
+			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetExpected (nameof (WriteInterfaceEventHandlerImpl)), writer.ToString ().NormalizeLineEndings ());
 		}
@@ -478,9 +478,9 @@ namespace generatortests
 			var iface = SupportTypeBuilder.CreateInterface ("java.code.IMyInterface", options);
 			var handlers = new List<string> ();
 
-			options.ContextTypes.Push (iface);
+			generator.Context.ContextTypes.Push (iface);
 			generator.WriteInterfaceEventHandlerImplContent (iface, iface.Methods[0], string.Empty, true, string.Empty, handlers);
-			options.ContextTypes.Pop ();
+			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (1, handlers.Count);
 			Assert.AreEqual ("GetCountForKey", handlers [0]);
@@ -492,9 +492,9 @@ namespace generatortests
 		{
 			var iface = SupportTypeBuilder.CreateInterface ("java.code.IMyInterface", options);
 
-			options.ContextTypes.Push (iface);
+			generator.Context.ContextTypes.Push (iface);
 			generator.WriteInterfaceExtensionsDeclaration (iface, string.Empty, "java.code.DeclaringType");
-			options.ContextTypes.Pop ();
+			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetExpected (nameof (WriteInterfaceExtensionsDeclaration)), writer.ToString ().NormalizeLineEndings ());
 		}
@@ -504,9 +504,9 @@ namespace generatortests
 		{
 			var iface = SupportTypeBuilder.CreateInterface ("java.code.IMyInterface", options);
 
-			options.ContextTypes.Push (iface);
+			generator.Context.ContextTypes.Push (iface);
 			generator.WriteInterfaceInvoker (iface, string.Empty);
-			options.ContextTypes.Pop ();
+			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteInterfaceInvoker)), writer.ToString ().NormalizeLineEndings ());
 		}
@@ -516,9 +516,9 @@ namespace generatortests
 		{
 			var iface = SupportTypeBuilder.CreateInterface ("java.code.IMyInterface", options);
 
-			options.ContextTypes.Push (iface);
+			generator.Context.ContextTypes.Push (iface);
 			generator.WriteInterfaceListenerEvent (iface, string.Empty, "MyName", "MyNameSpec", "MyMethodName", "MyFullDelegateName", true, "MyWrefSuffix", "Add", "Remove");
-			options.ContextTypes.Pop ();
+			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetExpected (nameof (WriteInterfaceListenerEvent)), writer.ToString ().NormalizeLineEndings ());
 		}
@@ -528,9 +528,9 @@ namespace generatortests
 		{
 			var iface = SupportTypeBuilder.CreateInterface ("java.code.IMyInterface", options);
 
-			options.ContextTypes.Push (iface);
+			generator.Context.ContextTypes.Push (iface);
 			generator.WriteInterfaceListenerProperty (iface, string.Empty, "MyName", "MyNameSpec", "MyMethodName", "MyConnectorFmt", "MyFullDelegateName");
-			options.ContextTypes.Pop ();
+			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetExpected (nameof (WriteInterfaceListenerProperty)), writer.ToString ().NormalizeLineEndings ());
 		}
@@ -542,9 +542,9 @@ namespace generatortests
 			var iface = SupportTypeBuilder.CreateInterface ("java.code.IMyInterface", options);
 			var members = new HashSet<string> ();
 
-			options.ContextTypes.Push (iface);
+			generator.Context.ContextTypes.Push (iface);
 			generator.WriteInterfaceMethodInvokers (iface, iface.Methods, string.Empty, members);
-			options.ContextTypes.Pop ();
+			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetExpected (nameof (WriteInterfaceMethodInvokers)), writer.ToString ().NormalizeLineEndings ());
 		}
@@ -556,9 +556,9 @@ namespace generatortests
 			var iface = SupportTypeBuilder.CreateInterface ("java.code.IMyInterface", options);
 			var members = new HashSet<string> (new [] { iface.Methods [0].Name });
 
-			options.ContextTypes.Push (iface);
+			generator.Context.ContextTypes.Push (iface);
 			generator.WriteInterfaceMethodInvokers (iface, iface.Methods, string.Empty, members);
-			options.ContextTypes.Pop ();
+			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetExpected (nameof (WriteInterfaceMethodInvokersWithSkips)), writer.ToString ().NormalizeLineEndings ());
 		}
@@ -568,9 +568,9 @@ namespace generatortests
 		{
 			var iface = SupportTypeBuilder.CreateInterface ("java.code.IMyInterface", options);
 
-			options.ContextTypes.Push (iface);
+			generator.Context.ContextTypes.Push (iface);
 			generator.WriteInterfaceMethods (iface, string.Empty);
-			options.ContextTypes.Pop ();
+			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetExpected (nameof (WriteInterfaceMethods)), writer.ToString ().NormalizeLineEndings ());
 		}
@@ -580,9 +580,9 @@ namespace generatortests
 		{
 			var iface = SupportTypeBuilder.CreateInterface ("java.code.IMyInterface", options);
 
-			options.ContextTypes.Push (iface);
+			generator.Context.ContextTypes.Push (iface);
 			generator.WriteInterfaceProperties (iface, string.Empty);
-			options.ContextTypes.Pop ();
+			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetExpected (nameof (WriteInterfaceProperties)), writer.ToString ().NormalizeLineEndings ());
 		}
@@ -594,9 +594,9 @@ namespace generatortests
 			var iface = SupportTypeBuilder.CreateInterface ("java.code.IMyInterface", options);
 			var members = new HashSet<string> ();
 
-			options.ContextTypes.Push (iface);
+			generator.Context.ContextTypes.Push (iface);
 			generator.WriteInterfacePropertyInvokers (iface, iface.Properties, string.Empty, members);
-			options.ContextTypes.Pop ();
+			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetExpected (nameof (WriteInterfacePropertyInvokers)), writer.ToString ().NormalizeLineEndings ());
 		}
@@ -608,9 +608,9 @@ namespace generatortests
 			var iface = SupportTypeBuilder.CreateInterface ("java.code.IMyInterface", options);
 			var members = new HashSet<string> (new [] { iface.Properties [0].Name });
 
-			options.ContextTypes.Push (iface);
+			generator.Context.ContextTypes.Push (iface);
 			generator.WriteInterfacePropertyInvokers (iface, iface.Properties, string.Empty, members);
-			options.ContextTypes.Pop ();
+			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetExpected (nameof (WriteInterfacePropertyInvokersWithSkips)), writer.ToString ().NormalizeLineEndings ());
 		}
@@ -621,7 +621,7 @@ namespace generatortests
 			var @class = new TestClass ("java.lang.Object", "com.mypackage.foo");
 			var method = new TestMethod (@class, "bar").SetAbstract ();
 
-			Assert.IsTrue (method.Validate (options, new GenericParameterDefinitionList ()), "method.Validate failed!");
+			Assert.IsTrue (method.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "method.Validate failed!");
 			generator.WriteMethod (method, string.Empty, @class, true);
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteMethodAbstractWithVoidReturn)), writer.ToString ().NormalizeLineEndings ());
@@ -633,7 +633,7 @@ namespace generatortests
 			var @class = new TestClass ("java.lang.Object", "com.mypackage.foo");
 			var method = new TestMethod (@class, "bar", @return: "int").SetAsyncify ();
 
-			Assert.IsTrue (method.Validate (options, new GenericParameterDefinitionList ()), "method.Validate failed!");
+			Assert.IsTrue (method.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "method.Validate failed!");
 			generator.WriteMethod (method, string.Empty, @class, true);
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteMethodAsyncifiedWithIntReturn)), writer.ToString ().NormalizeLineEndings ());
@@ -645,7 +645,7 @@ namespace generatortests
 			var @class = new TestClass ("java.lang.Object", "com.mypackage.foo");
 			var method = new TestMethod (@class, "bar").SetAsyncify ();
 
-			Assert.IsTrue (method.Validate (options, new GenericParameterDefinitionList ()), "method.Validate failed!");
+			Assert.IsTrue (method.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "method.Validate failed!");
 			generator.WriteMethod (method, string.Empty, @class, true);
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteMethodAsyncifiedWithVoidReturn)), writer.ToString ().NormalizeLineEndings ());
@@ -657,7 +657,7 @@ namespace generatortests
 			var @class = new TestClass ("java.lang.Object", "com.mypackage.foo");
 			var method = new TestMethod (@class, "bar");
 
-			Assert.IsTrue (method.Validate (options, new GenericParameterDefinitionList ()), "method.Validate failed!");
+			Assert.IsTrue (method.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "method.Validate failed!");
 			generator.WriteMethodBody (method, string.Empty);
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteMethodBody)), writer.ToString ().NormalizeLineEndings ());
@@ -669,7 +669,7 @@ namespace generatortests
 			var @class = new TestClass ("java.lang.Object", "com.mypackage.foo");
 			var method = new TestMethod (@class, "bar").SetFinal ();
 
-			Assert.IsTrue (method.Validate (options, new GenericParameterDefinitionList ()), "method.Validate failed!");
+			Assert.IsTrue (method.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "method.Validate failed!");
 			generator.WriteMethod (method, string.Empty, @class, true);
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteMethodFinalWithVoidReturn)), writer.ToString ().NormalizeLineEndings ());
@@ -692,7 +692,7 @@ namespace generatortests
 			var @class = new TestClass ("java.lang.Object", "com.mypackage.foo");
 			var method = new TestMethod (@class, "bar").SetVisibility ("protected");
 
-			Assert.IsTrue (method.Validate (options, new GenericParameterDefinitionList ()), "method.Validate failed!");
+			Assert.IsTrue (method.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "method.Validate failed!");
 			generator.WriteMethod (method, string.Empty, @class, true);
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteMethodProtected)), writer.ToString ().NormalizeLineEndings ());
@@ -704,7 +704,7 @@ namespace generatortests
 			var @class = new TestClass ("java.lang.Object", "com.mypackage.foo");
 			var method = new TestMethod (@class, "bar").SetStatic ();
 
-			Assert.IsTrue (method.Validate (options, new GenericParameterDefinitionList ()), "method.Validate failed!");
+			Assert.IsTrue (method.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "method.Validate failed!");
 			generator.WriteMethod (method, string.Empty, @class, true);
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteMethodStaticWithVoidReturn)), writer.ToString ().NormalizeLineEndings ());
@@ -716,7 +716,7 @@ namespace generatortests
 			var @class = new TestClass ("java.lang.Object", "com.mypackage.foo");
 			var method = new TestMethod (@class, "bar", @return: "int");
 
-			Assert.IsTrue (method.Validate (options, new GenericParameterDefinitionList ()), "method.Validate failed!");
+			Assert.IsTrue (method.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "method.Validate failed!");
 			generator.WriteMethod (method, string.Empty, @class, true);
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteMethodWithIntReturn)), writer.ToString ().NormalizeLineEndings ());
@@ -728,7 +728,7 @@ namespace generatortests
 			var @class = new TestClass ("java.lang.Object", "com.mypackage.foo");
 			var method = new TestMethod (@class, "bar", @return: "java.lang.String");
 
-			Assert.IsTrue (method.Validate (options, new GenericParameterDefinitionList ()), "method.Validate failed!");
+			Assert.IsTrue (method.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "method.Validate failed!");
 			generator.WriteMethod (method, string.Empty, @class, true);
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteMethodWithStringReturn)), writer.ToString ().NormalizeLineEndings ());
@@ -740,7 +740,7 @@ namespace generatortests
 			var @class = new TestClass ("java.lang.Object", "com.mypackage.foo");
 			var method = new TestMethod (@class, "bar");
 
-			Assert.IsTrue (method.Validate (options, new GenericParameterDefinitionList ()), "method.Validate failed!");
+			Assert.IsTrue (method.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "method.Validate failed!");
 			generator.WriteMethod (method, string.Empty, @class, true);
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteMethodWithVoidReturn)), writer.ToString ().NormalizeLineEndings ());
@@ -821,9 +821,9 @@ namespace generatortests
 		{
 			var @class = SupportTypeBuilder.CreateClassWithProperty ("java.lang.Object", "com.mypackage.foo", "MyProperty", "int", options);
 
-			options.ContextTypes.Push (@class);
+			generator.Context.ContextTypes.Push (@class);
 			generator.WritePropertyInvoker (@class.Properties.First (), string.Empty, @class);
-			options.ContextTypes.Pop ();
+			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetExpected (nameof (WritePropertyInvoker)), writer.ToString ().NormalizeLineEndings ());
 		}

--- a/tools/generator/Tests/Unit-Tests/DefaultInterfaceMethodsTests.cs
+++ b/tools/generator/Tests/Unit-Tests/DefaultInterfaceMethodsTests.cs
@@ -37,11 +37,11 @@ namespace generatortests
 			iface.Fields.Add (new TestField ("int", "MyConstantField").SetConstant ().SetValue ("7"));
 			iface.Methods.Add (new TestMethod (iface, "DoSomething").SetAbstract ());
 
-			iface.Validate (options, new GenericParameterDefinitionList ());
+			iface.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ());
 
-			options.ContextTypes.Push (iface);
+			generator.Context.ContextTypes.Push (iface);
 			generator.WriteInterfaceDeclaration (iface, string.Empty);
-			options.ContextTypes.Pop ();
+			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteInterfaceFields)), writer.ToString ().NormalizeLineEndings ());
 		}
@@ -62,11 +62,11 @@ namespace generatortests
 			iface.Fields.Add (new TestField ("int", "MyDeprecatedEnumField").SetConstant ().SetValue ("MyEnumValue").SetDeprecated ("This constant will be removed in the future version."));
 			iface.Fields.Add (new TestField ("int", "MyStaticField").SetStatic ().SetValue ("7"));
 
-			iface.Validate (options, new GenericParameterDefinitionList ());
+			iface.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ());
 
-			options.ContextTypes.Push (iface);
+			generator.Context.ContextTypes.Push (iface);
 			generator.WriteInterfaceDeclaration (iface, string.Empty);
-			options.ContextTypes.Pop ();
+			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteConstSugarInterfaceFields)), writer.ToString ().NormalizeLineEndings ());
 		}

--- a/tools/generator/Tests/Unit-Tests/ManagedTests.cs
+++ b/tools/generator/Tests/Unit-Tests/ManagedTests.cs
@@ -61,7 +61,7 @@ namespace generatortests
 
 			foreach (var type in module.Types.Where(t => t.IsClass && t.Namespace == "Java.Lang")) {
 				var @class = new ManagedClassGen (type, options);
-				Assert.IsTrue (@class.Validate (options, new GenericParameterDefinitionList ()), "@class.Validate failed!");
+				Assert.IsTrue (@class.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext()), "@class.Validate failed!");
 				options.SymbolTable.AddType (@class);
 			}
 		}
@@ -77,7 +77,7 @@ namespace generatortests
 		public void Class ()
 		{
 			var @class = new ManagedClassGen (module.GetType ("Com.Mypackage.Foo"), options);
-			Assert.IsTrue (@class.Validate (options, new GenericParameterDefinitionList ()), "@class.Validate failed!");
+			Assert.IsTrue (@class.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "@class.Validate failed!");
 
 			Assert.AreEqual ("public", @class.Visibility);
 			Assert.AreEqual ("Foo", @class.Name);
@@ -95,7 +95,7 @@ namespace generatortests
 			var type = module.GetType ("Com.Mypackage.Foo");
 			var @class = new ManagedClassGen (type, options);
 			var method = new ManagedMethod (@class, type.Methods.First (m => m.Name == "Bar"));
-			Assert.IsTrue (method.Validate (new CodeGenerationOptions (), new GenericParameterDefinitionList ()), "method.Validate failed!");
+			Assert.IsTrue (method.Validate (new CodeGenerationOptions (), new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "method.Validate failed!");
 
 			Assert.AreEqual ("public", method.Visibility);
 			Assert.AreEqual ("void", method.Return);
@@ -140,7 +140,7 @@ namespace generatortests
 			var type = module.GetType ("Com.Mypackage.Foo");
 			var @class = new ManagedClassGen (type, options);
 			var method = new ManagedMethod (@class, type.Methods.First (m => m.Name == "BarWithParams"));
-			Assert.IsTrue (method.Validate (new CodeGenerationOptions (), new GenericParameterDefinitionList ()), "method.Validate failed!");
+			Assert.IsTrue (method.Validate (new CodeGenerationOptions (), new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "method.Validate failed!");
 			Assert.AreEqual ("(ZID)Ljava/lang/String;", method.JniSignature);
 			Assert.AreEqual ("java.lang.String", method.Return);
 			Assert.AreEqual ("System.String", method.ManagedReturn);
@@ -170,7 +170,7 @@ namespace generatortests
 			var type = module.GetType ("Com.Mypackage.Foo");
 			var @class = new ManagedClassGen (type, options);
 			var ctor = new ManagedCtor (@class, type.Methods.First (m => m.IsConstructor && !m.IsStatic));
-			Assert.IsTrue (ctor.Validate (new CodeGenerationOptions (), new GenericParameterDefinitionList ()), "ctor.Validate failed!");
+			Assert.IsTrue (ctor.Validate (new CodeGenerationOptions (), new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "ctor.Validate failed!");
 
 			Assert.AreEqual ("public", ctor.Visibility);
 			Assert.AreEqual (".ctor", ctor.Name);
@@ -184,7 +184,7 @@ namespace generatortests
 			var type = module.GetType ("Com.Mypackage.Foo");
 			var @class = new ManagedClassGen (type, options);
 			var field = new ManagedField (type.Fields.First (f => f.Name == "Value"));
-			Assert.IsTrue (field.Validate (new CodeGenerationOptions (), new GenericParameterDefinitionList ()), "field.Validate failed!");
+			Assert.IsTrue (field.Validate (new CodeGenerationOptions (), new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "field.Validate failed!");
 
 			Assert.AreEqual ("Value", field.Name);
 			Assert.AreEqual ("value", field.JavaName);
@@ -199,7 +199,7 @@ namespace generatortests
 		{
 			var type = module.GetType ("Com.Mypackage.IService");
 			var @interface = new ManagedInterfaceGen (type, options);
-			Assert.IsTrue (@interface.Validate (new CodeGenerationOptions (), new GenericParameterDefinitionList ()), "interface.Validate failed!");
+			Assert.IsTrue (@interface.Validate (new CodeGenerationOptions (), new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "interface.Validate failed!");
 
 			Assert.AreEqual ("public", @interface.Visibility);
 			Assert.AreEqual ("IService", @interface.Name);

--- a/tools/generator/Tests/Unit-Tests/SupportTypes.cs
+++ b/tools/generator/Tests/Unit-Tests/SupportTypes.cs
@@ -353,7 +353,7 @@ namespace generatortests
 			foreach (var p in parameters)
 				ctor.Parameters.Add (p);
 
-			ctor.Validate (options, null);
+			ctor.Validate (options, null, new CodeGeneratorContext ());
 
 			return ctor;
 		}
@@ -394,8 +394,8 @@ namespace generatortests
 			foreach (var p in parameters)
 				method.Parameters.Add (p);
 
-			method.Validate (options, null);
-			method.RetVal.Validate (options, null);
+			method.Validate (options, null, new CodeGeneratorContext ());
+			method.RetVal.Validate (options, null, new CodeGeneratorContext ());
 
 			return method;
 		}
@@ -419,7 +419,7 @@ namespace generatortests
 			};
 
 			foreach (var p in list)
-				p.Validate (options, null);
+				p.Validate (options, null, new CodeGeneratorContext ());
 
 			return list;
 		}

--- a/tools/generator/Tests/Unit-Tests/XmlTests.cs
+++ b/tools/generator/Tests/Unit-Tests/XmlTests.cs
@@ -53,7 +53,7 @@ namespace generatortests
 			var javaLang = xml.Element ("api").Element ("package");
 			foreach (var type in javaLang.Elements("class")) {
 				var @class = new XmlClassGen (javaLang, type);
-				Assert.IsTrue (@class.Validate (options, new GenericParameterDefinitionList ()), "@class.Validate failed!");
+				Assert.IsTrue (@class.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "@class.Validate failed!");
 				options.SymbolTable.AddType (@class);
 			}
 
@@ -65,7 +65,7 @@ namespace generatortests
 		{
 			var element = package.Element ("class");
 			var @class = new XmlClassGen (package, element);
-			Assert.IsTrue (@class.Validate (options, new GenericParameterDefinitionList ()), "@class.Validate failed!");
+			Assert.IsTrue (@class.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "@class.Validate failed!");
 
 			Assert.AreEqual ("public", @class.Visibility);
 			Assert.AreEqual ("Foo", @class.Name);
@@ -83,7 +83,7 @@ namespace generatortests
 			var element = package.Element ("class");
 			var @class = new XmlClassGen (package, element);
 			var method = new XmlMethod (@class, element.Element ("method"));
-			Assert.IsTrue (method.Validate (options, new GenericParameterDefinitionList ()), "method.Validate failed!");
+			Assert.IsTrue (method.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "method.Validate failed!");
 
 			Assert.AreEqual ("public", method.Visibility);
 			Assert.AreEqual ("void", method.Return);
@@ -128,7 +128,7 @@ namespace generatortests
 			var element = package.Element ("class");
 			var @class = new XmlClassGen (package, element);
 			var method = new XmlMethod (@class, element.Elements ("method").Where (e => e.Attribute ("name").Value == "barWithParams").First ());
-			Assert.IsTrue (method.Validate (options, new GenericParameterDefinitionList ()), "method.Validate failed!");
+			Assert.IsTrue (method.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "method.Validate failed!");
 			Assert.AreEqual ("(ZID)Ljava/lang/String;", method.JniSignature);
 			Assert.AreEqual ("java.lang.String", method.Return);
 			Assert.AreEqual ("System.String", method.ManagedReturn);
@@ -158,7 +158,7 @@ namespace generatortests
 			var element = package.Element ("class");
 			var @class = new XmlClassGen (package, element);
 			var ctor = new XmlCtor (@class, element.Element ("constructor"));
-			Assert.IsTrue (ctor.Validate (options, new GenericParameterDefinitionList ()), "ctor.Validate failed!");
+			Assert.IsTrue (ctor.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "ctor.Validate failed!");
 
 			Assert.AreEqual ("public", ctor.Visibility);
 			Assert.AreEqual ("foo", ctor.Name);
@@ -172,7 +172,7 @@ namespace generatortests
 			var element = package.Element ("class");
 			var @class = new XmlClassGen (package, element);
 			var field = new XmlField (element.Element ("field"));
-			Assert.IsTrue (field.Validate (options, new GenericParameterDefinitionList ()), "field.Validate failed!");
+			Assert.IsTrue (field.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "field.Validate failed!");
 
 			Assert.AreEqual ("Value", field.Name);
 			Assert.AreEqual ("value", field.JavaName);
@@ -187,7 +187,7 @@ namespace generatortests
 		{
 			var element = package.Element ("interface");
 			var @interface = new XmlInterfaceGen (package, element);
-			Assert.IsTrue (@interface.Validate (options, new GenericParameterDefinitionList ()), "interface.Validate failed!");
+			Assert.IsTrue (@interface.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "interface.Validate failed!");
 
 			Assert.AreEqual ("public", @interface.Visibility);
 			Assert.AreEqual ("IService", @interface.Name);

--- a/tools/generator/generator.csproj
+++ b/tools/generator/generator.csproj
@@ -58,6 +58,7 @@
       <Link>utils\XmlExtensions.cs</Link>
     </Compile>
     <Compile Include="CodeGenerationTarget.cs" />
+    <Compile Include="CodeGeneratorContext.cs" />
     <Compile Include="CodeGeneratorOptions.cs" />
     <Compile Include="Java.Interop.Tools.Generator.ObjectModel\InterfaceExtensionInfo.cs" />
     <Compile Include="Java.Interop.Tools.Generator.Importers\Xml\InterfaceXmlGenBaseSupport.cs" />


### PR DESCRIPTION
A batch of commits that make generating the type `.cs` files thread-safe, and enables writing them in parallel.  On my 6 core machine, this reduces time taken generating the types in `Mono.Android.dll` from ~31s to ~5.2s.