### PR TITLE
[ApiXmlAdjuster] Guard against NRE when writing generic constraints.

### DIFF
--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiXmlGeneratorExtensions.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiXmlGeneratorExtensions.cs
@@ -124,7 +124,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 					// jar2xml does not emit that either.
 					var gcs = tp.GenericConstraints.GenericConstraints;
 					var gctr = gcs.Count == 1 ? gcs [0].ResolvedType : null;
-					if (gctr == null || gctr.ReferencedType.FullName != "java.lang.Object")
+					if (gctr?.ReferencedType?.FullName != "java.lang.Object")
 					{
 						writer.WriteStartElement ("genericConstraints");
 						foreach (var g in tp.GenericConstraints.GenericConstraints) {


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/issues/466

In an effort to get people unblocked on binding Kotlin libraries in 16.4 Preview 2, this PR simply guards against the NRE generated.  It does not attempt to figure out the underlying problem and generate better code.

This at least lets people get past the crash so they can do fixups in `metadata.xml` to continue.  I will be making our Kotlin bindings more "correct" in future sprints.  (This NRE happens before the `metadata` stage so there's nothing a user can currently do.)