### PR TITLE
[java-interop] Xamarin.Android host compilation fixes

### DIFF
--- a/src/java-interop/java-interop-gc-bridge-mono.cc
+++ b/src/java-interop/java-interop-gc-bridge-mono.cc
@@ -26,7 +26,7 @@
 
 #include <dlfcn.h>
 
-#if defined (ANDROID)
+#if defined (ANDROID) || defined (XAMARIN_ANDROID_DYLIB_MONO)
 using namespace xamarin::android;
 #endif
 


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/3504
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=2950467&view=results

Commit 5fe28cdd didn't go far enough.  While the xamarin-android build
is no longer trying to include `<mono/metadata/assembly.h>`, we get a
new set of compilation errors:

	/Users/vsts/agent/2.155.1/work/1/s/external/Java.Interop/src/java-interop/java-interop-gc-bridge-mono.cc(34,2): error GF2D19E48: unknown type name 'MonoClass'; did you mean 'xamarin::android::MonoClass'?
	          MonoClass          *klass;
	          ^~~~~~~~~
	          xamarin::android::MonoClass
	  ../../../jni/dylib-mono.h:101:31: note: 'xamarin::android::MonoClass' declared here
	          typedef struct _MonoClass {} MonoClass;
	                                       ^

This is because the `using namespace xamarin::android` on
`java-interop-gc-bridge-mono.cc` line 30 isn't evaluated, as `ANDROID`
isn't defined during *host* builds of xamarin-android/src/monodroid
(which builds e.g. `libmono-android.debug.*` for macOS & Windows).

Add `XAMARIN_ANDROID_DYLIB_MONO` to the `#if` list, so that the
`using namespace` statement is used on host builds.