### PR TITLE
[J.I, generator] Fix GetPeerMembers for interfaces.

### DIFF
--- a/gendarme-ignore.txt
+++ b/gendarme-ignore.txt
@@ -351,6 +351,7 @@ T: Java.Interop.JniInt32ArrayElements
 T: Java.Interop.JniInt64ArrayElements
 T: Java.Interop.JniLocationException
 T: Java.Interop.JniMethodInfo
+T: Java.Interop.JniPeerMembers
 T: Java.Interop.JniSByteArrayElements
 T: Java.Interop.JniSingleArrayElements
 T: Java.Interop.JniType

--- a/src/Java.Interop/Java.Interop/JniPeerMembers.cs
+++ b/src/Java.Interop/Java.Interop/JniPeerMembers.cs
@@ -7,8 +7,15 @@ namespace Java.Interop {
 
 	public partial class JniPeerMembers {
 
+		private bool isInterface;
+
+		public JniPeerMembers (string jniPeerTypeName, Type managedPeerType, bool isInterface)
+			: this (jniPeerTypeName, managedPeerType, checkManagedPeerType: true, isInterface: isInterface)
+		{
+		}
+
 		public JniPeerMembers (string jniPeerTypeName, Type managedPeerType)
-			: this (jniPeerTypeName, managedPeerType, checkManagedPeerType: true)
+			: this (jniPeerTypeName, managedPeerType, checkManagedPeerType: true, isInterface: false)
 		{
 			if (managedPeerType == null)
 				throw new ArgumentNullException ("managedPeerType");
@@ -27,7 +34,7 @@ namespace Java.Interop {
 			ManagedPeerType = managedPeerType;
 		}
 
-		JniPeerMembers (string jniPeerTypeName, Type managedPeerType, bool checkManagedPeerType)
+		JniPeerMembers (string jniPeerTypeName, Type managedPeerType, bool checkManagedPeerType, bool isInterface = false)
 		{
 			if (jniPeerTypeName == null)
 				throw new ArgumentNullException (nameof (jniPeerTypeName));
@@ -50,6 +57,8 @@ namespace Java.Interop {
 
 			JniPeerTypeName = jniPeerTypeName;
 			ManagedPeerType = managedPeerType;
+
+			this.isInterface = isInterface;
 
 			instanceMethods = new JniInstanceMethods (this);
 			instanceFields  = new JniInstanceFields (this);
@@ -140,7 +149,7 @@ namespace Java.Interop {
 
 		protected virtual JniPeerMembers GetPeerMembers (IJavaPeerable value)
 		{
-			return value.JniPeerMembers;
+			return isInterface ? this : value.JniPeerMembers;
 		}
 
 		internal static void AssertSelf (IJavaPeerable self)

--- a/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/JavaInteropCodeGenerator.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/JavaInteropCodeGenerator.cs
@@ -29,7 +29,7 @@ namespace MonoDroid.Generation {
 
 		internal override void WriteClassHandle (ClassGen type, string indent, bool requireNew)
 		{
-			WritePeerMembers (indent + '\t', true, requireNew, type.RawJniName, type.Name);
+			WritePeerMembers (indent + '\t', true, requireNew, type.RawJniName, type.Name, false);
 
 			writer.WriteLine ("{0}\tinternal static {1}IntPtr class_ref {{", indent, requireNew ? "new " : string.Empty);
 			writer.WriteLine ("{0}\t\tget {{", indent);
@@ -55,12 +55,12 @@ namespace MonoDroid.Generation {
 
 		internal override void WriteClassHandle (InterfaceGen type, string indent, string declaringType)
 		{
-			WritePeerMembers (indent, false, true, type.RawJniName, declaringType);
+			WritePeerMembers (indent, false, true, type.RawJniName, declaringType, type.Name == declaringType);
 		}
 
 		internal override void WriteClassInvokerHandle (ClassGen type, string indent, string declaringType)
 		{
-			WritePeerMembers (indent, true, true, type.RawJniName, declaringType);
+			WritePeerMembers (indent, true, true, type.RawJniName, declaringType, false);
 
 			writer.WriteLine ();
 			writer.WriteLine ("{0}public override global::Java.Interop.JniPeerMembers JniPeerMembers {{", indent);
@@ -75,7 +75,7 @@ namespace MonoDroid.Generation {
 
 		internal override void WriteInterfaceInvokerHandle (InterfaceGen type, string indent, string declaringType)
 		{
-			WritePeerMembers (indent, true, true, type.RawJniName, declaringType);
+			WritePeerMembers (indent, true, true, type.RawJniName, declaringType, false);
 
 			writer.WriteLine ();
 			writer.WriteLine ("{0}static IntPtr java_class_ref {{", indent);
@@ -262,10 +262,10 @@ namespace MonoDroid.Generation {
 			writer.WriteLine ("{0}}}", indent);
 		}
 
-		void WritePeerMembers (string indent, bool isInternal, bool isNew, string rawJniType, string declaringType)
+		void WritePeerMembers (string indent, bool isInternal, bool isNew, string rawJniType, string declaringType, bool isInterface)
 		{
 			var signature = $"{(isInternal ? "internal " : "")}static {(isNew ? "new " : "")}readonly JniPeerMembers _members = ";
-			var type = $"new {GetPeerMembersType ()} (\"{rawJniType}\", typeof ({declaringType}));";
+			var type = $"new {GetPeerMembersType ()} (\"{rawJniType}\", typeof ({declaringType}){(isInterface ? ", isInterface: true" : string.Empty)});";
 
 			writer.WriteLine ($"{indent}{signature}{type}");
 		}

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterfaceDefaultMethod.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterfaceDefaultMethod.txt
@@ -1,7 +1,7 @@
 // Metadata.xml XPath interface reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']"
 [Register ("java/code/IMyInterface", "", "java.code.IMyInterfaceInvoker")]
 public partial interface IMyInterface : IJavaObject, IJavaPeerable {
-	static new readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterface));
+	static new readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
 
 	static Delegate cb_DoSomething;
 #pragma warning disable 0169

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterfaceDefaultProperty.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterfaceDefaultProperty.txt
@@ -1,7 +1,7 @@
 // Metadata.xml XPath interface reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']"
 [Register ("java/code/IMyInterface", "", "java.code.IMyInterfaceInvoker")]
 public partial interface IMyInterface : IJavaObject, IJavaPeerable {
-	static new readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterface));
+	static new readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
 
 	static Delegate cb_get_Value;
 #pragma warning disable 0169

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterfaceDefaultPropertyGetterOnly.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterfaceDefaultPropertyGetterOnly.txt
@@ -1,7 +1,7 @@
 // Metadata.xml XPath interface reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']"
 [Register ("java/code/IMyInterface", "", "java.code.IMyInterfaceInvoker")]
 public partial interface IMyInterface : IJavaObject, IJavaPeerable {
-	static new readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterface));
+	static new readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
 
 	static Delegate cb_get_Value;
 #pragma warning disable 0169

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultMethod.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultMethod.txt
@@ -1,7 +1,7 @@
 // Metadata.xml XPath interface reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']"
 [Register ("java/code/IMyInterface", "", "java.code.IMyInterfaceInvoker")]
 public partial interface IMyInterface : IJavaObject, IJavaPeerable {
-	static new readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterface));
+	static new readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
 
 	static Delegate cb_DoSomething;
 #pragma warning disable 0169

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultProperty.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultProperty.txt
@@ -1,7 +1,7 @@
 // Metadata.xml XPath interface reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']"
 [Register ("java/code/IMyInterface", "", "java.code.IMyInterfaceInvoker")]
 public partial interface IMyInterface : IJavaObject, IJavaPeerable {
-	static new readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterface));
+	static new readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
 
 	static Delegate cb_get_Value;
 #pragma warning disable 0169

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultPropertyGetterOnly.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultPropertyGetterOnly.txt
@@ -1,7 +1,7 @@
 // Metadata.xml XPath interface reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']"
 [Register ("java/code/IMyInterface", "", "java.code.IMyInterfaceInvoker")]
 public partial interface IMyInterface : IJavaObject, IJavaPeerable {
-	static new readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterface));
+	static new readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
 
 	static Delegate cb_get_Value;
 #pragma warning disable 0169


### PR DESCRIPTION
The following DIM case currently fails:

```
Java:
package com.xamarin.android;

public interface DefaultMethodsInterface
{
    default int foo () { return 0; }
}

C#
class ManagedOverrideDefault : Java.Lang.Object, IDefaultMethodsInterface
{
}

var over = new ManagedOverrideDefault ();
(over as IDefaultMethodsInterface).Foo ();
```

with:

```
Java.Lang.NoSuchMethodError : no non-static method "Ljava/lang/Object;.foo()I"
```

This adds a parameter to the `JniPeerMembers` constructor denoting this type is an Interface rather than a Class, so that `GetPeerMembers` can correctly resolve the method.