### PR TITLE
[tests] Fix test semantics, JniValueMarshalerContractTests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,13 @@ BUILD_PROPS = bin/Build$(CONFIGURATION)/JdkInfo.props bin/Build$(CONFIGURATION)/
 
 all: $(DEPENDENCIES) $(TESTS)
 
-run-all-tests: run-tests run-test-jnimarshal run-test-generator-core run-ptests
+run-all-tests:
+	r=0; \
+	$(MAKE) run-tests                 || r=1 ; \
+	$(MAKE) run-test-jnimarshal       || r=1 ; \
+	$(MAKE) run-test-generator-core   || r=1 ; \
+	$(MAKE) run-ptests                || r=1 ; \
+	exit $$r;
 
 include build-tools/scripts/msbuild.mk
 
@@ -145,14 +151,18 @@ shell:
 
 # $(call RUN_TEST,filename,log-lref?)
 define RUN_TEST
-	$(MSBUILD) $(MSBUILD_FLAGS) build-tools/scripts/RunNUnitTests.targets /p:TestAssembly=$(1) ;
+	$(MSBUILD) $(MSBUILD_FLAGS) build-tools/scripts/RunNUnitTests.targets /p:TestAssembly=$(1) || r=1;
 endef
 
 run-tests: $(TESTS) bin/Test$(CONFIGURATION)/$(JAVA_INTEROP_LIB)
-	$(foreach t,$(TESTS), $(call RUN_TEST,$(t),1))
+	r=0; \
+	$(foreach t,$(TESTS), $(call RUN_TEST,$(t),1)) \
+	exit $$r;
 
 run-ptests: $(PTESTS) bin/Test$(CONFIGURATION)/$(JAVA_INTEROP_LIB)
-	$(foreach t,$(PTESTS), $(call RUN_TEST,$(t)))
+	r=0; \
+	$(foreach t,$(PTESTS), $(call RUN_TEST,$(t))) \
+	exit $$r;
 
 bin/Test$(CONFIGURATION)/$(JAVA_INTEROP_LIB): bin/$(CONFIGURATION)/$(JAVA_INTEROP_LIB)
 	cp $< $@

--- a/src/Java.Interop/Tests/Java.Interop/JniValueMarshalerContractTests.cs
+++ b/src/Java.Interop/Tests/Java.Interop/JniValueMarshalerContractTests.cs
@@ -601,7 +601,7 @@ namespace Java.InteropTests {
 		}}
 		else
 		{{
-			return {value}_ref = {value}.PeerReference;
+			return {value}_ref = (IJavaPeerable){value}.PeerReference;
 		}}
 		{value}_rtn = References.NewReturnToJniRef({value}_ref);
 		return {pret.Name};


### PR DESCRIPTION
Commit ffbb2dc4 introduced a unit test failure, as it overlooked
updating an "expected" string within the test
`Java.InteropTests.JniValueMarshaler_IJavaPeerable_ContractTests.CreateReturnValueFromManagedExpression()`.

The more important question is this: why was that test failure missed?

Turns Out™ that our unit test infrastructure is "dodgy": it was
possible for tests to fail while the overall `make run-all-tests`
target reported success!

For example, as of commit ffbb2dc4 we *know* that
`Java.Interop-Tests.dll` will report a test failure.  Yet, if we
run `make run-tests` such that a different (successful) unit test
assembly follows it, no error is reported:

	$ make run-tests TESTS="bin/TestDebug/Java.Interop-Tests.dll bin/TestDebug/Java.Interop.Export-Tests.dll"
	...
        …/Java.Interop/build-tools/scripts/RunNUnitTests.targets(35,5): error MSB3073: The command "mono --debug packages/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe  bin/TestDebug/Java.Interop-Tests.dll  --result="TestResult-Java.Interop-Tests.xml;format=nunit2" --output="bin/TestDebug/TestOutput-Java.Interop-Tests.txt"" exited with code 1.

          0 Warning(s)
          1 Error(s)
	...
	$ echo $?
	0

*This* is why the [DevOps build for PR #472][0] was green and the PR
was merged.  It's also why one of the [subsequent master builds][1]
was green, even though it [reported unit test failures][2].

Our tests are unreliable.  What will we do about it?

 1. Update `make run-all-tests` to explicitly invoke targets.
 2. Update the other `run-*` targets to exit with a non-zero value
    if *any* command exits with a non-zero value.

`make run-all-tests` cannot use prerequisites, because once a
prerequisites fails, all following prerequisites are skipped, and we
want *all* of the unit tests to run, so that we collect as many
errors as possible from a test run.  As such, this rule:

	run-all-tests: run-tests run-ptests

must be converted into:

	run-all-tests:
		r=0; \
		$(MAKE) run-tests   || r=1; \
		$(MAKE) run-ptests  || r=1; \
		exit $$r

The other `run-*` targets must be fixed in a similar way, to ensure
that if *any* command fails, the entire rule *also* fails, while also
executing as many tests as possible.

With these changes in place, `make run-all-tests` will now report an
error if any of the executed tests fail:

	$ make run-tests TESTS="bin/TestDebug/Java.Interop-Tests.dll bin/TestDebug/Java.Interop.Export-Tests.dll"
	...
	$ echo $?
	2

Finally, fix the error reported from
`Java.InteropTests.JniValueMarshaler_IJavaPeerable_ContractTests`.

[0]: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=2950259&view=results
[1]: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=2950430&view=results
[2]: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=2950430&view=ms.vss-test-web.build-test-results-tab