### PR TITLE
[generator] Use DIM to support static interface methods.

### DIFF
--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/InterfaceGen.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/InterfaceGen.cs
@@ -143,6 +143,8 @@ namespace MonoDroid.Generation
 
 		public bool HasDefaultMethods => GetAllMethods ().Any (m => m.IsInterfaceDefaultMethod);
 
+		public bool HasStaticMethods => GetAllMethods ().Any (m => m.IsStatic);
+
 		public bool IsConstSugar {
 			get {
 				if (Methods.Count > 0 || Properties.Count > 0)

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteStaticInterfaceMethod.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteStaticInterfaceMethod.txt
@@ -1,0 +1,101 @@
+[Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
+public abstract class MyInterface : Java.Lang.Object {
+
+	internal MyInterface ()
+	{
+	}
+	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='DoSomething' and count(parameter)=0]"
+	[Register ("DoSomething", "()V", "")]
+	public static unsafe void DoSomething ()
+	{
+		const string __id = "DoSomething.()V";
+		try {
+			_members.StaticMethods.InvokeVoidMethod (__id, null);
+		} finally {
+		}
+	}
+
+
+	static new readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (MyInterface));
+}
+
+[Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
+[global::System.Obsolete ("Use the 'MyInterface' type. This type will be removed in a future release.")]
+public abstract class MyInterfaceConsts : MyInterface {
+
+	private MyInterfaceConsts ()
+	{
+	}
+}
+
+// Metadata.xml XPath interface reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']"
+[Register ("java/code/IMyInterface", "", "java.code.IMyInterfaceInvoker")]
+public partial interface IMyInterface : IJavaObject, IJavaPeerable {
+	static new readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
+
+	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='DoSomething' and count(parameter)=0]"
+	[Register ("DoSomething", "()V", "")]
+	public static unsafe void DoSomething ()
+	{
+		const string __id = "DoSomething.()V";
+		try {
+			_members.StaticMethods.InvokeVoidMethod (__id, null);
+		} finally {
+		}
+	}
+
+}
+
+[global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
+internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
+
+	internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
+
+	static IntPtr java_class_ref {
+		get { return _members.JniPeerType.PeerReference.Handle; }
+	}
+
+	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+		get { return _members; }
+	}
+
+	protected override IntPtr ThresholdClass {
+		get { return class_ref; }
+	}
+
+	protected override global::System.Type ThresholdType {
+		get { return _members.ManagedPeerType; }
+	}
+
+	IntPtr class_ref;
+
+	public static IMyInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
+	{
+		return global::Java.Lang.Object.GetObject<IMyInterface> (handle, transfer);
+	}
+
+	static IntPtr Validate (IntPtr handle)
+	{
+		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
+			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
+						JNIEnv.GetClassNameFromInstance (handle), "java.code.IMyInterface"));
+		return handle;
+	}
+
+	protected override void Dispose (bool disposing)
+	{
+		if (this.class_ref != IntPtr.Zero)
+			JNIEnv.DeleteGlobalRef (this.class_ref);
+		this.class_ref = IntPtr.Zero;
+		base.Dispose (disposing);
+	}
+
+	public IMyInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
+	{
+		IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
+		this.class_ref = JNIEnv.NewGlobalRef (local_ref);
+		JNIEnv.DeleteLocalRef (local_ref);
+	}
+
+}
+

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteStaticInterfaceProperty.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteStaticInterfaceProperty.txt
@@ -1,0 +1,31 @@
+// Metadata.xml XPath interface reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']"
+[Register ("java/code/IMyInterface", "", "java.code.IMyInterfaceInvoker")]
+public partial interface IMyInterface : IJavaObject, IJavaPeerable {
+	static new readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
+
+	 static unsafe int Value {
+		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='get_Value' and count(parameter)=0]"
+		[Register ("get_Value", "()I", "Getget_ValueHandler")]
+		get {
+			const string __id = "get_Value.()I";
+			try {
+				var __rm = _members.StaticMethods.InvokeInt32Method (__id, null);
+				return __rm;
+			} finally {
+			}
+		}
+		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='set_Value' and count(parameter)=1 and parameter[1][@type='int']]"
+		[Register ("set_Value", "(I)V", "Getset_Value_IHandler")]
+		set {
+			const string __id = "set_Value.(I)V";
+			try {
+				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+				__args [0] = new JniArgumentValue (value);
+				_members.StaticMethods.InvokeVoidMethod (__id, __args);
+			} finally {
+			}
+		}
+	}
+
+}
+

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteStaticInterfaceMethod.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteStaticInterfaceMethod.txt
@@ -1,0 +1,101 @@
+[Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
+public abstract class MyInterface : Java.Lang.Object {
+
+	internal MyInterface ()
+	{
+	}
+	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='DoSomething' and count(parameter)=0]"
+	[Register ("DoSomething", "()V", "")]
+	public static unsafe void DoSomething ()
+	{
+		const string __id = "DoSomething.()V";
+		try {
+			_members.StaticMethods.InvokeVoidMethod (__id, null);
+		} finally {
+		}
+	}
+
+
+	static new readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (MyInterface));
+}
+
+[Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
+[global::System.Obsolete ("Use the 'MyInterface' type. This type will be removed in a future release.")]
+public abstract class MyInterfaceConsts : MyInterface {
+
+	private MyInterfaceConsts ()
+	{
+	}
+}
+
+// Metadata.xml XPath interface reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']"
+[Register ("java/code/IMyInterface", "", "java.code.IMyInterfaceInvoker")]
+public partial interface IMyInterface : IJavaObject, IJavaPeerable {
+	static new readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
+
+	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='DoSomething' and count(parameter)=0]"
+	[Register ("DoSomething", "()V", "")]
+	public static unsafe void DoSomething ()
+	{
+		const string __id = "DoSomething.()V";
+		try {
+			_members.StaticMethods.InvokeVoidMethod (__id, null);
+		} finally {
+		}
+	}
+
+}
+
+[global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
+internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
+
+	internal static new readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
+
+	static IntPtr java_class_ref {
+		get { return _members.JniPeerType.PeerReference.Handle; }
+	}
+
+	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+		get { return _members; }
+	}
+
+	protected override IntPtr ThresholdClass {
+		get { return class_ref; }
+	}
+
+	protected override global::System.Type ThresholdType {
+		get { return _members.ManagedPeerType; }
+	}
+
+	IntPtr class_ref;
+
+	public static IMyInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
+	{
+		return global::Java.Lang.Object.GetObject<IMyInterface> (handle, transfer);
+	}
+
+	static IntPtr Validate (IntPtr handle)
+	{
+		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
+			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
+						JNIEnv.GetClassNameFromInstance (handle), "java.code.IMyInterface"));
+		return handle;
+	}
+
+	protected override void Dispose (bool disposing)
+	{
+		if (this.class_ref != IntPtr.Zero)
+			JNIEnv.DeleteGlobalRef (this.class_ref);
+		this.class_ref = IntPtr.Zero;
+		base.Dispose (disposing);
+	}
+
+	public IMyInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
+	{
+		IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
+		this.class_ref = JNIEnv.NewGlobalRef (local_ref);
+		JNIEnv.DeleteLocalRef (local_ref);
+	}
+
+}
+

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteStaticInterfaceProperty.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteStaticInterfaceProperty.txt
@@ -1,0 +1,31 @@
+// Metadata.xml XPath interface reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']"
+[Register ("java/code/IMyInterface", "", "java.code.IMyInterfaceInvoker")]
+public partial interface IMyInterface : IJavaObject, IJavaPeerable {
+	static new readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
+
+	 static unsafe int Value {
+		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='get_Value' and count(parameter)=0]"
+		[Register ("get_Value", "()I", "Getget_ValueHandler")]
+		get {
+			const string __id = "get_Value.()I";
+			try {
+				var __rm = _members.StaticMethods.InvokeInt32Method (__id, null);
+				return __rm;
+			} finally {
+			}
+		}
+		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='set_Value' and count(parameter)=1 and parameter[1][@type='int']]"
+		[Register ("set_Value", "(I)V", "Getset_Value_IHandler")]
+		set {
+			const string __id = "set_Value.(I)V";
+			try {
+				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+				__args [0] = new JniArgumentValue (value);
+				_members.StaticMethods.InvokeVoidMethod (__id, __args);
+			} finally {
+			}
+		}
+	}
+
+}
+

