### PR TITLE
[Xamarin.Android.Tools.Bytecode] Add EnclosingMethod, SourceFile

### DIFF
--- a/src/Xamarin.Android.Tools.Bytecode/ClassFile.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/ClassFile.cs
@@ -98,6 +98,28 @@ namespace Xamarin.Android.Tools.Bytecode {
 			}
 		}
 
+		public string SourceFileName {
+			get {
+				var sourceFile  = Attributes.Get<SourceFileAttribute> ();
+				return sourceFile == null ? null : sourceFile.FileName;
+			}
+		}
+
+		public bool TryGetEnclosingMethodInfo (out string declaringClass, out string declaringMethod, out string declaringDescriptor)
+		{
+			declaringClass = declaringMethod = declaringDescriptor = null;
+
+			var enclosingMethod     = Attributes.Get<EnclosingMethodAttribute> ();
+			if (enclosingMethod == null) {
+				return false;
+			}
+
+			declaringClass          = enclosingMethod.Class.Name.Value;
+			declaringMethod         = enclosingMethod.Method.Name.Value;
+			declaringDescriptor     = enclosingMethod.Method.Descriptor.Value;
+			return true;
+		}
+
 		public ClassSignature GetSignature ()
 		{
 			if (this.signature != null)

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/ExpectedInnerClassInfo.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/ExpectedInnerClassInfo.cs
@@ -15,10 +15,10 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 
 		public void Assert (InnerClassInfo info)
 		{
-			NAssert.AreEqual (InnerClassName,   info.InnerClass.Name.Value);
-			NAssert.AreEqual (OuterClassName,   info.OuterClass.Name.Value);
-			NAssert.AreEqual (InnerName,        info.InnerName);
-			NAssert.AreEqual (AccessFlags,      info.InnerClassAccessFlags);
+			NAssert.AreEqual (InnerClassName,   info.InnerClass?.Name?.Value,   $"InnerClassName");
+			NAssert.AreEqual (OuterClassName,   info.OuterClass?.Name?.Value,   $"OuterClassName");
+			NAssert.AreEqual (InnerName,        info.InnerName,                 $"InnerName");
+			NAssert.AreEqual (AccessFlags,      info.InnerClassAccessFlags,     $"InnerClassAccessFlags");
 		}
 	}
 }

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/ExpectedMethodDeclaration.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/ExpectedMethodDeclaration.cs
@@ -43,7 +43,7 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 			}
 
 			var parameters  = method.GetParameters ();
