### PR TITLE
[Java.Interop-Tests] Remove Reflection from JavaPrimitiveArrayContract

### DIFF
--- a/src/Java.Interop/Tests/Java.Interop/JavaBooleanArrayContractTests.cs
+++ b/src/Java.Interop/Tests/Java.Interop/JavaBooleanArrayContractTests.cs
@@ -11,6 +11,21 @@ namespace Java.InteropTests
 	[TestFixture]
 	public class JavaBooleanArrayContractTests : JavaPrimitiveArrayContract<JavaBooleanArray, bool>
 	{
+		protected override ICollection<bool> CreateCollection (IEnumerable<bool> values)
+		{
+			return new JavaBooleanArray (values);
+		}
+
+		protected override ICollection<bool> CreateCollection (IList<bool> values)
+		{
+			return new JavaBooleanArray (values);
+		}
+
+		protected override ICollection<bool> CreateCollection (int length)
+		{
+			return new JavaBooleanArray (length);
+		}
+
 		protected override bool CreateValueA ()
 		{
 			return true;

--- a/src/Java.Interop/Tests/Java.Interop/JavaCharArrayContractTests.cs
+++ b/src/Java.Interop/Tests/Java.Interop/JavaCharArrayContractTests.cs
@@ -11,6 +11,20 @@ namespace Java.InteropTests
 	[TestFixture]
 	public class JavaCharArrayContractTests : JavaPrimitiveArrayContract<JavaCharArray, char>
 	{
+		protected override ICollection<char> CreateCollection (IEnumerable<char> values)
+		{
+			return new JavaCharArray (values);
+		}
+
+		protected override ICollection<char> CreateCollection (IList<char> values)
+		{
+			return new JavaCharArray (values);
+		}
+
+		protected override ICollection<char> CreateCollection (int length)
+		{
+			return new JavaCharArray (length);
+		}
 	}
 }
 

--- a/src/Java.Interop/Tests/Java.Interop/JavaDoubleArrayContractTests.cs
+++ b/src/Java.Interop/Tests/Java.Interop/JavaDoubleArrayContractTests.cs
@@ -11,6 +11,20 @@ namespace Java.InteropTests
 	[TestFixture]
 	public class JavaDoubleArrayContractTests : JavaPrimitiveArrayContract<JavaDoubleArray, double>
 	{
+		protected override ICollection<double> CreateCollection (IEnumerable<double> values)
+		{
+			return new JavaDoubleArray (values);
+		}
+
+		protected override ICollection<double> CreateCollection (IList<double> values)
+		{
+			return new JavaDoubleArray (values);
+		}
+
+		protected override ICollection<double> CreateCollection (int length)
+		{
+			return new JavaDoubleArray (length);
+		}
 	}
 }
 

--- a/src/Java.Interop/Tests/Java.Interop/JavaInt16ArrayContractTests.cs
+++ b/src/Java.Interop/Tests/Java.Interop/JavaInt16ArrayContractTests.cs
@@ -11,6 +11,20 @@ namespace Java.InteropTests
 	[TestFixture]
 	public class JavaInt16ArrayContractTests : JavaPrimitiveArrayContract<JavaInt16Array, short>
 	{
+		protected override ICollection<short> CreateCollection (IEnumerable<short> values)
+		{
+			return new JavaInt16Array (values);
+		}
+
+		protected override ICollection<short> CreateCollection (IList<short> values)
+		{
+			return new JavaInt16Array (values);
+		}
+
+		protected override ICollection<short> CreateCollection (int length)
+		{
+			return new JavaInt16Array (length);
+		}
 	}
 }
 

--- a/src/Java.Interop/Tests/Java.Interop/JavaInt32ArrayContractTests.cs
+++ b/src/Java.Interop/Tests/Java.Interop/JavaInt32ArrayContractTests.cs
@@ -11,6 +11,20 @@ namespace Java.InteropTests
 	[TestFixture]
 	public class JavaInt32ArrayContractTests : JavaPrimitiveArrayContract<JavaInt32Array, int>
 	{
+		protected override ICollection<int> CreateCollection (IEnumerable<int> values)
+		{
+			return new JavaInt32Array (values);
+		}
+
+		protected override ICollection<int> CreateCollection (IList<int> values)
+		{
+			return new JavaInt32Array (values);
+		}
+
+		protected override ICollection<int> CreateCollection (int length)
+		{
+			return new JavaInt32Array (length);
+		}
 	}
 }
 

--- a/src/Java.Interop/Tests/Java.Interop/JavaInt64ArrayContractTests.cs
+++ b/src/Java.Interop/Tests/Java.Interop/JavaInt64ArrayContractTests.cs
@@ -11,6 +11,20 @@ namespace Java.InteropTests
 	[TestFixture]
 	public class JavaInt64ArrayContractTests : JavaPrimitiveArrayContract<JavaInt64Array, long>
 	{
+		protected override ICollection<long> CreateCollection (IEnumerable<long> values)
+		{
+			return new JavaInt64Array (values);
+		}
+
+		protected override ICollection<long> CreateCollection (IList<long> values)
+		{
+			return new JavaInt64Array (values);
+		}
+
+		protected override ICollection<long> CreateCollection (int length)
+		{
+			return new JavaInt64Array (length);
+		}
 	}
 }
 

