### PR TITLE
[generator] Lazily populate members on referenced types.

### DIFF
--- a/tools/generator/CodeGenerationOptions.cs
+++ b/tools/generator/CodeGenerationOptions.cs
@@ -48,6 +48,7 @@ namespace MonoDroid.Generation
 		public bool UseShortFileNames { get; set; }
 		public int ProductVersion { get; set; }
 		public bool SupportInterfaceConstants { get; set; }
+		public bool UseShallowReferencedTypes { get; set; }
 
 		bool? buildingCoreAssembly;
 		public bool BuildingCoreAssembly {

--- a/tools/generator/CodeGenerator.cs
+++ b/tools/generator/CodeGenerator.cs
@@ -76,6 +76,21 @@ namespace Xamarin.Android.Binder
 			foreach (var reference in references) {
 				resolver.SearchDirectories.Add (Path.GetDirectoryName (reference));
 			}
+
+			// Figure out if this is class-parse
+			string apiXmlFile = filename;
+			string apiSourceAttr = null;
+
+			using (var xr = XmlReader.Create (filename)) {
+				xr.MoveToContent ();
+				apiSourceAttr = xr.GetAttribute ("api-source");
+			}
+
+			// We don't use shallow referenced types with class-parse because the Adjuster process
+			// enumerates every ctor/method/property/field to build its model, so we will need
+			// every type to be fully populated.
+			opt.UseShallowReferencedTypes = apiSourceAttr != "class-parse";
+
 			foreach (var reference in references) {
 				try {
 					Report.Verbose (0, "resolving assembly {0}.", reference);
@@ -99,16 +114,9 @@ namespace Xamarin.Android.Binder
 			}
 
 			// For class-parse API description, transform it to jar2xml style.
-			string apiXmlFile = filename;
-
-			string apiSourceAttr = null;
-			using (var xr = XmlReader.Create (filename)) {
-				xr.MoveToContent ();
-				apiSourceAttr = xr.GetAttribute ("api-source");
-			}
 			if (apiSourceAttr == "class-parse") {
 				apiXmlFile = api_xml_adjuster_output ?? Path.Combine (Path.GetDirectoryName (filename), Path.GetFileName (filename) + ".adjusted");
-				new Adjuster ().Process (filename, opt, opt.SymbolTable.AllRegisteredSymbols ().OfType<GenBase> ().ToArray (), apiXmlFile, Report.Verbosity ?? 0);
+				new Adjuster ().Process (filename, opt, opt.SymbolTable.AllRegisteredSymbols (opt).OfType<GenBase> ().ToArray (), apiXmlFile, Report.Verbosity ?? 0);
 			}
 			if (only_xml_adjuster)
 				return;

--- a/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/JavaInteropCodeGenerator.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/JavaInteropCodeGenerator.cs
@@ -235,7 +235,7 @@ namespace MonoDroid.Generation {
 			string arg;
 			bool have_prep = false;
 			if (field.Symbol.IsArray) {
-				arg = opt.GetSafeIdentifier (SymbolTable.GetNativeName ("value"));
+				arg = opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName ("value"));
 				writer.WriteLine ("{0}IntPtr {1} = global::Android.Runtime.JavaArray<{2}>.ToLocalJniHandle (value);", indent, arg, opt.GetOutputName (field.Symbol.ElementType));
 			} else {
 				foreach (string prep in field.SetParameters.GetCallPrep (opt)) {
@@ -245,7 +245,7 @@ namespace MonoDroid.Generation {
 
 				arg = field.SetParameters [0].ToNative (opt);
 				if (field.SetParameters.HasCleanup && !have_prep) {
-					arg = opt.GetSafeIdentifier (SymbolTable.GetNativeName ("value"));
+					arg = opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName ("value"));
 					writer.WriteLine ("{0}IntPtr {1} = global::Android.Runtime.JNIEnv.ToLocalJniHandle (value);", indent, arg);
 				}
 			}

--- a/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/XamarinAndroidCodeGenerator.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/XamarinAndroidCodeGenerator.cs
@@ -213,7 +213,7 @@ namespace MonoDroid.Generation {
 			string arg;
 			bool have_prep = false;
 			if (field.Symbol.IsArray) {
-				arg = opt.GetSafeIdentifier (SymbolTable.GetNativeName ("value"));
+				arg = opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName ("value"));
 				writer.WriteLine ("{0}IntPtr {1} = global::Android.Runtime.JavaArray<{2}>.ToLocalJniHandle (value);", indent, arg, opt.GetOutputName (field.Symbol.ElementType));
 			} else {
 				foreach (string prep in field.SetParameters.GetCallPrep (opt)) {
@@ -223,7 +223,7 @@ namespace MonoDroid.Generation {
 
 				arg = field.SetParameters [0].ToNative (opt);
 				if (field.SetParameters.HasCleanup && !have_prep) {
-					arg = opt.GetSafeIdentifier (SymbolTable.GetNativeName ("value"));
+					arg = opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName ("value"));
 					writer.WriteLine ("{0}IntPtr {1} = JNIEnv.ToLocalJniHandle (value);", indent, arg);
 				}
 			}

--- a/tools/generator/Java.Interop.Tools.Generator.Importers/CecilApiImporter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Importers/CecilApiImporter.cs
@@ -13,7 +13,7 @@ namespace MonoDroid.Generation
 			var klass = new ClassGen (CreateGenBaseSupport (t, opt)) {
 				IsAbstract = t.IsAbstract,
 				IsFinal = t.IsSealed,
-				IsShallow = opt.UseShallowReferencedTypes
+				IsShallow = opt.UseShallowReferencedTypes,
 			};
 
 			foreach (var ifaceImpl in t.Interfaces) {
@@ -154,7 +154,7 @@ namespace MonoDroid.Generation
 		public static InterfaceGen CreateInterface (TypeDefinition t, CodeGenerationOptions opt)
 		{
 			var iface = new InterfaceGen (CreateGenBaseSupport (t, opt)) {
-				IsShallow = opt.UseShallowReferencedTypes
+				IsShallow = opt.UseShallowReferencedTypes,
 			};
 
 			foreach (var ifaceImpl in t.Interfaces)

--- a/tools/generator/Java.Interop.Tools.Generator.Importers/CecilApiImporter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Importers/CecilApiImporter.cs
@@ -125,7 +125,7 @@ namespace MonoDroid.Generation
 				Visibility = t.IsPublic || t.IsNestedPublic ? "public" : "protected internal"
 			};
 
-			support.JavaSimpleName = SymbolTable.FilterPrimitiveFullName (t.FullNameCorrected ());
+			support.JavaSimpleName = TypeNameUtilities.FilterPrimitiveFullName (t.FullNameCorrected ());
 
 			if (support.JavaSimpleName == null) {
 				support.JavaSimpleName = idx < 0 ? jn : jn.Substring (idx + 1);
@@ -211,7 +211,7 @@ namespace MonoDroid.Generation
 			// FIXME: safe to use CLR type name? assuming yes as we often use it in metadatamap.
 			// FIXME: IsSender?
 			var isEnumType = GetGeneratedEnumAttribute (p.CustomAttributes) != null;;
-			return new Parameter (SymbolTable.MangleName (p.Name), jnitype ?? p.ParameterType.FullNameCorrected (), null, isEnumType, rawtype);
+			return new Parameter (TypeNameUtilities.MangleName (p.Name), jnitype ?? p.ParameterType.FullNameCorrected (), null, isEnumType, rawtype);
 		}
 
 		public static Parameter CreateParameter (string managedType, string javaType)

--- a/tools/generator/Java.Interop.Tools.Generator.Importers/CecilApiImporter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Importers/CecilApiImporter.cs
@@ -12,7 +12,8 @@ namespace MonoDroid.Generation
 		{
 			var klass = new ClassGen (CreateGenBaseSupport (t, opt)) {
 				IsAbstract = t.IsAbstract,
-				IsFinal = t.IsSealed
+				IsFinal = t.IsSealed,
+				IsShallow = opt.UseShallowReferencedTypes
 			};
 
 			foreach (var ifaceImpl in t.Interfaces) {
@@ -25,22 +26,29 @@ namespace MonoDroid.Generation
 				klass.AddImplementedInterface (iface.FullNameCorrected ());
 			}
 
-			var implements_charsequence = t.Interfaces.Any (it => it.InterfaceType.FullName == "Java.Lang.CharSequence");
+			Action populate = () => {
+				var implements_charsequence = t.Interfaces.Any (it => it.InterfaceType.FullName == "Java.Lang.CharSequence");
 
-			foreach (var m in t.Methods) {
-				if (m.IsPrivate || m.IsAssembly || GetRegisterAttribute (m.CustomAttributes) == null)
-					continue;
-				if (implements_charsequence && t.Methods.Any (mm => mm.Name == m.Name + "Formatted"))
-					continue;
-				if (m.IsConstructor)
-					klass.Ctors.Add (CreateCtor (klass, m));
-				else
-					klass.AddMethod (CreateMethod (klass, m));
-			}
+				foreach (var m in t.Methods) {
+					if (m.IsPrivate || m.IsAssembly || GetRegisterAttribute (m.CustomAttributes) == null)
+						continue;
+					if (implements_charsequence && t.Methods.Any (mm => mm.Name == m.Name + "Formatted"))
+						continue;
+					if (m.IsConstructor)
+						klass.Ctors.Add (CreateCtor (klass, m));
+					else
+						klass.AddMethod (CreateMethod (klass, m));
+				}
 
-			foreach (var f in t.Fields)
-				if (!f.IsPrivate && GetRegisterAttribute (f.CustomAttributes) == null)
-					klass.AddField (CreateField (f));
+				foreach (var f in t.Fields)
+					if (!f.IsPrivate && GetRegisterAttribute (f.CustomAttributes) == null)
+						klass.AddField (CreateField (f));
+			};
+
+			if (klass.IsShallow)
+				klass.PopulateAction = populate;
+			else
+				populate ();
 
 			TypeReference nominal_base_type;
 
@@ -145,19 +153,26 @@ namespace MonoDroid.Generation
 
 		public static InterfaceGen CreateInterface (TypeDefinition t, CodeGenerationOptions opt)
 		{
-			var reg_attr = GetRegisterAttribute (t.CustomAttributes);
-
-			var iface = new InterfaceGen (CreateGenBaseSupport (t, opt));
+			var iface = new InterfaceGen (CreateGenBaseSupport (t, opt)) {
+				IsShallow = opt.UseShallowReferencedTypes
+			};
 
 			foreach (var ifaceImpl in t.Interfaces)
 				iface.AddImplementedInterface (ifaceImpl.InterfaceType.FullNameCorrected ());
 
-			foreach (var m in t.Methods) {
-				if (m.IsPrivate || m.IsAssembly || GetRegisterAttribute (m.CustomAttributes) == null)
-					continue;
+			Action populate = () => {
+				foreach (var m in t.Methods) {
+					if (m.IsPrivate || m.IsAssembly || GetRegisterAttribute (m.CustomAttributes) == null)
+						continue;
 
-				iface.AddMethod (CecilApiImporter.CreateMethod (iface, m));
-			}
+					iface.AddMethod (CreateMethod (iface, m));
+				}
+			};
+
+			if (iface.IsShallow)
+				iface.PopulateAction = populate;
+			else
+				populate ();
 
 			iface.MayHaveManagedGenericArguments = !iface.IsAcw;
 

--- a/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
@@ -111,7 +111,7 @@ namespace MonoDroid.Generation
 			if (elem.Attribute ("managedName") != null)
 				field.Name = elem.XGetAttribute ("managedName");
 			else
-				field.Name = SymbolTable.StudlyCase (char.IsLower (field.JavaName [0]) || field.JavaName.ToLower ().ToUpper () != field.JavaName ? field.JavaName : field.JavaName.ToLower ());
+				field.Name = TypeNameUtilities.StudlyCase (char.IsLower (field.JavaName [0]) || field.JavaName.ToLower ().ToUpper () != field.JavaName ? field.JavaName : field.JavaName.ToLower ());
 
 			return field;
 		}
@@ -264,7 +264,7 @@ namespace MonoDroid.Generation
 		public static Parameter CreateParameter (XElement elem)
 		{
 			string managedName = elem.XGetAttribute ("managedName");
-			string name = !string.IsNullOrEmpty (managedName) ? managedName : SymbolTable.MangleName (elem.XGetAttribute ("name"));
+			string name = !string.IsNullOrEmpty (managedName) ? managedName : TypeNameUtilities.MangleName (elem.XGetAttribute ("name"));
 			string java_type = elem.XGetAttribute ("type");
 			string enum_type = elem.Attribute ("enumType") != null ? elem.XGetAttribute ("enumType") : null;
 			string managed_type = elem.Attribute ("managedType") != null ? elem.XGetAttribute ("managedType") : null;

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
@@ -33,6 +33,12 @@ namespace MonoDroid.Generation
 		public string DefaultValue { get; set; }
 		public bool HasVirtualMethods { get; set; }
 
+		// This means Ctors/Methods/Properties/Fields has not been populated yet.
+		// If this type is retrieved from the SymbolTable, it will call PopulateAction
+		// to fill in members before returning it to the user.
+		internal bool IsShallow { get; set; }
+		internal Action PopulateAction { get; set; }
+
 		public void AddField (Field f)
 		{
 			Fields.Add (f);

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
@@ -685,7 +685,7 @@ namespace MonoDroid.Generation
 				string.Format ("{0} {1} = {5}global::Java.Lang.Object.GetObject<{4}> ({2}, {3});",
 					       opt.GetOutputName (FullName),
 					       opt.GetSafeIdentifier (var_name),
-					       opt.GetSafeIdentifier (SymbolTable.GetNativeName (var_name)),
+					       opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name)),
 					       owned ? "JniHandleOwnership.TransferLocalRef" : "JniHandleOwnership.DoNotTransfer",
 					       opt.GetOutputName (rgm != null ? (rgm.GetGenericJavaObjectTypeOverride () ?? FullName) : FullName),
 					       rgm != null ? "(" + opt.GetOutputName (FullName) + ")" : string.Empty)

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/InterfaceGen.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/InterfaceGen.cs
@@ -194,14 +194,14 @@ namespace MonoDroid.Generation
 		public string GetGenericJavaObjectTypeOverride ()
 		{
 			int idx = FullName.IndexOf ('<');
-			return SymbolTable.GetGenericJavaObjectTypeOverride (
+			return TypeNameUtilities.GetGenericJavaObjectTypeOverride (
 				idx < 0 ? FullName : FullName.Substring (0, idx),
 				idx < 0 ? null : FullName.Substring (idx + 1).TrimEnd ('>'));
 		}
 
 		public string ToInteroperableJavaObject (string var_name)
 		{
-			return GetGenericJavaObjectTypeOverride () != null ? SymbolTable.GetNativeName (var_name) : var_name;
+			return GetGenericJavaObjectTypeOverride () != null ? TypeNameUtilities.GetNativeName (var_name) : var_name;
 		}
 		#endregion
 	}

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Parameter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Parameter.cs
@@ -112,7 +112,7 @@ namespace MonoDroid.Generation {
 			get {
 				if (Type == NativeType)
 					return Name;
-				return SymbolTable.GetNativeName (Name);
+				return TypeNameUtilities.GetNativeName (Name);
 			}
 		}
 

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/ArraySymbol.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/ArraySymbol.cs
@@ -91,20 +91,20 @@ namespace MonoDroid.Generation {
 
 		public string Call (CodeGenerationOptions opt, string var_name)
 		{
-			return opt.GetSafeIdentifier (SymbolTable.GetNativeName (var_name));
+			return opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name));
 		}
 
 		public string[] PostCallback (CodeGenerationOptions opt, string var_name)
 		{
 			string[] result = new string [2];
 			result [0] = String.Format ("if ({0} != null)", opt.GetSafeIdentifier (var_name));
-			result [1] = String.Format ("\tJNIEnv.CopyArray ({0}, {1});", opt.GetSafeIdentifier (var_name), opt.GetSafeIdentifier (SymbolTable.GetNativeName (var_name)));
+			result [1] = String.Format ("\tJNIEnv.CopyArray ({0}, {1});", opt.GetSafeIdentifier (var_name), opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name)));
 			return result;
 		}
 
 		public string[] PostCall (CodeGenerationOptions opt, string var_name)
 		{
-			string native_name = opt.GetSafeIdentifier (SymbolTable.GetNativeName (var_name));
+			string native_name = opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name));
 			string[] result = new string [4];
 			result [0] = String.Format ("if ({0} != null) {{", var_name);
 			result [1] = String.Format ("\tJNIEnv.CopyArray ({0}, {1});", native_name, var_name);
@@ -115,12 +115,12 @@ namespace MonoDroid.Generation {
 
 		public string[] PreCallback (CodeGenerationOptions opt, string var_name, bool owned)
 		{
-			return new string[] { String.Format ("{0}[] {1} = ({0}[]) JNIEnv.GetArray ({2}, JniHandleOwnership.DoNotTransfer, typeof ({3}));", opt.GetOutputName (ElementType), opt.GetSafeIdentifier (var_name), opt.GetSafeIdentifier (SymbolTable.GetNativeName (var_name)), opt.GetOutputName (sym.FullName)) };
+			return new string[] { String.Format ("{0}[] {1} = ({0}[]) JNIEnv.GetArray ({2}, JniHandleOwnership.DoNotTransfer, typeof ({3}));", opt.GetOutputName (ElementType), opt.GetSafeIdentifier (var_name), opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name)), opt.GetOutputName (sym.FullName)) };
 		}
 
 		public string[] PreCall (CodeGenerationOptions opt, string var_name)
 		{
-			return new string[] { String.Format ("IntPtr {0} = JNIEnv.NewArray ({1});", opt.GetSafeIdentifier (SymbolTable.GetNativeName (var_name)), opt.GetSafeIdentifier (var_name)) };
+			return new string[] { String.Format ("IntPtr {0} = JNIEnv.NewArray ({1});", opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name)), opt.GetSafeIdentifier (var_name)) };
 		}
 
 		public bool NeedsPrep { get { return true; } }

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/CharSequenceSymbol.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/CharSequenceSymbol.cs
@@ -68,7 +68,7 @@ namespace MonoDroid.Generation {
 
 		public string Call (CodeGenerationOptions opt, string var_name)
 		{
-			return opt.GetSafeIdentifier (SymbolTable.GetNativeName (var_name));
+			return opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name));
 		}
 
 		public string[] PostCallback (CodeGenerationOptions opt, string var_name)
