### PR TITLE
Revert "[generator] Enable parallel type generation."

### DIFF
--- a/tools/generator/CodeGenerator.cs
+++ b/tools/generator/CodeGenerator.cs
@@ -12,7 +12,6 @@ using Java.Interop.Tools.Cecil;
 using Java.Interop.Tools.Diagnostics;
 using Java.Interop.Tools.TypeNameMappings;
 using MonoDroid.Generation.Utilities;
-using System.Threading.Tasks;
 
 namespace Xamarin.Android.Binder
 {
@@ -180,10 +179,9 @@ namespace Xamarin.Android.Binder
 
 			new NamespaceMapping (gens).Generate (opt, gen_info);
 
-			Parallel.ForEach (gens, gen => {
+			foreach (IGeneratable gen in gens)
 				if (gen.IsGeneratable)
 					gen.Generate (opt, gen_info);
-			});
 
 
 			ClassGen.GenerateTypeRegistrations (opt, gen_info);


### PR DESCRIPTION
Reverts xamarin/java.interop#447

Revert parallel type generation.  There are some deeper thread-safety issues that will have to be resolved before this can safely be enabled.  These take the form of `CodeGenerator` manipulating the object model while it is writing.

For example:
https://github.com/xamarin/java.interop/blob/master/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/CodeGenerator.cs#L1437-L1440

```
string pname = property.Setter.Parameters [0].Name;
property.Setter.Parameters [0].Name = "value";
WriteMethodBody (property.Setter, indent + "\t\t");
property.Setter.Parameters [0].Name = pname;
```

This caused a test to sporadically fail on CI, but the pipeline is hiding test errors so it wasn't noticed.