--- a/src/Java.Interop/Tests/Java.Interop/JavaPrimitiveArrayContract.cs
+++ b/src/Java.Interop/Tests/Java.Interop/JavaPrimitiveArrayContract.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 
 using Java.Interop;
 
@@ -22,11 +21,9 @@ namespace Java.InteropTests
 			return FromInt32 ((int) 'B');
 		}
 
-		protected override ICollection<TElement> CreateCollection (IEnumerable<TElement> values)
-		{
-			var array       = (JavaPrimitiveArray<TElement>) Activator.CreateInstance (typeof (TArray), values);
-			return array;
-		}
+		protected abstract ICollection<TElement> CreateCollection (IList<TElement> values);
+
+		protected abstract ICollection<TElement> CreateCollection (int length);
 
 		protected TElement FromInt32 (int value)
 		{
@@ -36,17 +33,9 @@ namespace Java.InteropTests
 		[Test]
 		public void Constructor_Exceptions ()
 		{
-			var ctor = typeof (TArray).GetConstructor (new[]{ typeof (IList<TElement>) });
-			var ex = Assert.Throws<TargetInvocationException> (() => ctor.Invoke (new object[]{ null }));
-			Assert.IsTrue (ex.InnerException is ArgumentNullException);
-
-			ctor = typeof (TArray).GetConstructor (new[]{ typeof (IEnumerable<TElement>) });
-			ex = Assert.Throws<TargetInvocationException> (() => ctor.Invoke (new object[]{ null }));
-			Assert.IsTrue (ex.InnerException is ArgumentNullException);
-
-			ctor = typeof (TArray).GetConstructor (new[]{ typeof (int) });
-			ex = Assert.Throws<TargetInvocationException> (() => ctor.Invoke (new object[]{ -1 }));
-			Assert.IsTrue (ex.InnerException is ArgumentException);
+			Assert.Throws<ArgumentNullException>(() => CreateCollection ((IEnumerable<TElement>) null));
+			Assert.Throws<ArgumentNullException>(() => CreateCollection ((IList<TElement>) null));
+			Assert.Throws<ArgumentException>(() => CreateCollection (-1));
 		}
 
 		[Test]

--- a/src/Java.Interop/Tests/Java.Interop/JavaSByteArrayContractTests.cs
+++ b/src/Java.Interop/Tests/Java.Interop/JavaSByteArrayContractTests.cs
@@ -11,6 +11,20 @@ namespace Java.InteropTests
 	[TestFixture]
 	public class JavaSByteArrayContractTests : JavaPrimitiveArrayContract<JavaSByteArray, sbyte>
 	{
+		protected override ICollection<sbyte> CreateCollection (IEnumerable<sbyte> values)
+		{
+			return new JavaSByteArray (values);
+		}
+
+		protected override ICollection<sbyte> CreateCollection (IList<sbyte> values)
+		{
+			return new JavaSByteArray (values);
+		}
+
+		protected override ICollection<sbyte> CreateCollection (int length)
+		{
+			return new JavaSByteArray (length);
+		}
 	}
 }
 

--- a/src/Java.Interop/Tests/Java.Interop/JavaSingleArrayContractTests.cs
+++ b/src/Java.Interop/Tests/Java.Interop/JavaSingleArrayContractTests.cs
@@ -11,6 +11,20 @@ namespace Java.InteropTests
 	[TestFixture]
 	public class JavaSingleArrayContractTests : JavaPrimitiveArrayContract<JavaSingleArray, float>
 	{
+		protected override ICollection<float> CreateCollection (IEnumerable<float> values)
+		{
+			return new JavaSingleArray (values);
+		}
+
+		protected override ICollection<float> CreateCollection (IList<float> values)
+		{
+			return new JavaSingleArray (values);
+		}
+
+		protected override ICollection<float> CreateCollection (int length)
+		{
+			return new JavaSingleArray (length);
+		}
 	}
 }
 

--- a/src/Java.Interop/Tests/Java.Interop/JniEnvironmentTests.cs
+++ b/src/Java.Interop/Tests/Java.Interop/JniEnvironmentTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Reflection;
 using System.Runtime.InteropServices;
 
 using Java.Interop;

--- a/src/Java.Interop/Tests/Java.Interop/JniTransitionTest.cs
+++ b/src/Java.Interop/Tests/Java.Interop/JniTransitionTest.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Reflection;
 
 using Java.Interop;
 


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/3393
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3247796&view=ms.vss-test-web.build-test-results-tab&runId=9790200&resultId=100160&paneView=debug

In attempting to get Xamarin.Android to run the full compliement of
Java.Interop unit tests, there is one set of tests which are still
failing: the `JavaPrimitiveArrayContract.Constructor_Exceptions()`
tests fail because the *linker* is executed, and the linker is
removing the constructors which `Constructor_Exceptions()` relies on.

Make `JavaPrimitiveArrayContract` linker-safe, and instead of using
`System.Type.GetConstructor()` to get the constructor, introduce new
`abstract` methods on `JavaPrimitiveArrayContract.CreateCollection()`
which create instances of the appropriate type, using the appropriate
constructor.

This is more "linker friendly", as the linker can "see" that the
constructors are used, which in turn should allow the tests to pass.