@@ -79,18 +79,18 @@ namespace MonoDroid.Generation {
 		public string[] PostCall (CodeGenerationOptions opt, string var_name)
 		{
 			return new string[]{
-				string.Format ("JNIEnv.DeleteLocalRef ({0});", opt.GetSafeIdentifier (SymbolTable.GetNativeName (var_name))),
+				string.Format ("JNIEnv.DeleteLocalRef ({0});", opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name))),
 			};
 		}
 
 		public string[] PreCallback (CodeGenerationOptions opt, string var_name, bool owned)
 		{
-			return new string[] { String.Format ("global::Java.Lang.ICharSequence {0} = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> ({1}, JniHandleOwnership.DoNotTransfer);", var_name, SymbolTable.GetNativeName (var_name)) };
+			return new string[] { String.Format ("global::Java.Lang.ICharSequence {0} = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> ({1}, JniHandleOwnership.DoNotTransfer);", var_name, TypeNameUtilities.GetNativeName (var_name)) };
 		}
 
 		public string[] PreCall (CodeGenerationOptions opt, string var_name)
 		{
-			return new string[] { String.Format ("IntPtr {0} = CharSequence.ToLocalJniHandle ({1});", opt.GetSafeIdentifier (SymbolTable.GetNativeName (var_name)), opt.GetSafeIdentifier (var_name)) };
+			return new string[] { String.Format ("IntPtr {0} = CharSequence.ToLocalJniHandle ({1});", opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name)), opt.GetSafeIdentifier (var_name)) };
 		}
 
 		public bool NeedsPrep { get { return true; } }

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/CollectionSymbol.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/CollectionSymbol.cs
@@ -100,7 +100,7 @@ namespace MonoDroid.Generation {
 				string.Format ("var {0} = {1}.FromJniHandle ({2}, {3});",
 						opt.GetSafeIdentifier (var_name),
 						GetManagedTypeName (opt),
-						opt.GetSafeIdentifier (SymbolTable.GetNativeName (var_name)),
+						opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name)),
 						owned ? "JniHandleOwnership.TransferLocalRef" : "JniHandleOwnership.DoNotTransfer"),
 			};
 		}
