### PR TITLE
[generator] Ensure studly-case doesn't produce invalid C# field name.

### DIFF
--- a/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
@@ -110,8 +110,13 @@ namespace MonoDroid.Generation
 
 			if (elem.Attribute ("managedName") != null)
 				field.Name = elem.XGetAttribute ("managedName");
-			else
+			else {
 				field.Name = TypeNameUtilities.StudlyCase (char.IsLower (field.JavaName [0]) || field.JavaName.ToLower ().ToUpper () != field.JavaName ? field.JavaName : field.JavaName.ToLower ());
+
+				// Preserve starting underscore if 2nd char is a number (removing it is an invalid C# name)
+				if (field.Name.Length > 0 && char.IsNumber (field.Name [0]) && field.JavaName.StartsWith ("_"))
+					field.Name = $"_{field.Name}";
+			}
 
 			return field;
 		}

--- a/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
@@ -83,6 +83,8 @@ namespace MonoDroid.Generation
 					ctor.Parameters.Add (CreateParameter (child));
 			}
 
+			ctor.Name = EnsureValidIdentifer (ctor.Name);
+
 			return ctor;
 		}
 
@@ -111,11 +113,8 @@ namespace MonoDroid.Generation
 			if (elem.Attribute ("managedName") != null)
 				field.Name = elem.XGetAttribute ("managedName");
 			else {
-				field.Name = TypeNameUtilities.StudlyCase (char.IsLower (field.JavaName [0]) || field.JavaName.ToLower ().ToUpper () != field.JavaName ? field.JavaName : field.JavaName.ToLower ());
-
-				// Preserve starting underscore if 2nd char is a number (removing it is an invalid C# name)
-				if (field.Name.Length > 0 && char.IsNumber (field.Name [0]) && field.JavaName.StartsWith ("_"))
-					field.Name = $"_{field.Name}";
+				field.Name = TypeNameUtilities.StudlyCase (char.IsLower (field.JavaName [0]) || field.JavaName.ToLowerInvariant ().ToUpperInvariant () != field.JavaName ? field.JavaName : field.JavaName.ToLowerInvariant ());
+				field.Name = EnsureValidIdentifer (field.Name);
 			}
 
 			return field;
@@ -176,7 +175,7 @@ namespace MonoDroid.Generation
 					support.Name = StringRocks.TypeToPascalCase (support.Name);
 				raw_name = support.Name;
 				support.TypeNamePrefix = isInterface ? IsPrefixableName (raw_name) ? "I" : string.Empty : string.Empty;
-				support.Name = support.TypeNamePrefix + raw_name;
+				support.Name = EnsureValidIdentifer (support.TypeNamePrefix + raw_name);
 				support.FullName = string.Format ("{0}.{1}{2}", support.Namespace, idx > 0 ? StringRocks.TypeToPascalCase (support.JavaSimpleName.Substring (0, idx + 1)) : string.Empty, support.Name);
 			}
 
@@ -261,6 +260,8 @@ namespace MonoDroid.Generation
 					method.Parameters.Add (CreateParameter (child));
 			}
 
+			method.Name = EnsureValidIdentifer (method.Name);
+
 			method.FillReturnType ();
 
 			return method;
@@ -269,7 +270,7 @@ namespace MonoDroid.Generation
 		public static Parameter CreateParameter (XElement elem)
 		{
 			string managedName = elem.XGetAttribute ("managedName");
-			string name = !string.IsNullOrEmpty (managedName) ? managedName : TypeNameUtilities.MangleName (elem.XGetAttribute ("name"));
+			string name = !string.IsNullOrEmpty (managedName) ? managedName : EnsureValidIdentifer (TypeNameUtilities.MangleName (elem.XGetAttribute ("name")));
 			string java_type = elem.XGetAttribute ("type");
 			string enum_type = elem.Attribute ("enumType") != null ? elem.XGetAttribute ("enumType") : null;
 			string managed_type = elem.Attribute ("managedType") != null ? elem.XGetAttribute ("managedType") : null;
@@ -286,6 +287,19 @@ namespace MonoDroid.Generation
 			string java_type = elem.XGetAttribute ("name");
 			string java_package = elem.Parent.XGetAttribute ("name");
 			return new Parameter (name, java_package + "." + java_type, null, false);
+		}
+
+		static string EnsureValidIdentifer (string name)
+		{
+			if (string.IsNullOrWhiteSpace (name))
+				return name;
+
+			name = name.Replace ('$', '_');
+
+			if (char.IsNumber (name [0]))
+				name = $"_{name}";
+
+			return name;
 		}
 
 		static int GetApiLevel (string source)

