### PR TITLE
[Xamarin.Android.Tools.Bytecode] Allow null enclosing method

### DIFF
--- a/src/Xamarin.Android.Tools.Bytecode/ClassFile.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/ClassFile.cs
@@ -115,8 +115,8 @@ namespace Xamarin.Android.Tools.Bytecode {
 			}
 
 			declaringClass          = enclosingMethod.Class.Name.Value;
-			declaringMethod         = enclosingMethod.Method.Name.Value;
-			declaringDescriptor     = enclosingMethod.Method.Descriptor.Value;
+			declaringMethod         = enclosingMethod.Method?.Name.Value;
+			declaringDescriptor     = enclosingMethod.Method?.Descriptor.Value;
 			return true;
 		}
 

--- a/src/Xamarin.Android.Tools.Bytecode/XmlClassDeclarationBuilder.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/XmlClassDeclarationBuilder.cs
@@ -65,17 +65,18 @@ namespace Xamarin.Android.Tools.Bytecode {
 			return "deprecated";
 		}
 
-		XAttribute[] GetEnclosingMethod ()
+		IEnumerable<XAttribute> GetEnclosingMethod ()
 		{
 			string declaringClass, declaringMethod, declaringDescriptor;
 			if (!classFile.TryGetEnclosingMethodInfo (out declaringClass, out declaringMethod, out declaringDescriptor)) {
-				return null;
+				yield break;
 			}
-			return new []{
-				new XAttribute ("enclosing-method-jni-type",    "L" + declaringClass + ";"),
-				new XAttribute ("enclosing-method-name",        declaringMethod),
-				new XAttribute ("enclosing-method-signature",   declaringDescriptor),
-			};
+			if (declaringClass != null)
+				yield return new XAttribute ("enclosing-method-jni-type",    "L" + declaringClass + ";");
+			if (declaringMethod != null)
+				yield return new XAttribute ("enclosing-method-name",        declaringMethod);
+			if (declaringDescriptor != null)
+				yield return new XAttribute ("enclosing-method-signature",   declaringDescriptor);
 		}
 
 		XAttribute[] GetExtends ()


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/3504
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=2951424&view=ms.vss-test-web.build-test-results-tab&runId=7990780&resultId=100107&paneView=attachments

The attempt to bump the Java.Interop submodule within xamarin-android
hit a snag, as unit tests failed:

	The "ClassParse" task failed unexpectedly.
	System.NullReferenceException: Object reference not set to an instance of an object
	  at Xamarin.Android.Tools.Bytecode.ClassFile.TryGetEnclosingMethodInfo (System.String& declaringClass, System.String& declaringMethod, System.String& declaringDescriptor)
	  at Xamarin.Android.Tools.Bytecode.XmlClassDeclarationBuilder.GetEnclosingMethod ()
	  at Xamarin.Android.Tools.Bytecode.XmlClassDeclarationBuilder.ToXElement ()
	  at Xamarin.Android.Tools.Bytecode.ClassPath+<>c.<ToXElement>b__36_3 (Xamarin.Android.Tools.Bytecode.ClassFile c)
	  at System.Linq.Enumerable+SelectIPartitionIterator`2[TSource,TResult].MoveNext ()
	  at System.Xml.Linq.XContainer.AddContentSkipNotify (System.Object content)
	  at System.Xml.Linq.XContainer.AddContentSkipNotify (System.Object content)

The cause?  The [`material-menu`][0] library has `.class` files which
have an `EnclosingMethod` attribute blob, but doesn't mention method
name information, only an enclosing type:

	$ mono class-parse.exe com/balysv/material/drawable/menu/MaterialMenuDrawable\$5.class --dump
	...
	    1: EnclosingMethod(Class(nameIndex=58 Name="com/balysv/material/drawable/menu/MaterialMenuDrawable"), )
	# Behold! No method information!

Support generating an XML description of this type by adding
appropriate `null` checks around `EnclosingMethodAttribute`.

[0]: https://repo.jfrog.org/artifactory/libs-release-bintray/com/balysv/material-menu/1.1.0/material-menu-1.1.0.aar