@@ -115,7 +115,7 @@ namespace MonoDroid.Generation {
 		{
 			return new string[] {
 				string.Format ("IntPtr {0} = {1}.ToLocalJniHandle ({2});",
-						opt.GetSafeIdentifier (SymbolTable.GetNativeName (var_name)),
+						opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name)),
 						GetManagedTypeName (opt),
 						opt.GetSafeIdentifier (var_name)),
 			};
@@ -123,14 +123,14 @@ namespace MonoDroid.Generation {
 
 		public string Call (CodeGenerationOptions opt, string var_name)
 		{
-			return opt.GetSafeIdentifier (SymbolTable.GetNativeName (var_name));
+			return opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name));
 		}
 
 		public string[] PostCall (CodeGenerationOptions opt, string var_name)
 		{
 			return new string[]{
 				string.Format ("JNIEnv.DeleteLocalRef ({0});",
-						opt.GetSafeIdentifier (SymbolTable.GetNativeName (var_name))),
+						opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name))),
 			};
 		}
 
@@ -139,11 +139,11 @@ namespace MonoDroid.Generation {
 		#region IRequireGenericMarshal implementation
 		public string GetGenericJavaObjectTypeOverride ()
 		{
-			return SymbolTable.GetGenericJavaObjectTypeOverride (managed_name, parms != null ? parms.ToString () : null);
+			return TypeNameUtilities.GetGenericJavaObjectTypeOverride (managed_name, parms != null ? parms.ToString () : null);
 		}
 		public string ToInteroperableJavaObject (string var_name)
 		{
-			return SymbolTable.GetNativeName (var_name);
+			return TypeNameUtilities.GetNativeName (var_name);
 		}
 		#endregion
 	}

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/GenericTypeParameter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/GenericTypeParameter.cs
@@ -99,7 +99,7 @@ namespace MonoDroid.Generation {
 				string.Format ("{0} {1} = global::Java.Lang.Object.GetObject<{0}> ({2}, {3});",
 						opt.GetOutputName (FullName),
 						var_name,
-						opt.GetSafeIdentifier (SymbolTable.GetNativeName (var_name)),
+						opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name)),
 						owned ? "JniHandleOwnership.TransferLocalRef" : "JniHandleOwnership.DoNotTransfer"),
 			};
 		}
