### PR TITLE
[logcat-parse] Various semantic bugfixes

### DIFF
--- a/tools/logcat-parse/GrefParseOptions.cs
+++ b/tools/logcat-parse/GrefParseOptions.cs
@@ -5,8 +5,16 @@ namespace Xamarin.Android.Tools.LogcatParse {
 	[Flags]
 	public enum GrefParseOptions {
 		None,
-		CheckCounts             = 1,
-		WarnOnCountMismatch     = 1,
-		ThrowOnCountMismatch    = 2,
+
+		LogWarningOnMismatch            = 1 << 0,
+		ThrowExceptionOnMismatch        = 1 << 1,
+
+		CheckCounts                     = 1 << 2,
+		WarnOnCountMismatch             = CheckCounts | LogWarningOnMismatch,
+		ThrowOnCountMismatch            = CheckCounts | ThrowExceptionOnMismatch,
+
+		CheckAlivePeers                 = 1 << 3,
+		WarnOnAlivePeerMismatch         = CheckAlivePeers | LogWarningOnMismatch,
+		ThrowOnAlivePeerMismatch        = CheckAlivePeers | ThrowExceptionOnMismatch,
 	}
 }

--- a/tools/logcat-parse/PeerInfo.cs
+++ b/tools/logcat-parse/PeerInfo.cs
@@ -97,22 +97,30 @@ namespace Xamarin.Android.Tools.LogcatParse {
 
 		public static bool operator==(JniHandleInfo lhs, string rhs)
 		{
-			return lhs.Handle == rhs;
+			if (string.IsNullOrEmpty (rhs))
+				return lhs.Handle == rhs;
+			return lhs == new JniHandleInfo (rhs);
 		}
 
 		public static bool operator!=(JniHandleInfo lhs, string rhs)
 		{
-			return lhs.Handle != rhs;
+			if (string.IsNullOrEmpty (rhs))
+				return lhs.Handle != rhs;
+			return lhs != new JniHandleInfo (rhs);
 		}
 
 		public static bool operator==(string lhs, JniHandleInfo rhs)
 		{
-			return lhs == rhs.Handle;
+			if (string.IsNullOrEmpty (lhs))
+				return lhs == rhs.Handle;
+			return new JniHandleInfo (lhs) == rhs;
 		}
 
 		public static bool operator!=(string lhs, JniHandleInfo rhs)
 		{
-			return lhs != rhs.Handle;
+			if (string.IsNullOrEmpty (lhs))
+				return lhs != rhs.Handle;
+			return new JniHandleInfo (lhs) != rhs;
 		}
 	}
 
