### PR TITLE
[crc64] changes to fix a collision

### DIFF
--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/Crc64.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/Crc64.cs
@@ -174,7 +174,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers
 		};
 
 		ulong crc = ulong.MaxValue;
-		ulong length;
+		ulong length = 0;
 
 		public override void Initialize () { }
 

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/Crc64.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/Crc64.cs
@@ -36,6 +36,9 @@ namespace Java.Interop.Tools.JavaCallableWrappers
 	/// <summary>
 	///  CRC64 variant: crc-64-jones 64-bit
 	///  * Poly: 0xad93d23594c935a9
+	///  Changes beyond initial implementation:
+	///  * Starting Value: ulong.MaxValue
+	///  * XOR length in HashFinal()
 	/// </summary>
 	public class Crc64 : HashAlgorithm
 	{
@@ -170,7 +173,8 @@ namespace Java.Interop.Tools.JavaCallableWrappers
 		    0x536fa08fdfd90e51, 0x29b7d047efec8728,
 		};
 
-		ulong crc;
+		ulong crc = ulong.MaxValue;
+		ulong length;
 
 		public override void Initialize () { }
 
@@ -179,8 +183,9 @@ namespace Java.Interop.Tools.JavaCallableWrappers
 			for (int i = ibStart; i < cbSize; i++) {
 				crc = Table [(byte) (crc ^ array [i])] ^ (crc >> 8);
 			}
+			length += (ulong) cbSize;
 		}
 
-		protected override byte [] HashFinal () => BitConverter.GetBytes (crc);
+		protected override byte [] HashFinal () => BitConverter.GetBytes (crc ^ length);
 	}
 }

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers/Crc64Tests.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers/Crc64Tests.cs
@@ -9,7 +9,11 @@ namespace Java.Interop.Tools.JavaCallableWrappersTests
 	{
 		static string ToHash (string value)
 		{
-			var data = Encoding.UTF8.GetBytes (value);
+			return ToHash (Encoding.UTF8.GetBytes (value));
+		}
+
+		static string ToHash (byte[] data)
+		{
 			using (var crc = new Crc64 ()) {
 				var hash = crc.ComputeHash (data);
 				var buf = new StringBuilder (hash.Length * 2);
@@ -23,14 +27,20 @@ namespace Java.Interop.Tools.JavaCallableWrappersTests
 		public void Hello ()
 		{
 			var actual = ToHash ("hello");
-			Assert.AreEqual ("a27666cb10ddb0d6", actual);
+			Assert.AreEqual ("ad3d04bd697eb3c5", actual);
 		}
 
 		[Test]
 		public void XmlDocument ()
 		{
 			var actual = ToHash ("System.Xml.XmlDocument, System.Xml");
-			Assert.AreEqual ("2fbc43b3a95193ae", actual);
+			Assert.AreEqual ("348bbd9fecf1b865", actual);
+		}
+
+		[Test]
+		public void Collision ()
+		{
+			Assert.AreNotEqual (ToHash (""), ToHash (new byte [32]));
 		}
 	}
 }

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers/JavaNativeTypeManagerTests.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers/JavaNativeTypeManagerTests.cs
@@ -36,7 +36,7 @@ namespace Java.Interop.Tools.JavaCallableWrappersTests
 		public void Crc64 ()
 		{
 			JavaNativeTypeManager.PackageNamingPolicy = PackageNamingPolicy.LowercaseCrc64;
-			Assert.AreEqual ("crc640005e817d0491b19", JavaNativeTypeManager.GetPackageName (typeof (string)));
+			Assert.AreEqual ("crc64b74743e9328eed0a", JavaNativeTypeManager.GetPackageName (typeof (string)));
 		}
 
 		[Test]


### PR DESCRIPTION
When testing out the new hash function, I found a collision:

    Hash ("") == Hash(new byte[32])

Both values were `00-00-00-00-00-00-00-00`.

It seems that a value of length 0 would get the same hash as an empty
`byte[]`.

Two changes to the algorithm:

* The `crc` value starts at `ulong.MaxValue`. Many CRC algorithms do
  this.
* XOR the length of the bytes. Many CRC algorithms XOR a constant
  value at the end, but using the `length` should provide further
  uniqueness.

This should lessen the chance for collisions.