@@ -114,20 +114,20 @@ namespace MonoDroid.Generation {
 		{
 			return new string[] {
 				string.Format ("IntPtr {0} = JNIEnv.ToLocalJniHandle ({1});",
-						opt.GetSafeIdentifier (SymbolTable.GetNativeName (var_name)), opt.GetSafeIdentifier (var_name)),
+						opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name)), opt.GetSafeIdentifier (var_name)),
 			};
 		}
 
 		public string Call (CodeGenerationOptions opt, string var_name)
 		{
-			return opt.GetSafeIdentifier (SymbolTable.GetNativeName (var_name));
+			return opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name));
 		}
 
 		public string[] PostCall (CodeGenerationOptions opt, string var_name)
 		{
 			return new string[]{
 				string.Format ("JNIEnv.DeleteLocalRef ({0});",
-						opt.GetSafeIdentifier (SymbolTable.GetNativeName (var_name))),
+						opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name))),
 			};
 		}
 

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/StreamSymbol.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/StreamSymbol.cs
@@ -83,7 +83,7 @@ namespace MonoDroid.Generation {
 		{
 			return new string[] {
 				string.Format ("IntPtr {0} = global::Android.Runtime.{1}Adapter.ToLocalJniHandle ({2});",
-						opt.GetSafeIdentifier (SymbolTable.GetNativeName (var_name)),
+						opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name)),
 						base_name,
 						opt.GetSafeIdentifier (var_name)),
 			};