-			NAssert.AreEqual (Parameters.Count, parameters.Length);
+			NAssert.AreEqual (Parameters.Count, parameters.Length,  $"Method {Name} Parameter Count");
 			for (int i = 0; i < Parameters.Count; ++i) {
 				NAssert.AreEqual (Parameters [i].Name,                  parameters [i].Name,                message);
 				NAssert.AreEqual (i,                                    parameters [i].Position,            message);

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/ExpectedTypeDeclaration.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/ExpectedTypeDeclaration.cs
@@ -33,9 +33,9 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 
 			NAssert.AreEqual (Deprecated,   classDeclaration.Attributes.Get<DeprecatedAttribute> () != null,    FullName + " Deprecated");
 
-			NAssert.AreEqual (Interfaces.Count,         classDeclaration.Interfaces.Count);
+			NAssert.AreEqual (Interfaces.Count,         classDeclaration.Interfaces.Count,      $"{FullName} Interfaces Count");
 			for (int i = 0; i < Interfaces.Count; ++i) {
-				NAssert.AreEqual (Interfaces [i].BinaryName,    classDeclaration.Interfaces [i].Name.Value);
+				NAssert.AreEqual (Interfaces [i].BinaryName,    classDeclaration.Interfaces [i].Name.Value,     $"{FullName} Interface {i}");
 			}
 
 			var innerClasses    = classDeclaration.InnerClasses;
@@ -45,8 +45,8 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 
 			var interfaces  = classDeclaration.GetInterfaces ();
 			for (int i = 0; i < Interfaces.Count; ++i) {
-				NAssert.AreEqual (Interfaces [i].BinaryName,    interfaces [i].BinaryName,      FullName + " Interfaces");
-				NAssert.AreEqual (Interfaces [i].TypeSignature, interfaces [i].TypeSignature,   FullName + " Interfaces");
+				NAssert.AreEqual (Interfaces [i].BinaryName,    interfaces [i].BinaryName,      FullName + " Interfaces BinaryName");
+				NAssert.AreEqual (Interfaces [i].TypeSignature, interfaces [i].TypeSignature,   FullName + " Interfaces TypeSignature");
 			}
 
 			var signature   = classDeclaration.GetSignature ();

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/IJavaInterface.xml
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/IJavaInterface.xml
@@ -9,6 +9,7 @@
       final="false"
       name="IJavaInterface"
       jni-signature="Lcom/xamarin/IJavaInterface;"
+      source-file-name="IJavaInterface.java"
       static="false"
       visibility="">
       <typeParameters>

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/JavaAnnotation.xml
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/JavaAnnotation.xml
@@ -9,6 +9,7 @@
       final="false"
       name="JavaAnnotation"
       jni-signature="Lcom/xamarin/JavaAnnotation;"
+      source-file-name="JavaAnnotation.java"
       static="false"
       visibility="public">
       <implements

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/JavaEnum.xml
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/JavaEnum.xml
@@ -12,6 +12,7 @@
       final="true"
       name="JavaEnum"
       jni-signature="Lcom/xamarin/JavaEnum;"
+      source-file-name="JavaType.java"
       static="false"
       visibility="">
       <method

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/JavaType$1.xml
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/JavaType$1.xml
@@ -1,0 +1,41 @@
+<api
+  api-source="class-parse">
+  <package
+    name="com.xamarin"
+    jni-name="com/xamarin">
+    <class
+      abstract="false"
+      deprecated="not deprecated"
+      enclosing-method-jni-type="Lcom/xamarin/JavaType;"
+      enclosing-method-name="action"
+      enclosing-method-signature="(Ljava/lang/Object;)V"
+      jni-extends="Ljava/lang/Object;"
+      extends="java.lang.Object"
+      extends-generic-aware="java.lang.Object"
+      final="false"
+      name="JavaType.1"
+      jni-signature="Lcom/xamarin/JavaType$1;"
+      source-file-name="JavaType.java"
+      static="false"
+      visibility="">
+      <implements
+        name="java.lang.Runnable"
+        name-generic-aware="java.lang.Runnable"
+        jni-type="Ljava/lang/Runnable;" />
+      <method
+        abstract="false"
+        deprecated="not deprecated"
+        final="false"
+        name="run"
+        native="false"
+        return="void"
+        jni-return="V"
+        static="false"
+        synchronized="false"
+        visibility="public"
+        bridge="false"
+        synthetic="false"
+        jni-signature="()V" />
+    </class>
+  </package>
+</api>

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/JavaType$ASC.xml
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/JavaType$ASC.xml
@@ -12,6 +12,7 @@
       final="false"
       name="JavaType.ASC"
       jni-signature="Lcom/xamarin/JavaType$ASC;"
+      source-file-name="JavaType.java"
       static="true"
       visibility="" />
   </package>

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/JavaType$PSC.xml
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/JavaType$PSC.xml
@@ -12,6 +12,7 @@
       final="false"
       name="JavaType.PSC"
       jni-signature="Lcom/xamarin/JavaType$PSC;"
+      source-file-name="JavaType.java"
       static="true"
       visibility="public">
       <constructor

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/JavaType$RNC$RPNC.xml
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/JavaType$RNC$RPNC.xml
@@ -12,6 +12,7 @@
       final="false"
       name="JavaType.RNC.RPNC"
       jni-signature="Lcom/xamarin/JavaType$RNC$RPNC;"
+      source-file-name="JavaType.java"
       static="false"
       visibility="public">
       <typeParameters>

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/JavaType$RNC.xml
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/JavaType$RNC.xml
@@ -12,6 +12,7 @@
       final="false"
       name="JavaType.RNC"
       jni-signature="Lcom/xamarin/JavaType$RNC;"
+      source-file-name="JavaType.java"
       static="false"
       visibility="protected">
       <typeParameters>

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/JavaType.1Tests.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/JavaType.1Tests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+
+using Xamarin.Android.Tools.Bytecode;
+
+using NUnit.Framework;
+
+namespace Xamarin.Android.Tools.BytecodeTests {
+
+	[TestFixture]
+	public class JavaType_1Tests : ClassFileFixture {
+
+		const string JavaType = "JavaType$1";
+
+		[Test]
+		public void ClassFileDescription ()
+		{
+			var c   = LoadClassFile (JavaType + ".class");
+			new ExpectedTypeDeclaration {
+				MajorVersion        = 0x32,
+				MinorVersion        = 0,
+				ConstantPoolCount   = 47,
+				AccessFlags         = ClassAccessFlags.Super,
+				FullName            = "com/xamarin/JavaType$1",
+				Superclass          = new TypeInfo ("java/lang/Object", "Ljava/lang/Object;"),
+				InnerClasses = {
+					new ExpectedInnerClassInfo {
+						InnerClassName  = "com/xamarin/JavaType$1",
+						OuterClassName  = null,
+						InnerName       = null,
+						AccessFlags     = 0,
+					},
+				},
+				Interfaces = {
+					new TypeInfo ("java/lang/Runnable"),
+				},
+				Fields = {
+					new ExpectedFieldDeclaration {
+						Name                = "this$0",
+						Descriptor          = "Lcom/xamarin/JavaType;",
+						AccessFlags         = FieldAccessFlags.Final | FieldAccessFlags.Synthetic,
+					},
+				},
+				Methods = {
+					new ExpectedMethodDeclaration {
+						Name                    = "<init>",
+						AccessFlags             = 0,
+						ReturnDescriptor        = "V",
+					},
+					new ExpectedMethodDeclaration {
+						Name                    = "run",
+						AccessFlags             = MethodAccessFlags.Public,
+						ReturnDescriptor        = "V",
+					},
+				}
+			}.Assert (c);
+		}
+
+		[Test]
+		public void XmlDescription ()
+		{
+			AssertXmlDeclaration (JavaType + ".class", JavaType + ".xml");
+		}
+	}
+}

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/JavaType.xml
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/JavaType.xml
@@ -12,6 +12,7 @@
       final="false"
       name="JavaType"
       jni-signature="Lcom/xamarin/JavaType;"
+      source-file-name="JavaType.java"
       static="false"
       visibility="public">
       <typeParameters>

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/JavaTypeTests.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/JavaTypeTests.cs
@@ -20,7 +20,7 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 			new ExpectedTypeDeclaration {
 				MajorVersion        = 0x32,
 				MinorVersion        = 0,
-				ConstantPoolCount   = 184,
+				ConstantPoolCount   = 195,
 				AccessFlags         = ClassAccessFlags.Public | ClassAccessFlags.Super,
 				FullName            = "com/xamarin/JavaType",
 				Superclass          = new TypeInfo ("java/lang/Object", "Ljava/lang/Object;"),
@@ -53,6 +53,12 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 						OuterClassName  = "com/xamarin/JavaType",
 						InnerName       = "PSC",
 						AccessFlags     = ClassAccessFlags.Public | ClassAccessFlags.Static | ClassAccessFlags.Abstract,
+					},
+					new ExpectedInnerClassInfo {
+						InnerClassName  = "com/xamarin/JavaType$1",
+						OuterClassName  = null,
+						InnerName       = null,
+						AccessFlags     = 0,
 					},
 				},
 				Fields = {
@@ -132,7 +138,7 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 						Name                = "STATIC_FINAL_STRING",
 						Descriptor          = "Ljava/lang/String;",
 						AccessFlags         = FieldAccessFlags.Public | FieldAccessFlags.Static | FieldAccessFlags.Final,
-						ConstantValue       = "String(stringIndex=176 Utf8=\"Hello, \\\"embedded\0Nulls\" and \ud83d\udca9!\")",
+						ConstantValue       = "String(stringIndex=185 Utf8=\"Hello, \\\"embedded\0Nulls\" and \ud83d\udca9!\")",
 					},
 					new ExpectedFieldDeclaration {
 						Name                = "STATIC_FINAL_BOOL_FALSE",

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/NonGenericGlobalType.xml
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/NonGenericGlobalType.xml
@@ -12,6 +12,7 @@
       final="false"
       name="NonGenericGlobalType"
       jni-signature="LNonGenericGlobalType;"
+      source-file-name="NonGenericGlobalType.java"
       static="false"
       visibility="" />
   </package>

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/ParameterFixup.xml
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/ParameterFixup.xml
@@ -9,6 +9,7 @@
       final="false"
       name="IParameterInterface"
       jni-signature="Lcom/xamarin/IParameterInterface;"
+      source-file-name="IParameterInterface.java"
       static="false"
       visibility="">
       <method
@@ -90,6 +91,7 @@
       final="false"
       name="ParameterAbstractClass"
       jni-signature="Lcom/xamarin/ParameterAbstractClass;"
+      source-file-name="ParameterAbstractClass.java"
       static="false"
       visibility="public">
       <implements
@@ -184,6 +186,7 @@
       final="false"
       name="ParameterClass"
       jni-signature="Lcom/xamarin/ParameterClass;"
+      source-file-name="ParameterClass.java"
       static="false"
       visibility="public">
       <constructor
@@ -247,6 +250,7 @@
       final="false"
       name="ParameterClass2"
       jni-signature="Lcom/xamarin/ParameterClass2;"
+      source-file-name="ParameterClass2.java"
       static="false"
       visibility="public">
       <constructor

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/ParameterFixupFromDescriptionText.xml
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/ParameterFixupFromDescriptionText.xml
@@ -9,6 +9,7 @@
       final="false"
       name="NestedInterface.DnsSdTxtRecordListener"
       jni-signature="Lcom/xamarin/NestedInterface$DnsSdTxtRecordListener;"
+      source-file-name="NestedInterface.java"
       static="true"
       visibility="public">
       <method

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/ParameterFixupFromDocs.xml
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/ParameterFixupFromDocs.xml
@@ -9,6 +9,7 @@
       final="false"
       name="Collection"
       jni-signature="Ljava/util/Collection;"
+      source-file-name="Collection.java"
       static="false"
       visibility="public">
       <typeParameters>

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj
@@ -49,6 +49,7 @@
     <Compile Include="JavaAnnotationTests.cs" />
     <Compile Include="JavaEnumTests.cs" />
     <Compile Include="JavaTypeTests.cs" />
+    <Compile Include="JavaType.1Tests.cs" />
     <Compile Include="JavaType.ASCTests.cs" />
     <Compile Include="JavaType.RNCTests.cs" />
     <Compile Include="JavaType.RNC.RPNCTests.cs" />
@@ -81,6 +82,9 @@
     <EmbeddedResource Include="JavaType.xml">
       <LogicalName>JavaType.xml</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="JavaType%241.xml">
+      <LogicalName>JavaType$1.xml</LogicalName>
+    </EmbeddedResource>
     <EmbeddedResource Include="IJavaInterface.xml">
       <LogicalName>IJavaInterface.xml</LogicalName>
     </EmbeddedResource>
@@ -101,6 +105,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\xamarin\JavaType.class">
       <LogicalName>JavaType.class</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\xamarin\JavaType%241.class">
+      <LogicalName>JavaType$1.class</LogicalName>
     </EmbeddedResource>
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\xamarin\JavaType%24ASC.class">
       <LogicalName>JavaType$ASC.class</LogicalName>

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/java/com/xamarin/JavaType.java
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/java/com/xamarin/JavaType.java
@@ -107,9 +107,15 @@ public class JavaType<E>
 
 	@Deprecated
 	public void action (Object value) {
-	    Object local = new Object ();
-	    local.toString ();
-	    int i = 42;
+		Object local = new Object ();
+		local.toString ();
+		int i = 42;
+		Runnable r = new Runnable () {
+			public void run() {
+				System.out.println ("foo");
+			}
+		};
+		r.run();
 	}
 
 	public java.lang.Integer func (String[] values) {


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/issues/466

While looking at `class-parse --dump` output for various
Kotlin-compiled `.class` files, providing support for the
`EnclosingMethod` and `SourceFile` annotation blobs looks to be
useful.

Add support for parsing the `EnclosingMethod` and `SourceFile`
annotations.

Update the generated XML so that the `SourceFile` annotation is
avaialble from the `//class/@source-file-name` or
`//interface/@source-file-name` attributes.

Update the generated XML so that the `EnclosingMethod` annotation is
available from these new attributes on `//class` or `//interface`:

  * `enclosing-method-jni-type`: The JNI signature of the type
    declaring the enclosing method.

  * `enclosing-method-name`: The name of the enclosing method.

  * `enclosing-method-signature`: The JNI signature of the enclosing
    method.

For example, if `TestType.action()` had an anonymous inner class:

        class TestType {
          public void action (Object value) {
            Runnable r = new Runnable () {
              public void run() {
                System.out.println ("foo");
              }
            };
          }
        }

This could result in the creation of a new `TestType$1` class for the
anonymous inner class, with the resulting `enclosing-*` attributes:

        enclosing-method-jni-type="Lcom/xamarin/JavaType;"
        enclosing-method-name="action"
        enclosing-method-signature="(Ljava/lang/Object;)V"