### PR TITLE
Enabling fPIC on Linux build - part 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ NATIVE_TIMING_LIB   = libNativeTiming$(NATIVE_EXT)
 
 bin/Test$(CONFIGURATION)/$(NATIVE_TIMING_LIB): tests/NativeTiming/timing.c $(wildcard $(JI_JDK_INCLUDE_PATHS)/jni.h)
 	mkdir -p `dirname "$@"`
-	gcc -g -shared -m64 -o $@ $< $(JI_JDK_INCLUDE_PATHS:%=-I%)
+	gcc -g -shared -m64 -fPIC -o $@ $< $(JI_JDK_INCLUDE_PATHS:%=-I%)
 
 # Usage: $(call TestAssemblyTemplate,assembly-basename)
 define TestAssemblyTemplate

--- a/src/java-interop/java-interop.targets
+++ b/src/java-interop/java-interop.targets
@@ -43,7 +43,7 @@
       <_Libs>$(MonoLibs)</_Libs>
       <_Files>@(ClCompile->'obj\$(Configuration)\%(Filename).o', ' ')</_Files>
     </PropertyGroup>
-    <Exec Command="gcc -g -shared -m64 -std=c99 -o &quot;$(_MacLib)&quot; $(_LinkFlags) $(_Libs) $(_Files)" />
+    <Exec Command="gcc -g -shared -m64 -std=c99 -fPIC -o &quot;$(_MacLib)&quot; $(_LinkFlags) $(_Libs) $(_Files)" />
     <!-- Mono 4.4.0 (mono-4.4.0-branch/a3fabf1) has an incorrect shared library name. Fix it -->
     <Exec Command="install_name_tool -change /private/tmp/source-mono-4.4.0/bockbuild-mono-4.4.0-branch/profiles/mono-mac-xamarin/package-root/lib/libmonosgen-2.0.1.dylib /Library/Frameworks/Mono.framework/Libraries/libmonosgen-2.0.1.dylib &quot;$(_MacLib)&quot;" />
   </Target>

--- a/tests/invocation-overhead/Makefile
+++ b/tests/invocation-overhead/Makefile
@@ -28,7 +28,7 @@ jni.c jni.cs: $(JNIENV_GEN)
 	$(RUNTIME) $< jni.cs jni.c
 
 libjava-interop.dylib: jni.c
-	gcc -g -shared -o $@ $< -m64 -DJI_DLL_EXPORT -fvisibility=hidden $(JI_JDK_INCLUDE_PATHS:%=-I%)
+	gcc -g -shared -fPIC -o $@ $< -m64 -DJI_DLL_EXPORT -fvisibility=hidden $(JI_JDK_INCLUDE_PATHS:%=-I%)
 
 run:
 	$(RUNTIME) test-overheads.exe


### PR DESCRIPTION
We recently changed the build options to enable fPIC on Linux builds (see https://github.com/xamarin/java.interop/commit/10ba45ab4575c3ac9bca82082039fcc910670586), but there was a couple of places still missing.

The `src/java-interop` build fails on Linux Ubuntu 19.10:

gcc -g -shared -m64 -o bin/TestDebug/libNativeTiming.so tests/NativeTiming/timing.c -I/usr/lib/jvm/java-1.8.0-openjdk-amd64/include -I/usr/lib/jvm/java-1.8.0-openjdk-amd64/include/linux
/usr/bin/ld: /tmp/ccmuRrxZ.o: relocation R_X86_64_PC32 against symbol `foo_void_timing' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: nonrepresentable section on output
collect2: error: ld returned 1 exit status

Update the Linux build to use `gcc -fPIC` so that `src/java-interop` can be linked successfully.