### PR TITLE
[generator] Don't [Register] a Connector for static properties.

### DIFF
--- a/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/CodeGenerator.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/CodeGenerator.cs
@@ -1484,7 +1484,7 @@ namespace MonoDroid.Generation
 			writer.WriteLine ("{0}{1}{2} unsafe {3} {4} {{", indent, visibility, virtual_override, opt.GetOutputName (property.Getter.ReturnType), decl_name);
 			if (gen.IsGeneratable)
 				writer.WriteLine ("{0}\t// Metadata.xml XPath method reference: path=\"{1}/method[@name='{2}'{3}]\"", indent, gen.MetadataXPathReference, property.Getter.JavaName, property.Getter.Parameters.GetMethodXPathPredicate ());
-			writer.WriteLine ("{0}\t[Register (\"{1}\", \"{2}\", \"{3}\"{4})]", indent, property.Getter.JavaName, property.Getter.JniSignature, property.Getter.GetConnectorNameFull (opt), property.Getter.AdditionalAttributeString ());
+			writer.WriteLine ("{0}\t[Register (\"{1}\", \"{2}\", \"{3}\"{4})]", indent, property.Getter.JavaName, property.Getter.JniSignature, property.Getter.IsVirtual ? property.Getter.GetConnectorNameFull (opt) : string.Empty, property.Getter.AdditionalAttributeString ());
 			writer.WriteLine ("{0}\tget {{", indent);
 			WriteMethodBody (property.Getter, indent + "\t\t", gen);
 			writer.WriteLine ("{0}\t}}", indent);
@@ -1492,7 +1492,7 @@ namespace MonoDroid.Generation
 				if (gen.IsGeneratable)
 					writer.WriteLine ("{0}\t// Metadata.xml XPath method reference: path=\"{1}/method[@name='{2}'{3}]\"", indent, gen.MetadataXPathReference, property.Setter.JavaName, property.Setter.Parameters.GetMethodXPathPredicate ());
 				WriteMethodCustomAttributes (property.Setter, indent);
