### PR TITLE
[generator] Always use XAPeerMembers for XAJavaInterop1.

### DIFF
--- a/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/JavaInteropCodeGenerator.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/JavaInteropCodeGenerator.cs
@@ -25,14 +25,12 @@ namespace MonoDroid.Generation {
 
 		internal override string GetAllInterfaceImplements () => "IJavaObject, IJavaPeerable";
 
+		protected virtual string GetPeerMembersType () => "JniPeerMembers";
+
 		internal override void WriteClassHandle (ClassGen type, string indent, bool requireNew)
 		{
-			writer.WriteLine ("{0}\tinternal    {1}     static  readonly    JniPeerMembers  _members    = new {2} (\"{3}\", typeof ({4}));",
-					indent,
-					requireNew ? "new" : "   ",
-					GetPeerMembersType (),
-					type.RawJniName,
-					type.Name);
+			WritePeerMembers (indent + '\t', true, requireNew, type.RawJniName, type.Name);
+
 			writer.WriteLine ("{0}\tinternal static {1}IntPtr class_ref {{", indent, requireNew ? "new " : string.Empty);
 			writer.WriteLine ("{0}\t\tget {{", indent);
 			writer.WriteLine ("{0}\t\t\treturn _members.JniPeerType.PeerReference.Handle;", indent);
@@ -55,22 +53,15 @@ namespace MonoDroid.Generation {
 			}
 		}
 
-		protected virtual string GetPeerMembersType ()
-		{
-			return "JniPeerMembers";
-		}
-
 		internal override void WriteClassHandle (InterfaceGen type, string indent, string declaringType)
 		{
-			writer.WriteLine ("{0}new static JniPeerMembers _members = new JniPeerMembers (\"{1}\", typeof ({2}));",indent, type.RawJniName, declaringType);
+			WritePeerMembers (indent, false, true, type.RawJniName, declaringType);
 		}
 
 		internal override void WriteClassInvokerHandle (ClassGen type, string indent, string declaringType)
 		{
-			writer.WriteLine ("{0}internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers (\"{1}\", typeof ({2}));",
-					indent,
-					type.RawJniName,
-					declaringType);
+			WritePeerMembers (indent, true, true, type.RawJniName, declaringType);
+
 			writer.WriteLine ();
 			writer.WriteLine ("{0}public override global::Java.Interop.JniPeerMembers JniPeerMembers {{", indent);
 			writer.WriteLine ("{0}\tget {{ return _members; }}", indent);
@@ -84,10 +75,8 @@ namespace MonoDroid.Generation {
 
 		internal override void WriteInterfaceInvokerHandle (InterfaceGen type, string indent, string declaringType)
 		{
-			writer.WriteLine ("{0}internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers (\"{1}\", typeof ({2}));",
-					indent,
-					type.RawJniName,
-					declaringType);
+			WritePeerMembers (indent, true, true, type.RawJniName, declaringType);
+
 			writer.WriteLine ();
 			writer.WriteLine ("{0}static IntPtr java_class_ref {{", indent);
 			writer.WriteLine ("{0}\tget {{ return _members.JniPeerType.PeerReference.Handle; }}", indent);
@@ -271,6 +260,14 @@ namespace MonoDroid.Generation {
 				}
 			}
 			writer.WriteLine ("{0}}}", indent);
+		}
+
+		void WritePeerMembers (string indent, bool isInternal, bool isNew, string rawJniType, string declaringType)
+		{
+			var signature = $"{(isInternal ? "internal " : "")}static {(isNew ? "new " : "")}readonly JniPeerMembers _members = ";
+			var type = $"new {GetPeerMembersType ()} (\"{rawJniType}\", typeof ({declaringType}));";
+
+			writer.WriteLine ($"{indent}{signature}{type}");
 		}
 	}
 }

--- a/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/XAJavaInteropCodeGenerator.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/XAJavaInteropCodeGenerator.cs
@@ -9,10 +9,7 @@ namespace MonoDroid.Generation
 		{
 		}
 
-		protected override string GetPeerMembersType ()
-		{
-			return "XAPeerMembers";
-		}
+		protected override string GetPeerMembersType () => "XAPeerMembers";
 	}
 }
 

