### PR TITLE
[generator] Remove extraneous slash when creating .projitems.

### DIFF
--- a/tools/generator/GenerationInfo.cs
+++ b/tools/generator/GenerationInfo.cs
@@ -89,7 +89,9 @@ namespace MonoDroid.Generation {
 		XElement ToCompileElement (XName compile, string path)
 		{
 			path = path.Replace (CSharpDir, "$(MSBuildThisFileDirectory)")
-				.Replace ('/', '\\');
+				.Replace ('/', '\\')
+				.Replace ("$(MSBuildThisFileDirectory)\\", "$(MSBuildThisFileDirectory)");
+
 			return new XElement (compile, new XAttribute ("Include", path));
 		}
 	}

--- a/tools/generator/Tests-Core/expected.cp/GeneratedFiles.projitems
+++ b/tools/generator/Tests-Core/expected.cp/GeneratedFiles.projitems
@@ -5,12 +5,12 @@
   </PropertyGroup>
   <!-- Classes -->
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.String.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.Invalidnames.In.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.Invalidnames.InvalidNameMembers.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.String.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Xamarin.Test.Invalidnames.In.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Xamarin.Test.Invalidnames.InvalidNameMembers.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)__NamespaceMapping__.cs" />
   </ItemGroup>
   <!-- Enums -->
   <ItemGroup />

--- a/tools/generator/Tests-Core/expected.ji/GeneratedFiles.projitems
+++ b/tools/generator/Tests-Core/expected.ji/GeneratedFiles.projitems
@@ -5,17 +5,17 @@
   </PropertyGroup>
   <!-- Classes -->
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)\Android.Text.ISpannable.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Android.Text.ISpanned.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Android.Text.SpannableString.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Android.Text.SpannableStringInternal.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Android.Views.View.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Android.Text.ISpannable.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Android.Text.ISpanned.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Android.Text.SpannableString.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Android.Text.SpannableStringInternal.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Android.Views.View.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)__NamespaceMapping__.cs" />
   </ItemGroup>
   <!-- Enums -->
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)\Android.Text.SpanTypes.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Android.Text.SpanTypes.cs" />
   </ItemGroup>
 </Project>

--- a/tools/generator/Tests-Core/expected/GeneratedFiles.projitems
+++ b/tools/generator/Tests-Core/expected/GeneratedFiles.projitems
@@ -5,17 +5,17 @@
   </PropertyGroup>
   <!-- Classes -->
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)\Android.Text.ISpannable.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Android.Text.ISpanned.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Android.Text.SpannableString.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Android.Text.SpannableStringInternal.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Android.Views.View.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Android.Text.ISpannable.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Android.Text.ISpanned.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Android.Text.SpannableString.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Android.Text.SpannableStringInternal.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Android.Views.View.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)__NamespaceMapping__.cs" />
   </ItemGroup>
   <!-- Enums -->
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)\Android.Text.SpanTypes.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Android.Text.SpanTypes.cs" />
   </ItemGroup>
 </Project>

--- a/tools/generator/Tests/expected.ji/AccessModifiers/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/AccessModifiers/Mono.Android.projitems
@@ -5,13 +5,13 @@
   </PropertyGroup>
   <!-- Classes -->
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.BasePublicClass.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.ExtendPublicClass.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.PublicClass.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.PublicFinalClass.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Xamarin.Test.BasePublicClass.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Xamarin.Test.ExtendPublicClass.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Xamarin.Test.PublicClass.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Xamarin.Test.PublicFinalClass.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)__NamespaceMapping__.cs" />
   </ItemGroup>
   <!-- Enums -->
   <ItemGroup />

--- a/tools/generator/Tests/expected.ji/Adapters/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/Adapters/Mono.Android.projitems
@@ -5,14 +5,14 @@
   </PropertyGroup>
   <!-- Classes -->
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.AbsSpinner.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.AdapterView.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.GenericReturnObject.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.IAdapter.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.ISpinnerAdapter.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Xamarin.Test.AbsSpinner.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Xamarin.Test.AdapterView.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Xamarin.Test.GenericReturnObject.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Xamarin.Test.IAdapter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Xamarin.Test.ISpinnerAdapter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)__NamespaceMapping__.cs" />
   </ItemGroup>
   <!-- Enums -->
   <ItemGroup />

--- a/tools/generator/Tests/expected.ji/Android.Graphics.Color/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/Android.Graphics.Color/Mono.Android.projitems
@@ -5,10 +5,10 @@
   </PropertyGroup>
   <!-- Classes -->
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.SomeObject.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Xamarin.Test.SomeObject.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)__NamespaceMapping__.cs" />
   </ItemGroup>
   <!-- Enums -->
   <ItemGroup />

