### PR TITLE
Generator changes to support api level 29 and fixes to support extended events

### DIFF
--- a/build-tools/xamarin-android-docimporter-ng/generate.sh
+++ b/build-tools/xamarin-android-docimporter-ng/generate.sh
@@ -3,7 +3,7 @@
 ANDROID_TOOLCHAIN=~/android-toolchain
 
 DROID_DOC_API_LEVELS="10 15 16 17 18 19 20 21 22 23"
-JAVA_STUB_API_LEVELS="24 25 26 27 28 Q"
+JAVA_STUB_API_LEVELS="24 25 26 27 28 29"
 
 
 for n in $JAVA_STUB_API_LEVELS
@@ -15,4 +15,3 @@ for API_LEVEL in $DROID_DOC_API_LEVELS
 do
 	time mono --debug xamarin-android-docimporter-ng/bin/Debug/xamarin-android-docimporter-ng.exe -droiddoc=$ANDROID_TOOLCHAIN/docs/docs-api-$API_LEVEL/ -output-text=api-$API_LEVEL.params.txt -output-xml=api-$API_LEVEL.params.xml -verbose -framework-only
 done
-

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Method.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Method.cs
@@ -64,7 +64,8 @@ namespace MonoDroid.Generation
 
 		public bool CanAdd {
 			get {
-				return Name.Length > 3 && Name.StartsWith ("Add") && Name.EndsWith ("Listener") && Parameters.Count == 1 && IsVoid &&
+				return Name.Length > 3 && Name.StartsWith ("Add") && Name.EndsWith ("Listener") &&  IsVoid &&
+					(Parameters.Count == 1 || (Parameters.Count == 2 && Parameters [1].Type == "Android.OS.Handler")) &&
 					!(Parameters [0].IsArray);
 			}
 		}

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteInterfaceListenerEventWithHandlerArgument.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteInterfaceListenerEventWithHandlerArgument.txt
@@ -1,0 +1,22 @@
+public event MyFullDelegateName MyName {
+	add {
+		global::Java.Interop.EventHelper.AddEventHandler<java.code.IMyInterface, java.code.IMyInterfaceImplementor>(
+				ref weak_implementor_MyWrefSuffix,
+				__CreateIMyInterfaceImplementor,
+				AddMyName_Event_With_Handler_Helper,
+				__h => __h.MyNameSpecHandler += value);
+	}
+	remove {
+		global::Java.Interop.EventHelper.RemoveEventHandler<java.code.IMyInterface, java.code.IMyInterfaceImplementor>(
+				ref weak_implementor_MyWrefSuffix,
+				java.code.IMyInterfaceImplementor.__IsEmpty,
+				RemoveMyName,
+				__h => __h.MyNameSpecHandler -= value);
+	}
+}
+
+void AddMyName_Event_With_Handler_Helper (java.code.IMyInterface value)
+{
+	AddMyName (value, null);
+}
+

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorTests.cs
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorTests.cs
@@ -529,6 +529,18 @@ namespace generatortests
 		}
 
 		[Test]
+		public void WriteInterfaceListenerEventWithHandlerArgument ()
+		{
+			var iface = SupportTypeBuilder.CreateInterface ("java.code.IMyInterface", options);
+
+			generator.Context.ContextTypes.Push (iface);
+			generator.WriteInterfaceListenerEvent (iface, string.Empty, "MyName", "MyNameSpec", "MyMethodName", "MyFullDelegateName", true, "MyWrefSuffix", "AddMyName", "RemoveMyName", true);
+			generator.Context.ContextTypes.Pop ();
+
+			Assert.AreEqual (GetExpected (nameof (WriteInterfaceListenerEventWithHandlerArgument)), writer.ToString ().NormalizeLineEndings ());
+		}
+
+		[Test]
 		public void WriteInterfaceListenerProperty ()
 		{
 			var iface = SupportTypeBuilder.CreateInterface ("java.code.IMyInterface", options);

--- a/tools/generator/Tests/generator-Tests.csproj
+++ b/tools/generator/Tests/generator-Tests.csproj
@@ -503,6 +503,9 @@
     <Content Include="Unit-Tests\CodeGeneratorExpectedResults\Common\WriteInterfaceListenerEvent.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\Common\WriteInterfaceListenerEventWithHandlerArgument.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Unit-Tests\CodeGeneratorExpectedResults\Common\WriteInterfaceListenerProperty.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
On these changes: 

- Update generate.sh script to include Api 29
- During "on boarding" of api 29, we found a bug on the generator where Event handlers are not generate if the java methods contains handler argument as second argument.
The fix is to allow/consider methods with the second argument named handler and add a helper method that will always pass null as the handler internally. This will avoid that we manually add this support for all events matching this criteria.

here is an example of how the event handler will look like:
```
public event EventHandler<Android.Media.AudioRoutingOnRoutingChangedEventArgs> RoutingChanged {
	add {
		global::Java.Interop.EventHelper.AddEventHandler<Android.Media.IAudioRoutingOnRoutingChangedListener, Android.Media.IAudioRoutingOnRoutingChangedListenerImplementor>(
				ref weak_implementor_AddOnRoutingChangedListener,
				__CreateIAudioRoutingOnRoutingChangedListenerImplementor,
				AddOnRoutingChangedListener_Event_With_Handler_Helper,
				__h => __h.Handler += value);
	}
	remove {
		global::Java.Interop.EventHelper.RemoveEventHandler<Android.Media.IAudioRoutingOnRoutingChangedListener, Android.Media.IAudioRoutingOnRoutingChangedListenerImplementor>(
				ref weak_implementor_AddOnRoutingChangedListener,
				Android.Media.IAudioRoutingOnRoutingChangedListenerImplementor.__IsEmpty,
				__v => RemoveOnRoutingChangedListener (__v),
				__h => __h.Handler -= value);
	}
}

void AddOnRoutingChangedListener_Event_With_Handler_Helper (Android.Media.IAudioRoutingOnRoutingChangedListener value)
{
	AddOnRoutingChangedListener (value, null);
}
```