@@ -154,7 +162,9 @@ namespace Xamarin.Android.Tools.LogcatParse {
 		public string                       McwType     {get; internal set;}
 
 		public string                       KeyHandle   {get; internal set;}
-		public ISet<JniHandleInfo>          Handles     {get; private set;}
+		public IList<JniHandleInfo>         Handles     {get; private set;}
+
+		public IList<JniHandleInfo>         RemovedHandles      {get; private set;}
 
 		public string                       CreatedOnThread     { get; internal set; }
 		public string                       DestroyedOnThread   { get; internal set; }
@@ -167,8 +177,9 @@ namespace Xamarin.Android.Tools.LogcatParse {
 
 		public PeerInfo (string pid)
 		{
-			Handles   = new HashSet<JniHandleInfo> ();
+			Handles   = new List<JniHandleInfo> ();
 			KeyHandle = JniType = McwType = "";
+			RemovedHandles  = new List<JniHandleInfo> ();
 			int p;
 			if (int.TryParse (pid, NumberStyles.Integer, CultureInfo.InvariantCulture, out p))
 			    Pid = p;

--- a/tools/logcat-parse/Tests/GrefsTest.cs
+++ b/tools/logcat-parse/Tests/GrefsTest.cs
@@ -27,10 +27,12 @@ namespace Xamarin.Android.Tools.LogcatParse.Tests {
 				Assert.AreEqual ("android/widget/ProgressBar", peer.JniType);
 				Assert.AreEqual ("Android.Widget.ProgressBar", peer.McwType);
 				Assert.AreEqual ("0x41f008f8", peer.KeyHandle);
-				Assert.AreEqual (3, peer.Handles.Count);
-				Assert.IsTrue (peer.Handles.Contains ("0x1d20046a"));
-				Assert.IsTrue (peer.Handles.Contains ("0x1d200003"));
-				Assert.IsTrue (peer.Handles.Contains ("0x41f008f8"));
+				Assert.AreEqual (0, peer.Handles.Count);
+				Assert.AreEqual (3, peer.RemovedHandles.Count);
+				Assert.IsTrue (peer.RemovedHandles [0] == "0x41f008f8/L");
+				Assert.IsTrue (peer.RemovedHandles [1] == "0x1d20046a/G");
+				Assert.IsTrue (peer.RemovedHandles [2] == "0x1d200003/W");
+
 				Assert.AreEqual (
 						"   at Android.Runtime.JNIEnv.NewGlobalRef(IntPtr jobject)\n" +
 						"   at Java.Lang.Object.RegisterInstance(IJavaObject instance, IntPtr value, JniHandleOwnership transfer)\n" +
@@ -60,9 +62,10 @@ namespace Xamarin.Android.Tools.LogcatParse.Tests {
 				Assert.AreEqual ("java/lang/String", peer.JniType);
 				Assert.AreEqual ("Java.Lang.String", peer.McwType);
 				Assert.AreEqual ("0x41e29778", peer.KeyHandle);
-				Assert.AreEqual (2, peer.Handles.Count);
-				Assert.IsTrue (peer.Handles.Contains ("0x1d200282"));
-				Assert.IsTrue (peer.Handles.Contains ("0x41e29778"));
+				Assert.AreEqual (0, peer.Handles.Count);
+				Assert.AreEqual (2, peer.RemovedHandles.Count);
+				Assert.IsTrue (peer.RemovedHandles [0] == "0x41e29778/L");
+				Assert.IsTrue (peer.RemovedHandles [1] == "0x1d200282/G");
 				Assert.AreEqual (
 						"   at Android.Runtime.JNIEnv.NewGlobalRef(IntPtr jobject)\n" +
 						"   at Java.Lang.Object.RegisterInstance(IJavaObject instance, IntPtr value, JniHandleOwnership transfer)\n" +
@@ -95,11 +98,12 @@ namespace Xamarin.Android.Tools.LogcatParse.Tests {
 				Assert.AreEqual ("android/widget/LinearLayout", peer.JniType);
 				Assert.AreEqual ("Android.Widget.LinearLayout", peer.McwType);
 				Assert.AreEqual ("0x41ff8758", peer.KeyHandle);
-				Assert.AreEqual (4, peer.Handles.Count);
-				Assert.IsTrue (peer.Handles.Contains ("0x1d200f1e"));
-				Assert.IsTrue (peer.Handles.Contains ("0x1d9000cb"));
-				Assert.IsTrue (peer.Handles.Contains ("0x1d300eea"));
-				Assert.IsTrue (peer.Handles.Contains ("0x41ff8758"));
+				Assert.AreEqual (1, peer.Handles.Count);
+				Assert.IsTrue (peer.Handles [0] == "0x1d300eea");
+				Assert.AreEqual (3, peer.RemovedHandles.Count);
+				Assert.IsTrue (peer.RemovedHandles [0] == "0x41ff8758/L");
+				Assert.IsTrue (peer.RemovedHandles [1] == "0x1d200f1e/G");
+				Assert.IsTrue (peer.RemovedHandles [2] == "0x1d9000cb/W");
 				Assert.AreEqual (
 						"   at Android.Runtime.JNIEnv.NewGlobalRef(IntPtr jobject)\n" +
 						"   at Java.Lang.Object.RegisterInstance(IJavaObject instance, IntPtr value, JniHandleOwnership transfer)\n" +
@@ -130,9 +134,10 @@ namespace Xamarin.Android.Tools.LogcatParse.Tests {
 				Assert.IsFalse (peer.Disposed);
 				Assert.AreEqual ("Java.Lang.Thread+RunnableImplementor.class",      peer.JniType);
 				Assert.AreEqual ("typeof(Java.Lang.Thread+RunnableImplementor)",    peer.McwType);
-				Assert.AreEqual (2, peer.Handles.Count);
-				Assert.IsTrue (peer.Handles.Contains ("0x1d200276"));
-				Assert.IsTrue (peer.Handles.Contains ("0x41e29370"));
+				Assert.AreEqual (0, peer.Handles.Count);
+				Assert.AreEqual (2, peer.RemovedHandles.Count);
+				Assert.IsTrue (peer.RemovedHandles [0] == "0x41e29370/L");
+				Assert.IsTrue (peer.RemovedHandles [1] == "0x1d200276/G");
 				Assert.AreEqual (
 					"   at Android.Runtime.JNIEnv.NewGlobalRef(IntPtr jobject)\n" +
 					"   at Android.Runtime.JNIEnv.FindClass(System.String classname)\n" +
@@ -185,10 +190,11 @@ namespace Xamarin.Android.Tools.LogcatParse.Tests {
 				Assert.IsFalse (peer.Disposed);
 				Assert.AreEqual ("android/widget/NewButton", peer.JniType);
 				Assert.AreEqual ("Android.Widget.NewButton", peer.McwType);
-				Assert.AreEqual (3, peer.Handles.Count);
-				Assert.IsTrue (peer.Handles.Contains ("0xbecdf114"));
+				Assert.AreEqual (2, peer.Handles.Count);
 				Assert.IsTrue (peer.Handles.Contains ("0x100456"));
 				Assert.IsTrue (peer.Handles.Contains ("0x100472"));
+				Assert.AreEqual (1, peer.RemovedHandles.Count);
+				Assert.IsTrue (peer.RemovedHandles [0] == "0xbecdf114/L");
 				Assert.AreEqual (
 					"   at Android.Runtime.JNIEnv.NewGlobalRef(IntPtr jobject)\n" +
 					"   at Java.Lang.Object.RegisterInstance(IJavaObject instance, IntPtr value, JniHandleOwnership transfer, IntPtr ByRef handle)\n" +
@@ -220,9 +226,10 @@ namespace Xamarin.Android.Tools.LogcatParse.Tests {
 				Assert.IsFalse (peer.Disposed);
 				Assert.AreEqual ("Android.Widget.Button.class",     peer.JniType);
 				Assert.AreEqual ("typeof(Android.Widget.Button)",   peer.McwType);
-				Assert.AreEqual (2, peer.Handles.Count);
-				Assert.IsTrue (peer.Handles.Contains ("0x7830001d"));
-				Assert.IsTrue (peer.Handles.Contains ("0x10046a"));
+				Assert.AreEqual (1, peer.Handles.Count);
+				Assert.IsTrue (peer.Handles [0] == "0x10046a");
+				Assert.AreEqual (1, peer.RemovedHandles.Count);
+				Assert.IsTrue (peer.RemovedHandles [0] == "0x7830001d/L");
 
 				Assert.AreEqual (
 					"   at Android.Runtime.JNIEnv.NewGlobalRef(IntPtr jobject)\n" +
@@ -250,9 +257,10 @@ namespace Xamarin.Android.Tools.LogcatParse.Tests {
 				Assert.IsFalse (peer.Disposed);
 				Assert.AreEqual ("Android.Views.View+IOnClickListenerInvoker.class",    peer.JniType);
 				Assert.AreEqual ("typeof(Android.Views.View+IOnClickListenerInvoker)",  peer.McwType);
-				Assert.AreEqual (2, peer.Handles.Count);
-				Assert.IsTrue (peer.Handles.Contains ("0x78b0001d"));
-				Assert.IsTrue (peer.Handles.Contains ("0x100476"));
+				Assert.AreEqual (1, peer.Handles.Count);
+				Assert.IsTrue (peer.Handles [0] == "0x100476");
+				Assert.AreEqual (1, peer.RemovedHandles.Count);
+				Assert.IsTrue (peer.RemovedHandles [0] == "0x78b0001d/L");
 
 
 				Assert.AreEqual (
@@ -289,9 +297,9 @@ namespace Xamarin.Android.Tools.LogcatParse.Tests {
 				Assert.IsFalse (peer.Finalized);
 				Assert.AreEqual ("Android.Runtime.JavaList.class",      peer.JniType);
 				Assert.AreEqual ("typeof(Android.Runtime.JavaList)",    peer.McwType);
-				Assert.AreEqual (2, peer.Handles.Count);
-				Assert.IsTrue (peer.Handles.Contains ("0x4a00009"));
 				Assert.IsTrue (peer.Handles.Contains ("0x19004aa"));
+				Assert.AreEqual (1, peer.RemovedHandles.Count);
+				Assert.IsTrue (peer.RemovedHandles [0] == "0x4a00009/L");
 
 
 				Assert.AreEqual (
@@ -356,10 +364,11 @@ namespace Xamarin.Android.Tools.LogcatParse.Tests {
 				Assert.AreEqual ("'finalizer'(20660)",  peer.DestroyedOnThread);
 
 				Assert.AreEqual ("0x39bcfcb7",          peer.KeyHandle);
-				Assert.AreEqual (3, peer.Handles.Count);
-				Assert.IsTrue (peer.Handles.Contains ("0x9500001/L"));
-				Assert.IsTrue (peer.Handles.Contains ("0x100492/G"));
-				Assert.IsTrue (peer.Handles.Contains ("0x700003/W"));
+				Assert.AreEqual (0, peer.Handles.Count);
+				Assert.AreEqual (3, peer.RemovedHandles.Count);
+				Assert.IsTrue (peer.RemovedHandles [0] == "0x9500001/L");
+				Assert.IsTrue (peer.RemovedHandles [1] == "0x100492/G");
+				Assert.IsTrue (peer.RemovedHandles [2] == "0x700003/W");
 
 				Assert.AreEqual (
 					"   at Android.Runtime.JNIEnv.NewGlobalRef(IntPtr jobject)\n" +
@@ -420,9 +429,10 @@ namespace Xamarin.Android.Tools.LogcatParse.Tests {
 				Assert.AreEqual ("'(null)'(3)", peer.DestroyedOnThread);
 
 				Assert.AreEqual ("0x41e29778", peer.KeyHandle);
-				Assert.AreEqual (2, peer.Handles.Count);
-				Assert.IsTrue (peer.Handles.Contains ("0x4a00009/L"));
-				Assert.IsTrue (peer.Handles.Contains ("0x19004aa/G"));
+				Assert.AreEqual (0, peer.Handles.Count);
+				Assert.AreEqual (2, peer.RemovedHandles.Count);
+				Assert.IsTrue (peer.RemovedHandles [0] == "0x4a00009/L");
+				Assert.IsTrue (peer.RemovedHandles [1] == "0x19004aa/G");
 
 				Assert.AreEqual (
 					"  at Doesn't Matter",
@@ -439,9 +449,10 @@ namespace Xamarin.Android.Tools.LogcatParse.Tests {
 				Assert.AreEqual (null,          peer.DestroyedOnThread);
 
 				Assert.AreEqual ("0x41e29778", peer.KeyHandle);
-				Assert.AreEqual (2, peer.Handles.Count);
-				Assert.IsTrue (peer.Handles.Contains ("0x4a00009/L"));
-				Assert.IsTrue (peer.Handles.Contains ("0x19004aa/G"));
+				Assert.AreEqual (1, peer.Handles.Count);
+				Assert.IsTrue (peer.Handles [0] == "0x19004aa/G");
+				Assert.AreEqual (1, peer.RemovedHandles.Count);
+				Assert.IsTrue (peer.RemovedHandles [0] == "0x4a00009/L");
 
 				Assert.AreEqual (
 					"  at Doesn't Matter",


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/3706

A memory leak in an app is reported.

What Do We Do™?  We enable GREF logging and use `logcat-parse`!

GREF logging is enabled via the `debug.mono.log` Android system
property, by having it include `gref`:

	adb shell setprop debug.mono.log gref,timing,

When GREF logging is enabled, the app will write a `grefs.txt` file
into the `.__override__` directory.  Launch the app, use it for
awhile, then extract the `grefs.txt` file:

	adb shell run-as ActivityRecreateTest.ActivityRecreateTest cat files/.__override__/grefs.txt > grefs.txt

Once you have `grefs.txt`, use `logcat-parse.exe` to read it:

	$ mono /Library/Frameworks/Xamarin.Android.framework/Versions/Current/lib/xamarin.android/xbuild/Xamarin/Android/logcat-parse.exe grefs.txt
	# A different path is used on Windows, but it's still `logcat-parse.exe`
	// `adb logcat` GREF parsing utility
	//
	// Use `Grefs.Parse(stream)` to parse a file containing `adb logcat` output.
	// Grefs.AllocatedPeers contains all exposed Java.Lang.Object instances.
	// Grefs.AlivePeers contains those still alive by the end of parsing.
	var grefs = Grefs.Parse("grefs.txt");

That's when things get...weird:

	csharp> grefs.GrefCount;
	245
	csharp> grefs.AlivePeers.Count();
	18

There's a GREF count of 245, which matches what we can see within
`grefs.txt`, which has the following line toward the end:

	+g+ grefc 245 gwrefc 0 obj-handle 0x79/I -> new-handle 0x2aa6/G from thread '(null)'(1)

...but there's only *18* peers?  For 245 GREFs?

That does *not* make sense.

(It *is* possible to "alias" GREFs, but that's not very common in a
Xamarin.Android app, and the above would require ~14 GREFs per peer,
which is *very* unlikely.)

Turns Out™, `logcat-parse` has bugs!

![Bugs Everywhere][0]

~~ Initial Handle Reuse ~~

One of the problems was that the handle used when an instance entered
managed code could be *reused*:

	+g+ grefc 11 gwrefc 0 obj-handle 0x71/L -> new-handle 0x266a/G from thread '(null)'(1)
	...
	+g+ grefc 15 gwrefc 0 obj-handle 0x71/I -> new-handle 0x26aa/G from thread '(null)'(1)
	...
	+g+ grefc 21 gwrefc 0 obj-handle 0x71/I -> new-handle 0x2786/G from thread '(null)'(1)
	...
	+g+ grefc 25 gwrefc 0 obj-handle 0x71/I -> new-handle 0x280a/G from thread '(null)'(1)
	...
	+g+ grefc 26 gwrefc 0 obj-handle 0x71/I -> new-handle 0x2816/G from thread '(null)'(1)

Note that `obj-handle 0x71` is present in *all* of these messages, but
they *all* refer to *different object instances*.  However, because of
how `Grefs.GetPeerInfo()` and `PeerInfo.Handles` worked, they were all
associated with the same `PeerInfo` instance, because the *first*
`obj-handle 0x71` became the "owner" of all the *other*
`obj-handle 0x71` instances.

To address this, make two thanges to `Grefs` and `PeerInfo`:

 1. Split up `PeerInfo.Handles` into `PeerInfo.Handles`, which
    contains all *current* handles, and `PeerInfo.RemovedHandles`,
    which contains all *previously seen but no longer valid*
    JNI handles.

 2. When creating a new `PeerInfo` instance, DO NOT use the
    `obj-handle` value found in the `+g+` message.  That is
    *immediately* considered a `RemovedHandle` value.

These two changes prevent "accidental aliasing," in which
`logcat-parse` believes that two entirely unrelated JNI handles
actually belong to the same instance.

~~ Alive Peer Validation ~~

To help find related bugs, `GrefParseOptions` was overhauled so that
information about "Alive Peers" could be validated.

The semantics of `GrefParseOptions.CheckCounts` was altered so that
it's now a unique state; *just* specifying it won't do anything, it
needs to be combined with `GrefParseOptions.LogWarningOnMismatch` or
`GrefParseOptions.ThrowExceptionOnMismatch`, or continue using the
previously existing `GrefParseOptions.WarnOnCountMismatch` or
`GrefParseOptions.ThrowOnCountMismatch` options.

To these, we add:

	partial enum GrefParseOptions {
	    CheckAlivePeers = 1 << 3,
	    WarnOnAlivePeerMismatch   = CheckAlivePeers | LogWarningOnMismatch,
	    ThrowOnAlivePeerMismatch  = CheckAlivePeers | ThrowExceptionOnMismatch,
	}

You can enable Alive Peer validation by using the `Grefs.Parse()`
overload within `logcat-parse.exe`:

	csharp> var grefs = Grefs.Parse ("grefs.txt", null, GrefParseOptions.ThrowOnAlivePeerMismatch);

which will cause an exception to be thrown when an "alive peer"
mismatch is encountered.  This will happen when:

  * A `Disposing handle` message is encountered, but no `PeerInfo` can
    be found owning the specified handle.

  * A `Finalizing.*handle` message is encountered, but no `PeerInfo`
    can be found owning the specified handle.

  * A ``handle HANDLE; key_handle HANDLE; Java Type: `...`; MCW Type: `...```
    message is encountered, and (1) no `PeerInfo` can be found which
    owns the specified handle, or (2) `PeerInfo.KeyHandle` has already
    been set on the instance, and thus `logcat-parse` is erroneously
    trying to *alter* an already-existing `PeerInfo` instance.

  * A `-g-` message is encountered, and no `PeerInfo` can be found
    which owns the specified GREF.

~~ Assorted Extras ~~

`JniHandleInfo` was updated so that a "full" handle can be used in
comparisons, e.g.:

	grefs.AlivePeers.Count(p => p.Handles.Contains ("0x1234/G"));

Previously this wouldn't match, because the `0x1234/G` would be
compared against `0x1234` (no `/G`) in `JniHandleInfo.Handle`.

`PeerInfo.Handles` is now an `IList<JniHandleInfo>`, instead of an
`ISet<JniHandleInfo>`, so that we can now reason about *time*: earlier
entries will be created earlier in time, and the order of
`PeerInfo.Handles` and `PeerInfo.RemovedHandles` is the order
encountered within the log file.

~~ Result ~~

With the above changes, processing `grefs.txt` makes more sense:

	$ mono /Library/Frameworks/Xamarin.Android.framework/Versions/Current/lib/xamarin.android/xbuild/Xamarin/Android/logcat-parse.exe grefs.txt
	...
	csharp> grefs.GrefCount;
	245
	csharp> grefs.AlivePeers.Count();
	245

This in turn allows us to get appropriate type counts:

	csharp> grefs.GetAliveJniTypeCounts();
	{{ "", 14 },
	 { "com/android/internal/os/RuntimeInit$KillApplicationHandler", 1 },
	 { "android/runtime/UncaughtExceptionHandler", 1 },
	 { "md5327d1d288bcaf8c0cc06d09d4b2f8e3a/MainActivity", 45 },
	 { "android/support/v7/widget/Toolbar", 45 },
	 { "android/support/design/widget/FloatingActionButton", 45 },
	 { "android/support/v7/view/menu/MenuBuilder", 45 },
	 { "android/support/v7/view/SupportMenuInflater", 45 },
	 { "mono/android/view/View_OnClickListenerImplementor", 3 },
	 { "android/os/Bundle", 1 }}

For this run, there are 45 `MainActivity` instances, along with
instances which `MainActivity` references, such as `ToolBar`,
`FloatingActionButton`, `MenuBuilder`, etc.

[0]: https://media.makeameme.org/created/bugs-bugs-everywhere-kyn0a3.jpg