--- a/tools/generator/Tests/expected.ji/Arrays/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/Arrays/Mono.Android.projitems
@@ -5,10 +5,10 @@
   </PropertyGroup>
   <!-- Classes -->
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.SomeObject.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Xamarin.Test.SomeObject.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)__NamespaceMapping__.cs" />
   </ItemGroup>
   <!-- Enums -->
   <ItemGroup />

--- a/tools/generator/Tests/expected.ji/CSharpKeywords/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/CSharpKeywords/Mono.Android.projitems
@@ -5,11 +5,11 @@
   </PropertyGroup>
   <!-- Classes -->
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Throwable.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.CSharpKeywords.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.Throwable.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Xamarin.Test.CSharpKeywords.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)__NamespaceMapping__.cs" />
   </ItemGroup>
   <!-- Enums -->
   <ItemGroup />

--- a/tools/generator/Tests/expected.ji/Constructors/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/Constructors/Mono.Android.projitems
@@ -5,11 +5,11 @@
   </PropertyGroup>
   <!-- Classes -->
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.SomeObject.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.SomeObject2.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Xamarin.Test.SomeObject.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Xamarin.Test.SomeObject2.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)__NamespaceMapping__.cs" />
   </ItemGroup>
   <!-- Enums -->
   <ItemGroup />

--- a/tools/generator/Tests/expected.ji/NestedTypes/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/NestedTypes/Mono.Android.projitems
@@ -5,10 +5,10 @@
   </PropertyGroup>
   <!-- Classes -->
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.NotificationCompatBase.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Xamarin.Test.NotificationCompatBase.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)__NamespaceMapping__.cs" />
   </ItemGroup>
   <!-- Enums -->
   <ItemGroup />

--- a/tools/generator/Tests/expected.ji/NonStaticFields/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/NonStaticFields/Mono.Android.projitems
@@ -5,10 +5,10 @@
   </PropertyGroup>
   <!-- Classes -->
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.SomeObject.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Xamarin.Test.SomeObject.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)__NamespaceMapping__.cs" />
   </ItemGroup>
   <!-- Enums -->
   <ItemGroup />

--- a/tools/generator/Tests/expected.ji/NormalMethods/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/NormalMethods/Mono.Android.projitems
@@ -5,15 +5,15 @@
   </PropertyGroup>
   <!-- Classes -->
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Class.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Integer.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Throwable.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.A.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.C.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.SomeObject.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.Class.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.Integer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.Throwable.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Xamarin.Test.A.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Xamarin.Test.C.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Xamarin.Test.SomeObject.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)__NamespaceMapping__.cs" />
   </ItemGroup>
   <!-- Enums -->
   <ItemGroup />

--- a/tools/generator/Tests/expected.ji/NormalProperties/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/NormalProperties/Mono.Android.projitems
@@ -5,10 +5,10 @@
   </PropertyGroup>
   <!-- Classes -->
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.SomeObject.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Xamarin.Test.SomeObject.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)__NamespaceMapping__.cs" />
   </ItemGroup>
   <!-- Enums -->
   <ItemGroup />

--- a/tools/generator/Tests/expected.ji/ParameterXPath/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/ParameterXPath/Mono.Android.projitems
@@ -5,11 +5,11 @@
   </PropertyGroup>
   <!-- Classes -->
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Integer.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.A.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.Integer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Xamarin.Test.A.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)__NamespaceMapping__.cs" />
   </ItemGroup>
   <!-- Enums -->
   <ItemGroup />

--- a/tools/generator/Tests/expected.ji/StaticFields/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/StaticFields/Mono.Android.projitems
@@ -5,10 +5,10 @@
   </PropertyGroup>
   <!-- Classes -->
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.SomeObject.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Xamarin.Test.SomeObject.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)__NamespaceMapping__.cs" />
   </ItemGroup>
   <!-- Enums -->
   <ItemGroup />

--- a/tools/generator/Tests/expected.ji/StaticMethods/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/StaticMethods/Mono.Android.projitems
@@ -5,10 +5,10 @@
   </PropertyGroup>
   <!-- Classes -->
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.SomeObject.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Xamarin.Test.SomeObject.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)__NamespaceMapping__.cs" />
   </ItemGroup>
   <!-- Enums -->
   <ItemGroup />

