### PR TITLE
[java-interop] Selectively keep DylibMono for Xamarin.Android

### DIFF
--- a/src/java-interop/java-interop-gc-bridge-mono.cc
+++ b/src/java-interop/java-interop-gc-bridge-mono.cc
@@ -268,6 +268,13 @@ java_interop_gc_bridge_new (JavaVM *jvm)
 	if (jvm == NULL)
 		return NULL;
 
+#if defined (XAMARIN_ANDROID_DYLIB_MONO)
+	if (!monodroid_dylib_mono_init (monodroid_get_dylib (), NULL)) {
+		log_fatal (LOG_DEFAULT, "mono runtime initialization error: %s", dlerror ());
+		exit (FATAL_EXIT_CANNOT_FIND_MONO);
+	}
+#endif  /* defined (XAMARIN_ANDROID_DYLIB_MONO) */
+
 	lookup_optional_mono_thread_functions ();
 
 	JavaInteropGCBridge bridge = {0};

--- a/src/java-interop/java-interop-mono.h
+++ b/src/java-interop/java-interop-mono.h
@@ -3,6 +3,30 @@
 
 #include "java-interop.h"
 
+#if defined (XAMARIN_ANDROID_DYLIB_MONO)
+
+	#include "dylib-mono.h"
+	#include "monodroid-glue.h"
+
+	#define mono_class_from_mono_type               (monodroid_get_dylib ()->class_from_mono_type)
+	#define mono_class_from_name                    (monodroid_get_dylib ()->class_from_name)
+	#define mono_class_get_field_from_name          (monodroid_get_dylib ()->class_get_field_from_name)
+	#define mono_class_get_name                     (monodroid_get_dylib ()->class_get_name)
+	#define mono_class_get_namespace                (monodroid_get_dylib ()->class_get_namespace)
+	#define mono_class_is_subclass_of               (monodroid_get_dylib ()->class_is_subclass_of)
+	#define mono_class_vtable                       (monodroid_get_dylib ()->class_vtable)
+	#define mono_domain_get                         (monodroid_get_dylib ()->domain_get)
+	#define mono_field_get_value                    (monodroid_get_dylib ()->field_get_value)
+	#define mono_field_set_value                    (monodroid_get_dylib ()->field_set_value)
+	#define mono_field_static_set_value             (monodroid_get_dylib ()->field_static_set_value)
+	#define mono_object_get_class                   (monodroid_get_dylib ()->object_get_class)
+	#define mono_thread_attach                      (monodroid_get_dylib ()->thread_attach)
+	#define mono_thread_current                     (monodroid_get_dylib ()->thread_current)
+	#define mono_gc_register_bridge_callbacks       (monodroid_get_dylib ()->gc_register_bridge_callbacks)
+	#define mono_gc_wait_for_bridge_processing      (monodroid_get_dylib ()->gc_wait_for_bridge_processing)
+
+#else   /* !defined (XAMARIN_ANDROID_DYLIB_MONO) */
+
 	#undef MONO_API_EXPORT
 	#undef MONO_API_IMPORT
 	#undef MONO_API
@@ -14,6 +38,8 @@
 	#include <mono/metadata/threads.h>
 	#include <mono/utils/mono-counters.h>
 	#include <mono/utils/mono-dl-fallback.h>
+
+#endif  /* !defined (XAMARIN_ANDROID_DYLIB_MONO) */
 
 JAVA_INTEROP_BEGIN_DECLS
 


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/3504
Context: https://github.com/xamarin/xamarin-android/pull/3223

When bumping xamarin-android/master to 2abfc1e0, the build broke
because of commit 285a32b3:

	  In file included from /Users/vsts/agent/2.155.1/work/1/s/external/Java.Interop/src/java-interop/java-interop-mono.cc:2:
	  ../../../../../external/Java.Interop/src/java-interop/java-interop-mono.h:10:11: fatal error: 'mono/metadata/assembly.h' file not found
	          #include <mono/metadata/assembly.h>
	                   ^~~~~~~~~~~~~~~~~~~~~~~~~~
	  1 error generated.

We need to continue supporting the DylibMono backend for integration
purposes (xamarin/xamarin-android#3504) *while also* allowing for the
*removal* of DylibMono (xamarin/xamarin-android#3223).

Attempt to support these divergent needs by replacing this:

	#if defined (ANDROID) || defined (XAMARIN_ANDROID_DYLIB_MONO)

with this:

	#if defined (XAMARIN_ANDROID_DYLIB_MONO)

removing the check for the `ANDROID` define.

This will allow xamarin/xamarin-android#3223 to *remove* the
`XAMARIN_ANDROID_DYLIB_MONO` definition in order to introduce it's
desired behavior, removing DylibMono use.

This partially reverts commit 285a32b3.