--- a/tools/generator/Tests/Unit-Tests/XmlApiImporterTests.cs
+++ b/tools/generator/Tests/Unit-Tests/XmlApiImporterTests.cs
@@ -9,6 +9,24 @@ namespace generatortests
 	public class XmlApiImporterTests
 	{
 		[Test]
+		public void CreateClass_EnsureValidName ()
+		{
+			var xml = XDocument.Parse ("<package name=\"com.example.test\" jni-name=\"com/example/test\"><class name=\"$3\" /></package>");
+			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"));
+
+			Assert.AreEqual ("_3", klass.Name);
+		}
+
+		[Test]
+		public void CreateCtor_EnsureValidName ()
+		{
+			var xml = XDocument.Parse ("<package name=\"com.example.test\" jni-name=\"com/example/test\"><class name=\"test\"><constructor name=\"$3\" /></class></package>");
+			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"));
+
+			Assert.AreEqual ("_3", klass.Ctors[0].Name);
+		}
+
+		[Test]
 		public void CreateField_StudlyCaseName ()
 		{
 			var xml = XDocument.Parse ("<field name=\"_DES_EDE_CBC\" />");
@@ -24,6 +42,51 @@ namespace generatortests
 			var field = XmlApiImporter.CreateField (xml.Root);
 
 			Assert.AreEqual ("_3desEdeCbc", field.Name);
+		}
+
+		[Test]
+		public void CreateField_HandleDollarSign ()
+		{
+			var xml = XDocument.Parse ("<field name=\"A$3\" />");
+			var field = XmlApiImporter.CreateField (xml.Root);
+
+			Assert.AreEqual ("A_3", field.Name);
+		}
+
+		[Test]
+		public void CreateField_HandleDollarSignNumber ()
+		{
+			var xml = XDocument.Parse ("<field name=\"$3\" />");
+			var field = XmlApiImporter.CreateField (xml.Root);
+
+			Assert.AreEqual ("_3", field.Name);
+		}
+
+		[Test]
+		public void CreateInterface_EnsureValidName ()
+		{
+			var xml = XDocument.Parse ("<package name=\"com.example.test\" jni-name=\"com/example/test\"><interface name=\"$3\" /></package>");
+			var iface = XmlApiImporter.CreateInterface (xml.Root, xml.Root.Element ("interface"));
+
+			Assert.AreEqual ("I_3", iface.Name);
+		}
+
+		[Test]
+		public void CreateMethod_EnsureValidName ()
+		{
+			var xml = XDocument.Parse ("<package name=\"com.example.test\" jni-name=\"com/example/test\"><class name=\"test\"><method name=\"$3\" /></class></package>");
+			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"));
+
+			Assert.AreEqual ("_3", klass.Methods [0].Name);
+		}
+
+		[Test]
+		public void CreateParameter_EnsureValidName ()
+		{
+			var xml = XDocument.Parse ("<parameter name=\"$3\" />");
+			var p = XmlApiImporter.CreateParameter (xml.Root);
+
+			Assert.AreEqual ("_3", p.Name);
 		}
 	}
 }

--- a/tools/generator/Tests/Unit-Tests/XmlApiImporterTests.cs
+++ b/tools/generator/Tests/Unit-Tests/XmlApiImporterTests.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Xml.Linq;
+using MonoDroid.Generation;
+using NUnit.Framework;
+
+namespace generatortests
+{
+	[TestFixture]
+	public class XmlApiImporterTests
+	{
+		[Test]
+		public void CreateField_StudlyCaseName ()
+		{
+			var xml = XDocument.Parse ("<field name=\"_DES_EDE_CBC\" />");
+			var field = XmlApiImporter.CreateField (xml.Root);
+
+			Assert.AreEqual ("DesEdeCbc", field.Name);
+		}
+
+		[Test]
+		public void CreateField_EnsureValidName ()
+		{
+			var xml = XDocument.Parse ("<field name=\"_3DES_EDE_CBC\" />");
+			var field = XmlApiImporter.CreateField (xml.Root);
+
+			Assert.AreEqual ("_3desEdeCbc", field.Name);
+		}
+	}
+}

--- a/tools/generator/Tests/generator-Tests.csproj
+++ b/tools/generator/Tests/generator-Tests.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Unit-Tests\SupportTypes.cs" />
     <Compile Include="Unit-Tests\TestExtensions.cs" />
     <Compile Include="Unit-Tests\TypeNameUtilitiesTests.cs" />
+    <Compile Include="Unit-Tests\XmlApiImporterTests.cs" />
     <Compile Include="Unit-Tests\XmlTests.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
One issue with the BouncyCastle .jar in #424 is that it contains this field:

```
public static final int _3DES_EDE_CBC
```

We studly-case Java field names, however that removes underscores and we end up with `3desEdeCbc`, which is invalid C#.  This PR preserves a starting underscore if there was one and the resulting name starts with a number.  (`_3desEdeCbc` for this case.)