### PR TITLE
[ApiXmlAdjuster] Add additional expected attributes

### DIFF
--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiXmlLoaderExtensions.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiXmlLoaderExtensions.cs
@@ -84,11 +84,15 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		static readonly string [] expected_type_attributes = new String [] {
 			"abstract",
 			"deprecated",
+			"enclosing-method-jni-type",
+			"enclosing-method-name",
+			"enclosing-method-signature",
 			"final",
+			"jni-signature",
 			"name",
+			"source-file-name",
 			"static",
 			"visibility",
-			"jni-signature",
 		};
 
 		internal static void LoadTypeAttributes (this JavaType type, XmlReader reader, params string [] otherAllowedAttributes)

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/XmlUtil.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/XmlUtil.cs
@@ -24,7 +24,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		{
 			if (reader.NodeType != XmlNodeType.Attribute)
 				throw new ArgumentException (string.Format ("Internal error: XmlReader should be positioned on attribute, but it is on {0}", reader.NodeType));
-			return new Exception (string.Format ("{0}: Element '{1}' has an unexpected attribute: '{2}'. Expected attributes are: {2}",
+			return new Exception (string.Format ("{0}: Element '{1}' has an unexpected attribute: '{2}'. Expected attributes are: {3}",
 				GetLocation (reader), elementName, reader.LocalName, string.Join (", ", expected)));
 		}
 


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/3223
Context: https://jenkins.mono-project.com/job/xamarin-android-pr-pipeline-debug/619/

Commit a30523e2 breaks the xamarin-android build, as it introduces new
XML attributes to `class-parse` output which
`Xamarin.Android.Tools.ApiXmlAdjuster` doesn't appreciate:

	Unhandled Exception:
	System.Exception: …/xamarin-android/bin/BuildDebug/api/api-10.xml.class-parse (16,7): Element 'class' has an unexpected attribute: 'source-file-name'. Expected attributes are: source-file-name
	  at Xamarin.Android.Tools.ApiXmlAdjuster.XmlUtil.CheckExtraneousAttributes (System.String elementName, System.Xml.XmlReader reader, System.String[] expected)
	  at Xamarin.Android.Tools.ApiXmlAdjuster.JavaApiLoaderExtensions.LoadTypeAttributes (Xamarin.Android.Tools.ApiXmlAdjuster.JavaType type, System.Xml.XmlReader reader, System.String[] otherAllowedAttributes)
	  at Xamarin.Android.Tools.ApiXmlAdjuster.JavaApiLoaderExtensions.Load (Xamarin.Android.Tools.ApiXmlAdjuster.JavaClass kls, System.Xml.XmlReader reader)

Update `Xamarin.Android.Tools.ApiXmlAdjuster` so that the new
attributes introduced in a30523e2 are considered acceptable.

Additionally, fix the error message so that it *actually* lists the
"expected attributes", instead of repeating the *un*-expected attribute.