@@ -91,14 +91,14 @@ namespace MonoDroid.Generation {
 
 		public string Call (CodeGenerationOptions opt, string var_name)
 		{
-			return opt.GetSafeIdentifier (SymbolTable.GetNativeName (var_name));
+			return opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name));
 		}
 
 		public string[] PostCall (CodeGenerationOptions opt, string var_name)
 		{
 			return new string[]{
 				string.Format ("JNIEnv.DeleteLocalRef ({0});",
-						opt.GetSafeIdentifier (SymbolTable.GetNativeName (var_name))),
+						opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name))),
 			};
 		}
 
@@ -108,7 +108,7 @@ namespace MonoDroid.Generation {
 				string.Format ("System.IO.Stream {0} = global::Android.Runtime.{1}Invoker.FromJniHandle ({2}, {3});",
 						var_name,
 						base_name,
-						opt.GetSafeIdentifier (SymbolTable.GetNativeName (var_name)),
+						opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name)),
 						owned ? "JniHandleOwnership.TransferLocalRef" : "JniHandleOwnership.DoNotTransfer"),
 			};
 		}

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/StringSymbol.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/StringSymbol.cs
@@ -71,7 +71,7 @@ namespace MonoDroid.Generation {
 
 		public string Call (CodeGenerationOptions opt, string var_name)
 		{
-			return opt.GetSafeIdentifier (SymbolTable.GetNativeName (var_name));
+			return opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name));
 		}
 
 		public string[] PostCallback (CodeGenerationOptions opt, string var_name)
@@ -82,18 +82,18 @@ namespace MonoDroid.Generation {
 		public string[] PostCall (CodeGenerationOptions opt, string var_name)
 		{
 			return new string[]{
-				string.Format ("JNIEnv.DeleteLocalRef ({0});", opt.GetSafeIdentifier (SymbolTable.GetNativeName (var_name))),
+				string.Format ("JNIEnv.DeleteLocalRef ({0});", opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name))),
 			};
 		}
 
 		public string[] PreCallback (CodeGenerationOptions opt, string var_name, bool owned)
 		{
-			return new string[] { String.Format ("string {0} = JNIEnv.GetString ({1}, JniHandleOwnership.DoNotTransfer);", opt.GetSafeIdentifier (var_name), opt.GetSafeIdentifier (SymbolTable.GetNativeName (var_name))) };
+			return new string[] { String.Format ("string {0} = JNIEnv.GetString ({1}, JniHandleOwnership.DoNotTransfer);", opt.GetSafeIdentifier (var_name), opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name))) };
 		}
 
 		public string[] PreCall (CodeGenerationOptions opt, string var_name)
 		{
-			return new string[] { String.Format ("IntPtr {0} = JNIEnv.NewString ({1});", opt.GetSafeIdentifier (SymbolTable.GetNativeName (var_name)), opt.GetSafeIdentifier (var_name)) };
+			return new string[] { String.Format ("IntPtr {0} = JNIEnv.NewString ({1});", opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name)), opt.GetSafeIdentifier (var_name)) };
 		}
 
 		public bool NeedsPrep { get { return true; } }

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/SymbolTable.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/SymbolTable.cs
@@ -147,35 +147,6 @@ namespace MonoDroid.Generation {
 					values.Add (symbol);
 			}
 		}