--- a/tools/generator/Tests-Core/expected.ji/Android.Text.ISpannable.cs
+++ b/tools/generator/Tests-Core/expected.ji/Android.Text.ISpannable.cs
@@ -14,7 +14,7 @@ namespace Android.Text {
 	[global::Android.Runtime.Register ("android/text/Spannable", DoNotGenerateAcw=true)]
 	internal partial class ISpannableInvoker : global::Java.Lang.Object, ISpannable {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("android/text/Spannable", typeof (ISpannableInvoker));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("android/text/Spannable", typeof (ISpannableInvoker));
 
 		static IntPtr java_class_ref {
 			get { return _members.JniPeerType.PeerReference.Handle; }

--- a/tools/generator/Tests-Core/expected.ji/Android.Text.ISpanned.cs
+++ b/tools/generator/Tests-Core/expected.ji/Android.Text.ISpanned.cs
@@ -19,7 +19,7 @@ namespace Android.Text {
 	[global::Android.Runtime.Register ("android/text/Spanned", DoNotGenerateAcw=true)]
 	internal partial class ISpannedInvoker : global::Java.Lang.Object, ISpanned {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("android/text/Spanned", typeof (ISpannedInvoker));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("android/text/Spanned", typeof (ISpannedInvoker));
 
 		static IntPtr java_class_ref {
 			get { return _members.JniPeerType.PeerReference.Handle; }

--- a/tools/generator/Tests-Core/expected.ji/Android.Text.SpannableString.cs
+++ b/tools/generator/Tests-Core/expected.ji/Android.Text.SpannableString.cs
@@ -9,7 +9,7 @@ namespace Android.Text {
 	[global::Android.Runtime.Register ("android/text/SpannableString", DoNotGenerateAcw=true)]
 	public partial class SpannableString : Android.Text.SpannableStringInternal, Android.Text.ISpannable {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("android/text/SpannableString", typeof (SpannableString));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("android/text/SpannableString", typeof (SpannableString));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests-Core/expected.ji/Android.Text.SpannableStringInternal.cs
+++ b/tools/generator/Tests-Core/expected.ji/Android.Text.SpannableStringInternal.cs
@@ -9,7 +9,7 @@ namespace Android.Text {
 	[global::Android.Runtime.Register ("android/text/SpannableStringInternal", DoNotGenerateAcw=true)]
 	public abstract partial class SpannableStringInternal : Java.Lang.Object {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("android/text/SpannableStringInternal", typeof (SpannableStringInternal));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("android/text/SpannableStringInternal", typeof (SpannableStringInternal));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
@@ -70,7 +70,7 @@ namespace Android.Text {
 
 		public SpannableStringInternalInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("android/text/SpannableStringInternal", typeof (SpannableStringInternalInvoker));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("android/text/SpannableStringInternal", typeof (SpannableStringInternalInvoker));
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 			get { return _members; }

--- a/tools/generator/Tests-Core/expected.ji/Android.Views.View.cs
+++ b/tools/generator/Tests-Core/expected.ji/Android.Views.View.cs
@@ -22,7 +22,7 @@ namespace Android.Views {
 		[global::Android.Runtime.Register ("android/view/View$OnClickListener", DoNotGenerateAcw=true)]
 		internal partial class IOnClickListenerInvoker : global::Java.Lang.Object, IOnClickListener {
 
-			internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("android/view/View$OnClickListener", typeof (IOnClickListenerInvoker));
+			internal static new readonly JniPeerMembers _members = new JniPeerMembers ("android/view/View$OnClickListener", typeof (IOnClickListenerInvoker));
 
 			static IntPtr java_class_ref {
 				get { return _members.JniPeerType.PeerReference.Handle; }
@@ -128,7 +128,7 @@ namespace Android.Views {
 		}
 
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("android/view/View", typeof (View));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("android/view/View", typeof (View));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests-Core/expected.ji/Java.Lang.Object.cs
+++ b/tools/generator/Tests-Core/expected.ji/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/Integration-Tests/CSharpKeywords.cs
+++ b/tools/generator/Tests/Integration-Tests/CSharpKeywords.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using NUnit.Framework;
 
 namespace generatortests

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteClass.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteClass.txt
@@ -2,7 +2,7 @@
 [global::Android.Runtime.Register ("java/code/MyClass", DoNotGenerateAcw=true)]
 public partial class MyClass  {
 
-	internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/code/MyClass", typeof (MyClass));
+	internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/code/MyClass", typeof (MyClass));
 	internal static new IntPtr class_ref {
 		get {
 			return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteClassHandle.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteClassHandle.txt
@@ -1,4 +1,4 @@
-	internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("com/mypackage/foo", typeof (foo));
+	internal static readonly JniPeerMembers _members = new JniPeerMembers ("com/mypackage/foo", typeof (foo));
 	internal static IntPtr class_ref {
 		get {
 			return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteClassInvoker.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteClassInvoker.txt
@@ -3,7 +3,7 @@ internal partial class MyClassInvoker : MyClass {
 
 	public MyClassInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
 
-	internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/code/MyClass", typeof (MyClassInvoker));
+	internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/code/MyClass", typeof (MyClassInvoker));
 
 	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 		get { return _members; }

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteClassInvokerHandle.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteClassInvokerHandle.txt
@@ -1,4 +1,4 @@
-internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("com/mypackage/foo", typeof (Com.MyPackage.Foo));
+internal static new readonly JniPeerMembers _members = new JniPeerMembers ("com/mypackage/foo", typeof (Com.MyPackage.Foo));
 
 public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 	get { return _members; }

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterface.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterface.txt
@@ -16,7 +16,7 @@ public abstract class MyInterface : Java.Lang.Object {
 	}
 
 
-	new static JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (MyInterface));
+	static new readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (MyInterface));
 }
 
 [Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
@@ -70,7 +70,7 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 [global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
 
-	internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
+	internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
 
 	static IntPtr java_class_ref {
 		get { return _members.JniPeerType.PeerReference.Handle; }

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterfaceInvoker.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterfaceInvoker.txt
@@ -1,7 +1,7 @@
 [global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
 
-	internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
+	internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
 
 	static IntPtr java_class_ref {
 		get { return _members.JniPeerType.PeerReference.Handle; }

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClass.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClass.txt
@@ -1,0 +1,325 @@
+// Metadata.xml XPath class reference: path="/api/package[@name='java.code']/class[@name='MyClass']"
+[global::Android.Runtime.Register ("java/code/MyClass", DoNotGenerateAcw=true)]
+public partial class MyClass  {
+
+	internal static new readonly JniPeerMembers _members = new XAPeerMembers ("java/code/MyClass", typeof (MyClass));
+	internal static new IntPtr class_ref {
+		get {
+			return _members.JniPeerType.PeerReference.Handle;
+		}
+	}
+
+	protected MyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+	// Metadata.xml XPath constructor reference: path="/api/package[@name='java.code']/class[@name='MyClass']/constructor[@name='MyClass' and count(parameter)=0]"
+	[Register (".ctor", "()V", "")]
+	 unsafe MyClass ()
+		: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+	{
+		const string __id = "()V";
+
+		if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+			return;
+
+		try {
+			var __r = _members.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), null);
+			SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
+			_members.InstanceMethods.FinishCreateInstance (__id, this, null);
+		} finally {
+		}
+	}
+
+	// Metadata.xml XPath constructor reference: path="/api/package[@name='java.code']/class[@name='MyClass']/constructor[@name='MyClass' and count(parameter)=1 and parameter[1][@type='java.lang.String']]"
+	[Register (".ctor", "(Ljava/lang/String;)V", "")]
+	 unsafe MyClass (string p0)
+		: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+	{
+		const string __id = "(Ljava/lang/String;)V";
+
+		if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+			return;
+
+		IntPtr native_p0 = JNIEnv.NewString (p0);
+		try {
+			JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+			__args [0] = new JniArgumentValue (native_p0);
+			var __r = _members.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), __args);
+			SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
+			_members.InstanceMethods.FinishCreateInstance (__id, this, __args);
+		} finally {
+			JNIEnv.DeleteLocalRef (native_p0);
+		}
+	}
+
+	static Delegate cb_get_Count;
+#pragma warning disable 0169
+	static Delegate Getget_CountHandler ()
+	{
+		if (cb_get_Count == null)
+			cb_get_Count = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, int>) n_get_Count);
+		return cb_get_Count;
+	}
+
+	static int n_get_Count (IntPtr jnienv, IntPtr native__this)
+	{
+		java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		return __this.Count;
+	}
+#pragma warning restore 0169
+
+	static Delegate cb_set_Count_I;
+#pragma warning disable 0169
+	static Delegate Getset_Count_IHandler ()
+	{
+		if (cb_set_Count_I == null)
+			cb_set_Count_I = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr, int>) n_set_Count_I);
+		return cb_set_Count_I;
+	}
+
+	static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
+	{
+		java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		__this.Count = value;
+	}
+#pragma warning restore 0169
+
+	public virtual unsafe int Count {
+		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='get_Count' and count(parameter)=0]"
+		[Register ("get_Count", "()I", "Getget_CountHandler")]
+		get {
+			const string __id = "get_Count.()I";
+			try {
+				var __rm = _members.InstanceMethods.InvokeVirtualInt32Method (__id, this, null);
+				return __rm;
+			} finally {
+			}
+		}
+		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='set_Count' and count(parameter)=1 and parameter[1][@type='int']]"
+		[Register ("set_Count", "(I)V", "Getset_Count_IHandler")]
+		set {
+			const string __id = "set_Count.(I)V";
+			try {
+				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+				__args [0] = new JniArgumentValue (value);
+				_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, __args);
+			} finally {
+			}
+		}
+	}
+
+	static Delegate cb_get_Key;
+#pragma warning disable 0169
+	static Delegate Getget_KeyHandler ()
+	{
+		if (cb_get_Key == null)
+			cb_get_Key = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_get_Key);
+		return cb_get_Key;
+	}
+
+	static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
+	{
+		java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		return JNIEnv.NewString (__this.Key);
+	}
+#pragma warning restore 0169
+
+	static Delegate cb_set_Key_Ljava_lang_String_;
+#pragma warning disable 0169
+	static Delegate Getset_Key_Ljava_lang_String_Handler ()
+	{
+		if (cb_set_Key_Ljava_lang_String_ == null)
+			cb_set_Key_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr, IntPtr>) n_set_Key_Ljava_lang_String_);
+		return cb_set_Key_Ljava_lang_String_;
+	}
+
+	static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
+	{
+		java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		string value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
+		__this.Key = value;
+	}
+#pragma warning restore 0169
+
+	public virtual unsafe string Key {
+		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='get_Key' and count(parameter)=0]"
+		[Register ("get_Key", "()Ljava/lang/String;", "Getget_KeyHandler")]
+		get {
+			const string __id = "get_Key.()Ljava/lang/String;";
+			try {
+				var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, null);
+				return JNIEnv.GetString (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+			} finally {
+			}
+		}
+		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='set_Key' and count(parameter)=1 and parameter[1][@type='java.lang.String']]"
+		[Register ("set_Key", "(Ljava/lang/String;)V", "Getset_Key_Ljava_lang_String_Handler")]
+		set {
+			const string __id = "set_Key.(Ljava/lang/String;)V";
+			IntPtr native_value = JNIEnv.NewString (value);
+			try {
+				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+				__args [0] = new JniArgumentValue (native_value);
+				_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, __args);
+			} finally {
+				JNIEnv.DeleteLocalRef (native_value);
+			}
+		}
+	}
+
+	public static unsafe int StaticCount {
+		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='get_StaticCount' and count(parameter)=0]"
+		[Register ("get_StaticCount", "()I", "Getget_StaticCountHandler")]
+		get {
+			const string __id = "get_StaticCount.()I";
+			try {
+				var __rm = _members.StaticMethods.InvokeInt32Method (__id, null);
+				return __rm;
+			} finally {
+			}
+		}
+		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='set_StaticCount' and count(parameter)=1 and parameter[1][@type='int']]"
+		[Register ("set_StaticCount", "(I)V", "Getset_StaticCount_IHandler")]
+		set {
+			const string __id = "set_StaticCount.(I)V";
+			try {
+				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+				__args [0] = new JniArgumentValue (value);
+				_members.StaticMethods.InvokeVoidMethod (__id, __args);
+			} finally {
+			}
+		}
+	}
+
+	static Delegate cb_get_AbstractCount;
+#pragma warning disable 0169
+	static Delegate Getget_AbstractCountHandler ()
+	{
+		if (cb_get_AbstractCount == null)
+			cb_get_AbstractCount = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, int>) n_get_AbstractCount);
+		return cb_get_AbstractCount;
+	}
+
+	static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
+	{
+		java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		return __this.AbstractCount;
+	}
+#pragma warning restore 0169
+
+	static Delegate cb_set_AbstractCount_I;
+#pragma warning disable 0169
+	static Delegate Getset_AbstractCount_IHandler ()
+	{
+		if (cb_set_AbstractCount_I == null)
+			cb_set_AbstractCount_I = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr, int>) n_set_AbstractCount_I);
+		return cb_set_AbstractCount_I;
+	}
+
+	static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
+	{
+		java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		__this.AbstractCount = value;
+	}
+#pragma warning restore 0169
+
+	public abstract int AbstractCount {
+		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='get_AbstractCount' and count(parameter)=0]"
+		[Register ("get_AbstractCount", "()I", "Getget_AbstractCountHandler")] get;
+		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='set_AbstractCount' and count(parameter)=1 and parameter[1][@type='int']]"
+		[Register ("set_AbstractCount", "(I)V", "Getset_AbstractCount_IHandler")] set;
+	}
+
+	static Delegate cb_GetCountForKey_Ljava_lang_String_;
+#pragma warning disable 0169
+	static Delegate GetGetCountForKey_Ljava_lang_String_Handler ()
+	{
+		if (cb_GetCountForKey_Ljava_lang_String_ == null)
+			cb_GetCountForKey_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr, int>) n_GetCountForKey_Ljava_lang_String_);
+		return cb_GetCountForKey_Ljava_lang_String_;
+	}
+
+	static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
+	{
+		java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		string key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
+		int __ret = __this.GetCountForKey (key);
+		return __ret;
+	}
+#pragma warning restore 0169
+
+	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='GetCountForKey' and count(parameter)=1 and parameter[1][@type='java.lang.String']]"
+	[Register ("GetCountForKey", "(Ljava/lang/String;)I", "GetGetCountForKey_Ljava_lang_String_Handler")]
+	public virtual unsafe int GetCountForKey (string key)
+	{
+		const string __id = "GetCountForKey.(Ljava/lang/String;)I";
+		IntPtr native_key = JNIEnv.NewString (key);
+		try {
+			JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+			__args [0] = new JniArgumentValue (native_key);
+			var __rm = _members.InstanceMethods.InvokeVirtualInt32Method (__id, this, __args);
+			return __rm;
+		} finally {
+			JNIEnv.DeleteLocalRef (native_key);
+		}
+	}
+
+	static Delegate cb_Key;
+#pragma warning disable 0169
+	static Delegate GetKeyHandler ()
+	{
+		if (cb_Key == null)
+			cb_Key = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_Key);
+		return cb_Key;
+	}
+
+	static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
+	{
+		java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		return JNIEnv.NewString (__this.Key ());
+	}
+#pragma warning restore 0169
+
+	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='Key' and count(parameter)=0]"
+	[Register ("Key", "()Ljava/lang/String;", "GetKeyHandler")]
+	public virtual unsafe string Key ()
+	{
+		const string __id = "Key.()Ljava/lang/String;";
+		try {
+			var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, null);
+			return JNIEnv.GetString (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+		} finally {
+		}
+	}
+
+	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='StaticMethod' and count(parameter)=0]"
+	[Register ("StaticMethod", "()V", "")]
+	public static unsafe void StaticMethod ()
+	{
+		const string __id = "StaticMethod.()V";
+		try {
+			_members.StaticMethods.InvokeVoidMethod (__id, null);
+		} finally {
+		}
+	}
+
+	static Delegate cb_AbstractMethod;
+#pragma warning disable 0169
+	static Delegate GetAbstractMethodHandler ()
+	{
+		if (cb_AbstractMethod == null)
+			cb_AbstractMethod = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr>) n_AbstractMethod);
+		return cb_AbstractMethod;
+	}
+
+	static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)
+	{
+		java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		__this.AbstractMethod ();
+	}
+#pragma warning restore 0169
+
+	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='AbstractMethod' and count(parameter)=0]"
+	[Register ("AbstractMethod", "()V", "GetAbstractMethodHandler")]
+	public abstract void AbstractMethod ();
+
+}

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClassConstructors.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClassConstructors.txt
@@ -1,0 +1,42 @@
+protected MyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+// Metadata.xml XPath constructor reference: path="/api/package[@name='java.code']/class[@name='MyClass']/constructor[@name='MyClass' and count(parameter)=0]"
+[Register (".ctor", "()V", "")]
+ unsafe MyClass ()
+	: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+{
+	const string __id = "()V";
+
+	if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+		return;
+
+	try {
+		var __r = _members.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), null);
+		SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
+		_members.InstanceMethods.FinishCreateInstance (__id, this, null);
+	} finally {
+	}
+}
+
+// Metadata.xml XPath constructor reference: path="/api/package[@name='java.code']/class[@name='MyClass']/constructor[@name='MyClass' and count(parameter)=1 and parameter[1][@type='java.lang.String']]"
+[Register (".ctor", "(Ljava/lang/String;)V", "")]
+ unsafe MyClass (string p0)
+	: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+{
+	const string __id = "(Ljava/lang/String;)V";
+
+	if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+		return;
+
+	IntPtr native_p0 = JNIEnv.NewString (p0);
+	try {
+		JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+		__args [0] = new JniArgumentValue (native_p0);
+		var __r = _members.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), __args);
+		SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
+		_members.InstanceMethods.FinishCreateInstance (__id, this, __args);
+	} finally {
+		JNIEnv.DeleteLocalRef (native_p0);
+	}
+}
+

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClassHandle.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClassHandle.txt
@@ -1,0 +1,7 @@
+	internal static readonly JniPeerMembers _members = new XAPeerMembers ("com/mypackage/foo", typeof (foo));
+	internal static IntPtr class_ref {
+		get {
+			return _members.JniPeerType.PeerReference.Handle;
+		}
+	}
+

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClassInvoker.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClassInvoker.txt
@@ -1,0 +1,52 @@
+[global::Android.Runtime.Register ("java/code/MyClass", DoNotGenerateAcw=true)]
+internal partial class MyClassInvoker : MyClass {
+
+	public MyClassInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
+
+	internal static new readonly JniPeerMembers _members = new XAPeerMembers ("java/code/MyClass", typeof (MyClassInvoker));
+
+	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+		get { return _members; }
+	}
+
+	protected override global::System.Type ThresholdType {
+		get { return _members.ManagedPeerType; }
+	}
+
+	public override unsafe int AbstractCount {
+		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='get_AbstractCount' and count(parameter)=0]"
+		[Register ("get_AbstractCount", "()I", "Getget_AbstractCountHandler")]
+		get {
+			const string __id = "get_AbstractCount.()I";
+			try {
+				var __rm = _members.InstanceMethods.InvokeAbstractInt32Method (__id, this, null);
+				return __rm;
+			} finally {
+			}
+		}
+		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='set_AbstractCount' and count(parameter)=1 and parameter[1][@type='int']]"
+		[Register ("set_AbstractCount", "(I)V", "Getset_AbstractCount_IHandler")]
+		set {
+			const string __id = "set_AbstractCount.(I)V";
+			try {
+				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+				__args [0] = new JniArgumentValue (value);
+				_members.InstanceMethods.InvokeAbstractVoidMethod (__id, this, __args);
+			} finally {
+			}
+		}
+	}
+
+	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='AbstractMethod' and count(parameter)=0]"
+	[Register ("AbstractMethod", "()V", "GetAbstractMethodHandler")]
+	public override unsafe void AbstractMethod ()
+	{
+		const string __id = "AbstractMethod.()V";
+		try {
+			_members.InstanceMethods.InvokeAbstractVoidMethod (__id, this, null);
+		} finally {
+		}
+	}
+
+}
+

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClassInvokerHandle.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClassInvokerHandle.txt
@@ -1,0 +1,10 @@
+internal static new readonly JniPeerMembers _members = new XAPeerMembers ("com/mypackage/foo", typeof (Com.MyPackage.Foo));
+
+public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+	get { return _members; }
+}
+
+protected override global::System.Type ThresholdType {
+	get { return _members.ManagedPeerType; }
+}
+

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClassInvokerMembers.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClassInvokerMembers.txt
@@ -1,0 +1,35 @@
+public override unsafe int AbstractCount {
+	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='get_AbstractCount' and count(parameter)=0]"
+	[Register ("get_AbstractCount", "()I", "Getget_AbstractCountHandler")]
+	get {
+		const string __id = "get_AbstractCount.()I";
+		try {
+			var __rm = _members.InstanceMethods.InvokeAbstractInt32Method (__id, this, null);
+			return __rm;
+		} finally {
+		}
+	}
+	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='set_AbstractCount' and count(parameter)=1 and parameter[1][@type='int']]"
+	[Register ("set_AbstractCount", "(I)V", "Getset_AbstractCount_IHandler")]
+	set {
+		const string __id = "set_AbstractCount.(I)V";
+		try {
+			JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+			__args [0] = new JniArgumentValue (value);
+			_members.InstanceMethods.InvokeAbstractVoidMethod (__id, this, __args);
+		} finally {
+		}
+	}
+}
+
+// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='AbstractMethod' and count(parameter)=0]"
+[Register ("AbstractMethod", "()V", "GetAbstractMethodHandler")]
+public override unsafe void AbstractMethod ()
+{
+	const string __id = "AbstractMethod.()V";
+	try {
+		_members.InstanceMethods.InvokeAbstractVoidMethod (__id, this, null);
+	} finally {
+	}
+}
+

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClassMethodInvokers.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClassMethodInvokers.txt
@@ -1,0 +1,11 @@
+// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='AbstractMethod' and count(parameter)=0]"
+[Register ("AbstractMethod", "()V", "GetAbstractMethodHandler")]
+public override unsafe void AbstractMethod ()
+{
+	const string __id = "AbstractMethod.()V";
+	try {
+		_members.InstanceMethods.InvokeAbstractVoidMethod (__id, this, null);
+	} finally {
+	}
+}
+

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClassMethodInvokersWithSkips.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClassMethodInvokersWithSkips.txt
@@ -1,0 +1,11 @@
+// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='AbstractMethod' and count(parameter)=0]"
+[Register ("AbstractMethod", "()V", "GetAbstractMethodHandler")]
+public override unsafe void AbstractMethod ()
+{
+	const string __id = "AbstractMethod.()V";
+	try {
+		_members.InstanceMethods.InvokeAbstractVoidMethod (__id, this, null);
+	} finally {
+	}
+}
+

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClassMethods.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClassMethods.txt
@@ -1,0 +1,93 @@
+static Delegate cb_GetCountForKey_Ljava_lang_String_;
+#pragma warning disable 0169
+static Delegate GetGetCountForKey_Ljava_lang_String_Handler ()
+{
+	if (cb_GetCountForKey_Ljava_lang_String_ == null)
+		cb_GetCountForKey_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr, int>) n_GetCountForKey_Ljava_lang_String_);
+	return cb_GetCountForKey_Ljava_lang_String_;
+}
+
+static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
+{
+	java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	string key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
+	int __ret = __this.GetCountForKey (key);
+	return __ret;
+}
+#pragma warning restore 0169
+
+// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='GetCountForKey' and count(parameter)=1 and parameter[1][@type='java.lang.String']]"
+[Register ("GetCountForKey", "(Ljava/lang/String;)I", "GetGetCountForKey_Ljava_lang_String_Handler")]
+public virtual unsafe int GetCountForKey (string key)
+{
+	const string __id = "GetCountForKey.(Ljava/lang/String;)I";
+	IntPtr native_key = JNIEnv.NewString (key);
+	try {
+		JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+		__args [0] = new JniArgumentValue (native_key);
+		var __rm = _members.InstanceMethods.InvokeVirtualInt32Method (__id, this, __args);
+		return __rm;
+	} finally {
+		JNIEnv.DeleteLocalRef (native_key);
+	}
+}
+
+static Delegate cb_Key;
+#pragma warning disable 0169
+static Delegate GetKeyHandler ()
+{
+	if (cb_Key == null)
+		cb_Key = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_Key);
+	return cb_Key;
+}
+
+static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
+{
+	java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	return JNIEnv.NewString (__this.Key ());
+}
+#pragma warning restore 0169
+
+// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='Key' and count(parameter)=0]"
+[Register ("Key", "()Ljava/lang/String;", "GetKeyHandler")]
+public virtual unsafe string Key ()
+{
+	const string __id = "Key.()Ljava/lang/String;";
+	try {
+		var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, null);
+		return JNIEnv.GetString (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+	} finally {
+	}
+}
+
+// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='StaticMethod' and count(parameter)=0]"
+[Register ("StaticMethod", "()V", "")]
+public static unsafe void StaticMethod ()
+{
+	const string __id = "StaticMethod.()V";
+	try {
+		_members.StaticMethods.InvokeVoidMethod (__id, null);
+	} finally {
+	}
+}
+
+static Delegate cb_AbstractMethod;
+#pragma warning disable 0169
+static Delegate GetAbstractMethodHandler ()
+{
+	if (cb_AbstractMethod == null)
+		cb_AbstractMethod = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr>) n_AbstractMethod);
+	return cb_AbstractMethod;
+}
+
+static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)
+{
+	java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	__this.AbstractMethod ();
+}
+#pragma warning restore 0169
+
+// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='AbstractMethod' and count(parameter)=0]"
+[Register ("AbstractMethod", "()V", "GetAbstractMethodHandler")]
+public abstract void AbstractMethod ();
+

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClassProperties.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClassProperties.txt
@@ -1,0 +1,178 @@
+static Delegate cb_get_Count;
+#pragma warning disable 0169
+static Delegate Getget_CountHandler ()
+{
+	if (cb_get_Count == null)
+		cb_get_Count = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, int>) n_get_Count);
+	return cb_get_Count;
+}
+
+static int n_get_Count (IntPtr jnienv, IntPtr native__this)
+{
+	java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	return __this.Count;
+}
+#pragma warning restore 0169
+
+static Delegate cb_set_Count_I;
+#pragma warning disable 0169
+static Delegate Getset_Count_IHandler ()
+{
+	if (cb_set_Count_I == null)
+		cb_set_Count_I = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr, int>) n_set_Count_I);
+	return cb_set_Count_I;
+}
+
+static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
+{
+	java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	__this.Count = value;
+}
+#pragma warning restore 0169
+
+public virtual unsafe int Count {
+	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='get_Count' and count(parameter)=0]"
+	[Register ("get_Count", "()I", "Getget_CountHandler")]
+	get {
+		const string __id = "get_Count.()I";
+		try {
+			var __rm = _members.InstanceMethods.InvokeVirtualInt32Method (__id, this, null);
+			return __rm;
+		} finally {
+		}
+	}
+	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='set_Count' and count(parameter)=1 and parameter[1][@type='int']]"
+	[Register ("set_Count", "(I)V", "Getset_Count_IHandler")]
+	set {
+		const string __id = "set_Count.(I)V";
+		try {
+			JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+			__args [0] = new JniArgumentValue (value);
+			_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, __args);
+		} finally {
+		}
+	}
+}
+
+static Delegate cb_get_Key;
+#pragma warning disable 0169
+static Delegate Getget_KeyHandler ()
+{
+	if (cb_get_Key == null)
+		cb_get_Key = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_get_Key);
+	return cb_get_Key;
+}
+
+static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
+{
+	java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	return JNIEnv.NewString (__this.Key);
+}
+#pragma warning restore 0169
+
+static Delegate cb_set_Key_Ljava_lang_String_;
+#pragma warning disable 0169
+static Delegate Getset_Key_Ljava_lang_String_Handler ()
+{
+	if (cb_set_Key_Ljava_lang_String_ == null)
+		cb_set_Key_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr, IntPtr>) n_set_Key_Ljava_lang_String_);
+	return cb_set_Key_Ljava_lang_String_;
+}
+
+static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
+{
+	java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	string value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
+	__this.Key = value;
+}
+#pragma warning restore 0169
+
+public virtual unsafe string Key {
+	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='get_Key' and count(parameter)=0]"
+	[Register ("get_Key", "()Ljava/lang/String;", "Getget_KeyHandler")]
+	get {
+		const string __id = "get_Key.()Ljava/lang/String;";
+		try {
+			var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, null);
+			return JNIEnv.GetString (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+		} finally {
+		}
+	}
+	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='set_Key' and count(parameter)=1 and parameter[1][@type='java.lang.String']]"
+	[Register ("set_Key", "(Ljava/lang/String;)V", "Getset_Key_Ljava_lang_String_Handler")]
+	set {
+		const string __id = "set_Key.(Ljava/lang/String;)V";
+		IntPtr native_value = JNIEnv.NewString (value);
+		try {
+			JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+			__args [0] = new JniArgumentValue (native_value);
+			_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, __args);
+		} finally {
+			JNIEnv.DeleteLocalRef (native_value);
+		}
+	}
+}
+
+public static unsafe int StaticCount {
+	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='get_StaticCount' and count(parameter)=0]"
+	[Register ("get_StaticCount", "()I", "Getget_StaticCountHandler")]
+	get {
+		const string __id = "get_StaticCount.()I";
+		try {
+			var __rm = _members.StaticMethods.InvokeInt32Method (__id, null);
+			return __rm;
+		} finally {
+		}
+	}
+	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='set_StaticCount' and count(parameter)=1 and parameter[1][@type='int']]"
+	[Register ("set_StaticCount", "(I)V", "Getset_StaticCount_IHandler")]
+	set {
+		const string __id = "set_StaticCount.(I)V";
+		try {
+			JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+			__args [0] = new JniArgumentValue (value);
+			_members.StaticMethods.InvokeVoidMethod (__id, __args);
+		} finally {
+		}
+	}
+}
+
+static Delegate cb_get_AbstractCount;
+#pragma warning disable 0169
+static Delegate Getget_AbstractCountHandler ()
+{
+	if (cb_get_AbstractCount == null)
+		cb_get_AbstractCount = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, int>) n_get_AbstractCount);
+	return cb_get_AbstractCount;
+}
+
+static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
+{
+	java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	return __this.AbstractCount;
+}
+#pragma warning restore 0169
+
+static Delegate cb_set_AbstractCount_I;
+#pragma warning disable 0169
+static Delegate Getset_AbstractCount_IHandler ()
+{
+	if (cb_set_AbstractCount_I == null)
+		cb_set_AbstractCount_I = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr, int>) n_set_AbstractCount_I);
+	return cb_set_AbstractCount_I;
+}
+
+static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
+{
+	java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	__this.AbstractCount = value;
+}
+#pragma warning restore 0169
+
+public abstract int AbstractCount {
+	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='get_AbstractCount' and count(parameter)=0]"
+	[Register ("get_AbstractCount", "()I", "Getget_AbstractCountHandler")] get;
+	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='set_AbstractCount' and count(parameter)=1 and parameter[1][@type='int']]"
+	[Register ("set_AbstractCount", "(I)V", "Getset_AbstractCount_IHandler")] set;
+}
+

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClassPropertyInvokers.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClassPropertyInvokers.txt
@@ -1,0 +1,24 @@
+public override unsafe int AbstractCount {
+	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='get_AbstractCount' and count(parameter)=0]"
+	[Register ("get_AbstractCount", "()I", "Getget_AbstractCountHandler")]
+	get {
+		const string __id = "get_AbstractCount.()I";
+		try {
+			var __rm = _members.InstanceMethods.InvokeAbstractInt32Method (__id, this, null);
+			return __rm;
+		} finally {
+		}
+	}
+	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='set_AbstractCount' and count(parameter)=1 and parameter[1][@type='int']]"
+	[Register ("set_AbstractCount", "(I)V", "Getset_AbstractCount_IHandler")]
+	set {
+		const string __id = "set_AbstractCount.(I)V";
+		try {
+			JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+			__args [0] = new JniArgumentValue (value);
+			_members.InstanceMethods.InvokeAbstractVoidMethod (__id, this, __args);
+		} finally {
+		}
+	}
+}
+

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClassPropertyInvokersWithSkips.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClassPropertyInvokersWithSkips.txt
@@ -1,0 +1,24 @@
+public override unsafe int AbstractCount {
+	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='get_AbstractCount' and count(parameter)=0]"
+	[Register ("get_AbstractCount", "()I", "Getget_AbstractCountHandler")]
+	get {
+		const string __id = "get_AbstractCount.()I";
+		try {
+			var __rm = _members.InstanceMethods.InvokeAbstractInt32Method (__id, this, null);
+			return __rm;
+		} finally {
+		}
+	}
+	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='set_AbstractCount' and count(parameter)=1 and parameter[1][@type='int']]"
+	[Register ("set_AbstractCount", "(I)V", "Getset_AbstractCount_IHandler")]
+	set {
+		const string __id = "set_AbstractCount.(I)V";
+		try {
+			JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+			__args [0] = new JniArgumentValue (value);
+			_members.InstanceMethods.InvokeAbstractVoidMethod (__id, this, __args);
+		} finally {
+		}
+	}
+}
+

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteCtor.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteCtor.txt
@@ -1,0 +1,18 @@
+// Metadata.xml XPath constructor reference: path="/api/package[@name='com.mypackage']/class[@name='foo']/constructor[@name='foo' and count(parameter)=0]"
+[Register (".ctor", "", "")]
+ unsafe Object ()
+	: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+{
+	const string __id = "";
+
+	if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+		return;
+
+	try {
+		var __r = _members.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), null);
+		SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
+		_members.InstanceMethods.FinishCreateInstance (__id, this, null);
+	} finally {
+	}
+}
+

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteCtorDeprecated.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteCtorDeprecated.txt
@@ -1,0 +1,21 @@
+// Metadata.xml XPath constructor reference: path="/api/package[@name='com.mypackage']/class[@name='foo']/constructor[@name='foo' and count(parameter)=0]"
+[Register (".ctor", "", "")]
+[Obsolete (@"This constructor is obsolete")]
+[MyAttribute]
+[global::Android.Runtime.IntDefinition (null, JniField = "xamarin/test/SomeObject.SOME_VALUE")]
+ unsafe Object ()
+	: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+{
+	const string __id = "";
+
+	if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+		return;
+
+	try {
+		var __r = _members.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), null);
+		SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
+		_members.InstanceMethods.FinishCreateInstance (__id, this, null);
+	} finally {
+	}
+}
+

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteCtorWithStringOverload.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteCtorWithStringOverload.txt
@@ -1,0 +1,43 @@
+// Metadata.xml XPath constructor reference: path="/api/package[@name='com.mypackage']/class[@name='foo']/constructor[@name='foo' and count(parameter)=1 and parameter[1][@type='java.lang.CharSequence']]"
+[Register (".ctor", "(Ljava/lang/CharSequence;)V", "")]
+ unsafe Object (Java.Lang.ICharSequence mystring)
+	: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+{
+	const string __id = "(Ljava/lang/CharSequence;)V";
+
+	if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+		return;
+
+	IntPtr native_mystring = CharSequence.ToLocalJniHandle (mystring);
+	try {
+		JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+		__args [0] = new JniArgumentValue (native_mystring);
+		var __r = _members.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), __args);
+		SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
+		_members.InstanceMethods.FinishCreateInstance (__id, this, __args);
+	} finally {
+		JNIEnv.DeleteLocalRef (native_mystring);
+	}
+}
+
+[Register (".ctor", "(Ljava/lang/CharSequence;)V", "")]
+ unsafe Object (string mystring)
+	: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+{
+	const string __id = "(Ljava/lang/CharSequence;)V";
+
+	if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+		return;
+
+	IntPtr native_mystring = CharSequence.ToLocalJniHandle (mystring);
+	try {
+		JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+		__args [0] = new JniArgumentValue (native_mystring);
+		var __r = _members.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), __args);
+		SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
+		_members.InstanceMethods.FinishCreateInstance (__id, this, __args);
+	} finally {
+		JNIEnv.DeleteLocalRef (native_mystring);
+	}
+}
+

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteFieldConstant.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteFieldConstant.txt
@@ -1,0 +1,11 @@
+
+// Metadata.xml XPath field reference: path="/api/package[@name='com.mypackage']/class[@name='foo']/field[@name='bar']"
+[Register ("bar")]
+public static string bar {
+	get {
+		const string __id = "bar.Ljava/lang/String;";
+
+		var __v = _members.StaticFields.GetObjectValue (__id);
+		return JNIEnv.GetString (__v.Handle, JniHandleOwnership.TransferLocalRef);
+	}
+}

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteFieldConstantWithIntValue.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteFieldConstantWithIntValue.txt
@@ -1,0 +1,3 @@
+// Metadata.xml XPath field reference: path="/api/package[@name='com.mypackage']/class[@name='foo']/field[@name='bar']"
+[Register ("bar")]
+public const int bar = (int) 1234;

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteFieldConstantWithStringValue.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteFieldConstantWithStringValue.txt
@@ -1,0 +1,3 @@
+// Metadata.xml XPath field reference: path="/api/package[@name='com.mypackage']/class[@name='foo']/field[@name='bar']"
+[Register ("bar")]
+public const string bar = (string) "hello";

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteFieldGetBody.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteFieldGetBody.txt
@@ -1,0 +1,4 @@
+const string __id = "bar.Ljava/lang/String;";
+
+var __v = _members.InstanceFields.GetObjectValue (__id, this);
+return JNIEnv.GetString (__v.Handle, JniHandleOwnership.TransferLocalRef);

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteFieldInt.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteFieldInt.txt
@@ -1,0 +1,19 @@
+
+// Metadata.xml XPath field reference: path="/api/package[@name='com.mypackage']/class[@name='foo']/field[@name='bar']"
+[Register ("bar")]
+public int bar {
+	get {
+		const string __id = "bar.I";
+
+		var __v = _members.InstanceFields.GetInt32Value (__id, this);
+		return __v;
+	}
+	set {
+		const string __id = "bar.I";
+
+		try {
+			_members.InstanceFields.SetValue (__id, this, value);
+		} finally {
+		}
+	}
+}

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteFieldSetBody.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteFieldSetBody.txt
@@ -1,0 +1,8 @@
+const string __id = "bar.Ljava/lang/String;";
+
+IntPtr native_value = JNIEnv.NewString (value);
+try {
+	_members.InstanceFields.SetValue (__id, this, new JniObjectReference (native_value));
+} finally {
+	JNIEnv.DeleteLocalRef (native_value);
+}

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteFieldString.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteFieldString.txt
@@ -1,0 +1,21 @@
+
+// Metadata.xml XPath field reference: path="/api/package[@name='com.mypackage']/class[@name='foo']/field[@name='bar']"
+[Register ("bar")]
+public string bar {
+	get {
+		const string __id = "bar.Ljava/lang/String;";
+
+		var __v = _members.InstanceFields.GetObjectValue (__id, this);
+		return JNIEnv.GetString (__v.Handle, JniHandleOwnership.TransferLocalRef);
+	}
+	set {
+		const string __id = "bar.Ljava/lang/String;";
+
+		IntPtr native_value = JNIEnv.NewString (value);
+		try {
+			_members.InstanceFields.SetValue (__id, this, new JniObjectReference (native_value));
+		} finally {
+			JNIEnv.DeleteLocalRef (native_value);
+		}
+	}
+}

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterface.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterface.txt
@@ -1,0 +1,351 @@
+[Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
+public abstract class MyInterface : Java.Lang.Object {
+
+	internal MyInterface ()
+	{
+	}
+	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='StaticMethod' and count(parameter)=0]"
+	[Register ("StaticMethod", "()V", "")]
+	public static unsafe void StaticMethod ()
+	{
+		const string __id = "StaticMethod.()V";
+		try {
+			_members.StaticMethods.InvokeVoidMethod (__id, null);
+		} finally {
+		}
+	}
+
+
+	static new readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (MyInterface));
+}
+
+[Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
+[global::System.Obsolete ("Use the 'MyInterface' type. This type will be removed in a future release.")]
+public abstract class MyInterfaceConsts : MyInterface {
+
+	private MyInterfaceConsts ()
+	{
+	}
+}
+
+// Metadata.xml XPath interface reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']"
+[Register ("java/code/IMyInterface", "", "java.code.IMyInterfaceInvoker")]
+public partial interface IMyInterface : IJavaObject, IJavaPeerable {
+
+	int Count {
+		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='get_Count' and count(parameter)=0]"
+		[Register ("get_Count", "()I", "Getget_CountHandler:java.code.IMyInterfaceInvoker, ")] get;
+		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='set_Count' and count(parameter)=1 and parameter[1][@type='int']]"
+		[Register ("set_Count", "(I)V", "Getset_Count_IHandler:java.code.IMyInterfaceInvoker, ")] set;
+	}
+
+	java.lang.String Key {
+		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='get_Key' and count(parameter)=0]"
+		[Register ("get_Key", "()Ljava/lang/String;", "Getget_KeyHandler:java.code.IMyInterfaceInvoker, ")] get;
+		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='set_Key' and count(parameter)=1 and parameter[1][@type='java.lang.String']]"
+		[Register ("set_Key", "(Ljava/lang/String;)V", "Getset_Key_Ljava_lang_String_Handler:java.code.IMyInterfaceInvoker, ")] set;
+	}
+
+	int AbstractCount {
+		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='get_AbstractCount' and count(parameter)=0]"
+		[Register ("get_AbstractCount", "()I", "Getget_AbstractCountHandler:java.code.IMyInterfaceInvoker, ")] get;
+		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='set_AbstractCount' and count(parameter)=1 and parameter[1][@type='int']]"
+		[Register ("set_AbstractCount", "(I)V", "Getset_AbstractCount_IHandler:java.code.IMyInterfaceInvoker, ")] set;
+	}
+
+	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='GetCountForKey' and count(parameter)=1 and parameter[1][@type='java.lang.String']]"
+	[Register ("GetCountForKey", "(Ljava/lang/String;)I", "GetGetCountForKey_Ljava_lang_String_Handler:java.code.IMyInterfaceInvoker, ")]
+	int GetCountForKey (string key);
+
+	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='Key' and count(parameter)=0]"
+	[Register ("Key", "()Ljava/lang/String;", "GetKeyHandler:java.code.IMyInterfaceInvoker, ")]
+	string Key ();
+
+	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='AbstractMethod' and count(parameter)=0]"
+	[Register ("AbstractMethod", "()V", "GetAbstractMethodHandler:java.code.IMyInterfaceInvoker, ")]
+	void AbstractMethod ();
+
+}
+
+[global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
+internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
+
+	internal static new readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
+
+	static IntPtr java_class_ref {
+		get { return _members.JniPeerType.PeerReference.Handle; }
+	}
+
+	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+		get { return _members; }
+	}
+
+	protected override IntPtr ThresholdClass {
+		get { return class_ref; }
+	}
+
+	protected override global::System.Type ThresholdType {
+		get { return _members.ManagedPeerType; }
+	}
+
+	IntPtr class_ref;
+
+	public static IMyInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
+	{
+		return global::Java.Lang.Object.GetObject<IMyInterface> (handle, transfer);
+	}
+
+	static IntPtr Validate (IntPtr handle)
+	{
+		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
+			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
+						JNIEnv.GetClassNameFromInstance (handle), "java.code.IMyInterface"));
+		return handle;
+	}
+
+	protected override void Dispose (bool disposing)
+	{
+		if (this.class_ref != IntPtr.Zero)
+			JNIEnv.DeleteGlobalRef (this.class_ref);
+		this.class_ref = IntPtr.Zero;
+		base.Dispose (disposing);
+	}
+
+	public IMyInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
+	{
+		IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
+		this.class_ref = JNIEnv.NewGlobalRef (local_ref);
+		JNIEnv.DeleteLocalRef (local_ref);
+	}
+
+	static Delegate cb_get_Count;
+#pragma warning disable 0169
+	static Delegate Getget_CountHandler ()
+	{
+		if (cb_get_Count == null)
+			cb_get_Count = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, int>) n_get_Count);
+		return cb_get_Count;
+	}
+
+	static int n_get_Count (IntPtr jnienv, IntPtr native__this)
+	{
+		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		return __this.Count;
+	}
+#pragma warning restore 0169
+
+	static Delegate cb_set_Count_I;
+#pragma warning disable 0169
+	static Delegate Getset_Count_IHandler ()
+	{
+		if (cb_set_Count_I == null)
+			cb_set_Count_I = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr, int>) n_set_Count_I);
+		return cb_set_Count_I;
+	}
+
+	static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
+	{
+		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		__this.Count = value;
+	}
+#pragma warning restore 0169
+
+	IntPtr id_get_Count;
+	IntPtr id_set_Count_I;
+	public unsafe int Count {
+		get {
+			if (id_get_Count == IntPtr.Zero)
+				id_get_Count = JNIEnv.GetMethodID (class_ref, "get_Count", "()I");
+			return JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_get_Count);
+		}
+		set {
+			if (id_set_Count_I == IntPtr.Zero)
+				id_set_Count_I = JNIEnv.GetMethodID (class_ref, "set_Count", "(I)V");
+			JValue* __args = stackalloc JValue [1];
+			__args [0] = new JValue (value);
+			JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_set_Count_I, __args);
+		}
+	}
+
+	static Delegate cb_get_Key;
+#pragma warning disable 0169
+	static Delegate Getget_KeyHandler ()
+	{
+		if (cb_get_Key == null)
+			cb_get_Key = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_get_Key);
+		return cb_get_Key;
+	}
+
+	static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
+	{
+		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		return JNIEnv.NewString (__this.Key);
+	}
+#pragma warning restore 0169
+
+	static Delegate cb_set_Key_Ljava_lang_String_;
+#pragma warning disable 0169
+	static Delegate Getset_Key_Ljava_lang_String_Handler ()
+	{
+		if (cb_set_Key_Ljava_lang_String_ == null)
+			cb_set_Key_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr, IntPtr>) n_set_Key_Ljava_lang_String_);
+		return cb_set_Key_Ljava_lang_String_;
+	}
+
+	static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
+	{
+		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		string value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
+		__this.Key = value;
+	}
+#pragma warning restore 0169
+
+	IntPtr id_get_Key;
+	IntPtr id_set_Key_Ljava_lang_String_;
+	public unsafe string Key {
+		get {
+			if (id_get_Key == IntPtr.Zero)
+				id_get_Key = JNIEnv.GetMethodID (class_ref, "get_Key", "()Ljava/lang/String;");
+			return JNIEnv.GetString (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_get_Key), JniHandleOwnership.TransferLocalRef);
+		}
+		set {
+			if (id_set_Key_Ljava_lang_String_ == IntPtr.Zero)
+				id_set_Key_Ljava_lang_String_ = JNIEnv.GetMethodID (class_ref, "set_Key", "(Ljava/lang/String;)V");
+			IntPtr native_value = JNIEnv.NewString (value);
+			JValue* __args = stackalloc JValue [1];
+			__args [0] = new JValue (native_value);
+			JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_set_Key_Ljava_lang_String_, __args);
+			JNIEnv.DeleteLocalRef (native_value);
+		}
+	}
+
+	static Delegate cb_get_AbstractCount;
+#pragma warning disable 0169
+	static Delegate Getget_AbstractCountHandler ()
+	{
+		if (cb_get_AbstractCount == null)
+			cb_get_AbstractCount = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, int>) n_get_AbstractCount);
+		return cb_get_AbstractCount;
+	}
+
+	static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
+	{
+		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		return __this.AbstractCount;
+	}
+#pragma warning restore 0169
+
+	static Delegate cb_set_AbstractCount_I;
+#pragma warning disable 0169
+	static Delegate Getset_AbstractCount_IHandler ()
+	{
+		if (cb_set_AbstractCount_I == null)
+			cb_set_AbstractCount_I = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr, int>) n_set_AbstractCount_I);
+		return cb_set_AbstractCount_I;
+	}
+
+	static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
+	{
+		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		__this.AbstractCount = value;
+	}
+#pragma warning restore 0169
+
+	IntPtr id_get_AbstractCount;
+	IntPtr id_set_AbstractCount_I;
+	public unsafe int AbstractCount {
+		get {
+			if (id_get_AbstractCount == IntPtr.Zero)
+				id_get_AbstractCount = JNIEnv.GetMethodID (class_ref, "get_AbstractCount", "()I");
+			return JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_get_AbstractCount);
+		}
+		set {
+			if (id_set_AbstractCount_I == IntPtr.Zero)
+				id_set_AbstractCount_I = JNIEnv.GetMethodID (class_ref, "set_AbstractCount", "(I)V");
+			JValue* __args = stackalloc JValue [1];
+			__args [0] = new JValue (value);
+			JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_set_AbstractCount_I, __args);
+		}
+	}
+
+	static Delegate cb_GetCountForKey_Ljava_lang_String_;
+#pragma warning disable 0169
+	static Delegate GetGetCountForKey_Ljava_lang_String_Handler ()
+	{
+		if (cb_GetCountForKey_Ljava_lang_String_ == null)
+			cb_GetCountForKey_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr, int>) n_GetCountForKey_Ljava_lang_String_);
+		return cb_GetCountForKey_Ljava_lang_String_;
+	}
+
+	static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
+	{
+		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		string key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
+		int __ret = __this.GetCountForKey (key);
+		return __ret;
+	}
+#pragma warning restore 0169
+
+	IntPtr id_GetCountForKey_Ljava_lang_String_;
+	public unsafe int GetCountForKey (string key)
+	{
+		if (id_GetCountForKey_Ljava_lang_String_ == IntPtr.Zero)
+			id_GetCountForKey_Ljava_lang_String_ = JNIEnv.GetMethodID (class_ref, "GetCountForKey", "(Ljava/lang/String;)I");
+		IntPtr native_key = JNIEnv.NewString (key);
+		JValue* __args = stackalloc JValue [1];
+		__args [0] = new JValue (native_key);
+		int __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_GetCountForKey_Ljava_lang_String_, __args);
+		JNIEnv.DeleteLocalRef (native_key);
+		return __ret;
+	}
+
+	static Delegate cb_Key;
+#pragma warning disable 0169
+	static Delegate GetKeyHandler ()
+	{
+		if (cb_Key == null)
+			cb_Key = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_Key);
+		return cb_Key;
+	}
+
+	static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
+	{
+		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		return JNIEnv.NewString (__this.Key ());
+	}
+#pragma warning restore 0169
+
+	IntPtr id_Key;
+	public unsafe string Key ()
+	{
+		if (id_Key == IntPtr.Zero)
+			id_Key = JNIEnv.GetMethodID (class_ref, "Key", "()Ljava/lang/String;");
+		return JNIEnv.GetString (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_Key), JniHandleOwnership.TransferLocalRef);
+	}
+
+	static Delegate cb_AbstractMethod;
+#pragma warning disable 0169
+	static Delegate GetAbstractMethodHandler ()
+	{
+		if (cb_AbstractMethod == null)
+			cb_AbstractMethod = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr>) n_AbstractMethod);
+		return cb_AbstractMethod;
+	}
+
+	static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)
+	{
+		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		__this.AbstractMethod ();
+	}
+#pragma warning restore 0169
+
+	IntPtr id_AbstractMethod;
+	public unsafe void AbstractMethod ()
+	{
+		if (id_AbstractMethod == IntPtr.Zero)
+			id_AbstractMethod = JNIEnv.GetMethodID (class_ref, "AbstractMethod", "()V");
+		JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_AbstractMethod);
+	}
+
+}
+

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDeclaration.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDeclaration.txt
@@ -1,0 +1,39 @@
+// Metadata.xml XPath interface reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']"
+[Register ("java/code/IMyInterface", "", "java.code.IMyInterfaceInvoker")]
+public partial interface IMyInterface : IJavaObject, IJavaPeerable {
+
+	int Count {
+		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='get_Count' and count(parameter)=0]"
+		[Register ("get_Count", "()I", "Getget_CountHandler:java.code.IMyInterfaceInvoker, ")] get;
+		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='set_Count' and count(parameter)=1 and parameter[1][@type='int']]"
+		[Register ("set_Count", "(I)V", "Getset_Count_IHandler:java.code.IMyInterfaceInvoker, ")] set;
+	}
+
+	java.lang.String Key {
+		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='get_Key' and count(parameter)=0]"
+		[Register ("get_Key", "()Ljava/lang/String;", "Getget_KeyHandler:java.code.IMyInterfaceInvoker, ")] get;
+		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='set_Key' and count(parameter)=1 and parameter[1][@type='java.lang.String']]"
+		[Register ("set_Key", "(Ljava/lang/String;)V", "Getset_Key_Ljava_lang_String_Handler:java.code.IMyInterfaceInvoker, ")] set;
+	}
+
+	int AbstractCount {
+		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='get_AbstractCount' and count(parameter)=0]"
+		[Register ("get_AbstractCount", "()I", "Getget_AbstractCountHandler:java.code.IMyInterfaceInvoker, ")] get;
+		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='set_AbstractCount' and count(parameter)=1 and parameter[1][@type='int']]"
+		[Register ("set_AbstractCount", "(I)V", "Getset_AbstractCount_IHandler:java.code.IMyInterfaceInvoker, ")] set;
+	}
+
+	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='GetCountForKey' and count(parameter)=1 and parameter[1][@type='java.lang.String']]"
+	[Register ("GetCountForKey", "(Ljava/lang/String;)I", "GetGetCountForKey_Ljava_lang_String_Handler:java.code.IMyInterfaceInvoker, ")]
+	int GetCountForKey (string key);
+
+	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='Key' and count(parameter)=0]"
+	[Register ("Key", "()Ljava/lang/String;", "GetKeyHandler:java.code.IMyInterfaceInvoker, ")]
+	string Key ();
+
+	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='AbstractMethod' and count(parameter)=0]"
+	[Register ("AbstractMethod", "()V", "GetAbstractMethodHandler:java.code.IMyInterfaceInvoker, ")]
+	void AbstractMethod ();
+
+}
+

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceInvoker.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceInvoker.txt
@@ -1,0 +1,282 @@
+[global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
+internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
+
+	internal static new readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
+
+	static IntPtr java_class_ref {
+		get { return _members.JniPeerType.PeerReference.Handle; }
+	}
+
+	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+		get { return _members; }
+	}
+
+	protected override IntPtr ThresholdClass {
+		get { return class_ref; }
+	}
+
+	protected override global::System.Type ThresholdType {
+		get { return _members.ManagedPeerType; }
+	}
+
+	IntPtr class_ref;
+
+	public static IMyInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
+	{
+		return global::Java.Lang.Object.GetObject<IMyInterface> (handle, transfer);
+	}
+
+	static IntPtr Validate (IntPtr handle)
+	{
+		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
+			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
+						JNIEnv.GetClassNameFromInstance (handle), "java.code.IMyInterface"));
+		return handle;
+	}
+
+	protected override void Dispose (bool disposing)
+	{
+		if (this.class_ref != IntPtr.Zero)
+			JNIEnv.DeleteGlobalRef (this.class_ref);
+		this.class_ref = IntPtr.Zero;
+		base.Dispose (disposing);
+	}
+
+	public IMyInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
+	{
+		IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
+		this.class_ref = JNIEnv.NewGlobalRef (local_ref);
+		JNIEnv.DeleteLocalRef (local_ref);
+	}
+
+	static Delegate cb_get_Count;
+#pragma warning disable 0169
+	static Delegate Getget_CountHandler ()
+	{
+		if (cb_get_Count == null)
+			cb_get_Count = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, int>) n_get_Count);
+		return cb_get_Count;
+	}
+
+	static int n_get_Count (IntPtr jnienv, IntPtr native__this)
+	{
+		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		return __this.Count;
+	}
+#pragma warning restore 0169
+
+	static Delegate cb_set_Count_I;
+#pragma warning disable 0169
+	static Delegate Getset_Count_IHandler ()
+	{
+		if (cb_set_Count_I == null)
+			cb_set_Count_I = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr, int>) n_set_Count_I);
+		return cb_set_Count_I;
+	}
+
+	static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
+	{
+		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		__this.Count = value;
+	}
+#pragma warning restore 0169
+
+	IntPtr id_get_Count;
+	IntPtr id_set_Count_I;
+	public unsafe int Count {
+		get {
+			if (id_get_Count == IntPtr.Zero)
+				id_get_Count = JNIEnv.GetMethodID (class_ref, "get_Count", "()I");
+			return JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_get_Count);
+		}
+		set {
+			if (id_set_Count_I == IntPtr.Zero)
+				id_set_Count_I = JNIEnv.GetMethodID (class_ref, "set_Count", "(I)V");
+			JValue* __args = stackalloc JValue [1];
+			__args [0] = new JValue (value);
+			JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_set_Count_I, __args);
+		}
+	}
+
+	static Delegate cb_get_Key;
+#pragma warning disable 0169
+	static Delegate Getget_KeyHandler ()
+	{
+		if (cb_get_Key == null)
+			cb_get_Key = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_get_Key);
+		return cb_get_Key;
+	}
+
+	static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
+	{
+		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		return JNIEnv.NewString (__this.Key);
+	}
+#pragma warning restore 0169
+
+	static Delegate cb_set_Key_Ljava_lang_String_;
+#pragma warning disable 0169
+	static Delegate Getset_Key_Ljava_lang_String_Handler ()
+	{
+		if (cb_set_Key_Ljava_lang_String_ == null)
+			cb_set_Key_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr, IntPtr>) n_set_Key_Ljava_lang_String_);
+		return cb_set_Key_Ljava_lang_String_;
+	}
+
+	static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
+	{
+		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		string value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
+		__this.Key = value;
+	}
+#pragma warning restore 0169
+
+	IntPtr id_get_Key;
+	IntPtr id_set_Key_Ljava_lang_String_;
+	public unsafe string Key {
+		get {
+			if (id_get_Key == IntPtr.Zero)
+				id_get_Key = JNIEnv.GetMethodID (class_ref, "get_Key", "()Ljava/lang/String;");
+			return JNIEnv.GetString (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_get_Key), JniHandleOwnership.TransferLocalRef);
+		}
+		set {
+			if (id_set_Key_Ljava_lang_String_ == IntPtr.Zero)
+				id_set_Key_Ljava_lang_String_ = JNIEnv.GetMethodID (class_ref, "set_Key", "(Ljava/lang/String;)V");
+			IntPtr native_value = JNIEnv.NewString (value);
+			JValue* __args = stackalloc JValue [1];
+			__args [0] = new JValue (native_value);
+			JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_set_Key_Ljava_lang_String_, __args);
+			JNIEnv.DeleteLocalRef (native_value);
+		}
+	}
+
+	static Delegate cb_get_AbstractCount;
+#pragma warning disable 0169
+	static Delegate Getget_AbstractCountHandler ()
+	{
+		if (cb_get_AbstractCount == null)
+			cb_get_AbstractCount = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, int>) n_get_AbstractCount);
+		return cb_get_AbstractCount;
+	}
+
+	static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
+	{
+		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		return __this.AbstractCount;
+	}
+#pragma warning restore 0169
+
+	static Delegate cb_set_AbstractCount_I;
+#pragma warning disable 0169
+	static Delegate Getset_AbstractCount_IHandler ()
+	{
+		if (cb_set_AbstractCount_I == null)
+			cb_set_AbstractCount_I = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr, int>) n_set_AbstractCount_I);
+		return cb_set_AbstractCount_I;
+	}
+
+	static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
+	{
+		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		__this.AbstractCount = value;
+	}
+#pragma warning restore 0169
+
+	IntPtr id_get_AbstractCount;
+	IntPtr id_set_AbstractCount_I;
+	public unsafe int AbstractCount {
+		get {
+			if (id_get_AbstractCount == IntPtr.Zero)
+				id_get_AbstractCount = JNIEnv.GetMethodID (class_ref, "get_AbstractCount", "()I");
+			return JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_get_AbstractCount);
+		}
+		set {
+			if (id_set_AbstractCount_I == IntPtr.Zero)
+				id_set_AbstractCount_I = JNIEnv.GetMethodID (class_ref, "set_AbstractCount", "(I)V");
+			JValue* __args = stackalloc JValue [1];
+			__args [0] = new JValue (value);
+			JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_set_AbstractCount_I, __args);
+		}
+	}
+
+	static Delegate cb_GetCountForKey_Ljava_lang_String_;
+#pragma warning disable 0169
+	static Delegate GetGetCountForKey_Ljava_lang_String_Handler ()
+	{
+		if (cb_GetCountForKey_Ljava_lang_String_ == null)
+			cb_GetCountForKey_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr, int>) n_GetCountForKey_Ljava_lang_String_);
+		return cb_GetCountForKey_Ljava_lang_String_;
+	}
+
+	static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
+	{
+		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		string key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
+		int __ret = __this.GetCountForKey (key);
+		return __ret;
+	}
+#pragma warning restore 0169
+
+	IntPtr id_GetCountForKey_Ljava_lang_String_;
+	public unsafe int GetCountForKey (string key)
+	{
+		if (id_GetCountForKey_Ljava_lang_String_ == IntPtr.Zero)
+			id_GetCountForKey_Ljava_lang_String_ = JNIEnv.GetMethodID (class_ref, "GetCountForKey", "(Ljava/lang/String;)I");
+		IntPtr native_key = JNIEnv.NewString (key);
+		JValue* __args = stackalloc JValue [1];
+		__args [0] = new JValue (native_key);
+		int __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_GetCountForKey_Ljava_lang_String_, __args);
+		JNIEnv.DeleteLocalRef (native_key);
+		return __ret;
+	}
+
+	static Delegate cb_Key;
+#pragma warning disable 0169
+	static Delegate GetKeyHandler ()
+	{
+		if (cb_Key == null)
+			cb_Key = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_Key);
+		return cb_Key;
+	}
+
+	static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
+	{
+		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		return JNIEnv.NewString (__this.Key ());
+	}
+#pragma warning restore 0169
+
+	IntPtr id_Key;
+	public unsafe string Key ()
+	{
+		if (id_Key == IntPtr.Zero)
+			id_Key = JNIEnv.GetMethodID (class_ref, "Key", "()Ljava/lang/String;");
+		return JNIEnv.GetString (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_Key), JniHandleOwnership.TransferLocalRef);
+	}
+
+	static Delegate cb_AbstractMethod;
+#pragma warning disable 0169
+	static Delegate GetAbstractMethodHandler ()
+	{
+		if (cb_AbstractMethod == null)
+			cb_AbstractMethod = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr>) n_AbstractMethod);
+		return cb_AbstractMethod;
+	}
+
+	static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)
+	{
+		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		__this.AbstractMethod ();
+	}
+#pragma warning restore 0169
+
+	IntPtr id_AbstractMethod;
+	public unsafe void AbstractMethod ()
+	{
+		if (id_AbstractMethod == IntPtr.Zero)
+			id_AbstractMethod = JNIEnv.GetMethodID (class_ref, "AbstractMethod", "()V");
+		JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_AbstractMethod);
+	}
+
+}
+

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodAbstractWithVoidReturn.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodAbstractWithVoidReturn.txt
@@ -1,0 +1,27 @@
+static Delegate cb_bar;
+#pragma warning disable 0169
+static Delegate GetbarHandler ()
+{
+	if (cb_bar == null)
+		cb_bar = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr>) n_bar);
+	return cb_bar;
+}
+
+static void n_bar (IntPtr jnienv, IntPtr native__this)
+{
+	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	__this.bar ();
+}
+#pragma warning restore 0169
+
+// Metadata.xml XPath method reference: path="/api/package[@name='com.mypackage']/class[@name='foo']/method[@name='bar' and count(parameter)=0]"
+[Register ("bar", "()V", "GetbarHandler")]
+public virtual unsafe void bar ()
+{
+	const string __id = "bar.()V";
+	try {
+		_members.InstanceMethods.InvokeAbstractVoidMethod (__id, this, null);
+	} finally {
+	}
+}
+

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodAsyncifiedWithIntReturn.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodAsyncifiedWithIntReturn.txt
@@ -1,0 +1,33 @@
+static Delegate cb_bar;
+#pragma warning disable 0169
+static Delegate GetbarHandler ()
+{
+	if (cb_bar == null)
+		cb_bar = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, int>) n_bar);
+	return cb_bar;
+}
+
+static int n_bar (IntPtr jnienv, IntPtr native__this)
+{
+	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	return __this.bar ();
+}
+#pragma warning restore 0169
+
+// Metadata.xml XPath method reference: path="/api/package[@name='com.mypackage']/class[@name='foo']/method[@name='bar' and count(parameter)=0]"
+[Register ("bar", "()I", "GetbarHandler")]
+public virtual unsafe int bar ()
+{
+	const string __id = "bar.()I";
+	try {
+		var __rm = _members.InstanceMethods.InvokeVirtualInt32Method (__id, this, null);
+		return __rm;
+	} finally {
+	}
+}
+
+public global::System.Threading.Tasks.Task<int> barAsync ()
+{
+	return global::System.Threading.Tasks.Task.Run (() => bar ());
+}
+

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodAsyncifiedWithVoidReturn.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodAsyncifiedWithVoidReturn.txt
@@ -1,0 +1,32 @@
+static Delegate cb_bar;
+#pragma warning disable 0169
+static Delegate GetbarHandler ()
+{
+	if (cb_bar == null)
+		cb_bar = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr>) n_bar);
+	return cb_bar;
+}
+
+static void n_bar (IntPtr jnienv, IntPtr native__this)
+{
+	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	__this.bar ();
+}
+#pragma warning restore 0169
+
+// Metadata.xml XPath method reference: path="/api/package[@name='com.mypackage']/class[@name='foo']/method[@name='bar' and count(parameter)=0]"
+[Register ("bar", "()V", "GetbarHandler")]
+public virtual unsafe void bar ()
+{
+	const string __id = "bar.()V";
+	try {
+		_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, null);
+	} finally {
+	}
+}
+
+public global::System.Threading.Tasks.Task barAsync ()
+{
+	return global::System.Threading.Tasks.Task.Run (() => bar ());
+}
+

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodBody.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodBody.txt
@@ -1,0 +1,5 @@
+const string __id = "bar.()V";
+try {
+	_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, null);
+} finally {
+}

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodFinalWithVoidReturn.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodFinalWithVoidReturn.txt
@@ -1,0 +1,11 @@
+// Metadata.xml XPath method reference: path="/api/package[@name='com.mypackage']/class[@name='foo']/method[@name='bar' and count(parameter)=0]"
+[Register ("bar", "()V", "")]
+public unsafe void bar ()
+{
+	const string __id = "bar.()V";
+	try {
+		_members.InstanceMethods.InvokeNonvirtualVoidMethod (__id, this, null);
+	} finally {
+	}
+}
+

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodProtected.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodProtected.txt
@@ -1,0 +1,27 @@
+static Delegate cb_bar;
+#pragma warning disable 0169
+static Delegate GetbarHandler ()
+{
+	if (cb_bar == null)
+		cb_bar = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr>) n_bar);
+	return cb_bar;
+}
+
+static void n_bar (IntPtr jnienv, IntPtr native__this)
+{
+	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	__this.bar ();
+}
+#pragma warning restore 0169
+
+// Metadata.xml XPath method reference: path="/api/package[@name='com.mypackage']/class[@name='foo']/method[@name='bar' and count(parameter)=0]"
+[Register ("bar", "()V", "GetbarHandler")]
+protected virtual unsafe void bar ()
+{
+	const string __id = "bar.()V";
+	try {
+		_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, null);
+	} finally {
+	}
+}
+

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodStaticWithVoidReturn.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodStaticWithVoidReturn.txt
@@ -1,0 +1,11 @@
+// Metadata.xml XPath method reference: path="/api/package[@name='com.mypackage']/class[@name='foo']/method[@name='bar' and count(parameter)=0]"
+[Register ("bar", "()V", "")]
+public static unsafe void bar ()
+{
+	const string __id = "bar.()V";
+	try {
+		_members.StaticMethods.InvokeVoidMethod (__id, null);
+	} finally {
+	}
+}
+

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodWithIntReturn.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodWithIntReturn.txt
@@ -1,0 +1,28 @@
+static Delegate cb_bar;
+#pragma warning disable 0169
+static Delegate GetbarHandler ()
+{
+	if (cb_bar == null)
+		cb_bar = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, int>) n_bar);
+	return cb_bar;
+}
+
+static int n_bar (IntPtr jnienv, IntPtr native__this)
+{
+	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	return __this.bar ();
+}
+#pragma warning restore 0169
+
+// Metadata.xml XPath method reference: path="/api/package[@name='com.mypackage']/class[@name='foo']/method[@name='bar' and count(parameter)=0]"
+[Register ("bar", "()I", "GetbarHandler")]
+public virtual unsafe int bar ()
+{
+	const string __id = "bar.()I";
+	try {
+		var __rm = _members.InstanceMethods.InvokeVirtualInt32Method (__id, this, null);
+		return __rm;
+	} finally {
+	}
+}
+

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodWithStringReturn.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodWithStringReturn.txt
@@ -1,0 +1,28 @@
+static Delegate cb_bar;
+#pragma warning disable 0169
+static Delegate GetbarHandler ()
+{
+	if (cb_bar == null)
+		cb_bar = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, IntPtr>) n_bar);
+	return cb_bar;
+}
+
+static IntPtr n_bar (IntPtr jnienv, IntPtr native__this)
+{
+	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	return JNIEnv.NewString (__this.bar ());
+}
+#pragma warning restore 0169
+
+// Metadata.xml XPath method reference: path="/api/package[@name='com.mypackage']/class[@name='foo']/method[@name='bar' and count(parameter)=0]"
+[Register ("bar", "()Ljava/lang/String;", "GetbarHandler")]
+public virtual unsafe string bar ()
+{
+	const string __id = "bar.()Ljava/lang/String;";
+	try {
+		var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, null);
+		return JNIEnv.GetString (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+	} finally {
+	}
+}
+

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodWithVoidReturn.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodWithVoidReturn.txt
@@ -1,0 +1,27 @@
+static Delegate cb_bar;
+#pragma warning disable 0169
+static Delegate GetbarHandler ()
+{
+	if (cb_bar == null)
+		cb_bar = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr>) n_bar);
+	return cb_bar;
+}
+
+static void n_bar (IntPtr jnienv, IntPtr native__this)
+{
+	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	__this.bar ();
+}
+#pragma warning restore 0169
+
+// Metadata.xml XPath method reference: path="/api/package[@name='com.mypackage']/class[@name='foo']/method[@name='bar' and count(parameter)=0]"
+[Register ("bar", "()V", "GetbarHandler")]
+public virtual unsafe void bar ()
+{
+	const string __id = "bar.()V";
+	try {
+		_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, null);
+	} finally {
+	}
+}
+

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteParameterListCallArgs.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteParameterListCallArgs.txt
@@ -1,0 +1,4 @@
+JniArgumentValue* __args = stackalloc JniArgumentValue [3];
+__args [0] = new JniArgumentValue (value);
+__args [1] = new JniArgumentValue (native_str);
+__args [2] = new JniArgumentValue (flag);

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteParameterListCallArgsForInvoker.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteParameterListCallArgsForInvoker.txt
@@ -1,0 +1,4 @@
+JValue* __args = stackalloc JValue [3];
+__args [0] = new JValue (value);
+__args [1] = new JValue (native_str);
+__args [2] = new JValue (flag);

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteProperty.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteProperty.txt
@@ -1,0 +1,56 @@
+static Delegate cb_get_MyProperty;
+#pragma warning disable 0169
+static Delegate Getget_MyPropertyHandler ()
+{
+	if (cb_get_MyProperty == null)
+		cb_get_MyProperty = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, int>) n_get_MyProperty);
+	return cb_get_MyProperty;
+}
+
+static int n_get_MyProperty (IntPtr jnienv, IntPtr native__this)
+{
+	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	return __this.MyProperty;
+}
+#pragma warning restore 0169
+
+static Delegate cb_set_MyProperty_I;
+#pragma warning disable 0169
+static Delegate Getset_MyProperty_IHandler ()
+{
+	if (cb_set_MyProperty_I == null)
+		cb_set_MyProperty_I = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr, int>) n_set_MyProperty_I);
+	return cb_set_MyProperty_I;
+}
+
+static void n_set_MyProperty_I (IntPtr jnienv, IntPtr native__this, int value)
+{
+	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	__this.MyProperty = value;
+}
+#pragma warning restore 0169
+
+public virtual unsafe int MyProperty {
+	// Metadata.xml XPath method reference: path="/api/package[@name='com.mypackage']/class[@name='foo']/method[@name='get_MyProperty' and count(parameter)=0]"
+	[Register ("get_MyProperty", "()I", "Getget_MyPropertyHandler")]
+	get {
+		const string __id = "get_MyProperty.()I";
+		try {
+			var __rm = _members.InstanceMethods.InvokeVirtualInt32Method (__id, this, null);
+			return __rm;
+		} finally {
+		}
+	}
+	// Metadata.xml XPath method reference: path="/api/package[@name='com.mypackage']/class[@name='foo']/method[@name='set_MyProperty' and count(parameter)=1 and parameter[1][@type='int']]"
+	[Register ("set_MyProperty", "(I)V", "Getset_MyProperty_IHandler")]
+	set {
+		const string __id = "set_MyProperty.(I)V";
+		try {
+			JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+			__args [0] = new JniArgumentValue (value);
+			_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, __args);
+		} finally {
+		}
+	}
+}
+

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorTestBase.cs
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorTestBase.cs
@@ -5,7 +5,7 @@ using System.Text;
 using MonoDroid.Generation;
 using NUnit.Framework;
 
