### PR TITLE
[generator] Ratchet [Obsolete] *InterfaceConsts classes up to an error.

### DIFF
--- a/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/CodeGenerator.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/CodeGenerator.cs
@@ -747,7 +747,7 @@ namespace MonoDroid.Generation
 
 				if (!@interface.HasManagedName) {
 					writer.WriteLine ("{0}[Register (\"{1}\"{2}, DoNotGenerateAcw=true)]", indent, @interface.RawJniName, @interface.AdditionalAttributeString ());
-					writer.WriteLine ("{0}[global::System.Obsolete (\"Use the '{1}' type. This type will be removed in a future release.\")]", indent, name);
+					writer.WriteLine ("{0}[global::System.Obsolete (\"Use the '{1}' type. This type will be removed in a future release.\", error: true)]", indent, name);
 					writer.WriteLine ("{0}public abstract class {1}Consts : {1} {{", indent, name);
 					writer.WriteLine ();
 					writer.WriteLine ("{0}\tprivate {1}Consts ()", indent, name);

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterface.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterface.txt
@@ -20,7 +20,7 @@ public abstract class MyInterface : Java.Lang.Object {
 }
 
 [Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
-[global::System.Obsolete ("Use the 'MyInterface' type. This type will be removed in a future release.")]
+[global::System.Obsolete ("Use the 'MyInterface' type. This type will be removed in a future release.", error: true)]
 public abstract class MyInterfaceConsts : MyInterface {
 
 	private MyInterfaceConsts ()

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteStaticInterfaceMethod.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteStaticInterfaceMethod.txt
@@ -20,7 +20,7 @@ public abstract class MyInterface : Java.Lang.Object {
 }
 
 [Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
-[global::System.Obsolete ("Use the 'MyInterface' type. This type will be removed in a future release.")]
+[global::System.Obsolete ("Use the 'MyInterface' type. This type will be removed in a future release.", error: true)]
 public abstract class MyInterfaceConsts : MyInterface {
 
 	private MyInterfaceConsts ()

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterface.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterface.txt
@@ -20,7 +20,7 @@ public abstract class MyInterface : Java.Lang.Object {
 }
 
 [Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
-[global::System.Obsolete ("Use the 'MyInterface' type. This type will be removed in a future release.")]
+[global::System.Obsolete ("Use the 'MyInterface' type. This type will be removed in a future release.", error: true)]
 public abstract class MyInterfaceConsts : MyInterface {
 
 	private MyInterfaceConsts ()

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteStaticInterfaceMethod.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteStaticInterfaceMethod.txt
@@ -20,7 +20,7 @@ public abstract class MyInterface : Java.Lang.Object {
 }
 
 [Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
-[global::System.Obsolete ("Use the 'MyInterface' type. This type will be removed in a future release.")]
+[global::System.Obsolete ("Use the 'MyInterface' type. This type will be removed in a future release.", error: true)]
 public abstract class MyInterfaceConsts : MyInterface {
 
 	private MyInterfaceConsts ()

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteInterface.txt
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteInterface.txt
@@ -22,7 +22,7 @@ public abstract class MyInterface : Java.Lang.Object {
 }
 
 [Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
-[global::System.Obsolete ("Use the 'MyInterface' type. This type will be removed in a future release.")]
+[global::System.Obsolete ("Use the 'MyInterface' type. This type will be removed in a future release.", error: true)]
 public abstract class MyInterfaceConsts : MyInterface {
 
 	private MyInterfaceConsts ()

--- a/tools/generator/Tests/expected.ji/TestInterface/Test.ME.ITestInterface.cs
+++ b/tools/generator/Tests/expected.ji/TestInterface/Test.ME.ITestInterface.cs
@@ -32,7 +32,7 @@ namespace Test.ME {
 	}
 
 	[Register ("test/me/TestInterface", DoNotGenerateAcw=true)]
-	[global::System.Obsolete ("Use the 'TestInterface' type. This type will be removed in a future release.")]
+	[global::System.Obsolete ("Use the 'TestInterface' type. This type will be removed in a future release.", error: true)]
 	public abstract class TestInterfaceConsts : TestInterface {
 
 		private TestInterfaceConsts ()

--- a/tools/generator/Tests/expected/TestInterface/Test.ME.ITestInterface.cs
+++ b/tools/generator/Tests/expected/TestInterface/Test.ME.ITestInterface.cs
@@ -32,7 +32,7 @@ namespace Test.ME {
 	}
 
 	[Register ("test/me/TestInterface", DoNotGenerateAcw=true)]
-	[global::System.Obsolete ("Use the 'TestInterface' type. This type will be removed in a future release.")]
+	[global::System.Obsolete ("Use the 'TestInterface' type. This type will be removed in a future release.", error: true)]
 	public abstract class TestInterfaceConsts : TestInterface {
 
 		private TestInterfaceConsts ()


### PR DESCRIPTION
The `*InterfaceConsts` classes we originally generated have been marked as `[Obsolete]` for at least 3 years:

```csharp
[Obsolete ("Use the 'MyInterface' type. This type will be removed in a future release.")]
public abstract class MyInterfaceConsts : MyInterface { }
```

It's time to tighten the screws a little bit and make this an error.

```csharp
[Obsolete ("Use the 'MyInterface' type. This type will be removed in a future release.", error: true)]
public abstract class MyInterfaceConsts : MyInterface { }
```

Related to #436.