-		
-		public static string FilterPrimitiveFullName (string s)
-		{
-			switch (s) {
-			case "System.Boolean":
-				return "boolean";
-			case "System.Char":
-				return "char";
-			case "System.Byte":
-				return "byte";
-			case "System.SByte":
-				return "byte";
-			case "System.Int16":
-				return "short";
-			case "System.Int32":
-				return "int";
-			case "System.Int64":
-				return "long";
-			case "System.Single":
-				return "float";
-			case "System.Double":
-				return "double";
-			case "System.Void":
-				return "void";
-			case "System.String":
-				return "java.lang.String";
-			}
-			return null;
-		}
 
 		public ISymbol Lookup (string java_type, GenericParameterDefinitionList in_params)
 		{
@@ -191,7 +162,7 @@ namespace MonoDroid.Generation {
 				key = key.Substring (0, key.Length - 1);
 				break;
 			}
-			key = FilterPrimitiveFullName (key) ?? key;
+			key = TypeNameUtilities.FilterPrimitiveFullName (key) ?? key;
 
 			switch (key) {
 			case "android.content.res.XmlResourceParser":
@@ -296,86 +267,6 @@ namespace MonoDroid.Generation {
 					Console.Error.WriteLine ("[{0}]: {1} {2}", p.Key, s.GetType (), s.FullName);
 				}
 			}
-		}
-
-		public static string GetNativeName (string name)
-		{
-			if (name.StartsWith ("@"))
-				return "native__" + name.Substring (1);
-			return "native_" + name;
-		}
-
-		public static string MangleName (string name)
-		{
-			switch (name) {
-			case "event":
-				return "e";
-			case "base":
-			case "bool":
-			case "byte":
-			case "callback":
-			case "checked":
-			case "decimal":
-			case "delegate":
-			case "fixed":
-			case "foreach":
-			case "in":
-			case "int":
-			case "interface":
-			case "internal":
-			case "is":
-			case "lock":
-			case "namespace":
-			case "new":
-			case "null":
-			case "object":
-			case "out":
-			case "override":
-			case "params":
-			case "readonly":
-			case "ref":
-			case "remove":
-			case "string":
-			case "where":
-				return "@" + name;
-			default:
-				return name;
-			}
-		}
-
-		public static string StudlyCase (string name)
-		{
-			StringBuilder builder = new StringBuilder ();
-			bool raise = true;
-			foreach (char c in name) {
-				if (c == '_' || c == '-')
-					raise = true;
-				else if (raise) {
-					builder.Append (Char.ToUpper (c));
-					raise = false;
-				} else
-					builder.Append (c);
-			}
-			return builder.ToString ();
-		}
-
-		public static string GetGenericJavaObjectTypeOverride (string managed_name, string parms)
-		{
-			switch (managed_name) {
-			case "System.Collections.ICollection":
-				return "JavaCollection";
-			case "System.Collections.IDictionary":
-				return "JavaDictionary";
-			case "System.Collections.IList":
-				return "JavaList";
-			case "System.Collections.Generic.ICollection":
-				return "JavaCollection" + parms;
-			case "System.Collections.Generic.IList":
-				return "JavaList" + parms;
-			case "System.Collections.Generic.IDictionary":
-				return "JavaDictionary" + parms;
-			}
-			return null;
 		}
 	}
 }

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/XmlPullParserSymbol.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/XmlPullParserSymbol.cs
@@ -68,7 +68,7 @@ namespace MonoDroid.Generation {
 
 		public string Call (CodeGenerationOptions opt, string var_name)
 		{
-			return opt.GetSafeIdentifier (SymbolTable.GetNativeName (var_name));
+			return opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name));
 		}
 
 		public string[] PostCallback (CodeGenerationOptions opt, string var_name)
@@ -79,18 +79,18 @@ namespace MonoDroid.Generation {
 		public string[] PostCall (CodeGenerationOptions opt, string var_name)
 		{
 			return new string []{
-				string.Format ("JNIEnv.DeleteLocalRef ({0});", opt.GetSafeIdentifier (SymbolTable.GetNativeName (var_name))),
+				string.Format ("JNIEnv.DeleteLocalRef ({0});", opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name))),
 			};
 		}
 
 		public string[] PreCallback (CodeGenerationOptions opt, string var_name, bool owned)
 		{
-			return new string[] { String.Format ("System.Xml.XmlReader {0} = global::Android.Runtime.XmlPullParserReader.FromJniHandle ({1}, JniHandleOwnership.DoNotTransfer);", opt.GetSafeIdentifier (var_name), opt.GetSafeIdentifier (SymbolTable.GetNativeName (var_name))) };
+			return new string[] { String.Format ("System.Xml.XmlReader {0} = global::Android.Runtime.XmlPullParserReader.FromJniHandle ({1}, JniHandleOwnership.DoNotTransfer);", opt.GetSafeIdentifier (var_name), opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name))) };
 		}
 
 		public string[] PreCall (CodeGenerationOptions opt, string var_name)
 		{
-			return new string[] { String.Format ("IntPtr {0} = global::Android.Runtime.XmlReaderPullParser.ToLocalJniHandle ({1});", opt.GetSafeIdentifier (SymbolTable.GetNativeName (var_name)), opt.GetSafeIdentifier (var_name)) };
+			return new string[] { String.Format ("IntPtr {0} = global::Android.Runtime.XmlReaderPullParser.ToLocalJniHandle ({1});", opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name)), opt.GetSafeIdentifier (var_name)) };
 		}
 
 		public bool NeedsPrep { get { return true; } }

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/XmlResourceParserSymbol.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/XmlResourceParserSymbol.cs
@@ -68,7 +68,7 @@ namespace MonoDroid.Generation {
 
 		public string Call (CodeGenerationOptions opt, string var_name)
 		{
-			return opt.GetSafeIdentifier (SymbolTable.GetNativeName (var_name));
+			return opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name));
 		}
 
 		public string[] PostCallback (CodeGenerationOptions opt, string var_name)
