### PR TITLE
[Java.Interop-Tests] Allow consumption by Xamarin.Android

### DIFF
--- a/src/Java.Interop/Tests/Java.Interop/JavaArrayContract.cs
+++ b/src/Java.Interop/Tests/Java.Interop/JavaArrayContract.cs
@@ -12,13 +12,21 @@ namespace Java.InteropTests
 	{
 		int lrefStartCount;
 
+#if __ANDROID__
+		[TestFixtureSetUp]
+#else   // __ANDROID__
 		[OneTimeSetUp]
+#endif  // __ANDROID__
 		public void StartArrayTests ()
 		{
 			lrefStartCount  = JniEnvironment.LocalReferenceCount;
 		}
 
+#if __ANDROID__
+		[TestFixtureTearDown]
+#else   // __ANDROID__
 		[OneTimeTearDown]
+#endif  // __ANDROID__
 		public void EndArrayTests ()
 		{
 			int lref    = JniEnvironment.LocalReferenceCount;

--- a/src/Java.Interop/Tests/Java.Interop/JavaExceptionTests.cs
+++ b/src/Java.Interop/Tests/Java.Interop/JavaExceptionTests.cs
@@ -24,6 +24,18 @@ namespace Java.InteropTests
 						// Dalvik, JVM
 						e.JavaStackTrace.StartsWith ("java.lang.NoClassDefFoundError: this/type/had/better/not/exist", StringComparison.Ordinal));
 				e.Dispose ();
+#if __ANDROID__
+			} catch (Java.Lang.Throwable e) {
+				Assert.IsTrue (
+						string.Equals ("this/type/had/better/not/exist", e.Message, StringComparison.OrdinalIgnoreCase) ||
+						e.Message.StartsWith ("Didn't find class \"this.type.had.better.not.exist\" on path: DexPathList"));
+				Assert.IsTrue (
+						// ART
+						e.StackTrace.Contains ("java.lang.ClassNotFoundException: ", StringComparison.Ordinal) ||
+						// Dalvik, JVM
+						e.StackTrace.Contains ("java.lang.NoClassDefFoundError: this/type/had/better/not/exist", StringComparison.Ordinal));
+				e.Dispose ();
+#endif  // __ANDROID__
 			}
 		}
 

--- a/src/Java.Interop/Tests/Java.Interop/JavaObjectArrayTest.cs
+++ b/src/Java.Interop/Tests/Java.Interop/JavaObjectArrayTest.cs
@@ -130,7 +130,11 @@ namespace Java.InteropTests
 
 		int grefStartCount;
 
+#if __ANDROID__
+		[TestFixtureSetUp]
+#else   // __ANDROID__
 		[OneTimeSetUp]
+#endif  // __ANDROID__
 		public void BeginCheckGlobalRefCount ()
 		{
 			// So that the JavaProxyObject.TypeRef GREF isn't counted.
@@ -139,7 +143,11 @@ namespace Java.InteropTests
 			grefStartCount  = JniEnvironment.Runtime.GlobalReferenceCount;
 		}
 
+#if __ANDROID__
+		[TestFixtureTearDown]
+#else   // __ANDROID__
 		[OneTimeTearDown]
+#endif  // __ANDROID__
 		public void EndCheckGlobalRefCount ()
 		{
 			int gref    = JniEnvironment.Runtime.GlobalReferenceCount;

--- a/src/Java.Interop/Tests/Java.Interop/JavaObjectTest.cs
+++ b/src/Java.Interop/Tests/Java.Interop/JavaObjectTest.cs
@@ -166,7 +166,11 @@ namespace Java.InteropTests
 
 			// Note: This may break if/when JavaVM provides "default"
 			Assert.Throws<NotSupportedException> (() => new JavaObjectWithNoJavaPeer ());
+#if __ANDROID__
+			Assert.Throws<Java.Lang.ClassNotFoundException> (() => new JavaObjectWithMissingJavaPeer ()).Dispose ();
+#else   // !__ANDROID__
 			Assert.Throws<JavaException> (() => new JavaObjectWithMissingJavaPeer ()).Dispose ();
+#endif  // !__ANDROID__
 		}
 
 		[Test]

--- a/src/Java.Interop/Tests/Java.Interop/JniRuntime.JniValueManagerTests.cs
+++ b/src/Java.Interop/Tests/Java.Interop/JniRuntime.JniValueManagerTests.cs
@@ -126,6 +126,7 @@ namespace Java.InteropTests {
 			Assert.IsNull (JniRuntime.CurrentRuntime.ValueManager.GetValue (ref invalid, JniObjectReferenceOptions.CopyAndDispose));
 		}
 