-				writer.WriteLine ("{0}\t[Register (\"{1}\", \"{2}\", \"{3}\"{4})]", indent, property.Setter.JavaName, property.Setter.JniSignature, property.Setter.GetConnectorNameFull (opt), property.Setter.AdditionalAttributeString ());
+				writer.WriteLine ("{0}\t[Register (\"{1}\", \"{2}\", \"{3}\"{4})]", indent, property.Setter.JavaName, property.Setter.JniSignature, property.Setter.IsVirtual ? property.Setter.GetConnectorNameFull (opt) : string.Empty, property.Setter.AdditionalAttributeString ());
 				writer.WriteLine ("{0}\tset {{", indent);
 				string pname = property.Setter.Parameters [0].Name;
 				property.Setter.Parameters [0].Name = "value";

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteClass.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteClass.txt
@@ -168,7 +168,7 @@ public partial class MyClass  {
 
 	public static unsafe int StaticCount {
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='get_StaticCount' and count(parameter)=0]"
-		[Register ("get_StaticCount", "()I", "Getget_StaticCountHandler")]
+		[Register ("get_StaticCount", "()I", "")]
 		get {
 			const string __id = "get_StaticCount.()I";
 			try {
@@ -178,7 +178,7 @@ public partial class MyClass  {
 			}
 		}
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='set_StaticCount' and count(parameter)=1 and parameter[1][@type='int']]"
-		[Register ("set_StaticCount", "(I)V", "Getset_StaticCount_IHandler")]
+		[Register ("set_StaticCount", "(I)V", "")]
 		set {
 			const string __id = "set_StaticCount.(I)V";
 			try {

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteClassProperties.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteClassProperties.txt
@@ -115,7 +115,7 @@ public virtual unsafe string Key {
 
 public static unsafe int StaticCount {
 	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='get_StaticCount' and count(parameter)=0]"
-	[Register ("get_StaticCount", "()I", "Getget_StaticCountHandler")]
+	[Register ("get_StaticCount", "()I", "")]
 	get {
 		const string __id = "get_StaticCount.()I";
 		try {
@@ -125,7 +125,7 @@ public static unsafe int StaticCount {
 		}
 	}
 	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='set_StaticCount' and count(parameter)=1 and parameter[1][@type='int']]"
-	[Register ("set_StaticCount", "(I)V", "Getset_StaticCount_IHandler")]
+	[Register ("set_StaticCount", "(I)V", "")]
 	set {
 		const string __id = "set_StaticCount.(I)V";
 		try {

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteStaticInterfaceProperty.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteStaticInterfaceProperty.txt
@@ -5,7 +5,7 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 
 	 static unsafe int Value {
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='get_Value' and count(parameter)=0]"
-		[Register ("get_Value", "()I", "Getget_ValueHandler")]
+		[Register ("get_Value", "()I", "")]
 		get {
 			const string __id = "get_Value.()I";
 			try {
@@ -15,7 +15,7 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 			}
 		}
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='set_Value' and count(parameter)=1 and parameter[1][@type='int']]"
-		[Register ("set_Value", "(I)V", "Getset_Value_IHandler")]
+		[Register ("set_Value", "(I)V", "")]
 		set {
 			const string __id = "set_Value.(I)V";
 			try {

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClass.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClass.txt
@@ -168,7 +168,7 @@ public partial class MyClass  {
 
 	public static unsafe int StaticCount {
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='get_StaticCount' and count(parameter)=0]"
-		[Register ("get_StaticCount", "()I", "Getget_StaticCountHandler")]
+		[Register ("get_StaticCount", "()I", "")]
 		get {
 			const string __id = "get_StaticCount.()I";
 			try {
@@ -178,7 +178,7 @@ public partial class MyClass  {
 			}
 		}
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='set_StaticCount' and count(parameter)=1 and parameter[1][@type='int']]"
-		[Register ("set_StaticCount", "(I)V", "Getset_StaticCount_IHandler")]
+		[Register ("set_StaticCount", "(I)V", "")]
 		set {
 			const string __id = "set_StaticCount.(I)V";
 			try {

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClassProperties.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClassProperties.txt
@@ -115,7 +115,7 @@ public virtual unsafe string Key {
 
 public static unsafe int StaticCount {
 	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='get_StaticCount' and count(parameter)=0]"
-	[Register ("get_StaticCount", "()I", "Getget_StaticCountHandler")]
+	[Register ("get_StaticCount", "()I", "")]
 	get {
 		const string __id = "get_StaticCount.()I";
 		try {
@@ -125,7 +125,7 @@ public static unsafe int StaticCount {
 		}
 	}
 	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='set_StaticCount' and count(parameter)=1 and parameter[1][@type='int']]"
-	[Register ("set_StaticCount", "(I)V", "Getset_StaticCount_IHandler")]
+	[Register ("set_StaticCount", "(I)V", "")]
 	set {
 		const string __id = "set_StaticCount.(I)V";
 		try {

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteStaticInterfaceProperty.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteStaticInterfaceProperty.txt
@@ -5,7 +5,7 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 
 	 static unsafe int Value {
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='get_Value' and count(parameter)=0]"
-		[Register ("get_Value", "()I", "Getget_ValueHandler")]
+		[Register ("get_Value", "()I", "")]
 		get {
 			const string __id = "get_Value.()I";
 			try {
@@ -15,7 +15,7 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 			}
 		}
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='set_Value' and count(parameter)=1 and parameter[1][@type='int']]"
-		[Register ("set_Value", "(I)V", "Getset_Value_IHandler")]
+		[Register ("set_Value", "(I)V", "")]
 		set {
 			const string __id = "set_Value.(I)V";
 			try {

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteClass.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteClass.txt
@@ -212,7 +212,7 @@ public partial class MyClass  {
 	static IntPtr id_set_StaticCount_I;
 	public static unsafe int StaticCount {
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='get_StaticCount' and count(parameter)=0]"
-		[Register ("get_StaticCount", "()I", "Getget_StaticCountHandler")]
+		[Register ("get_StaticCount", "()I", "")]
 		get {
 			if (id_get_StaticCount == IntPtr.Zero)
 				id_get_StaticCount = JNIEnv.GetStaticMethodID (class_ref, "get_StaticCount", "()I");
@@ -222,7 +222,7 @@ public partial class MyClass  {
 			}
 		}
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='set_StaticCount' and count(parameter)=1 and parameter[1][@type='int']]"
-		[Register ("set_StaticCount", "(I)V", "Getset_StaticCount_IHandler")]
+		[Register ("set_StaticCount", "(I)V", "")]
 		set {
 			if (id_set_StaticCount_I == IntPtr.Zero)
 				id_set_StaticCount_I = JNIEnv.GetStaticMethodID (class_ref, "set_StaticCount", "(I)V");

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteClassProperties.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteClassProperties.txt
@@ -139,7 +139,7 @@ static IntPtr id_get_StaticCount;
 static IntPtr id_set_StaticCount_I;
 public static unsafe int StaticCount {
 	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='get_StaticCount' and count(parameter)=0]"
-	[Register ("get_StaticCount", "()I", "Getget_StaticCountHandler")]
+	[Register ("get_StaticCount", "()I", "")]
 	get {
 		if (id_get_StaticCount == IntPtr.Zero)
 			id_get_StaticCount = JNIEnv.GetStaticMethodID (class_ref, "get_StaticCount", "()I");
@@ -149,7 +149,7 @@ public static unsafe int StaticCount {
 		}
 	}
 	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='set_StaticCount' and count(parameter)=1 and parameter[1][@type='int']]"
-	[Register ("set_StaticCount", "(I)V", "Getset_StaticCount_IHandler")]
+	[Register ("set_StaticCount", "(I)V", "")]
 	set {
 		if (id_set_StaticCount_I == IntPtr.Zero)
 			id_set_StaticCount_I = JNIEnv.GetStaticMethodID (class_ref, "set_StaticCount", "(I)V");

--- a/tools/generator/Tests/expected.ji/StaticProperties/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected.ji/StaticProperties/Xamarin.Test.SomeObject.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Test {
 
 		public static unsafe int SomeInteger {
 			// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/method[@name='getSomeInteger' and count(parameter)=0]"
-			[Register ("getSomeInteger", "()I", "GetGetSomeIntegerHandler")]
+			[Register ("getSomeInteger", "()I", "")]
 			get {
 				const string __id = "getSomeInteger.()I";
 				try {
@@ -42,7 +42,7 @@ namespace Xamarin.Test {
 				}
 			}
 			// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/method[@name='setSomeInteger' and count(parameter)=1 and parameter[1][@type='int']]"
-			[Register ("setSomeInteger", "(I)V", "GetSetSomeInteger_IHandler")]
+			[Register ("setSomeInteger", "(I)V", "")]
 			set {
 				const string __id = "setSomeInteger.(I)V";
 				try {
@@ -56,7 +56,7 @@ namespace Xamarin.Test {
 
 		public static unsafe string SomeString {
 			// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/method[@name='getSomeString' and count(parameter)=0]"
-			[Register ("getSomeString", "()Ljava/lang/String;", "GetGetSomeStringHandler")]
+			[Register ("getSomeString", "()Ljava/lang/String;", "")]
 			get {
 				const string __id = "getSomeString.()Ljava/lang/String;";
 				try {
@@ -66,7 +66,7 @@ namespace Xamarin.Test {
 				}
 			}
 			// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/method[@name='setSomeString' and count(parameter)=1 and parameter[1][@type='java.lang.String']]"
-			[Register ("setSomeString", "(Ljava/lang/String;)V", "GetSetSomeString_Ljava_lang_String_Handler")]
+			[Register ("setSomeString", "(Ljava/lang/String;)V", "")]
 			set {
 				const string __id = "setSomeString.(Ljava/lang/String;)V";
 				IntPtr native_value = JNIEnv.NewString (value);

--- a/tools/generator/Tests/expected/StaticProperties/Xamarin.Test.SomeObject.cs
+++ b/tools/generator/Tests/expected/StaticProperties/Xamarin.Test.SomeObject.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Test {
 		static IntPtr id_setSomeInteger_I;
 		public static unsafe int SomeInteger {
 			// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/method[@name='getSomeInteger' and count(parameter)=0]"
-			[Register ("getSomeInteger", "()I", "GetGetSomeIntegerHandler")]
+			[Register ("getSomeInteger", "()I", "")]
 			get {
 				if (id_getSomeInteger == IntPtr.Zero)
 					id_getSomeInteger = JNIEnv.GetStaticMethodID (class_ref, "getSomeInteger", "()I");
@@ -39,7 +39,7 @@ namespace Xamarin.Test {
 				}
 			}
 			// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/method[@name='setSomeInteger' and count(parameter)=1 and parameter[1][@type='int']]"
-			[Register ("setSomeInteger", "(I)V", "GetSetSomeInteger_IHandler")]
+			[Register ("setSomeInteger", "(I)V", "")]
 			set {
 				if (id_setSomeInteger_I == IntPtr.Zero)
 					id_setSomeInteger_I = JNIEnv.GetStaticMethodID (class_ref, "setSomeInteger", "(I)V");
@@ -56,7 +56,7 @@ namespace Xamarin.Test {
 		static IntPtr id_setSomeString_Ljava_lang_String_;
 		public static unsafe string SomeString {
 			// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/method[@name='getSomeString' and count(parameter)=0]"
-			[Register ("getSomeString", "()Ljava/lang/String;", "GetGetSomeStringHandler")]
+			[Register ("getSomeString", "()Ljava/lang/String;", "")]
 			get {
 				if (id_getSomeString == IntPtr.Zero)
 					id_getSomeString = JNIEnv.GetStaticMethodID (class_ref, "getSomeString", "()Ljava/lang/String;");
@@ -66,7 +66,7 @@ namespace Xamarin.Test {
 				}
 			}
 			// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/method[@name='setSomeString' and count(parameter)=1 and parameter[1][@type='java.lang.String']]"
-			[Register ("setSomeString", "(Ljava/lang/String;)V", "GetSetSomeString_Ljava_lang_String_Handler")]
+			[Register ("setSomeString", "(Ljava/lang/String;)V", "")]
 			set {
 				if (id_setSomeString_Ljava_lang_String_ == IntPtr.Zero)
 					id_setSomeString_Ljava_lang_String_ = JNIEnv.GetStaticMethodID (class_ref, "setSomeString", "(Ljava/lang/String;)V");


### PR DESCRIPTION
Default interface member static properties do not need to mention a
*connector-method* within the `[Register]` custom attribute.
Connector-methods are only for method *overrides*, and static methods
cannot be overridden.

Additionally, the connector method-related "glue" code isn't emitted,
so the connector-method value doesn't exist.

Update default interface member static property generation to mirror
that of [class static member generation][0] and emit the empty string
(`string.Empty`) as the conector method for static properties.

[0]: https://github.com/xamarin/java.interop/blob/fe13b1655d8a979f281cf923c97c9e0bf58dc614/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/CodeGenerator.cs#L1376-L1377