@@ -79,18 +79,18 @@ namespace MonoDroid.Generation {
 		public string[] PostCall (CodeGenerationOptions opt, string var_name)
 		{
 			return new string []{
-				string.Format ("JNIEnv.DeleteLocalRef ({0});", opt.GetSafeIdentifier (SymbolTable.GetNativeName (var_name))),
+				string.Format ("JNIEnv.DeleteLocalRef ({0});", opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name))),
 			};
 		}
 
 		public string[] PreCallback (CodeGenerationOptions opt, string var_name, bool owned)
 		{
-			return new string[] { String.Format ("System.Xml.XmlReader {0} = global::Android.Runtime.XmlResourceParserReader.FromJniHandle ({1}, JniHandleOwnership.DoNotTransfer);", opt.GetSafeIdentifier (var_name), opt.GetSafeIdentifier (SymbolTable.GetNativeName (var_name))) };
+			return new string[] { String.Format ("System.Xml.XmlReader {0} = global::Android.Runtime.XmlResourceParserReader.FromJniHandle ({1}, JniHandleOwnership.DoNotTransfer);", opt.GetSafeIdentifier (var_name), opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name))) };
 		}
 
 		public string[] PreCall (CodeGenerationOptions opt, string var_name)
 		{
-			return new string[] { String.Format ("IntPtr {0} = global::Android.Runtime.XmlReaderResourceParser.ToLocalJniHandle ({1});", opt.GetSafeIdentifier (SymbolTable.GetNativeName (var_name)), opt.GetSafeIdentifier (var_name)) };
+			return new string[] { String.Format ("IntPtr {0} = global::Android.Runtime.XmlReaderResourceParser.ToLocalJniHandle ({1});", opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name)), opt.GetSafeIdentifier (var_name)) };
 		}
 
 		public bool NeedsPrep { get { return true; } }

--- a/tools/generator/Tests/Unit-Tests/AdjusterTests.cs
+++ b/tools/generator/Tests/Unit-Tests/AdjusterTests.cs
@@ -67,7 +67,7 @@ namespace generatortests
 				Xamarin.Android.Binder.CodeGenerator.ProcessReferencedType (type, options);
 			}
 
-			adjuster.Process (inputFile, options, options.SymbolTable.AllRegisteredSymbols ().OfType<GenBase> ().ToArray (), outputFile, (int)Log.LoggingLevel.Debug);
+			adjuster.Process (inputFile, options, options.SymbolTable.AllRegisteredSymbols (options).OfType<GenBase> ().ToArray (), outputFile, (int)Log.LoggingLevel.Debug);
 
 			FileAssert.Exists (outputFile);
 		}

--- a/tools/generator/Tests/Unit-Tests/TypeNameUtilitiesTests.cs
+++ b/tools/generator/Tests/Unit-Tests/TypeNameUtilitiesTests.cs
@@ -1,0 +1,23 @@
+using System;
+using MonoDroid.Generation;
+using NUnit.Framework;
+
+namespace generatortests
+{
+	[TestFixture]
+	public class TypeNameUtilitiesTests
+	{
+		[Test]
+		public void MangleName ()
+		{
+			Assert.AreEqual ("@abstract", TypeNameUtilities.MangleName ("abstract"));
+			Assert.AreEqual ("@case", TypeNameUtilities.MangleName ("case"));
+			Assert.AreEqual ("@namespace", TypeNameUtilities.MangleName ("namespace"));
+			Assert.AreEqual ("@while", TypeNameUtilities.MangleName ("while"));
+
+			Assert.AreEqual ("e", TypeNameUtilities.MangleName ("event"));
+			Assert.AreEqual ("byte_var", TypeNameUtilities.MangleName ("byte_var"));
+			Assert.AreEqual ("foo", TypeNameUtilities.MangleName ("foo"));
+		}
+	}
+}

--- a/tools/generator/Tests/generator-Tests.csproj
+++ b/tools/generator/Tests/generator-Tests.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Unit-Tests\ManagedTests.cs" />
     <Compile Include="Unit-Tests\SupportTypes.cs" />
     <Compile Include="Unit-Tests\TestExtensions.cs" />
+    <Compile Include="Unit-Tests\TypeNameUtilitiesTests.cs" />
     <Compile Include="Unit-Tests\XmlTests.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/tools/generator/Utilities/TypeNameUtilities.cs
+++ b/tools/generator/Utilities/TypeNameUtilities.cs
@@ -17,7 +17,7 @@ namespace MonoDroid.Generation
 			"is", "lock", "long", "namespace", "new", "null", "object", "operator", "out", "override", "params", "private",
 			"protected", "public", "readonly", "ref", "remove", "return", "sbyte", "sealed", "short", "sizeof", "stackalloc", "static", "string",
 			"struct", "switch", "throw", "true", "try", "typeof", "uint", "ulong", "unchecked", "unsafe", "ushort",
-			"using", "virtual", "void", "volatile", "where", "while"
+			"using", "virtual", "void", "volatile", "where", "while",
 		};
 
 		public static string FilterPrimitiveFullName (string s)