+#if !NO_MARSHAL_MEMBER_BUILDER_SUPPORT
 		[Test]
 		public unsafe void GetValue_FindBestMatchType ()
 		{
@@ -138,6 +139,7 @@ namespace Java.InteropTests {
 				}
 			}
 		}
+#endif  // !NO_MARSHAL_MEMBER_BUILDER_SUPPORT
 	}
 }
 

--- a/src/Java.Interop/Tests/Java.Interop/JniTypeManagerTests.cs
+++ b/src/Java.Interop/Tests/Java.Interop/JniTypeManagerTests.cs
@@ -75,7 +75,10 @@ namespace Java.InteropTests
 			AssertGetJniTypeInfoForType (typeof (JavaArray<int[]>),         "[[I",                  true,   2);
 			AssertGetJniTypeInfoForType (typeof (JavaArray<int[]>[]),       "[[[I",                 true,   3);
 
+#if !__ANDROID__
+			// Re-enable once typemap files contain `JavaObject` subclasses, not just Java.Lang.Object subclasses
 			AssertGetJniTypeInfoForType (typeof (GenericHolder<int>),       GenericHolder<int>.JniTypeName,    false,   0);
+#endif  // !__ANDROID__
 		}
 
 		static void AssertGetJniTypeInfoForType (Type type, string jniType, bool isKeyword, int arrayRank)

--- a/src/Java.Interop/Tests/Java.Interop/TestType.cs
+++ b/src/Java.Interop/Tests/Java.Interop/TestType.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 
 namespace Java.InteropTests
 {
+#if !NO_MARSHAL_MEMBER_BUILDER_SUPPORT
 	[JniTypeSignature (TestType.JniTypeName)]
 	public partial class TestType : JavaObject
 	{
@@ -204,5 +205,6 @@ namespace Java.InteropTests
 			return value.ToString ();
 		}
 	}
+#endif  // !NO_MARSHAL_MEMBER_BUILDER_SUPPORT
 }
 

--- a/src/Java.Interop/Tests/Java.Interop/TestTypeTests.cs
+++ b/src/Java.Interop/Tests/Java.Interop/TestTypeTests.cs
@@ -7,18 +7,27 @@ using NUnit.Framework;
 
 namespace Java.InteropTests
 {
+#if !NO_MARSHAL_MEMBER_BUILDER_SUPPORT
 	[TestFixture]
 	public class TestTypeTests : JavaVMFixture
 	{
 		int lrefStartCount;
 
+#if __ANDROID__
+		[TestFixtureSetUp]
+#else   // __ANDROID__
 		[OneTimeSetUp]
+#endif  // __ANDROID__
 		public void StartArrayTests ()
 		{
 			lrefStartCount  = JniEnvironment.LocalReferenceCount;
 		}
 
+#if __ANDROID__
+		[TestFixtureTearDown]
+#else   // __ANDROID__
 		[OneTimeTearDown]
+#endif  // __ANDROID__
 		public void EndArrayTests ()
 		{
 			int lref    = JniEnvironment.LocalReferenceCount;
@@ -49,6 +58,14 @@ namespace Java.InteropTests
 			using (var t = new TestType ()) {
 				t.UnregisterFromRuntime ();
 				t.RunTests ();
+			}
+		}
+
+		[Test]
+		public void ObjectBinding ()
+		{
+			using (var b = new TestType ()) {
+				Console.WriteLine ("# ObjectBinding: {0}", b.ToString ());
 			}
 		}
 
@@ -143,5 +160,6 @@ namespace Java.InteropTests
 			}
 		}
 	}
+#endif  // !NO_MARSHAL_MEMBER_BUILDER_SUPPORT
 }
 


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/3393

Allow the Java.Interop unit tests to be consumed by Xamarin.Android.

In particular, this means:

  * "Proper" exceptions such as `Java.Lang.ClassNotFoundException` are
    thrown, not "based" `JavaException` types.

  * `Xamarin.Android.NUnitLite.dll` doesn't provide
    `[OneTimeSetUpAttribute]`/etc., so use
    `[TestFixtureSetUpAttribute]` instead.

  * Xamarin.Android doesn't currently support
    `Java.Interop.MarshalMemberBuilder`, so any tests which require it
    will not work.  "Hide" those behind
    `#if !NO_MARSHAL_MEMBER_BUILDER_SUPPORT`.