### PR TITLE
[generator] Replace hyphens in managed names.

### DIFF
--- a/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
+using Java.Interop.Tools.JavaCallableWrappers;
 using MonoDroid.Utils;
 using Xamarin.Android.Tools;
 
@@ -270,7 +271,7 @@ namespace MonoDroid.Generation
 		public static Parameter CreateParameter (XElement elem)
 		{
 			string managedName = elem.XGetAttribute ("managedName");
-			string name = !string.IsNullOrEmpty (managedName) ? managedName : EnsureValidIdentifer (TypeNameUtilities.MangleName (elem.XGetAttribute ("name")));
+			string name = !string.IsNullOrEmpty (managedName) ? managedName : TypeNameUtilities.MangleName (EnsureValidIdentifer (elem.XGetAttribute ("name")));
 			string java_type = elem.XGetAttribute ("type");
 			string enum_type = elem.Attribute ("enumType") != null ? elem.XGetAttribute ("enumType") : null;
 			string managed_type = elem.Attribute ("managedType") != null ? elem.XGetAttribute ("managedType") : null;
@@ -294,7 +295,7 @@ namespace MonoDroid.Generation
 			if (string.IsNullOrWhiteSpace (name))
 				return name;
 
-			name = name.Replace ('$', '_');
+			name = IdentifierValidator.CreateValidIdentifier (name);
 
 			if (char.IsNumber (name [0]))
 				name = $"_{name}";

--- a/tools/generator/Tests/Unit-Tests/XmlApiImporterTests.cs
+++ b/tools/generator/Tests/Unit-Tests/XmlApiImporterTests.cs
@@ -81,6 +81,15 @@ namespace generatortests
 		}
 
 		[Test]
+		public void CreateMethod_EnsureValidNameHyphen ()
+		{
+			var xml = XDocument.Parse ("<package name=\"com.example.test\" jni-name=\"com/example/test\"><class name=\"test\"><method name=\"-3\" /></class></package>");
+			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"));
+
+			Assert.AreEqual ("_3", klass.Methods [0].Name);
+		}
+
+		[Test]
 		public void CreateParameter_EnsureValidName ()
 		{
 			var xml = XDocument.Parse ("<parameter name=\"$3\" />");


### PR DESCRIPTION
Context: #464 issues 1 and 2.

Kotlin allows hyphens in class/member names.  Replace them with underscores for the managed name so we generate valid C# names.