--- a/tools/generator/Utilities/TypeNameUtilities.cs
+++ b/tools/generator/Utilities/TypeNameUtilities.cs
@@ -7,7 +7,19 @@ using System.Threading.Tasks;
 namespace MonoDroid.Generation
 {
 	public static class TypeNameUtilities
-	{		
+	{
+		// These must be sorted for BinarySearch to work
+		// Missing "this" because it's handled elsewhere as "this_"
+		static string [] reserved_keywords = new [] {
+			"abstract", "as", "base", "bool", "break", "byte", "callback", "case", "catch", "char", "checked", "class", "const",
+			"continue", "decimal", "default", "delegate", "do", "double", "else", "enum", "event", "explicit", "extern", "false",
+			"finally", "fixed", "float", "for", "foreach", "goto", "if", "implicit", "in", "int", "interface", "internal",
+			"is", "lock", "long", "namespace", "new", "null", "object", "operator", "out", "override", "params", "private",
+			"protected", "public", "readonly", "ref", "remove", "return", "sbyte", "sealed", "short", "sizeof", "stackalloc", "static", "string",
+			"struct", "switch", "throw", "true", "try", "typeof", "uint", "ulong", "unchecked", "unsafe", "ushort",
+			"using", "virtual", "void", "volatile", "where", "while"
+		};
+
 		public static string FilterPrimitiveFullName (string s)
 		{
 			switch (s) {
@@ -65,40 +77,13 @@ namespace MonoDroid.Generation
 
 		public static string MangleName (string name)
 		{
-			switch (name) {
-			case "event":
+			if (name == "event")
 				return "e";
-			case "base":
-			case "bool":
-			case "byte":
-			case "callback":
-			case "checked":
-			case "decimal":
-			case "delegate":
-			case "fixed":
-			case "foreach":
-			case "in":
-			case "int":
-			case "interface":
-			case "internal":
-			case "is":
-			case "lock":
-			case "namespace":
-			case "new":
-			case "null":
-			case "object":
-			case "out":
-			case "override":
-			case "params":
-			case "readonly":
-			case "ref":
-			case "remove":
-			case "string":
-			case "where":
+			
+			if (Array.BinarySearch (reserved_keywords, name) >= 0)
 				return "@" + name;
-			default:
-				return name;
-			}
+
+			return name;
 		}
 
 		public static string StudlyCase (string name)

--- a/tools/generator/Utilities/TypeNameUtilities.cs
+++ b/tools/generator/Utilities/TypeNameUtilities.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MonoDroid.Generation
+{
+	public static class TypeNameUtilities
+	{		
+		public static string FilterPrimitiveFullName (string s)
+		{
+			switch (s) {
+			case "System.Boolean":
+				return "boolean";
+			case "System.Char":
+				return "char";
+			case "System.Byte":
+				return "byte";
+			case "System.SByte":
+				return "byte";
+			case "System.Int16":
+				return "short";
+			case "System.Int32":
+				return "int";
+			case "System.Int64":
+				return "long";
+			case "System.Single":
+				return "float";
+			case "System.Double":
+				return "double";
+			case "System.Void":
+				return "void";
+			case "System.String":
+				return "java.lang.String";
+			}
+			return null;
+		}
+
+		public static string GetGenericJavaObjectTypeOverride (string managed_name, string parms)
+		{
+			switch (managed_name) {
+			case "System.Collections.ICollection":
+				return "JavaCollection";
+			case "System.Collections.IDictionary":
+				return "JavaDictionary";
+			case "System.Collections.IList":
+				return "JavaList";
+			case "System.Collections.Generic.ICollection":
+				return "JavaCollection" + parms;
+			case "System.Collections.Generic.IList":
+				return "JavaList" + parms;
+			case "System.Collections.Generic.IDictionary":
+				return "JavaDictionary" + parms;
+			}
+			return null;
+		}
+
+		public static string GetNativeName (string name)
+		{
+			if (name.StartsWith ("@"))
+				return "native__" + name.Substring (1);
+			return "native_" + name;
+		}
+
+		public static string MangleName (string name)
+		{
+			switch (name) {
+			case "event":
+				return "e";
+			case "base":
+			case "bool":
+			case "byte":
+			case "callback":
+			case "checked":
+			case "decimal":
+			case "delegate":
+			case "fixed":
+			case "foreach":
+			case "in":
+			case "int":
+			case "interface":
+			case "internal":
+			case "is":
+			case "lock":
+			case "namespace":
+			case "new":
+			case "null":
+			case "object":
+			case "out":
+			case "override":
+			case "params":
+			case "readonly":
+			case "ref":
+			case "remove":
+			case "string":
+			case "where":
+				return "@" + name;
+			default:
+				return name;
+			}
+		}
+
+		public static string StudlyCase (string name)
+		{
+			StringBuilder builder = new StringBuilder ();
+			bool raise = true;
+			foreach (char c in name) {
+				if (c == '_' || c == '-')
+					raise = true;
+				else if (raise) {
+					builder.Append (Char.ToUpper (c));
+					raise = false;
+				} else
+					builder.Append (c);
+			}
+			return builder.ToString ();
+		}
+	}
+}

--- a/tools/generator/generator.csproj
+++ b/tools/generator/generator.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Extensions\JavaApiDllLoaderExtensions.cs" />
     <Compile Include="ManagedTypeFinderGeneratorTypeSystem.cs" />
     <Compile Include="Extensions\GenBaseExtensions.cs" />
+    <Compile Include="Utilities\TypeNameUtilities.cs" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
Binding projects typically reference most of the Mono.Android profile, which get passed into generator as reference assemblies:

```
mscorlib.dll
Java.Interop.dll
Mono.Android.dll
System.Core.dll
System.dll
System.Runtime.dll
System.Xml.dll
```

`generator` uses Cecil to reflect over these assemblies and build an in-memory model of the types.  However, the majority of these types are not referenced by the `jar` the user is binding.  For [BetterPickers](https://github.com/xamarin/XamarinComponents/tree/master/Android/BetterPickers/source/BetterPickers), 11632 types are imported, but only 529 are used.

This PR creates the `BaseGen` for these classes but does not iterate through the Constructors/Methods/Properties/Fields unless the type is actually used.  These types are added directly to the `SymbolTable` and are only accessible through it, so we can ensure that any type access will first populate the type members.  Because these are types built from Cecil `TypeReference`s, we place a lock around the lazy population so it is thread-safe in case multiple threads are attempting to populate a type.

We do not use this mechanism for the `class-parse` case because that process iterates all type members, so there is no benefit to being lazy.  Additionally this does not affect the `Mono.Android.dll` case, as it does not reference any assemblies.

This only benefits the `jar2xml` case:

Scenario | Original | This PR
------------ | ------------- | -
Jar2Xml | 5517ms | 3992ms

The first commit simply moves public static methods out of `SymbolTable` to a static utilities class.  This was done to reduce the size of `SymbolTable` code to make it easier to ensure all access paths were covered.   The second commit contains the actual behavior change.