--- a/tools/generator/Tests/Unit-Tests/DefaultInterfaceMethodsTests.cs
+++ b/tools/generator/Tests/Unit-Tests/DefaultInterfaceMethodsTests.cs
@@ -148,5 +148,40 @@ namespace generatortests
 			// The method should not be marked as 'virtual sealed'
 			Assert.False (writer.ToString ().Contains ("virtual sealed"));
 		}
+
+		[Test]
+		public void WriteStaticInterfaceMethod ()
+		{
+			// Create an interface with a static method
+			var iface = SupportTypeBuilder.CreateEmptyInterface ("java.code.IMyInterface");
+			iface.Methods.Add (new TestMethod (iface, "DoSomething").SetStatic ());
+
+			iface.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ());
+
+			generator.WriteInterface (iface, string.Empty, new GenerationInfo (string.Empty, string.Empty, "MyAssembly"));
+
+			Assert.AreEqual (GetTargetedExpected (nameof (WriteStaticInterfaceMethod)), writer.ToString ().NormalizeLineEndings ());
+		}
+
+		[Test]
+		public void WriteStaticInterfaceProperty ()
+		{
+			// Create an interface with a static property
+			var iface = SupportTypeBuilder.CreateEmptyInterface ("java.code.IMyInterface");
+			var prop = SupportTypeBuilder.CreateProperty (iface, "Value", "int", options);
+
+			prop.Getter.IsStatic = true;
+			prop.Getter.IsVirtual = false;
+			prop.Setter.IsStatic = true;
+			prop.Setter.IsVirtual = false;
+
+			iface.Properties.Add (prop);
+
+			iface.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ());
+
+			generator.WriteInterfaceDeclaration (iface, string.Empty);
+
+			Assert.AreEqual (GetTargetedExpected (nameof (WriteStaticInterfaceProperty)), writer.ToString ().NormalizeLineEndings ());
+		}
 	}
 }

--- a/tools/generator/Tests/generator-Tests.csproj
+++ b/tools/generator/Tests/generator-Tests.csproj
@@ -295,6 +295,12 @@
     <Content Include="Unit-Tests\CodeGeneratorExpectedResults\JavaInterop1\WriteMethodWithVoidReturn.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\JavaInterop1\WriteStaticInterfaceMethod.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\JavaInterop1\WriteStaticInterfaceProperty.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteClass.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -425,6 +431,12 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteProperty.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteStaticInterfaceMethod.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XAJavaInterop1\WriteStaticInterfaceProperty.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Unit-Tests\CodeGeneratorExpectedResults\XamarinAndroid\WriteClass.txt">


### PR DESCRIPTION
Using the new DIM support we can now also support static interface methods/properties.

Example:
```java
public interface StaticMethodsInterface
{
    static int foo () { return 10; }
    static int getValue () { return 3; }
    static void setValue (int value) { }
}
```

Can now be invoked:
```csharp
[Test]
public void TestStaticMethods ()
{
    Assert.AreEqual (10, IStaticMethodsInterface.Foo ());
			
    Assert.AreEqual (3, IStaticMethodsInterface.Value);
    Assert.DoesNotThrow (() => IStaticMethodsInterface.Value = 5);
}
```