### PR TITLE
[build] remove BuildJnienvGen from Java.Interop-MonoAndroid.csproj

### DIFF
--- a/src/Java.Interop/Java.Interop-MonoAndroid.csproj
+++ b/src/Java.Interop/Java.Interop-MonoAndroid.csproj
@@ -76,7 +76,6 @@
   <Import Project="Java.Interop.targets" />
   <PropertyGroup>
     <BuildDependsOn>
-      BuildJnienvGen;
       BuildJniEnvironment_g_cs;
       BuildInteropJar;
       $(BuildDependsOn)


### PR DESCRIPTION
In f7d97c2, I forgot to update `Java.Interop-MonoAndroid.csproj`,
which was failing with:

    "external\Java.Interop\src\Java.Interop\Java.Interop-MonoAndroid.csproj" (default target) (29) ->
      Microsoft.Common.CurrentVersion.targets(837,7):
      error MSB4057: The target "BuildJnienvGen" does not exist in the project.

We need to remove the `BuildJnienvGen` MSBuild target since it no
longer exists.