### PR TITLE
[build] fix usage of /p:CscToolExe=`which mcs`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ bin/$(CONFIGURATION)/Java.Interop.dll: $(wildcard src/Java.Interop/*/*.cs) src/J
 	$(MSBUILD) $(if $(V),/v:diag,) /p:Configuration=$(CONFIGURATION) $(if $(SNK),"/p:AssemblyOriginatorKeyFile=$(SNK)",)
 
 bin/GendarmeDebug/netstandard2.0/Java.Interop.dll: $(wildcard src/Java.Interop/*/*.cs) src/Java.Interop/Java.Interop.csproj
-	$(MSBUILD) $(if $(V),/v:diag,) /p:Configuration="Gendarme" $(if $(SNK),"/p:AssemblyOriginatorKeyFile=$(SNK)",) /p:CscToolExe=`which mcs` src/Java.Interop/Java.Interop.csproj
+	$(MSBUILD) $(if $(V),/v:diag,) /p:Configuration="Gendarme" $(if $(SNK),"/p:AssemblyOriginatorKeyFile=$(SNK)",) /p:CscToolExe=`which mcs` /p:LangVersion=Default /p:DiscoverEditorConfigFiles=False src/Java.Interop/Java.Interop.csproj
 
 CSHARP_REFS = \
 	bin/$(CONFIGURATION)/Java.Interop.dll               \


### PR DESCRIPTION
Context: https://build.azdo.io/3182458

Our build is currently failing with:

    (CoreCompile target) ->
    CSC : error CS1617: Invalid -langversion option `7.3'. It must be `ISO-1', `ISO-2', Default, Latest or value in range 1 to 7.2

I think this is due to:

    /p:CscToolExe=`which mcs`

We need to use `mcs`, because `gendarme` does not yet support portable
`.pdb` files. However, it also appears that it does not support C# 7.2.

If we set `/p:LangVersion=Default`, it may select a usable C# version.
Things might continue to work as long as we don't use a C# 7.3
feature.

Then we got to the next failure:

    (CoreCompile target) ->
    Microsoft.CSharp.Core.targets(59,5): error : error CS2001: Source file `/analyzerconfig:/Users/runner/runners/2.159.2/work/1/s/.editorconfig' could not be found

The error is a little misleading, basically `mcs` does not understand
the `/analyzerconfig` switch. So it is trying to treat it as a source
code file.

I found the source code for this here:

https://github.com/dotnet/roslyn/blob/6fc75491954be7ddff8c489a4ff424b3524ae80f/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets#L63

So we can add `/p:DiscoverEditorConfigFiles=False` to ignore
`.editorconfig` files.