--- a/tools/generator/Tests/expected.ji/StaticProperties/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/StaticProperties/Mono.Android.projitems
@@ -5,10 +5,10 @@
   </PropertyGroup>
   <!-- Classes -->
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.SomeObject.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Xamarin.Test.SomeObject.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)__NamespaceMapping__.cs" />
   </ItemGroup>
   <!-- Enums -->
   <ItemGroup />

--- a/tools/generator/Tests/expected.ji/Streams/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/Streams/Mono.Android.projitems
@@ -5,14 +5,14 @@
   </PropertyGroup>
   <!-- Classes -->
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.IO.FilterOutputStream.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.IO.InputStream.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.IO.IOException.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.IO.OutputStream.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Throwable.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.IO.FilterOutputStream.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.IO.InputStream.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.IO.IOException.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.IO.OutputStream.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.Throwable.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)__NamespaceMapping__.cs" />
   </ItemGroup>
   <!-- Enums -->
   <ItemGroup />

--- a/tools/generator/Tests/expected.ji/TestInterface/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/TestInterface/Mono.Android.projitems
@@ -5,18 +5,18 @@
   </PropertyGroup>
   <!-- Classes -->
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.String.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Test.ME.GenericImplementation.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Test.ME.GenericObjectPropertyImplementation.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Test.ME.GenericStringImplementation.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Test.ME.GenericStringPropertyImplementation.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Test.ME.IGenericInterface.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Test.ME.IGenericPropertyInterface.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Test.ME.ITestInterface.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Test.ME.TestInterfaceImplementation.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.String.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Test.ME.GenericImplementation.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Test.ME.GenericObjectPropertyImplementation.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Test.ME.GenericStringImplementation.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Test.ME.GenericStringPropertyImplementation.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Test.ME.IGenericInterface.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Test.ME.IGenericPropertyInterface.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Test.ME.ITestInterface.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Test.ME.TestInterfaceImplementation.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)__NamespaceMapping__.cs" />
   </ItemGroup>
   <!-- Enums -->
   <ItemGroup />

--- a/tools/generator/Tests/expected.ji/java.lang.Enum/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/java.lang.Enum/Mono.Android.projitems
@@ -5,12 +5,12 @@
   </PropertyGroup>
   <!-- Classes -->
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Enum.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.IComparable.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.State.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.Enum.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.IComparable.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.State.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)__NamespaceMapping__.cs" />
   </ItemGroup>
   <!-- Enums -->
   <ItemGroup />

--- a/tools/generator/Tests/expected.ji/java.lang.Object/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/java.lang.Object/Mono.Android.projitems
@@ -5,9 +5,9 @@
   </PropertyGroup>
   <!-- Classes -->
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)__NamespaceMapping__.cs" />
   </ItemGroup>
   <!-- Enums -->
   <ItemGroup />

--- a/tools/generator/Tests/expected.ji/java.util.List/Mono.Android.projitems
+++ b/tools/generator/Tests/expected.ji/java.util.List/Mono.Android.projitems
@@ -5,10 +5,10 @@
   </PropertyGroup>
   <!-- Classes -->
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Interop.__TypeRegistrations.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Java.Lang.Object.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Xamarin.Test.SomeObject.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\__NamespaceMapping__.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Interop.__TypeRegistrations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.Object.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Xamarin.Test.SomeObject.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)__NamespaceMapping__.cs" />
   </ItemGroup>
   <!-- Enums -->
   <ItemGroup />


### PR DESCRIPTION
Change our `.projitems` to remove an extraneous slash:
```
- <Compile Include="$(MSBuildThisFileDirectory)\Android.Accounts.Account.cs" />
+ <Compile Include="$(MSBuildThisFileDirectory)Android.Accounts.Account.cs" />
```
This slash causes our files to get interpreted as:
```
...\src\Mono.Android\obj\Debug\android-29\mcw\\Android.Accounts.Account.cs
```
This is valid-ish and builds fine, but when building `Mono.Android.dll` we also add files via this in `Mono.Android.targets`:
```
<ItemGroup>
  <Compile Include="$(_FullIntermediateOutputPath)\mcw\**\*.cs" KeepDuplicates="False" />
</ItemGroup>
```
The extra slash is enough to prevent the `KeepDuplicates` from working correctly, so the file is added twice to `<Compile>`.  This results in ~3k warnings of `Duplicate source file specified` when building `Mono.Android.dll`.  This PR removes those warnings.

`$(MSBuildThisFileDirectory)` is documented as containing the trailing slash: https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-reserved-and-well-known-properties?view=vs-2019.