-namespace generatortests.Unit_Tests
+namespace generatortests
 {
 	abstract class CodeGeneratorTestBase
 	{

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorTests.cs
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using generatortests.Unit_Tests;
 using MonoDroid.Generation;
 using NUnit.Framework;
 using Xamarin.Android.Binder;
@@ -12,6 +11,12 @@ namespace generatortests
 	class JavaInteropCodeGeneratorTests : CodeGeneratorTests
 	{
 		protected override CodeGenerationTarget Target => CodeGenerationTarget.JavaInterop1;
+	}
+
+	[TestFixture]
+	class XAJavaInteropCodeGeneratorTests : CodeGeneratorTests
+	{
+		protected override CodeGenerationTarget Target => CodeGenerationTarget.XAJavaInterop1;
 	}
 
 	[TestFixture]

--- a/tools/generator/Tests/Unit-Tests/DefaultInterfaceMethodsTests.cs
+++ b/tools/generator/Tests/Unit-Tests/DefaultInterfaceMethodsTests.cs
@@ -1,5 +1,4 @@
 using System;
-using generatortests.Unit_Tests;
 using MonoDroid.Generation;
 using NUnit.Framework;
 

--- a/tools/generator/Tests/Unit-Tests/EnumGeneratorTests.cs
+++ b/tools/generator/Tests/Unit-Tests/EnumGeneratorTests.cs
@@ -7,7 +7,7 @@ using MonoDroid.Generation;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
 
-namespace generatortests.Unit_Tests
+namespace generatortests
 {
 	[TestFixture]
 	class EnumGeneratorTests

--- a/tools/generator/Tests/Unit-Tests/TestExtensions.cs
+++ b/tools/generator/Tests/Unit-Tests/TestExtensions.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace generatortests.Unit_Tests
+namespace generatortests
 {
 	static class TestExtensions
 	{

--- a/tools/generator/Tests/expected.ji/AccessModifiers/Xamarin.Test.BasePublicClass.cs
+++ b/tools/generator/Tests/expected.ji/AccessModifiers/Xamarin.Test.BasePublicClass.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/BasePublicClass", DoNotGenerateAcw=true)]
 	public partial class BasePublicClass : global::Java.Lang.Object {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/BasePublicClass", typeof (BasePublicClass));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/BasePublicClass", typeof (BasePublicClass));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/AccessModifiers/Xamarin.Test.ExtendPublicClass.cs
+++ b/tools/generator/Tests/expected.ji/AccessModifiers/Xamarin.Test.ExtendPublicClass.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/ExtendPublicClass", DoNotGenerateAcw=true)]
 	public partial class ExtendPublicClass : global::Java.Lang.Object {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/ExtendPublicClass", typeof (ExtendPublicClass));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/ExtendPublicClass", typeof (ExtendPublicClass));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/AccessModifiers/Xamarin.Test.PublicClass.cs
+++ b/tools/generator/Tests/expected.ji/AccessModifiers/Xamarin.Test.PublicClass.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/PublicClass", DoNotGenerateAcw=true)]
 	public partial class PublicClass : global::Java.Lang.Object {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/PublicClass", typeof (PublicClass));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/PublicClass", typeof (PublicClass));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/AccessModifiers/Xamarin.Test.PublicFinalClass.cs
+++ b/tools/generator/Tests/expected.ji/AccessModifiers/Xamarin.Test.PublicFinalClass.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/PublicFinalClass", DoNotGenerateAcw=true)]
 	public sealed partial class PublicFinalClass : global::Xamarin.Test.BasePublicClass {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/PublicFinalClass", typeof (PublicFinalClass));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/PublicFinalClass", typeof (PublicFinalClass));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/Adapters/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/Adapters/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/Adapters/Xamarin.Test.AbsSpinner.cs
+++ b/tools/generator/Tests/expected.ji/Adapters/Xamarin.Test.AbsSpinner.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/AbsSpinner", DoNotGenerateAcw=true)]
 	public abstract partial class AbsSpinner : Xamarin.Test.AdapterView<Xamarin.Test.ISpinnerAdapter> {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/AbsSpinner", typeof (AbsSpinner));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/AbsSpinner", typeof (AbsSpinner));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
@@ -94,7 +94,7 @@ namespace Xamarin.Test {
 
 		public AbsSpinnerInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/AbsSpinner", typeof (AbsSpinnerInvoker));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/AbsSpinner", typeof (AbsSpinnerInvoker));
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 			get { return _members; }

--- a/tools/generator/Tests/expected.ji/Adapters/Xamarin.Test.AdapterView.cs
+++ b/tools/generator/Tests/expected.ji/Adapters/Xamarin.Test.AdapterView.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Test {
 	[global::Java.Interop.JavaTypeParameters (new string [] {"T extends xamarin.test.Adapter"})]
 	public abstract partial class AdapterView : global::Java.Lang.Object {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/AdapterView", typeof (AdapterView));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/AdapterView", typeof (AdapterView));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
@@ -78,7 +78,7 @@ namespace Xamarin.Test {
 
 		public AdapterViewInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/AdapterView", typeof (AdapterViewInvoker));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/AdapterView", typeof (AdapterViewInvoker));
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 			get { return _members; }

--- a/tools/generator/Tests/expected.ji/Adapters/Xamarin.Test.GenericReturnObject.cs
+++ b/tools/generator/Tests/expected.ji/Adapters/Xamarin.Test.GenericReturnObject.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/GenericReturnObject", DoNotGenerateAcw=true)]
 	public partial class GenericReturnObject : global::Java.Lang.Object {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/GenericReturnObject", typeof (GenericReturnObject));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/GenericReturnObject", typeof (GenericReturnObject));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/Adapters/Xamarin.Test.IAdapter.cs
+++ b/tools/generator/Tests/expected.ji/Adapters/Xamarin.Test.IAdapter.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/Adapter", DoNotGenerateAcw=true)]
 	internal partial class IAdapterInvoker : global::Java.Lang.Object, IAdapter {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/Adapter", typeof (IAdapterInvoker));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/Adapter", typeof (IAdapterInvoker));
 
 		static IntPtr java_class_ref {
 			get { return _members.JniPeerType.PeerReference.Handle; }

--- a/tools/generator/Tests/expected.ji/Adapters/Xamarin.Test.ISpinnerAdapter.cs
+++ b/tools/generator/Tests/expected.ji/Adapters/Xamarin.Test.ISpinnerAdapter.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/SpinnerAdapter", DoNotGenerateAcw=true)]
 	internal partial class ISpinnerAdapterInvoker : global::Java.Lang.Object, ISpinnerAdapter {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SpinnerAdapter", typeof (ISpinnerAdapterInvoker));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SpinnerAdapter", typeof (ISpinnerAdapterInvoker));
 
 		static IntPtr java_class_ref {
 			get { return _members.JniPeerType.PeerReference.Handle; }

--- a/tools/generator/Tests/expected.ji/Android.Graphics.Color/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/Android.Graphics.Color/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/Android.Graphics.Color/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected.ji/Android.Graphics.Color/Xamarin.Test.SomeObject.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Test {
 				}
 			}
 		}
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
@@ -97,7 +97,7 @@ namespace Xamarin.Test {
 
 		public SomeObjectInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObjectInvoker));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObjectInvoker));
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 			get { return _members; }

--- a/tools/generator/Tests/expected.ji/Arrays/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/Arrays/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/Arrays/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected.ji/Arrays/Xamarin.Test.SomeObject.cs
@@ -163,7 +163,7 @@ namespace Xamarin.Test {
 				}
 			}
 		}
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/CSharpKeywords/Xamarin.Test.CSharpKeywords.cs
+++ b/tools/generator/Tests/expected.ji/CSharpKeywords/Xamarin.Test.CSharpKeywords.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/CSharpKeywords", DoNotGenerateAcw=true)]
 	public partial class CSharpKeywords : global::Java.Lang.Object {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/CSharpKeywords", typeof (CSharpKeywords));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/CSharpKeywords", typeof (CSharpKeywords));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/Constructors/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/Constructors/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/Constructors/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected.ji/Constructors/Xamarin.Test.SomeObject.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public partial class SomeObject : global::Java.Lang.Object {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/GenericArguments/Com.Google.Android.Exoplayer.Drm.FrameworkMediaDrm.cs
+++ b/tools/generator/Tests/expected.ji/GenericArguments/Com.Google.Android.Exoplayer.Drm.FrameworkMediaDrm.cs
@@ -9,7 +9,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 	[global::Android.Runtime.Register ("com/google/android/exoplayer/drm/FrameworkMediaDrm", DoNotGenerateAcw=true)]
 	public sealed partial class FrameworkMediaDrm : global::Java.Lang.Object, global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("com/google/android/exoplayer/drm/FrameworkMediaDrm", typeof (FrameworkMediaDrm));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("com/google/android/exoplayer/drm/FrameworkMediaDrm", typeof (FrameworkMediaDrm));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
+++ b/tools/generator/Tests/expected.ji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
@@ -19,7 +19,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 	[global::Android.Runtime.Register ("com/google/android/exoplayer/drm/ExoMediaDrm$OnEventListener", DoNotGenerateAcw=true)]
 	internal partial class IExoMediaDrmOnEventListenerInvoker : global::Java.Lang.Object, IExoMediaDrmOnEventListener {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("com/google/android/exoplayer/drm/ExoMediaDrm$OnEventListener", typeof (IExoMediaDrmOnEventListenerInvoker));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("com/google/android/exoplayer/drm/ExoMediaDrm$OnEventListener", typeof (IExoMediaDrmOnEventListenerInvoker));
 
 		static IntPtr java_class_ref {
 			get { return _members.JniPeerType.PeerReference.Handle; }
@@ -200,7 +200,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 	[global::Android.Runtime.Register ("com/google/android/exoplayer/drm/ExoMediaDrm", DoNotGenerateAcw=true)]
 	internal partial class IExoMediaDrmInvoker : global::Java.Lang.Object, IExoMediaDrm {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("com/google/android/exoplayer/drm/ExoMediaDrm", typeof (IExoMediaDrmInvoker));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("com/google/android/exoplayer/drm/ExoMediaDrm", typeof (IExoMediaDrmInvoker));
 
 		static IntPtr java_class_ref {
 			get { return _members.JniPeerType.PeerReference.Handle; }

--- a/tools/generator/Tests/expected.ji/GenericArguments/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/GenericArguments/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.II1.cs
+++ b/tools/generator/Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.II1.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/I1", DoNotGenerateAcw=true)]
 	internal partial class II1Invoker : global::Java.Lang.Object, II1 {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/I1", typeof (II1Invoker));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/I1", typeof (II1Invoker));
 
 		static IntPtr java_class_ref {
 			get { return _members.JniPeerType.PeerReference.Handle; }

--- a/tools/generator/Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.II2.cs
+++ b/tools/generator/Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.II2.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/I2", DoNotGenerateAcw=true)]
 	internal partial class II2Invoker : global::Java.Lang.Object, II2 {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/I2", typeof (II2Invoker));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/I2", typeof (II2Invoker));
 
 		static IntPtr java_class_ref {
 			get { return _members.JniPeerType.PeerReference.Handle; }

--- a/tools/generator/Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.SomeObject.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public partial class SomeObject : global::Java.Lang.Object, global::Xamarin.Test.II1, global::Xamarin.Test.II2 {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.SomeObject2.cs
+++ b/tools/generator/Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.SomeObject2.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject2", DoNotGenerateAcw=true)]
 	public abstract partial class SomeObject2 : global::Java.Lang.Object, global::Xamarin.Test.II1, global::Xamarin.Test.II2 {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject2", typeof (SomeObject2));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject2", typeof (SomeObject2));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
@@ -84,7 +84,7 @@ namespace Xamarin.Test {
 
 		public SomeObject2Invoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject2", typeof (SomeObject2Invoker));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject2", typeof (SomeObject2Invoker));
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 			get { return _members; }

--- a/tools/generator/Tests/expected.ji/NestedTypes/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/NestedTypes/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
+++ b/tools/generator/Tests/expected.ji/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Test {
 			[global::Android.Runtime.Register ("xamarin/test/NotificationCompatBase$Action$Factory", DoNotGenerateAcw=true)]
 			internal partial class IFactoryInvoker : global::Java.Lang.Object, IFactory {
 
-				internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/NotificationCompatBase$Action$Factory", typeof (IFactoryInvoker));
+				internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/NotificationCompatBase$Action$Factory", typeof (IFactoryInvoker));
 
 				static IntPtr java_class_ref {
 					get { return _members.JniPeerType.PeerReference.Handle; }
@@ -103,7 +103,7 @@ namespace Xamarin.Test {
 			}
 
 
-			internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/NotificationCompatBase$Action", typeof (Action));
+			internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/NotificationCompatBase$Action", typeof (Action));
 			internal static new IntPtr class_ref {
 				get {
 					return _members.JniPeerType.PeerReference.Handle;
@@ -131,7 +131,7 @@ namespace Xamarin.Test {
 
 			public ActionInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
 
-			internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/NotificationCompatBase$Action", typeof (ActionInvoker));
+			internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/NotificationCompatBase$Action", typeof (ActionInvoker));
 
 			public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 				get { return _members; }
@@ -148,7 +148,7 @@ namespace Xamarin.Test {
 		[global::Android.Runtime.Register ("xamarin/test/NotificationCompatBase$InstanceInner", DoNotGenerateAcw=true)]
 		public abstract partial class InstanceInner : global::Java.Lang.Object {
 
-			internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/NotificationCompatBase$InstanceInner", typeof (InstanceInner));
+			internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/NotificationCompatBase$InstanceInner", typeof (InstanceInner));
 			internal static new IntPtr class_ref {
 				get {
 					return _members.JniPeerType.PeerReference.Handle;
@@ -196,7 +196,7 @@ namespace Xamarin.Test {
 
 			public InstanceInnerInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
 
-			internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/NotificationCompatBase$InstanceInner", typeof (InstanceInnerInvoker));
+			internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/NotificationCompatBase$InstanceInner", typeof (InstanceInnerInvoker));
 
 			public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 				get { return _members; }
@@ -209,7 +209,7 @@ namespace Xamarin.Test {
 		}
 
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/NotificationCompatBase", typeof (NotificationCompatBase));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/NotificationCompatBase", typeof (NotificationCompatBase));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/NonStaticFields/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/NonStaticFields/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/NonStaticFields/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected.ji/NonStaticFields/Xamarin.Test.SomeObject.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Test {
 				}
 			}
 		}
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/NormalMethods/Java.Lang.Class.cs
+++ b/tools/generator/Tests/expected.ji/NormalMethods/Java.Lang.Class.cs
@@ -10,7 +10,7 @@ namespace Java.Lang {
 	[global::Java.Interop.JavaTypeParameters (new string [] {"T"})]
 	public partial class Class : global::Java.Lang.Object {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Class", typeof (Class));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Class", typeof (Class));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/NormalMethods/Java.Lang.Integer.cs
+++ b/tools/generator/Tests/expected.ji/NormalMethods/Java.Lang.Integer.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Integer", DoNotGenerateAcw=true)]
 	public partial class Integer : global::Java.Lang.Object {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Integer", typeof (Integer));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Integer", typeof (Integer));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/NormalMethods/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/NormalMethods/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/NormalMethods/Java.Lang.Throwable.cs
+++ b/tools/generator/Tests/expected.ji/NormalMethods/Java.Lang.Throwable.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Throwable", DoNotGenerateAcw=true)]
 	public partial class Throwable  {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Throwable", typeof (Throwable));
+		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Throwable", typeof (Throwable));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/NormalMethods/Xamarin.Test.A.cs
+++ b/tools/generator/Tests/expected.ji/NormalMethods/Xamarin.Test.A.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Test {
 		[global::Java.Interop.JavaTypeParameters (new string [] {"T extends xamarin.test.A.B"})]
 		public partial class B : global::Java.Lang.Object {
 
-			internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/A$B", typeof (B));
+			internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/A$B", typeof (B));
 			internal static new IntPtr class_ref {
 				get {
 					return _members.JniPeerType.PeerReference.Handle;
@@ -67,7 +67,7 @@ namespace Xamarin.Test {
 
 		}
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/A", typeof (A));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/A", typeof (A));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/NormalMethods/Xamarin.Test.C.cs
+++ b/tools/generator/Tests/expected.ji/NormalMethods/Xamarin.Test.C.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Test {
 	[global::Java.Interop.JavaTypeParameters (new string [] {"T extends xamarin.test.C"})]
 	public partial class C : global::Java.Lang.Object {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/C", typeof (C));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/C", typeof (C));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/NormalMethods/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected.ji/NormalMethods/Xamarin.Test.SomeObject.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public partial class SomeObject : global::Java.Lang.Object {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/NormalProperties/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/NormalProperties/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/NormalProperties/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected.ji/NormalProperties/Xamarin.Test.SomeObject.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public abstract partial class SomeObject : global::Java.Lang.Object {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
@@ -156,7 +156,7 @@ namespace Xamarin.Test {
 
 		public SomeObjectInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObjectInvoker));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObjectInvoker));
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 			get { return _members; }

--- a/tools/generator/Tests/expected.ji/ParameterXPath/Java.Lang.Integer.cs
+++ b/tools/generator/Tests/expected.ji/ParameterXPath/Java.Lang.Integer.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Integer", DoNotGenerateAcw=true)]
 	public partial class Integer : global::Java.Lang.Object {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Integer", typeof (Integer));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Integer", typeof (Integer));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/ParameterXPath/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/ParameterXPath/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/ParameterXPath/Xamarin.Test.A.cs
+++ b/tools/generator/Tests/expected.ji/ParameterXPath/Xamarin.Test.A.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Test {
 	[global::Java.Interop.JavaTypeParameters (new string [] {"T extends java.lang.Object"})]
 	public partial class A : global::Java.Lang.Object {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/A", typeof (A));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/A", typeof (A));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/StaticFields/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/StaticFields/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/StaticFields/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected.ji/StaticFields/Xamarin.Test.SomeObject.cs
@@ -41,7 +41,7 @@ namespace Xamarin.Test {
 				}
 			}
 		}
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/StaticMethods/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/StaticMethods/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/StaticMethods/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected.ji/StaticMethods/Xamarin.Test.SomeObject.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public partial class SomeObject : global::Java.Lang.Object {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/StaticProperties/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/StaticProperties/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/StaticProperties/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected.ji/StaticProperties/Xamarin.Test.SomeObject.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public partial class SomeObject : global::Java.Lang.Object {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/Streams/Java.IO.FilterOutputStream.cs
+++ b/tools/generator/Tests/expected.ji/Streams/Java.IO.FilterOutputStream.cs
@@ -9,7 +9,7 @@ namespace Java.IO {
 	[global::Android.Runtime.Register ("java/io/FilterOutputStream", DoNotGenerateAcw=true)]
 	public partial class FilterOutputStream : global::Java.IO.OutputStream {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/io/FilterOutputStream", typeof (FilterOutputStream));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/io/FilterOutputStream", typeof (FilterOutputStream));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/Streams/Java.IO.IOException.cs
+++ b/tools/generator/Tests/expected.ji/Streams/Java.IO.IOException.cs
@@ -9,7 +9,7 @@ namespace Java.IO {
 	[global::Android.Runtime.Register ("java/io/IOException", DoNotGenerateAcw=true)]
 	public abstract partial class IOException : global::Java.Lang.Throwable {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/io/IOException", typeof (IOException));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/io/IOException", typeof (IOException));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
@@ -64,7 +64,7 @@ namespace Java.IO {
 
 		public IOExceptionInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/io/IOException", typeof (IOExceptionInvoker));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/io/IOException", typeof (IOExceptionInvoker));
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 			get { return _members; }

--- a/tools/generator/Tests/expected.ji/Streams/Java.IO.InputStream.cs
+++ b/tools/generator/Tests/expected.ji/Streams/Java.IO.InputStream.cs
@@ -9,7 +9,7 @@ namespace Java.IO {
 	[global::Android.Runtime.Register ("java/io/InputStream", DoNotGenerateAcw=true)]
 	public abstract partial class InputStream : global::Java.Lang.Object {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/io/InputStream", typeof (InputStream));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/io/InputStream", typeof (InputStream));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
@@ -324,7 +324,7 @@ namespace Java.IO {
 
 		public InputStreamInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/io/InputStream", typeof (InputStreamInvoker));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/io/InputStream", typeof (InputStreamInvoker));
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 			get { return _members; }

--- a/tools/generator/Tests/expected.ji/Streams/Java.IO.OutputStream.cs
+++ b/tools/generator/Tests/expected.ji/Streams/Java.IO.OutputStream.cs
@@ -9,7 +9,7 @@ namespace Java.IO {
 	[global::Android.Runtime.Register ("java/io/OutputStream", DoNotGenerateAcw=true)]
 	public abstract partial class OutputStream : global::Java.Lang.Object {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/io/OutputStream", typeof (OutputStream));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/io/OutputStream", typeof (OutputStream));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
@@ -205,7 +205,7 @@ namespace Java.IO {
 
 		public OutputStreamInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/io/OutputStream", typeof (OutputStreamInvoker));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/io/OutputStream", typeof (OutputStreamInvoker));
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 			get { return _members; }

--- a/tools/generator/Tests/expected.ji/Streams/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/Streams/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/Streams/Java.Lang.Throwable.cs
+++ b/tools/generator/Tests/expected.ji/Streams/Java.Lang.Throwable.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Throwable", DoNotGenerateAcw=true)]
 	public partial class Throwable  {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Throwable", typeof (Throwable));
+		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Throwable", typeof (Throwable));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/TestInterface/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/TestInterface/Java.Lang.String.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Java.Lang.String.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/String", DoNotGenerateAcw=true)]
 	public sealed partial class String : global::Java.Lang.Object {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/String", typeof (String));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/String", typeof (String));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/TestInterface/Test.ME.GenericImplementation.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Test.ME.GenericImplementation.cs
@@ -9,7 +9,7 @@ namespace Test.ME {
 	[global::Android.Runtime.Register ("test/me/GenericImplementation", DoNotGenerateAcw=true)]
 	public partial class GenericImplementation : global::Java.Lang.Object, global::Test.ME.IGenericInterface {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("test/me/GenericImplementation", typeof (GenericImplementation));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("test/me/GenericImplementation", typeof (GenericImplementation));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/TestInterface/Test.ME.GenericObjectPropertyImplementation.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Test.ME.GenericObjectPropertyImplementation.cs
@@ -9,7 +9,7 @@ namespace Test.ME {
 	[global::Android.Runtime.Register ("test/me/GenericObjectPropertyImplementation", DoNotGenerateAcw=true)]
 	public partial class GenericObjectPropertyImplementation : global::Java.Lang.Object, global::Test.ME.IGenericPropertyInterface {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("test/me/GenericObjectPropertyImplementation", typeof (GenericObjectPropertyImplementation));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("test/me/GenericObjectPropertyImplementation", typeof (GenericObjectPropertyImplementation));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/TestInterface/Test.ME.GenericStringImplementation.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Test.ME.GenericStringImplementation.cs
@@ -9,7 +9,7 @@ namespace Test.ME {
 	[global::Android.Runtime.Register ("test/me/GenericStringImplementation", DoNotGenerateAcw=true)]
 	public partial class GenericStringImplementation : global::Java.Lang.Object, global::Test.ME.IGenericInterface {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("test/me/GenericStringImplementation", typeof (GenericStringImplementation));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("test/me/GenericStringImplementation", typeof (GenericStringImplementation));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/TestInterface/Test.ME.GenericStringPropertyImplementation.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Test.ME.GenericStringPropertyImplementation.cs
@@ -9,7 +9,7 @@ namespace Test.ME {
 	[global::Android.Runtime.Register ("test/me/GenericStringPropertyImplementation", DoNotGenerateAcw=true)]
 	public partial class GenericStringPropertyImplementation : global::Java.Lang.Object, global::Test.ME.IGenericPropertyInterface {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("test/me/GenericStringPropertyImplementation", typeof (GenericStringPropertyImplementation));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("test/me/GenericStringPropertyImplementation", typeof (GenericStringPropertyImplementation));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/TestInterface/Test.ME.IGenericInterface.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Test.ME.IGenericInterface.cs
@@ -19,7 +19,7 @@ namespace Test.ME {
 	[global::Android.Runtime.Register ("test/me/GenericInterface", DoNotGenerateAcw=true)]
 	internal partial class IGenericInterfaceInvoker : global::Java.Lang.Object, IGenericInterface {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("test/me/GenericInterface", typeof (IGenericInterfaceInvoker));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("test/me/GenericInterface", typeof (IGenericInterfaceInvoker));
 
 		static IntPtr java_class_ref {
 			get { return _members.JniPeerType.PeerReference.Handle; }

--- a/tools/generator/Tests/expected.ji/TestInterface/Test.ME.IGenericPropertyInterface.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Test.ME.IGenericPropertyInterface.cs
@@ -22,7 +22,7 @@ namespace Test.ME {
 	[global::Android.Runtime.Register ("test/me/GenericPropertyInterface", DoNotGenerateAcw=true)]
 	internal partial class IGenericPropertyInterfaceInvoker : global::Java.Lang.Object, IGenericPropertyInterface {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("test/me/GenericPropertyInterface", typeof (IGenericPropertyInterfaceInvoker));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("test/me/GenericPropertyInterface", typeof (IGenericPropertyInterfaceInvoker));
 
 		static IntPtr java_class_ref {
 			get { return _members.JniPeerType.PeerReference.Handle; }

--- a/tools/generator/Tests/expected.ji/TestInterface/Test.ME.ITestInterface.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Test.ME.ITestInterface.cs
@@ -28,7 +28,7 @@ namespace Test.ME {
 			}
 		}
 
-		new static JniPeerMembers _members = new JniPeerMembers ("test/me/TestInterface", typeof (TestInterface));
+		static new readonly JniPeerMembers _members = new JniPeerMembers ("test/me/TestInterface", typeof (TestInterface));
 	}
 
 	[Register ("test/me/TestInterface", DoNotGenerateAcw=true)]
@@ -80,7 +80,7 @@ namespace Test.ME {
 	[global::Android.Runtime.Register ("test/me/TestInterface", DoNotGenerateAcw=true)]
 	internal partial class ITestInterfaceInvoker : global::Java.Lang.Object, ITestInterface {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("test/me/TestInterface", typeof (ITestInterfaceInvoker));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("test/me/TestInterface", typeof (ITestInterfaceInvoker));
 
 		static IntPtr java_class_ref {
 			get { return _members.JniPeerType.PeerReference.Handle; }

--- a/tools/generator/Tests/expected.ji/TestInterface/Test.ME.TestInterfaceImplementation.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Test.ME.TestInterfaceImplementation.cs
@@ -31,7 +31,7 @@ namespace Test.ME {
 			}
 		}
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("test/me/TestInterfaceImplementation", typeof (TestInterfaceImplementation));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("test/me/TestInterfaceImplementation", typeof (TestInterfaceImplementation));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
@@ -158,7 +158,7 @@ namespace Test.ME {
 
 		public TestInterfaceImplementationInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("test/me/TestInterfaceImplementation", typeof (TestInterfaceImplementationInvoker));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("test/me/TestInterfaceImplementation", typeof (TestInterfaceImplementationInvoker));
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 			get { return _members; }

--- a/tools/generator/Tests/expected.ji/java.lang.Enum/Java.Lang.Enum.cs
+++ b/tools/generator/Tests/expected.ji/java.lang.Enum/Java.Lang.Enum.cs
@@ -10,7 +10,7 @@ namespace Java.Lang {
 	[global::Java.Interop.JavaTypeParameters (new string [] {"E extends java.lang.Enum<E>"})]
 	public abstract partial class Enum : global::Java.Lang.Object, global::Java.Lang.IComparable {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Enum", typeof (Enum));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Enum", typeof (Enum));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
@@ -54,7 +54,7 @@ namespace Java.Lang {
 
 		public EnumInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Enum", typeof (EnumInvoker));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Enum", typeof (EnumInvoker));
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 			get { return _members; }

--- a/tools/generator/Tests/expected.ji/java.lang.Enum/Java.Lang.IComparable.cs
+++ b/tools/generator/Tests/expected.ji/java.lang.Enum/Java.Lang.IComparable.cs
@@ -19,7 +19,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Comparable", DoNotGenerateAcw=true)]
 	internal partial class IComparableInvoker : global::Java.Lang.Object, IComparable {
 
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Comparable", typeof (IComparableInvoker));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Comparable", typeof (IComparableInvoker));
 
 		static IntPtr java_class_ref {
 			get { return _members.JniPeerType.PeerReference.Handle; }

--- a/tools/generator/Tests/expected.ji/java.lang.Enum/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/java.lang.Enum/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/java.lang.Enum/Java.Lang.State.cs
+++ b/tools/generator/Tests/expected.ji/java.lang.Enum/Java.Lang.State.cs
@@ -81,7 +81,7 @@ namespace Java.Lang {
 				return global::Java.Lang.Object.GetObject<global::Java.Lang.State> (__v.Handle, JniHandleOwnership.TransferLocalRef);
 			}
 		}
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/State", typeof (State));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/State", typeof (State));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/java.lang.Object/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/java.lang.Object/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/java.util.List/Java.Lang.Object.cs
+++ b/tools/generator/Tests/expected.ji/java.util.List/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal            static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/expected.ji/java.util.List/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected.ji/java.util.List/Xamarin.Test.SomeObject.cs
@@ -163,7 +163,7 @@ namespace Xamarin.Test {
 				}
 			}
 		}
-		internal    new     static  readonly    JniPeerMembers  _members    = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Tests/generator-Tests.csproj
+++ b/tools/generator/Tests/generator-Tests.csproj
@@ -278,6 +278,126 @@
     <Content Include="Unit-Tests\CodeGeneratorExpectedResults\JavaInterop1\WriteMethodWithVoidReturn.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteClass.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteClassConstructors.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteClassHandle.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteClassInvoker.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteClassInvokerHandle.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteClassInvokerMembers.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteClassMethodInvokers.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteClassMethodInvokersWithSkips.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteClassMethods.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteClassProperties.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteClassPropertyInvokers.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteClassPropertyInvokersWithSkips.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteCtor.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteCtorDeprecated.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteCtorWithStringOverload.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteFieldConstant.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteFieldConstantWithIntValue.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteFieldConstantWithStringValue.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteFieldGetBody.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteFieldIdField.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteFieldInt.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteFieldSetBody.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteFieldString.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteInterface.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteInterfaceDeclaration.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteInterfaceInvoker.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteMethodAbstractWithVoidReturn.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteMethodAsyncifiedWithIntReturn.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteMethodAsyncifiedWithVoidReturn.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteMethodBody.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteMethodFinalWithVoidReturn.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteMethodIdField.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteMethodProtected.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteMethodStaticWithVoidReturn.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteMethodWithIntReturn.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteMethodWithStringReturn.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteMethodWithVoidReturn.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteParameterListCallArgs.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteParameterListCallArgsForInvoker.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteProperty.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XamarinAndroid\WriteClass.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
Broken out of #341.

When generating the `_members` field for `XAJavaInterop1`, in one instance we generate:
```
... static JniPeerMembers _members = new XAPeerMembers ("android/text/foo", typeof (ISpannableInvoker));
```
while in the 3 other instances we generate:
```
... static JniPeerMembers _members = new JniPeerMembers ("android/text/foo", typeof (ISpannableInvoker));
```
This refactors all the instances of writing this line to a single method which correctly uses `XAPeerMembers` when needed.