### PR TITLE
Bumped cecil to mono/cecil@cb6c1ca 

### DIFF
--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/MethodDefinitionRocks.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/MethodDefinitionRocks.cs
@@ -110,7 +110,7 @@ namespace Java.Interop.Tools.Cecil {
 					return true;
 				var gpa = (GenericParameter) a;
 				foreach (var c in gpa.Constraints) {
-					if (!c.IsAssignableFrom (b))
+					if (!c.ConstraintType.IsAssignableFrom (b))
 						return false;
 				}
 				return true;

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenericParameterDefinition.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenericParameterDefinition.cs
@@ -72,7 +72,7 @@ namespace MonoDroid.Generation
 				ret.Add (new GenericParameterDefinition (
 					p.FullNameCorrected (),
 					(from a in p.Constraints
-					 select a.FullNameCorrected ()).ToArray ()));
+					 select a.ConstraintType.FullNameCorrected ()).ToArray ()));
 			}
 			return ret;
 		}


### PR DESCRIPTION
Fixed places that used GenericParameterConstraint assuming it was a TypeReference.
Cecil changed GPC to have a TypeReference (ConstraintType)  property be available as opposed to
inherit from it.