### PR TITLE
[generator] Enable parallel type generation.

### DIFF
--- a/tools/generator/CodeGenerator.cs
+++ b/tools/generator/CodeGenerator.cs
@@ -12,6 +12,7 @@ using Java.Interop.Tools.Cecil;
 using Java.Interop.Tools.Diagnostics;
 using Java.Interop.Tools.TypeNameMappings;
 using MonoDroid.Generation.Utilities;
+using System.Threading.Tasks;
 
 namespace Xamarin.Android.Binder
 {
@@ -171,9 +172,10 @@ namespace Xamarin.Android.Binder
 
 			new NamespaceMapping (gens).Generate (opt, gen_info);
 
-			foreach (IGeneratable gen in gens)
+			Parallel.ForEach (gens, gen => {
 				if (gen.IsGeneratable)
 					gen.Generate (opt, gen_info);
+			});
 
 
 			ClassGen.GenerateTypeRegistrations (opt, gen_info);


### PR DESCRIPTION
#446 removed Cecil usage from the step that generates the type `.cs` files, which was the remaining thread-safety issue.  This PR enables generating those files in parallel.

This results in a nice performance win, particularly for projects binding a lot of types:

Scenario | Original | This PR
------------ | ------------- | -
Mono.Android.dll | 16423ms | 11506ms
Jar2Xml | 5517ms | 5309ms
Class-Parse | 15511ms | 15615ms