### PR TITLE
Drop dependency on DylibMono when building for Xamarin.Android

### DIFF
--- a/src/java-interop/java-interop-gc-bridge-mono.cc
+++ b/src/java-interop/java-interop-gc-bridge-mono.cc
@@ -26,7 +26,7 @@
 
 #include <dlfcn.h>
 
-#if defined (XAMARIN_ANDROID_DYLIB_MONO)
+#if defined (ANDROID)
 using namespace xamarin::android;
 #endif
 
@@ -267,13 +267,6 @@ java_interop_gc_bridge_new (JavaVM *jvm)
 {
 	if (jvm == NULL)
 		return NULL;
-
-#if defined (ANDROID) || defined (XAMARIN_ANDROID_DYLIB_MONO)
-	if (!monodroid_dylib_mono_init (monodroid_get_dylib (), NULL)) {
-		log_fatal (LOG_DEFAULT, "mono runtime initialization error: %s", dlerror ());
-		exit (FATAL_EXIT_CANNOT_FIND_MONO);
-	}
-#endif  /* defined (ANDROID) || defined (XAMARIN_ANDROID_DYLIB_MONO) */
 
 	lookup_optional_mono_thread_functions ();
 

--- a/src/java-interop/java-interop-mono.h
+++ b/src/java-interop/java-interop-mono.h
@@ -3,30 +3,6 @@
 
 #include "java-interop.h"
 
-#if defined (ANDROID) || defined (XAMARIN_ANDROID_DYLIB_MONO)
-
-	#include "dylib-mono.h"
-	#include "monodroid-glue.h"
-
-	#define mono_class_from_mono_type               (monodroid_get_dylib ()->class_from_mono_type)
-	#define mono_class_from_name                    (monodroid_get_dylib ()->class_from_name)
-	#define mono_class_get_field_from_name          (monodroid_get_dylib ()->class_get_field_from_name)
-	#define mono_class_get_name                     (monodroid_get_dylib ()->class_get_name)
-	#define mono_class_get_namespace                (monodroid_get_dylib ()->class_get_namespace)
-	#define mono_class_is_subclass_of               (monodroid_get_dylib ()->class_is_subclass_of)
-	#define mono_class_vtable                       (monodroid_get_dylib ()->class_vtable)
-	#define mono_domain_get                         (monodroid_get_dylib ()->domain_get)
-	#define mono_field_get_value                    (monodroid_get_dylib ()->field_get_value)
-	#define mono_field_set_value                    (monodroid_get_dylib ()->field_set_value)
-	#define mono_field_static_set_value             (monodroid_get_dylib ()->field_static_set_value)
-	#define mono_object_get_class                   (monodroid_get_dylib ()->object_get_class)
-	#define mono_thread_attach                      (monodroid_get_dylib ()->thread_attach)
-	#define mono_thread_current                     (monodroid_get_dylib ()->thread_current)
-	#define mono_gc_register_bridge_callbacks       (monodroid_get_dylib ()->gc_register_bridge_callbacks)
-	#define mono_gc_wait_for_bridge_processing      (monodroid_get_dylib ()->gc_wait_for_bridge_processing)
-
-#else   /* !defined (ANDROID) && !defined (XAMARIN_ANDROID_DYLIB_MONO) */
-
 	#undef MONO_API_EXPORT
 	#undef MONO_API_IMPORT
 	#undef MONO_API
@@ -38,8 +14,6 @@
 	#include <mono/metadata/threads.h>
 	#include <mono/utils/mono-counters.h>
 	#include <mono/utils/mono-dl-fallback.h>
-
-#endif  /* !defined (ANDROID) && !defined (XAMARIN_ANDROID_DYLIB_MONO) */
 
 JAVA_INTEROP_BEGIN_DECLS
 


### PR DESCRIPTION
Xamarin.Android no longer uses `dlopen/dlsym` to load Mono symbols on the
runtime, instead it links libmonosgen-2.0 directly. In effect, the `DylibMono`
class and all the associated workarounds, code etc are going away. This commit
removes `DylibMono` use from `Java.Interop`