### PR TITLE
[jnimarshalmethod-gen] fixes for interfaces

### DIFF
--- a/src/Java.Interop.Export/Tests/Java.Interop/ExportTest.cs
+++ b/src/Java.Interop.Export/Tests/Java.Interop/ExportTest.cs
@@ -107,6 +107,11 @@ namespace Java.InteropTests
 		}
 	}
 
+	public interface MyInterface : IJavaPeerable
+	{
+		void MyMethod ();
+	}
+
 	public class MyColorValueMarshaler : JniValueMarshaler<MyColor> {
 
 		public override Type MarshalType {

--- a/src/Java.Interop.Export/Tests/Java.Interop/MarshalMemberBuilderTest.cs
+++ b/src/Java.Interop.Export/Tests/Java.Interop/MarshalMemberBuilderTest.cs
@@ -465,7 +465,7 @@ namespace Java.InteropTests
 		}
 		else
 		{
-			return __mret_ref = __mret.PeerReference;
+			return __mret_ref = (IJavaPeerable) __mret.PeerReference;
 		}
 		__mret_rtn = References.NewReturnToJniRef(__mret_ref);
 		return __mret_rtn;

--- a/src/Java.Interop.Export/Tests/Java.Interop/MarshalMemberBuilderTest.cs
+++ b/src/Java.Interop.Export/Tests/Java.Interop/MarshalMemberBuilderTest.cs
@@ -465,7 +465,7 @@ namespace Java.InteropTests
 		}
 		else
 		{
-			return __mret_ref = (IJavaPeerable) __mret.PeerReference;
+			return __mret_ref = (IJavaPeerable)__mret.PeerReference;
 		}
 		__mret_rtn = References.NewReturnToJniRef(__mret_ref);
 		return __mret_rtn;

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -621,7 +621,7 @@ namespace Java.Interop
 					Expression.IfThenElse (
 						test:       Expression.Equal (Expression.Constant (null), sourceValue),
 						ifTrue:     Expression.Assign (r, Expression.New (typeof (JniObjectReference))),
-						ifFalse:    Expression.Assign (r, Expression.Property (sourceValue, "PeerReference"))));
+						ifFalse:    Expression.Assign (r, Expression.Property (Expression.Convert (sourceValue, typeof (IJavaPeerable)), "PeerReference"))));
 
 			return r;
 		}

--- a/tools/jnimarshalmethod-gen/App.cs
+++ b/tools/jnimarshalmethod-gen/App.cs
@@ -330,7 +330,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 						continue;
 				}
 
-				if (type.IsGenericType || type.IsGenericTypeDefinition)
+				if (type.IsInterface || type.IsGenericType || type.IsGenericTypeDefinition)
 					continue;
 
 				var td = FindType (type);


### PR DESCRIPTION
When bumping xamarin-android to java.interop/master, we are hitting a
failure:

    Instance property 'PeerReference' is not defined for type 'Android.Widget.IListAdapter'
    Parameter name: propertyName
    System.ArgumentException: Instance property 'PeerReference' is not defined for type 'Android.Widget.IListAdapter'
    Parameter name: propertyName
        at System.Linq.Expressions.Expression.Property (System.Linq.Expressions.Expression expression, System.String propertyName) [0x00051] in <9536922a6deb4f2dbdd3b7dedc620be3>:0
        at Java.Interop.JavaPeerableValueMarshaler.CreateIntermediaryExpressionFromManagedExpression (Java.Interop.Expressions.JniValueMarshalerContext context, System.Linq.Expressions.ParameterExpression sourceValue) [0x0002e] in external/Java.Interop/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs:620
        at Java.Interop.JavaPeerableValueMarshaler.CreateReturnValueFromManagedExpression (Java.Interop.Expressions.JniValueMarshalerContext context, System.Linq.Expressions.ParameterExpression sourceValue) [0x00001] in external/Java.Interop/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs:631
        at Java.Interop.MarshalMemberBuilder.CreateMarshalToManagedExpression (System.Reflection.MethodInfo method, Java.Interop.JavaCallableAttribute callable, System.Type type) [0x0042d] in external/Java.Interop/src/Java.Interop.Export/Java.Interop/MarshalMemberBuilder.cs:207
        at Java.Interop.MarshalMemberBuilder.CreateMarshalToManagedExpression (System.Reflection.MethodInfo method) [0x00017] in external/Java.Interop/src/Java.Interop.Export/Java.Interop/MarshalMemberBuilder.cs:32
        at Xamarin.Android.Tools.JniMarshalMethodGenerator.App.CreateMarshalMethodAssembly (System.String path) [0x003fc] in external/Java.Interop/tools/jnimarshalmethod-gen/App.cs:393
        at Xamarin.Android.Tools.JniMarshalMethodGenerator.App.ProcessAssemblies (System.Collections.Generic.List`1[T] assemblies) [0x00150] in external/Java.Interop/tools/jnimarshalmethod-gen/App.cs:186

Since ef092a8 introduced some changes to interfaces, there are a
couple spots in `jnimarshalmethod-gen.exe` that need a fix.

First, there was an additional cast needed where an interface might
extend `IJavaPeerable`:

    interface IListAdapter : IJavaPeerable { }

After this, we got a new error:

    System.ArgumentException: 'this' type cannot be an interface itself
        at System.RuntimeType.GetInterfaceMap (System.Type ifaceType) [0x00069] in <2d5573434b724f28896144eecd6f4489>:0
        at Xamarin.Android.Tools.JniMarshalMethodGenerator.Extensions.NeedsMarshalMethod (Mono.Cecil.MethodDefinition md, Java.Interop.Tools.Cecil.DirectoryAssemblyResolver resolver, System.Reflection.MethodInfo method, System.String& name, System.String& methodName, System.String& signature) [0x0006b] in external/Java.Interop/tools/jnimarshalmethod-gen/App.cs:642
        at Xamarin.Android.Tools.JniMarshalMethodGenerator.App.CreateMarshalMethodAssembly (System.String path) [0x00370] in external/Java.Interop/tools/jnimarshalmethod-gen/App.cs:374
        at Xamarin.Android.Tools.JniMarshalMethodGenerator.App.ProcessAssemblies (System.Collections.Generic.List`1[T] assemblies) [0x00150] in external/Java.Interop/tools/jnimarshalmethod-gen/App.cs:186

For this one, we can actually skip processing of interfaces -- we
don't need to generate marshal methods for interfaces at all.

I also updated `ExportTest.cs` so it included a problematic interface.
Before these fixes, I could repro the same problems with `make
run-test-jnimarshal`.