### PR TITLE
[Java.Interop.Tools.JavaCallableWrappers] remove all usage of MD5

### DIFF
--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/Crc64.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/Crc64.cs
@@ -176,7 +176,11 @@ namespace Java.Interop.Tools.JavaCallableWrappers
 		ulong crc = ulong.MaxValue;
 		ulong length = 0;
 
-		public override void Initialize () { }
+		public override void Initialize ()
+		{
+			crc = ulong.MaxValue;
+			length = 0;
+		}
 
 		protected override void HashCore (byte [] array, int ibStart, int cbSize)
 		{

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGeneratorTests.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGeneratorTests.cs
@@ -102,7 +102,7 @@ public class Name
 		)
 		{
 			var actual      = Generate (typeof (IndirectApplication), applicationJavaClass);
-			var expected    = @"package md5f43cdfade412ae71b21bb70a5c2841ab;
+			var expected    = @"package crc64197ae30a36756915;
 
 
 public class IndirectApplication
@@ -153,7 +153,7 @@ public class IndirectApplication
 		public void GenerateExportedMembers ()
 		{
 			var actual = Generate (typeof (ExportsMembers));
-			var expected = @"package md5f43cdfade412ae71b21bb70a5c2841ab;
+			var expected = @"package crc64197ae30a36756915;
 
 
 public class ExportsMembers
@@ -165,7 +165,7 @@ public class ExportsMembers
 	public static final String __md_methods;
 	static {
 		__md_methods = 
-			""n_GetInstance:()Lmd5f43cdfade412ae71b21bb70a5c2841ab/ExportsMembers;:__export__\n"" +
+			""n_GetInstance:()Lcrc64197ae30a36756915/ExportsMembers;:__export__\n"" +
 			""n_GetValue:()Ljava/lang/String;:__export__\n"" +
 			""n_methodNamesNotMangled:()V:__export__\n"" +
 			""n_CompletelyDifferentName:(Ljava/lang/String;I)Ljava/lang/String;:__export__\n"" +
@@ -176,17 +176,17 @@ public class ExportsMembers
 	}
 
 
-	public static md5f43cdfade412ae71b21bb70a5c2841ab.ExportsMembers STATIC_INSTANCE = GetInstance ();
+	public static crc64197ae30a36756915.ExportsMembers STATIC_INSTANCE = GetInstance ();
 
 
 	public java.lang.String VALUE = GetValue ();
 
-	public static md5f43cdfade412ae71b21bb70a5c2841ab.ExportsMembers GetInstance ()
+	public static crc64197ae30a36756915.ExportsMembers GetInstance ()
 	{
 		return n_GetInstance ();
 	}
 
-	private static native md5f43cdfade412ae71b21bb70a5c2841ab.ExportsMembers n_GetInstance ();
+	private static native crc64197ae30a36756915.ExportsMembers n_GetInstance ();
 
 	public java.lang.String GetValue ()
 	{
@@ -249,7 +249,7 @@ public class ExportsMembers
 		public void GenerateInnerClass ()
 		{
 			var actual = Generate (typeof (ExampleOuterClass));
-			var expected = @"package md5f43cdfade412ae71b21bb70a5c2841ab;
+			var expected = @"package crc64197ae30a36756915;
 
 
 public class ExampleOuterClass

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers/JavaNativeTypeManagerTests.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers/JavaNativeTypeManagerTests.cs
@@ -26,13 +26,6 @@ namespace Java.Interop.Tools.JavaCallableWrappersTests
 		}
 
 		[Test]
-		public void MD5 ()
-		{
-			JavaNativeTypeManager.PackageNamingPolicy = PackageNamingPolicy.LowercaseMD5;
-			Assert.AreEqual ("md5acb69d261d9efeb0927dd7ff443b9a3a", JavaNativeTypeManager.GetPackageName (typeof (string)));
-		}
-
-		[Test]
 		public void Crc64 ()
 		{
 			JavaNativeTypeManager.PackageNamingPolicy = PackageNamingPolicy.LowercaseCrc64;

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers/TypeNameMapGeneratorTests.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Test/Java.Interop.Tools.JavaCallableWrappers/TypeNameMapGeneratorTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -50,8 +50,8 @@ namespace Xamarin.Android.ToolsTests
 			v.WriteJavaToManaged (o);
 			var a = ToArray (o);
 			Save (a, "__j2m");
-			var length = 204;
-			var offset = 90;
+			var length = 190;
+			var offset = 76;
 			var e =
 				"version=1\u0000" +
 				$"entry-count={types.Count - 1}\u0000" +
@@ -59,13 +59,13 @@ namespace Xamarin.Android.ToolsTests
 				"value-offset=" + offset + "\u0000" +
 				GetJ2MEntryLine (typeof (ActivityName),                             "activity/Name",                                                                                offset, length) +
 				GetJ2MEntryLine (typeof (ApplicationName),                          "application/Name",                                                                             offset, length) +
+				GetJ2MEntryLine (typeof (DefaultName),                              "crc64197ae30a36756915/DefaultName",                                                            offset, length) +
+				GetJ2MEntryLine (typeof (DefaultName.A),                            "crc64197ae30a36756915/DefaultName_A",                                                          offset, length) +
+				GetJ2MEntryLine (typeof (DefaultName.A.B),                          "crc64197ae30a36756915/DefaultName_A_B",                                                        offset, length) +
+				GetJ2MEntryLine (typeof (DefaultName.C.D),                          "crc64197ae30a36756915/DefaultName_C_D",                                                        offset, length) +
+				GetJ2MEntryLine (typeof (ExampleOuterClass),                        "crc64197ae30a36756915/ExampleOuterClass",                                                      offset, length) +
+				GetJ2MEntryLine (typeof (ExampleOuterClass.ExampleInnerClass),      "crc64197ae30a36756915/ExampleOuterClass$ExampleOuterClass_ExampleInnerClass",                  offset, length) +
 				GetJ2MEntryLine (typeof (InstrumentationName),                      "instrumentation/Name",                                                                         offset, length) +
-				GetJ2MEntryLine (typeof (DefaultName),                              "md5f43cdfade412ae71b21bb70a5c2841ab/DefaultName",                                              offset, length) +
-				GetJ2MEntryLine (typeof (DefaultName.A),                            "md5f43cdfade412ae71b21bb70a5c2841ab/DefaultName_A",                                            offset, length) +
-				GetJ2MEntryLine (typeof (DefaultName.A.B),                          "md5f43cdfade412ae71b21bb70a5c2841ab/DefaultName_A_B",                                          offset, length) +
-				GetJ2MEntryLine (typeof (DefaultName.C.D),                          "md5f43cdfade412ae71b21bb70a5c2841ab/DefaultName_C_D",                                          offset, length) +
-				GetJ2MEntryLine (typeof (ExampleOuterClass),                        "md5f43cdfade412ae71b21bb70a5c2841ab/ExampleOuterClass",                                        offset, length) +
-				GetJ2MEntryLine (typeof (ExampleOuterClass.ExampleInnerClass),      "md5f43cdfade412ae71b21bb70a5c2841ab/ExampleOuterClass$ExampleOuterClass_ExampleInnerClass",    offset, length) +
 				GetJ2MEntryLine (typeof (AbstractClass),                            "my/AbstractClass",                                                                             offset, length) +
 				GetJ2MEntryLine (typeof (ExampleActivity),                          "my/ExampleActivity",                                                                           offset, length) +
 				GetJ2MEntryLine (typeof (ExampleInstrumentation),                   "my/ExampleInstrumentation",                                                                    offset, length) +
@@ -128,7 +128,7 @@ namespace Xamarin.Android.ToolsTests
 			v.WriteManagedToJava (o);
 			var a = ToArray (o);
 			Save (a, "__m2j");
-			var length = 204;
+			var length = 190;
 			var offset = 114;
 			var e =
 				"version=1\u0000" +
@@ -139,14 +139,14 @@ namespace Xamarin.Android.ToolsTests
 				GetM2JEntryLine (typeof (AbstractClassInvoker),                     "my/AbstractClass",                                                                             offset, length) +
 				GetM2JEntryLine (typeof (ActivityName),                             "activity/Name",                                                                                offset, length) +
 				GetM2JEntryLine (typeof (ApplicationName),                          "application/Name",                                                                             offset, length) +
-				GetM2JEntryLine (typeof (DefaultName.A.B),                          "md5f43cdfade412ae71b21bb70a5c2841ab/DefaultName_A_B",                                          offset, length) +
-				GetM2JEntryLine (typeof (DefaultName.A),                            "md5f43cdfade412ae71b21bb70a5c2841ab/DefaultName_A",                                            offset, length) +
-				GetM2JEntryLine (typeof (DefaultName.C.D),                          "md5f43cdfade412ae71b21bb70a5c2841ab/DefaultName_C_D",                                          offset, length) +
-				GetM2JEntryLine (typeof (DefaultName),                              "md5f43cdfade412ae71b21bb70a5c2841ab/DefaultName",                                              offset, length) +
+				GetM2JEntryLine (typeof (DefaultName.A.B),                          "crc64197ae30a36756915/DefaultName_A_B",                                                        offset, length) +
+				GetM2JEntryLine (typeof (DefaultName.A),                            "crc64197ae30a36756915/DefaultName_A",                                                          offset, length) +
+				GetM2JEntryLine (typeof (DefaultName.C.D),                          "crc64197ae30a36756915/DefaultName_C_D",                                                        offset, length) +
+				GetM2JEntryLine (typeof (DefaultName),                              "crc64197ae30a36756915/DefaultName",                                                            offset, length) +
 				GetM2JEntryLine (typeof (ExampleActivity),                          "my/ExampleActivity",                                                                           offset, length) +
 				GetM2JEntryLine (typeof (ExampleInstrumentation),                   "my/ExampleInstrumentation",                                                                    offset, length) +
-				GetM2JEntryLine (typeof (ExampleOuterClass.ExampleInnerClass),      "md5f43cdfade412ae71b21bb70a5c2841ab/ExampleOuterClass$ExampleOuterClass_ExampleInnerClass",    offset, length) +
-				GetM2JEntryLine (typeof (ExampleOuterClass),                        "md5f43cdfade412ae71b21bb70a5c2841ab/ExampleOuterClass",                                        offset, length) +
+				GetM2JEntryLine (typeof (ExampleOuterClass.ExampleInnerClass),      "crc64197ae30a36756915/ExampleOuterClass$ExampleOuterClass_ExampleInnerClass",                  offset, length) +
+				GetM2JEntryLine (typeof (ExampleOuterClass),                        "crc64197ae30a36756915/ExampleOuterClass",                                                      offset, length) +
 				GetM2JEntryLine (typeof (InstrumentationName),                      "instrumentation/Name",                                                                         offset, length) +
 				GetM2JEntryLine (typeof (NonStaticOuterClass.NonStaticInnerClass),  "register/NonStaticOuterClass$NonStaticInnerClass",                                             offset, length) +
 				GetM2JEntryLine (typeof (NonStaticOuterClass),                      "register/NonStaticOuterClass",                                                                 offset, length) +

--- a/src/Java.Interop.Tools.TypeNameMappings/Java.Interop.Tools.TypeNameMappings/JavaNativeTypeManager.cs
+++ b/src/Java.Interop.Tools.TypeNameMappings/Java.Interop.Tools.TypeNameMappings/JavaNativeTypeManager.cs
@@ -19,12 +19,11 @@ namespace Java.Interop.Tools.TypeNameMappings
 	public
 #endif
 	enum PackageNamingPolicy {
-		/// <summary>
-		/// A hashed package name, currently defaults to LowercaseMD5
-		/// </summary>
+		[Obsolete ("No longer supported. Use PackageNamingPolicy.LowercaseCrc64 instead.", error: true)]
 		LowercaseHash = 0,
 		Lowercase = 1,
 		LowercaseWithAssemblyName = 2,
+		[Obsolete ("No longer supported. Use PackageNamingPolicy.LowercaseCrc64 instead.", error: true)]
 		LowercaseMD5 = LowercaseHash,
 		LowercaseCrc64 = 3,
 	}
@@ -43,7 +42,7 @@ namespace Java.Interop.Tools.TypeNameMappings
 #endif
 	static class JavaNativeTypeManager {
 
-		public static PackageNamingPolicy PackageNamingPolicy { get; set; }
+		public static PackageNamingPolicy PackageNamingPolicy { get; set; } = PackageNamingPolicy.LowercaseCrc64;
 
 		public static string ApplicationJavaClass { get; set; }
 
@@ -203,10 +202,8 @@ namespace Java.Interop.Tools.TypeNameMappings
 			case PackageNamingPolicy.LowercaseCrc64:
 				using (var crc = new Crc64 ())
 					return "crc64" + ToHash (type.Namespace + ":" + assemblyName, crc);
-			case PackageNamingPolicy.LowercaseMD5:
 			default:
-				using (var md5 = MD5.Create ())
-					return "md5" + ToHash (type.Namespace + ":" + assemblyName, md5);
+					throw new NotSupportedException ($"PackageNamingPolicy.{PackageNamingPolicy} is no longer supported.");
 			}
 		}
 
@@ -528,10 +525,8 @@ namespace Java.Interop.Tools.TypeNameMappings
 			case PackageNamingPolicy.LowercaseCrc64:
 				using (var crc = new Crc64 ())
 					return "crc64" + ToHash (type.Namespace + ":" + type.GetPartialAssemblyName (), crc);
-			case PackageNamingPolicy.LowercaseMD5:
 			default:
-				using (var md5 = MD5.Create ())
-					return "md5" + ToHash (type.Namespace + ":" + type.GetPartialAssemblyName (), md5);
+					throw new NotSupportedException ($"PackageNamingPolicy.{PackageNamingPolicy} is no longer supported.");
 			}
 		}
 #endif

--- a/tools/generator/Tests/Integration-Tests/BaseGeneratorTest.cs
+++ b/tools/generator/Tests/Integration-Tests/BaseGeneratorTest.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using System.Linq;
+using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
-using System.Security.Cryptography;
+using Java.Interop.Tools.JavaCallableWrappers;
 using NUnit.Framework;
 using Xamarin.Android.Binder;
-using System.Collections.Generic;
 
 namespace generatortests
 {
@@ -93,10 +93,11 @@ namespace generatortests
 				byte[] f1 = ReadAllBytesIgnoringLineEndings (file1);
 				byte[] f2 = ReadAllBytesIgnoringLineEndings (file2);
 
-				var hash = MD5.Create ();
-				var f1hash = Convert.ToBase64String (hash.ComputeHash (f1));
-				var f2hash = Convert.ToBase64String (hash.ComputeHash (f2));
-				result = f1hash.Equals (f2hash);
+				using (var hash = new Crc64 ()) {
+					var f1hash = Convert.ToBase64String (hash.ComputeHash (f1));
+					var f2hash = Convert.ToBase64String (hash.ComputeHash (f2));
+					result = f1hash.Equals (f2hash);
+				}
 			}
 
 			return result;

--- a/tools/generator/Tests/generator-Tests.csproj
+++ b/tools/generator/Tests/generator-Tests.csproj
@@ -86,6 +86,10 @@
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Java.Interop.Tools.JavaCallableWrappers\Java.Interop.Tools.JavaCallableWrappers.csproj">
+      <Project>{D18FCF91-8876-48A0-A693-2DC1E7D3D80A}</Project>
+      <Name>Java.Interop.Tools.JavaCallableWrappers</Name>
+    </ProjectReference>
     <ProjectReference Include="..\generator.csproj">
       <Project>{D14A1B5C-2060-4930-92BE-F7190256C735}</Project>
       <Name>generator</Name>


### PR DESCRIPTION
This adds `[Obsolete]` (with `error:true`) to:

* `PackageNamingPolicy.LowercaseHash`
* `PackageNamingPolicy.LowercaseMD5`

If these values are encountered at runtime a `NotSupportedException`
will be thrown.

Most of the remaining changes were updates to tests. Upstream in
xamarin/xamarin-android, we will likely need to emit a new build error
with an error code.

Other changes:

* I removed a place `BaseGeneratorTest.cs` was using `MD5.Create()`.
* This exposed a place we need to reset the initial state of `Crc64`
  when an instance is reused for hashing.