### PR TITLE
[build] Java.Interop should use <ProjectReference/> for jnienv-gen

### DIFF
--- a/build-tools/jnienv-gen/jnienv-gen.csproj
+++ b/build-tools/jnienv-gen/jnienv-gen.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>jnienv-gen</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' Or '$(Configuration)|$(Platform)' == 'Gendarme|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>

--- a/src/Java.Interop/Java.Interop.csproj
+++ b/src/Java.Interop/Java.Interop.csproj
@@ -35,7 +35,6 @@
   <Import Project="Java.Interop.targets" />
   <PropertyGroup>
     <BuildDependsOn>
-      BuildJnienvGen;
       BuildJniEnvironment_g_cs;
       BuildInteropJar;
       $(BuildDependsOn)
@@ -61,5 +60,10 @@
     <None Include="Documentation\Java.Interop\IJavaPeerable.xml" />
     <None Include="Documentation\Java.Interop\JniManagedPeerStates.xml" />
     <None Include="Documentation\Java.Interop\JniEnvironment.References.xml" />
+    <ProjectReference Include="..\..\build-tools\jnienv-gen\jnienv-gen.csproj">
+      <Project>{6410DA0F-5E14-4FC0-9AEE-F4C542C96C7A}</Project>
+      <Name>jnienv-gen</Name>
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
 </Project>

--- a/src/Java.Interop/Java.Interop.targets
+++ b/src/Java.Interop/Java.Interop.targets
@@ -14,16 +14,8 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  <Target Name="BuildJnienvGen"
-      Inputs="..\..\build-tools\jnienv-gen\jnienv-gen.csproj"
-      Outputs="$(JNIEnvGenPath)\jnienv-gen.exe">
-    <MSBuild
-        Projects="..\..\build-tools\jnienv-gen\jnienv-gen.csproj"
-    />
-  </Target>
   <Target Name="BuildJniEnvironment_g_cs"
       BeforeTargets="BeforeCompile"
-      DependsOnTargets="BuildJnienvGen"
       Inputs="$(JNIEnvGenPath)\jnienv-gen.exe"
       Outputs="Java.Interop\JniEnvironment.g.cs;$(IntermediateOutputPath)\jni.c">
     <MakeDir Directories="$(IntermediateOutputPath)" />


### PR DESCRIPTION
Java.Interop had a custom MSBuild target that builds
`jnienv-gen.csproj`:

    <Target Name="BuildJnienvGen"
        Inputs="..\..\build-tools\jnienv-gen\jnienv-gen.csproj"
        Outputs="$(JNIEnvGenPath)\jnienv-gen.exe">
        <MSBuild
            Projects="..\..\build-tools\jnienv-gen\jnienv-gen.csproj"
        />
    </Target>

The problem with this, is if any `.cs` files change in
`jnienv-gen.csproj`, then this target will not run.

Instead we should be able to use `<ProjectReference/>` with
`%(ReferenceOutputAssembly)=False`, and everything should "just work".