### PR TITLE
[generator] Fix DIM error when subclassing a class that inherits an interface with a DIM method

### DIFF
--- a/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/CodeGenerator.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/CodeGenerator.cs
@@ -1470,8 +1470,13 @@ namespace MonoDroid.Generation
 			if ((property.Getter ?? property.Setter).IsStatic)
 				virtual_override = " static";
 			// It should be using AdjustedName instead of Name, but ICharSequence ("Formatted") properties are not caught by this...
-			else if (gen.BaseSymbol != null && gen.BaseSymbol.GetPropertyByName (property.Name, true) != null)
-				virtual_override = " override";
+			else if (gen.BaseSymbol != null) {
+				var base_prop = gen.BaseSymbol.GetPropertyByName (property.Name, true);
+
+				// If the matching base getter we found is a DIM, we do not override it, it should stay virtual
+				if (base_prop != null && !base_prop.Getter.IsInterfaceDefaultMethod)
+					virtual_override = " override";
+			}
 
 			WriteMethodIdField (property.Getter, indent);
 			if (property.Setter != null)


### PR DESCRIPTION
Given this Java hierarchy:

```java
public interface DefaultMethodsInterface
{
    default int getBar () { return 2; }
}

public class EmptyOverrideClass implements DefaultMethodsInterface
{
}

public class ImplementedChainOverrideClass extends EmptyOverrideClass
{
    @Override
    public int getBar () { return 100; }
}
```

We are generating the `Bar` property improperly as `override`:
```csharp
public override unsafe int Bar { get { ... } }
```

In C# you do not `override` a DIM, you need to declare it as `virtual`.  (see https://github.com/dotnet/csharplang/issues/2757)

We need to see if we are "overriding" a property and not use `override` if it is a DIM.
```csharp
public virtual unsafe int Bar { get { ... } }
```