### PR TITLE
[jnimarshalmethod-gen] When using -o DIR, put temp assembly in DIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,9 +172,16 @@ JRE_DLL_CONFIG=bin/$(CONFIGURATION)/Java.Runtime.Environment.dll.config
 $(JRE_DLL_CONFIG): src/Java.Runtime.Environment/Java.Runtime.Environment.csproj
 	$(MSBUILD) $(MSBUILD_FLAGS) $<
 
-run-test-jnimarshal: bin/Test$(CONFIGURATION)/Java.Interop.Export-Tests.dll bin/Test$(CONFIGURATION)/$(JAVA_INTEROP_LIB) $(JRE_DLL_CONFIG)
+define run-jnimarshalmethod-gen
 	MONO_TRACE_LISTENER=Console.Out \
-	$(RUNTIME) bin/$(CONFIGURATION)/jnimarshalmethod-gen.exe -v --jvm "$(JI_JVM_PATH)" -L "$(JI_MONO_LIB_PATH)mono/4.5" -L "$(JI_MONO_LIB_PATH)mono/4.5/Facades" "$<"
+	$(RUNTIME) bin/$(CONFIGURATION)/jnimarshalmethod-gen.exe -v --jvm "$(JI_JVM_PATH)" -L "$(JI_MONO_LIB_PATH)mono/4.5" -L "$(JI_MONO_LIB_PATH)mono/4.5/Facades" $(2) $(1)
+endef
+
+run-test-jnimarshal: bin/Test$(CONFIGURATION)/Java.Interop.Export-Tests.dll bin/Test$(CONFIGURATION)/$(JAVA_INTEROP_LIB) $(JRE_DLL_CONFIG)
+	mkdir -p test-jni-output
+	$(call run-jnimarshalmethod-gen,"$<",-f -o test-jni-output)
+	test -f test-jni-output/$(notdir $<) || { echo "jnimarshalmethod-gen did not create the assembly in the test-jni-output directory"; exit 1; }
+	$(call run-jnimarshalmethod-gen,"$<")
 	$(call RUN_TEST,$<)
 
 # $(call GEN_CORE_OUTPUT, outdir, suffix, extra)

--- a/Makefile
+++ b/Makefile
@@ -179,8 +179,8 @@ endef
 
 run-test-jnimarshal: bin/Test$(CONFIGURATION)/Java.Interop.Export-Tests.dll bin/Test$(CONFIGURATION)/$(JAVA_INTEROP_LIB) $(JRE_DLL_CONFIG)
 	mkdir -p test-jni-output
-	$(call run-jnimarshalmethod-gen,"$<",-f -o test-jni-output)
-	test -f test-jni-output/$(notdir $<) || { echo "jnimarshalmethod-gen did not create the assembly in the test-jni-output directory"; exit 1; }
+	$(call run-jnimarshalmethod-gen,"$<",-f -o test-jni-output --keeptemp)
+	(test -f test-jni-output/$(notdir $<) && test -f test-jni-output/Java.Interop.Export-Tests-JniMarshalMethods.dll) || { echo "jnimarshalmethod-gen did not create the expected assemblies in the test-jni-output directory"; exit 1; }
 	$(call run-jnimarshalmethod-gen,"$<")
 	$(call RUN_TEST,$<)
 

--- a/tools/jnimarshalmethod-gen/App.cs
+++ b/tools/jnimarshalmethod-gen/App.cs
@@ -287,7 +287,8 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 
 			var baseName        = Path.GetFileNameWithoutExtension (path);
 			var assemblyName    = new AssemblyName (baseName + "-JniMarshalMethods");
-			var destPath        = assemblyName.Name + ".dll";
+			var fileName        = assemblyName.Name + ".dll";
+			var destDir         = string.IsNullOrEmpty (outDirectory) ? Path.GetDirectoryName (path) : outDirectory;
 			var builder         = CreateExportedMemberBuilder ();
 			var matchType       = typeNameRegexes.Count > 0;
 
@@ -297,9 +298,9 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 			var da = AppDomain.CurrentDomain.DefineDynamicAssembly (
 					assemblyName,
 					AssemblyBuilderAccess.Save,
-					Path.GetDirectoryName (path));
+					destDir);
 
-			var dm = da.DefineDynamicModule ("<default>", destPath);
+			var dm = da.DefineDynamicModule ("<default>", fileName);
 
 			var ad = resolver.GetAssembly (path);
 
@@ -428,12 +429,13 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 			foreach (var tb in definedTypes)
 				tb.Value.CreateType ();
 
-			da.Save (destPath);
+			da.Save (fileName);
 
 			if (Verbose)
 				ColorWriteLine ($"Marshal method assembly '{assemblyName}' created", ConsoleColor.Cyan);
 
-			var dstAssembly = resolver.GetAssembly (destPath);
+			resolver.SearchDirectories.Add (destDir);
+			var dstAssembly = resolver.GetAssembly (fileName);
 
 			if (!string.IsNullOrEmpty (outDirectory))
 				path = Path.Combine (outDirectory, Path.GetFileName (path));


### PR DESCRIPTION
Instead of trying to create it in the location of the original
assembly as that might not be writable.