### PR TITLE
[generator] Strip arity from Cecil imported generic types.

### DIFF
--- a/tools/generator/Extensions/ManagedExtensions.cs
+++ b/tools/generator/Extensions/ManagedExtensions.cs
@@ -45,6 +45,26 @@ namespace MonoDroid.Generation
 				yield return CecilApiImporter.CreateParameter (p, type, rawtype);
 			}
 		}
+
+		public static string StripArity (this string type)
+		{
+			if (string.IsNullOrWhiteSpace (type))
+				return type;
+
+			int tick_index;
+
+			// Need to loop for things like List`1<List`1<string>>
+			while ((tick_index = type.IndexOf ('`')) >= 0) {
+				var less_than_index = type.IndexOf ('<', tick_index);
+
+				if (less_than_index == -1)
+					return type;
+
+				type = type.Substring (0, tick_index) + type.Substring (less_than_index);
+			}
+
+			return type;
+		}
 	}
 #endif
 }

--- a/tools/generator/Java.Interop.Tools.Generator.Importers/CecilApiImporter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Importers/CecilApiImporter.cs
@@ -93,7 +93,7 @@ namespace MonoDroid.Generation
 				IsStatic = f.IsStatic,
 				JavaName = reg_attr != null ? ((string) reg_attr.ConstructorArguments [0].Value).Replace ('/', '.') : f.Name,
 				Name = f.Name,
-				TypeName = f.FieldType.FullNameCorrected (),
+				TypeName = f.FieldType.FullNameCorrected ().StripArity (),
 				Value = f.Constant == null ? null : f.FieldType.FullName == "System.String" ? '"' + f.Constant.ToString () + '"' : f.Constant.ToString (),
 				Visibility = f.IsPublic ? "public" : f.IsFamilyOrAssembly ? "protected internal" : f.IsFamily ? "protected" : f.IsAssembly ? "internal" : "private"
 			};
@@ -181,8 +181,8 @@ namespace MonoDroid.Generation
 				IsStatic = m.IsStatic,
 				IsVirtual = m.IsVirtual,
 				JavaName = reg_attr != null ? ((string) reg_attr.ConstructorArguments [0].Value) : m.Name,
-				ManagedReturn = m.ReturnType.FullNameCorrected (),
-				Return = m.ReturnType.FullNameCorrected (),
+				ManagedReturn = m.ReturnType.FullNameCorrected ().StripArity (),
+				Return = m.ReturnType.FullNameCorrected ().StripArity (),
 				Visibility = m.Visibility ()
 			};
 
@@ -211,7 +211,7 @@ namespace MonoDroid.Generation
 			// FIXME: safe to use CLR type name? assuming yes as we often use it in metadatamap.
 			// FIXME: IsSender?
 			var isEnumType = GetGeneratedEnumAttribute (p.CustomAttributes) != null;;
-			return new Parameter (SymbolTable.MangleName (p.Name), jnitype ?? p.ParameterType.FullNameCorrected (), null, isEnumType, rawtype);
+			return new Parameter (SymbolTable.MangleName (p.Name), jnitype ?? p.ParameterType.FullNameCorrected ().StripArity (), null, isEnumType, rawtype);
 		}
 
 		public static Parameter CreateParameter (string managedType, string javaType)

--- a/tools/generator/Tests/Unit-Tests/ManagedExtensionsTests.cs
+++ b/tools/generator/Tests/Unit-Tests/ManagedExtensionsTests.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MonoDroid.Generation;
+using NUnit.Framework;
+
+namespace generatortests
+{
+	[TestFixture]
+	public class ManagedExtensionsTests
+	{
+		[Test]
+		public void StripArity ()
+		{
+			Assert.AreEqual ("List<string>", "List`1<string>".StripArity ());
+			Assert.AreEqual ("List<List<string>>", "List`10<List`1<string>>".StripArity ());
+			Assert.AreEqual ("List<string>", "List<string>".StripArity ());
+			Assert.AreEqual ("List`1", "List`1".StripArity ());
+			Assert.AreEqual ("L<blah>ist<string>", "L<blah>ist`1<string>".StripArity ());
+			Assert.AreEqual ("List<string>", "List`1`<string>".StripArity ());
+			Assert.AreEqual ("List<<string>", "List`1<<string>".StripArity ());
+			Assert.AreEqual ("List<", "List`<".StripArity ());
+			Assert.AreEqual ("<", "`1<".StripArity ());
+			Assert.AreEqual ("`", "`".StripArity ());
+			Assert.AreEqual (string.Empty, string.Empty.StripArity ());
+			Assert.IsNull ((null as string).StripArity ());
+		}
+	}
+}

--- a/tools/generator/Tests/generator-Tests.csproj
+++ b/tools/generator/Tests/generator-Tests.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Unit-Tests\AdjusterTests.cs" />
     <Compile Include="Unit-Tests\DefaultInterfaceMethodsTests.cs" />
     <Compile Include="Unit-Tests\EnumGeneratorTests.cs" />
+    <Compile Include="Unit-Tests\ManagedExtensionsTests.cs" />
     <Compile Include="Unit-Tests\ManagedTests.cs" />
     <Compile Include="Unit-Tests\SupportTypes.cs" />
     <Compile Include="Unit-Tests\TestExtensions.cs" />


### PR DESCRIPTION
One of the issues trying to bind the BouncyCastle .jar in #424 is that we write generic types with invalid signatures, like:

```
public List`1<string> MyProperty { get; set; }
```

This is how a Cecil type reference `FullName` is returned.  Since this notation is not useful to us, this PR strips the arity while reading the assembly.

This results in the proper type syntax:
```
public List<string> MyProperty { get; set; }
```