### PR TITLE
[generator] Ensure all usages of parameter names are escaped the same.

### DIFF
--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/ArraySymbol.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/ArraySymbol.cs
@@ -106,8 +106,8 @@ namespace MonoDroid.Generation {
 		{
 			string native_name = opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name));
 			string[] result = new string [4];
-			result [0] = String.Format ("if ({0} != null) {{", var_name);
-			result [1] = String.Format ("\tJNIEnv.CopyArray ({0}, {1});", native_name, var_name);
+			result [0] = String.Format ("if ({0} != null) {{", opt.GetSafeIdentifier (var_name));
+			result [1] = String.Format ("\tJNIEnv.CopyArray ({0}, {1});", native_name, opt.GetSafeIdentifier (var_name));
 			result [2] = String.Format ("\tJNIEnv.DeleteLocalRef ({0});", native_name);
 			result [3] = "}";
 			return result;

--- a/tools/generator/Tests/Unit-Tests/CodeGeneratorTests.cs
+++ b/tools/generator/Tests/Unit-Tests/CodeGeneratorTests.cs
@@ -862,5 +862,22 @@ namespace generatortests
 			Assert.False (result.Contains ("cb_has-hyp$hen"));
 			Assert.True (result.Contains ("cb_has_x45_hyp_x36_hen"));
 		}
+
+		[Test]
+		public void WriteMethodWithInvalidParameterName ()
+		{
+			var @class = new TestClass ("java.lang.Object", "com.mypackage.foo");
+			var method = new TestMethod (@class, "DoStuff");
+
+			method.Parameters.Add (new Parameter ("$this", "byte[]", "byte[]", false));
+
+			Assert.IsTrue (method.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "method.Validate failed!");
+			generator.WriteMethod (method, string.Empty, @class, true);
+
+			var result = writer.ToString ().NormalizeLineEndings ();
+
+			// Ensure we escape dollar signs
+			Assert.False (result.Contains ("$this"));
+		}
 	}
 }


### PR DESCRIPTION
If a method parameter contains a dollar sign, we sometimes escape it properly and sometimes we do not:

```
public unsafe global::Okio.ByteString Of (byte[] _this_toByteString_, int offset, int byteCount)
{
  ...
    if ($this$toByteString != null) {
        JNIEnv.CopyArray (native__this_toByteString_, $this$toByteString);
        JNIEnv.DeleteLocalRef (native__this_toByteString_);
}
```

That contains both `_this_toByteString_` and `$this$toByteString`.

This PR ensures all instances use the same `opt.GetSafeIdentifier (string)` escaping method.