### PR TITLE
[generator] Use a lookup cache in SymbolTable to find types.

### DIFF
--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/SymbolTable.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/SymbolTable.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Text;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 
 namespace MonoDroid.Generation {
 
@@ -11,7 +12,7 @@ namespace MonoDroid.Generation {
 		// If you make any changes to the SymbolTable class that accesses the symbols you need to keep
 		// that in mind.  Also if you add any new public methods that expose symbols from the table you must
 		// EnsurePopulated them before letting them leave this class.
-		Dictionary<string, List<ISymbol>> symbols = new Dictionary<string, List<ISymbol>> ();
+		ConcurrentDictionary<string, List<ISymbol>> symbols = new ConcurrentDictionary<string, List<ISymbol>> ();
 
 		ISymbol char_seq;
 		ISymbol fileinstream_sym;
@@ -146,15 +147,21 @@ namespace MonoDroid.Generation {
 			if (!ShouldAddType (key))
 				return;
 
-			List<ISymbol> values;
-			if (!symbols.TryGetValue (key, out values)) {
-				symbols.Add (key, new List<ISymbol> { symbol });
-				all_symbols_cache = null;
-			}
-			else {
-				if (!values.Any (v => object.ReferenceEquals (v, symbol)))
-					values.Add (symbol);
-			}
+			symbols.AddOrUpdate (key,
+				(value) => {
+					// Key not found, add it to Dictionary
+					lock (cache_population_lock)
+						all_symbols_cache = null;
+
+					return new List<ISymbol> { symbol };
+				},
+				(value, list) => {
+					// Key already exists, add it to List
+					if (!list.Any (v => object.ReferenceEquals (v, symbol)))
+						list.Add (symbol);
+
+					return list;
+				});
 		}
 
 		public ISymbol Lookup (string java_type, GenericParameterDefinitionList in_params)
@@ -232,7 +239,8 @@ namespace MonoDroid.Generation {
 			return symbol;
 		}
 
-		Dictionary<string, ISymbol> all_symbols_cache;
+		ConcurrentDictionary<string, ISymbol> all_symbols_cache;
+		static object cache_population_lock = new object ();
 
 		public ISymbol Lookup (string java_type)
 		{
@@ -247,11 +255,13 @@ namespace MonoDroid.Generation {
 			} else {
 				// Note we're potentially searching shallow types, but this is only looking at the type name
 				// Anything we find we will populate before returning to the user
-				//sym = symbols.Values.SelectMany (v => v).FirstOrDefault (v => v.FullName == key);
-				if (all_symbols_cache == null)
-					all_symbols_cache = symbols.Values.SelectMany (v => v).GroupBy (s => s.FullName).ToDictionary (s => s.Key, s => s.FirstOrDefault ());
 
-				all_symbols_cache.TryGetValue (key, out sym);
+				lock (cache_population_lock) {
+					if (all_symbols_cache == null)
+						all_symbols_cache = new ConcurrentDictionary<string, ISymbol> (symbols.Values.SelectMany (v => v).GroupBy (s => s.FullName).ToDictionary (s => s.Key, s => s.FirstOrDefault ()));
+
+					all_symbols_cache.TryGetValue (key, out sym);
+				}
 			}
 			ISymbol result;
 			if (sym != null) {

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/SymbolTable.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/SymbolTable.cs
@@ -149,6 +149,7 @@ namespace MonoDroid.Generation {
 			List<ISymbol> values;
 			if (!symbols.TryGetValue (key, out values)) {
 				symbols.Add (key, new List<ISymbol> { symbol });
+				all_symbols_cache = null;
 			}
 			else {
 				if (!values.Any (v => object.ReferenceEquals (v, symbol)))
@@ -231,6 +232,8 @@ namespace MonoDroid.Generation {
 			return symbol;
 		}
 
+		Dictionary<string, ISymbol> all_symbols_cache;
+
 		public ISymbol Lookup (string java_type)
 		{
 			string type_params;
@@ -244,7 +247,11 @@ namespace MonoDroid.Generation {
 			} else {
 				// Note we're potentially searching shallow types, but this is only looking at the type name
 				// Anything we find we will populate before returning to the user
-				sym = symbols.Values.SelectMany (v => v).FirstOrDefault (v => v.FullName == key);
+				//sym = symbols.Values.SelectMany (v => v).FirstOrDefault (v => v.FullName == key);
+				if (all_symbols_cache == null)
+					all_symbols_cache = symbols.Values.SelectMany (v => v).GroupBy (s => s.FullName).ToDictionary (s => s.Key, s => s.FirstOrDefault ());
+
+				all_symbols_cache.TryGetValue (key, out sym);
 			}
 			ISymbol result;
 			if (sym != null) {


### PR DESCRIPTION
The way we use a `SymbolTable` is to fully populate it with types and then perform lots of lookups on it.  We can optimize this by building a lookup cache when we start accessing the types and then using it for all subsequent lookups.

If any additional types are added to the table, we clear the cache so it will be rebuilt.  In practice this doesn't happen often, so we are not constantly rebuilding the cache. (In testing the most we build the cache is twice, out of thousands of accesses.)

Scenario | Original | This PR
------------ | ------------- | -
jar2xml | 2645ms | 782ms
class-parse | 5563ms | 2555ms