### PR TITLE
[generator] Make _members private to reduce warnings building binding projects.

### DIFF
--- a/tests/generator-Tests/Tests-Core/expected.ji/Android.Text.ISpannable.cs
+++ b/tests/generator-Tests/Tests-Core/expected.ji/Android.Text.ISpannable.cs
@@ -14,7 +14,7 @@ namespace Android.Text {
 	[global::Android.Runtime.Register ("android/text/Spannable", DoNotGenerateAcw=true)]
 	internal partial class ISpannableInvoker : global::Java.Lang.Object, ISpannable {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("android/text/Spannable", typeof (ISpannableInvoker));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("android/text/Spannable", typeof (ISpannableInvoker));
 
 		static IntPtr java_class_ref {
 			get { return _members.JniPeerType.PeerReference.Handle; }

--- a/tests/generator-Tests/Tests-Core/expected.ji/Android.Text.ISpanned.cs
+++ b/tests/generator-Tests/Tests-Core/expected.ji/Android.Text.ISpanned.cs
@@ -19,7 +19,7 @@ namespace Android.Text {
 	[global::Android.Runtime.Register ("android/text/Spanned", DoNotGenerateAcw=true)]
 	internal partial class ISpannedInvoker : global::Java.Lang.Object, ISpanned {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("android/text/Spanned", typeof (ISpannedInvoker));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("android/text/Spanned", typeof (ISpannedInvoker));
 
 		static IntPtr java_class_ref {
 			get { return _members.JniPeerType.PeerReference.Handle; }

--- a/tests/generator-Tests/Tests-Core/expected.ji/Android.Text.SpannableString.cs
+++ b/tests/generator-Tests/Tests-Core/expected.ji/Android.Text.SpannableString.cs
@@ -9,7 +9,7 @@ namespace Android.Text {
 	[global::Android.Runtime.Register ("android/text/SpannableString", DoNotGenerateAcw=true)]
 	public partial class SpannableString : Android.Text.SpannableStringInternal, Android.Text.ISpannable {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("android/text/SpannableString", typeof (SpannableString));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("android/text/SpannableString", typeof (SpannableString));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/Tests-Core/expected.ji/Android.Text.SpannableStringInternal.cs
+++ b/tests/generator-Tests/Tests-Core/expected.ji/Android.Text.SpannableStringInternal.cs
@@ -9,7 +9,7 @@ namespace Android.Text {
 	[global::Android.Runtime.Register ("android/text/SpannableStringInternal", DoNotGenerateAcw=true)]
 	public abstract partial class SpannableStringInternal : Java.Lang.Object {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("android/text/SpannableStringInternal", typeof (SpannableStringInternal));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("android/text/SpannableStringInternal", typeof (SpannableStringInternal));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
@@ -70,7 +70,7 @@ namespace Android.Text {
 
 		public SpannableStringInternalInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("android/text/SpannableStringInternal", typeof (SpannableStringInternalInvoker));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("android/text/SpannableStringInternal", typeof (SpannableStringInternalInvoker));
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 			get { return _members; }

--- a/tests/generator-Tests/Tests-Core/expected.ji/Android.Views.View.cs
+++ b/tests/generator-Tests/Tests-Core/expected.ji/Android.Views.View.cs
@@ -22,7 +22,7 @@ namespace Android.Views {
 		[global::Android.Runtime.Register ("android/view/View$OnClickListener", DoNotGenerateAcw=true)]
 		internal partial class IOnClickListenerInvoker : global::Java.Lang.Object, IOnClickListener {
 
-			internal static new readonly JniPeerMembers _members = new JniPeerMembers ("android/view/View$OnClickListener", typeof (IOnClickListenerInvoker));
+			static readonly JniPeerMembers _members = new JniPeerMembers ("android/view/View$OnClickListener", typeof (IOnClickListenerInvoker));
 
 			static IntPtr java_class_ref {
 				get { return _members.JniPeerType.PeerReference.Handle; }
@@ -128,7 +128,7 @@ namespace Android.Views {
 		}
 
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("android/view/View", typeof (View));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("android/view/View", typeof (View));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/Tests-Core/expected.ji/Java.Lang.Object.cs
+++ b/tests/generator-Tests/Tests-Core/expected.ji/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteClass.txt
@@ -2,7 +2,7 @@
 [global::Android.Runtime.Register ("java/code/MyClass", DoNotGenerateAcw=true)]
 public partial class MyClass  {
 
-	internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/code/MyClass", typeof (MyClass));
+	static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/MyClass", typeof (MyClass));
 	internal static new IntPtr class_ref {
 		get {
 			return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteClassHandle.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteClassHandle.txt
@@ -1,4 +1,4 @@
-	internal static readonly JniPeerMembers _members = new JniPeerMembers ("com/mypackage/foo", typeof (foo));
+	static readonly JniPeerMembers _members = new JniPeerMembers ("com/mypackage/foo", typeof (foo));
 	internal static IntPtr class_ref {
 		get {
 			return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteClassInvoker.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteClassInvoker.txt
@@ -3,7 +3,7 @@ internal partial class MyClassInvoker : MyClass {
 
 	public MyClassInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
 
-	internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/code/MyClass", typeof (MyClassInvoker));
+	static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/MyClass", typeof (MyClassInvoker));
 
 	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 		get { return _members; }

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteClassInvokerHandle.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteClassInvokerHandle.txt
@@ -1,4 +1,4 @@
-internal static new readonly JniPeerMembers _members = new JniPeerMembers ("com/mypackage/foo", typeof (Com.MyPackage.Foo));
+static readonly JniPeerMembers _members = new JniPeerMembers ("com/mypackage/foo", typeof (Com.MyPackage.Foo));
 
 public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 	get { return _members; }

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteDefaultInterfaceMethodInvoker.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteDefaultInterfaceMethodInvoker.txt
@@ -1,7 +1,7 @@
 [global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
 
-	internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
+	static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
 
 	static IntPtr java_class_ref {
 		get { return _members.JniPeerType.PeerReference.Handle; }

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterface.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterface.txt
@@ -16,7 +16,7 @@ public abstract class MyInterface : Java.Lang.Object {
 	}
 
 
-	static new readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (MyInterface));
+	static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (MyInterface));
 }
 
 [Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
@@ -70,7 +70,7 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 [global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
 
-	internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
+	static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
 
 	static IntPtr java_class_ref {
 		get { return _members.JniPeerType.PeerReference.Handle; }

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterfaceDefaultMethod.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterfaceDefaultMethod.txt
@@ -1,7 +1,7 @@
 // Metadata.xml XPath interface reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']"
 [Register ("java/code/IMyInterface", "", "java.code.IMyInterfaceInvoker")]
 public partial interface IMyInterface : IJavaObject, IJavaPeerable {
-	static new readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
+	static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
 
 	static Delegate cb_DoSomething;
 #pragma warning disable 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterfaceDefaultProperty.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterfaceDefaultProperty.txt
@@ -1,7 +1,7 @@
 // Metadata.xml XPath interface reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']"
 [Register ("java/code/IMyInterface", "", "java.code.IMyInterfaceInvoker")]
 public partial interface IMyInterface : IJavaObject, IJavaPeerable {
-	static new readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
+	static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
 
 	static Delegate cb_get_Value;
 #pragma warning disable 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterfaceDefaultPropertyGetterOnly.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterfaceDefaultPropertyGetterOnly.txt
@@ -1,7 +1,7 @@
 // Metadata.xml XPath interface reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']"
 [Register ("java/code/IMyInterface", "", "java.code.IMyInterfaceInvoker")]
 public partial interface IMyInterface : IJavaObject, IJavaPeerable {
-	static new readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
+	static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
 
 	static Delegate cb_get_Value;
 #pragma warning disable 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterfaceInvoker.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterfaceInvoker.txt
@@ -1,7 +1,7 @@
 [global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
 
-	internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
+	static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
 
 	static IntPtr java_class_ref {
 		get { return _members.JniPeerType.PeerReference.Handle; }

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteStaticInterfaceMethod.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteStaticInterfaceMethod.txt
@@ -16,7 +16,7 @@ public abstract class MyInterface : Java.Lang.Object {
 	}
 
 
-	static new readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (MyInterface));
+	static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (MyInterface));
 }
 
 [Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
@@ -31,7 +31,7 @@ public abstract class MyInterfaceConsts : MyInterface {
 // Metadata.xml XPath interface reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']"
 [Register ("java/code/IMyInterface", "", "java.code.IMyInterfaceInvoker")]
 public partial interface IMyInterface : IJavaObject, IJavaPeerable {
-	static new readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
+	static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
 
 	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='DoSomething' and count(parameter)=0]"
 	[Register ("DoSomething", "()V", "")]
@@ -49,7 +49,7 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 [global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
 
-	internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
+	static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
 
 	static IntPtr java_class_ref {
 		get { return _members.JniPeerType.PeerReference.Handle; }

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteStaticInterfaceProperty.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteStaticInterfaceProperty.txt
@@ -1,7 +1,7 @@
 // Metadata.xml XPath interface reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']"
 [Register ("java/code/IMyInterface", "", "java.code.IMyInterfaceInvoker")]
 public partial interface IMyInterface : IJavaObject, IJavaPeerable {
-	static new readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
+	static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
 
 	 static unsafe int Value {
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='get_Value' and count(parameter)=0]"

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClass.txt
@@ -2,7 +2,7 @@
 [global::Android.Runtime.Register ("java/code/MyClass", DoNotGenerateAcw=true)]
 public partial class MyClass  {
 
-	internal static new readonly JniPeerMembers _members = new XAPeerMembers ("java/code/MyClass", typeof (MyClass));
+	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/MyClass", typeof (MyClass));
 	internal static new IntPtr class_ref {
 		get {
 			return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClassHandle.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClassHandle.txt
@@ -1,4 +1,4 @@
-	internal static readonly JniPeerMembers _members = new XAPeerMembers ("com/mypackage/foo", typeof (foo));
+	static readonly JniPeerMembers _members = new XAPeerMembers ("com/mypackage/foo", typeof (foo));
 	internal static IntPtr class_ref {
 		get {
 			return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClassInvoker.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClassInvoker.txt
@@ -3,7 +3,7 @@ internal partial class MyClassInvoker : MyClass {
 
 	public MyClassInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
 
-	internal static new readonly JniPeerMembers _members = new XAPeerMembers ("java/code/MyClass", typeof (MyClassInvoker));
+	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/MyClass", typeof (MyClassInvoker));
 
 	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 		get { return _members; }

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClassInvokerHandle.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClassInvokerHandle.txt
@@ -1,4 +1,4 @@
-internal static new readonly JniPeerMembers _members = new XAPeerMembers ("com/mypackage/foo", typeof (Com.MyPackage.Foo));
+static readonly JniPeerMembers _members = new XAPeerMembers ("com/mypackage/foo", typeof (Com.MyPackage.Foo));
 
 public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 	get { return _members; }

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteDefaultInterfaceMethodInvoker.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteDefaultInterfaceMethodInvoker.txt
@@ -1,7 +1,7 @@
 [global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
 
-	internal static new readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
+	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
 
 	static IntPtr java_class_ref {
 		get { return _members.JniPeerType.PeerReference.Handle; }

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterface.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterface.txt
@@ -16,7 +16,7 @@ public abstract class MyInterface : Java.Lang.Object {
 	}
 
 
-	static new readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (MyInterface));
+	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (MyInterface));
 }
 
 [Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
@@ -70,7 +70,7 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 [global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
 
-	internal static new readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
+	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
 
 	static IntPtr java_class_ref {
 		get { return _members.JniPeerType.PeerReference.Handle; }

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultMethod.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultMethod.txt
@@ -1,7 +1,7 @@
 // Metadata.xml XPath interface reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']"
 [Register ("java/code/IMyInterface", "", "java.code.IMyInterfaceInvoker")]
 public partial interface IMyInterface : IJavaObject, IJavaPeerable {
-	static new readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
+	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
 
 	static Delegate cb_DoSomething;
 #pragma warning disable 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultProperty.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultProperty.txt
@@ -1,7 +1,7 @@
 // Metadata.xml XPath interface reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']"
 [Register ("java/code/IMyInterface", "", "java.code.IMyInterfaceInvoker")]
 public partial interface IMyInterface : IJavaObject, IJavaPeerable {
-	static new readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
+	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
 
 	static Delegate cb_get_Value;
 #pragma warning disable 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultPropertyGetterOnly.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultPropertyGetterOnly.txt
@@ -1,7 +1,7 @@
 // Metadata.xml XPath interface reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']"
 [Register ("java/code/IMyInterface", "", "java.code.IMyInterfaceInvoker")]
 public partial interface IMyInterface : IJavaObject, IJavaPeerable {
-	static new readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
+	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
 
 	static Delegate cb_get_Value;
 #pragma warning disable 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceInvoker.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceInvoker.txt
@@ -1,7 +1,7 @@
 [global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
 
-	internal static new readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
+	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
 
 	static IntPtr java_class_ref {
 		get { return _members.JniPeerType.PeerReference.Handle; }

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteStaticInterfaceMethod.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteStaticInterfaceMethod.txt
@@ -16,7 +16,7 @@ public abstract class MyInterface : Java.Lang.Object {
 	}
 
 
-	static new readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (MyInterface));
+	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (MyInterface));
 }
 
 [Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
@@ -31,7 +31,7 @@ public abstract class MyInterfaceConsts : MyInterface {
 // Metadata.xml XPath interface reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']"
 [Register ("java/code/IMyInterface", "", "java.code.IMyInterfaceInvoker")]
 public partial interface IMyInterface : IJavaObject, IJavaPeerable {
-	static new readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
+	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
 
 	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='DoSomething' and count(parameter)=0]"
 	[Register ("DoSomething", "()V", "")]
@@ -49,7 +49,7 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 [global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
 
-	internal static new readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
+	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
 
 	static IntPtr java_class_ref {
 		get { return _members.JniPeerType.PeerReference.Handle; }

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteStaticInterfaceProperty.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteStaticInterfaceProperty.txt
@@ -1,7 +1,7 @@
 // Metadata.xml XPath interface reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']"
 [Register ("java/code/IMyInterface", "", "java.code.IMyInterfaceInvoker")]
 public partial interface IMyInterface : IJavaObject, IJavaPeerable {
-	static new readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
+	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
 
 	 static unsafe int Value {
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='get_Value' and count(parameter)=0]"

--- a/tests/generator-Tests/expected.ji/AccessModifiers/Xamarin.Test.BasePublicClass.cs
+++ b/tests/generator-Tests/expected.ji/AccessModifiers/Xamarin.Test.BasePublicClass.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/BasePublicClass", DoNotGenerateAcw=true)]
 	public partial class BasePublicClass : global::Java.Lang.Object {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/BasePublicClass", typeof (BasePublicClass));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/BasePublicClass", typeof (BasePublicClass));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/AccessModifiers/Xamarin.Test.ExtendPublicClass.cs
+++ b/tests/generator-Tests/expected.ji/AccessModifiers/Xamarin.Test.ExtendPublicClass.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/ExtendPublicClass", DoNotGenerateAcw=true)]
 	public partial class ExtendPublicClass : global::Java.Lang.Object {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/ExtendPublicClass", typeof (ExtendPublicClass));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/ExtendPublicClass", typeof (ExtendPublicClass));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/AccessModifiers/Xamarin.Test.PublicClass.cs
+++ b/tests/generator-Tests/expected.ji/AccessModifiers/Xamarin.Test.PublicClass.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/PublicClass", DoNotGenerateAcw=true)]
 	public partial class PublicClass : global::Java.Lang.Object {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/PublicClass", typeof (PublicClass));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/PublicClass", typeof (PublicClass));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/AccessModifiers/Xamarin.Test.PublicFinalClass.cs
+++ b/tests/generator-Tests/expected.ji/AccessModifiers/Xamarin.Test.PublicFinalClass.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/PublicFinalClass", DoNotGenerateAcw=true)]
 	public sealed partial class PublicFinalClass : global::Xamarin.Test.BasePublicClass {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/PublicFinalClass", typeof (PublicFinalClass));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/PublicFinalClass", typeof (PublicFinalClass));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/Adapters/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/Adapters/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/Adapters/Xamarin.Test.AbsSpinner.cs
+++ b/tests/generator-Tests/expected.ji/Adapters/Xamarin.Test.AbsSpinner.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/AbsSpinner", DoNotGenerateAcw=true)]
 	public abstract partial class AbsSpinner : Xamarin.Test.AdapterView<Xamarin.Test.ISpinnerAdapter> {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/AbsSpinner", typeof (AbsSpinner));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/AbsSpinner", typeof (AbsSpinner));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
@@ -94,7 +94,7 @@ namespace Xamarin.Test {
 
 		public AbsSpinnerInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/AbsSpinner", typeof (AbsSpinnerInvoker));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/AbsSpinner", typeof (AbsSpinnerInvoker));
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 			get { return _members; }

--- a/tests/generator-Tests/expected.ji/Adapters/Xamarin.Test.AdapterView.cs
+++ b/tests/generator-Tests/expected.ji/Adapters/Xamarin.Test.AdapterView.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Test {
 	[global::Java.Interop.JavaTypeParameters (new string [] {"T extends xamarin.test.Adapter"})]
 	public abstract partial class AdapterView : global::Java.Lang.Object {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/AdapterView", typeof (AdapterView));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/AdapterView", typeof (AdapterView));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
@@ -78,7 +78,7 @@ namespace Xamarin.Test {
 
 		public AdapterViewInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/AdapterView", typeof (AdapterViewInvoker));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/AdapterView", typeof (AdapterViewInvoker));
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 			get { return _members; }

--- a/tests/generator-Tests/expected.ji/Adapters/Xamarin.Test.GenericReturnObject.cs
+++ b/tests/generator-Tests/expected.ji/Adapters/Xamarin.Test.GenericReturnObject.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/GenericReturnObject", DoNotGenerateAcw=true)]
 	public partial class GenericReturnObject : global::Java.Lang.Object {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/GenericReturnObject", typeof (GenericReturnObject));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/GenericReturnObject", typeof (GenericReturnObject));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/Adapters/Xamarin.Test.IAdapter.cs
+++ b/tests/generator-Tests/expected.ji/Adapters/Xamarin.Test.IAdapter.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/Adapter", DoNotGenerateAcw=true)]
 	internal partial class IAdapterInvoker : global::Java.Lang.Object, IAdapter {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/Adapter", typeof (IAdapterInvoker));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/Adapter", typeof (IAdapterInvoker));
 
 		static IntPtr java_class_ref {
 			get { return _members.JniPeerType.PeerReference.Handle; }

--- a/tests/generator-Tests/expected.ji/Adapters/Xamarin.Test.ISpinnerAdapter.cs
+++ b/tests/generator-Tests/expected.ji/Adapters/Xamarin.Test.ISpinnerAdapter.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/SpinnerAdapter", DoNotGenerateAcw=true)]
 	internal partial class ISpinnerAdapterInvoker : global::Java.Lang.Object, ISpinnerAdapter {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SpinnerAdapter", typeof (ISpinnerAdapterInvoker));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SpinnerAdapter", typeof (ISpinnerAdapterInvoker));
 
 		static IntPtr java_class_ref {
 			get { return _members.JniPeerType.PeerReference.Handle; }

--- a/tests/generator-Tests/expected.ji/Android.Graphics.Color/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/Android.Graphics.Color/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/Android.Graphics.Color/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/Android.Graphics.Color/Xamarin.Test.SomeObject.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Test {
 				}
 			}
 		}
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
@@ -97,7 +97,7 @@ namespace Xamarin.Test {
 
 		public SomeObjectInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObjectInvoker));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObjectInvoker));
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 			get { return _members; }

--- a/tests/generator-Tests/expected.ji/Arrays/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/Arrays/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/Arrays/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/Arrays/Xamarin.Test.SomeObject.cs
@@ -163,7 +163,7 @@ namespace Xamarin.Test {
 				}
 			}
 		}
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/CSharpKeywords/Xamarin.Test.CSharpKeywords.cs
+++ b/tests/generator-Tests/expected.ji/CSharpKeywords/Xamarin.Test.CSharpKeywords.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/CSharpKeywords", DoNotGenerateAcw=true)]
 	public partial class CSharpKeywords : global::Java.Lang.Object {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/CSharpKeywords", typeof (CSharpKeywords));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/CSharpKeywords", typeof (CSharpKeywords));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/Constructors/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/Constructors/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/Constructors/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/Constructors/Xamarin.Test.SomeObject.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public partial class SomeObject : global::Java.Lang.Object {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/GenericArguments/Com.Google.Android.Exoplayer.Drm.FrameworkMediaDrm.cs
+++ b/tests/generator-Tests/expected.ji/GenericArguments/Com.Google.Android.Exoplayer.Drm.FrameworkMediaDrm.cs
@@ -9,7 +9,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 	[global::Android.Runtime.Register ("com/google/android/exoplayer/drm/FrameworkMediaDrm", DoNotGenerateAcw=true)]
 	public sealed partial class FrameworkMediaDrm : global::Java.Lang.Object, global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("com/google/android/exoplayer/drm/FrameworkMediaDrm", typeof (FrameworkMediaDrm));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("com/google/android/exoplayer/drm/FrameworkMediaDrm", typeof (FrameworkMediaDrm));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
+++ b/tests/generator-Tests/expected.ji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
@@ -19,7 +19,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 	[global::Android.Runtime.Register ("com/google/android/exoplayer/drm/ExoMediaDrm$OnEventListener", DoNotGenerateAcw=true)]
 	internal partial class IExoMediaDrmOnEventListenerInvoker : global::Java.Lang.Object, IExoMediaDrmOnEventListener {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("com/google/android/exoplayer/drm/ExoMediaDrm$OnEventListener", typeof (IExoMediaDrmOnEventListenerInvoker));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("com/google/android/exoplayer/drm/ExoMediaDrm$OnEventListener", typeof (IExoMediaDrmOnEventListenerInvoker));
 
 		static IntPtr java_class_ref {
 			get { return _members.JniPeerType.PeerReference.Handle; }
@@ -200,7 +200,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 	[global::Android.Runtime.Register ("com/google/android/exoplayer/drm/ExoMediaDrm", DoNotGenerateAcw=true)]
 	internal partial class IExoMediaDrmInvoker : global::Java.Lang.Object, IExoMediaDrm {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("com/google/android/exoplayer/drm/ExoMediaDrm", typeof (IExoMediaDrmInvoker));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("com/google/android/exoplayer/drm/ExoMediaDrm", typeof (IExoMediaDrmInvoker));
 
 		static IntPtr java_class_ref {
 			get { return _members.JniPeerType.PeerReference.Handle; }

--- a/tests/generator-Tests/expected.ji/GenericArguments/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/GenericArguments/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.II1.cs
+++ b/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.II1.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/I1", DoNotGenerateAcw=true)]
 	internal partial class II1Invoker : global::Java.Lang.Object, II1 {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/I1", typeof (II1Invoker));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/I1", typeof (II1Invoker));
 
 		static IntPtr java_class_ref {
 			get { return _members.JniPeerType.PeerReference.Handle; }

--- a/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.II2.cs
+++ b/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.II2.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/I2", DoNotGenerateAcw=true)]
 	internal partial class II2Invoker : global::Java.Lang.Object, II2 {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/I2", typeof (II2Invoker));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/I2", typeof (II2Invoker));
 
 		static IntPtr java_class_ref {
 			get { return _members.JniPeerType.PeerReference.Handle; }

--- a/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.SomeObject.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public partial class SomeObject : global::Java.Lang.Object, global::Xamarin.Test.II1, global::Xamarin.Test.II2 {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.SomeObject2.cs
+++ b/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.SomeObject2.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject2", DoNotGenerateAcw=true)]
 	public abstract partial class SomeObject2 : global::Java.Lang.Object, global::Xamarin.Test.II1, global::Xamarin.Test.II2 {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject2", typeof (SomeObject2));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject2", typeof (SomeObject2));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
@@ -84,7 +84,7 @@ namespace Xamarin.Test {
 
 		public SomeObject2Invoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject2", typeof (SomeObject2Invoker));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject2", typeof (SomeObject2Invoker));
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 			get { return _members; }

--- a/tests/generator-Tests/expected.ji/NestedTypes/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/NestedTypes/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
+++ b/tests/generator-Tests/expected.ji/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Test {
 			[global::Android.Runtime.Register ("xamarin/test/NotificationCompatBase$Action$Factory", DoNotGenerateAcw=true)]
 			internal partial class IFactoryInvoker : global::Java.Lang.Object, IFactory {
 
-				internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/NotificationCompatBase$Action$Factory", typeof (IFactoryInvoker));
+				static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/NotificationCompatBase$Action$Factory", typeof (IFactoryInvoker));
 
 				static IntPtr java_class_ref {
 					get { return _members.JniPeerType.PeerReference.Handle; }
@@ -103,7 +103,7 @@ namespace Xamarin.Test {
 			}
 
 
-			internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/NotificationCompatBase$Action", typeof (Action));
+			static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/NotificationCompatBase$Action", typeof (Action));
 			internal static new IntPtr class_ref {
 				get {
 					return _members.JniPeerType.PeerReference.Handle;
@@ -131,7 +131,7 @@ namespace Xamarin.Test {
 
 			public ActionInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
 
-			internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/NotificationCompatBase$Action", typeof (ActionInvoker));
+			static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/NotificationCompatBase$Action", typeof (ActionInvoker));
 
 			public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 				get { return _members; }
@@ -148,7 +148,7 @@ namespace Xamarin.Test {
 		[global::Android.Runtime.Register ("xamarin/test/NotificationCompatBase$InstanceInner", DoNotGenerateAcw=true)]
 		public abstract partial class InstanceInner : global::Java.Lang.Object {
 
-			internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/NotificationCompatBase$InstanceInner", typeof (InstanceInner));
+			static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/NotificationCompatBase$InstanceInner", typeof (InstanceInner));
 			internal static new IntPtr class_ref {
 				get {
 					return _members.JniPeerType.PeerReference.Handle;
@@ -196,7 +196,7 @@ namespace Xamarin.Test {
 
 			public InstanceInnerInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
 
-			internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/NotificationCompatBase$InstanceInner", typeof (InstanceInnerInvoker));
+			static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/NotificationCompatBase$InstanceInner", typeof (InstanceInnerInvoker));
 
 			public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 				get { return _members; }
@@ -209,7 +209,7 @@ namespace Xamarin.Test {
 		}
 
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/NotificationCompatBase", typeof (NotificationCompatBase));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/NotificationCompatBase", typeof (NotificationCompatBase));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/NonStaticFields/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/NonStaticFields/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/NonStaticFields/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/NonStaticFields/Xamarin.Test.SomeObject.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Test {
 				}
 			}
 		}
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/NormalMethods/Java.Lang.Class.cs
+++ b/tests/generator-Tests/expected.ji/NormalMethods/Java.Lang.Class.cs
@@ -10,7 +10,7 @@ namespace Java.Lang {
 	[global::Java.Interop.JavaTypeParameters (new string [] {"T"})]
 	public partial class Class : global::Java.Lang.Object {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Class", typeof (Class));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Class", typeof (Class));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/NormalMethods/Java.Lang.Integer.cs
+++ b/tests/generator-Tests/expected.ji/NormalMethods/Java.Lang.Integer.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Integer", DoNotGenerateAcw=true)]
 	public partial class Integer : global::Java.Lang.Object {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Integer", typeof (Integer));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Integer", typeof (Integer));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/NormalMethods/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/NormalMethods/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/NormalMethods/Java.Lang.Throwable.cs
+++ b/tests/generator-Tests/expected.ji/NormalMethods/Java.Lang.Throwable.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Throwable", DoNotGenerateAcw=true)]
 	public partial class Throwable  {
 
-		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Throwable", typeof (Throwable));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Throwable", typeof (Throwable));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/NormalMethods/Xamarin.Test.A.cs
+++ b/tests/generator-Tests/expected.ji/NormalMethods/Xamarin.Test.A.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Test {
 		[global::Java.Interop.JavaTypeParameters (new string [] {"T extends xamarin.test.A.B"})]
 		public partial class B : global::Java.Lang.Object {
 
-			internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/A$B", typeof (B));
+			static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/A$B", typeof (B));
 			internal static new IntPtr class_ref {
 				get {
 					return _members.JniPeerType.PeerReference.Handle;
@@ -67,7 +67,7 @@ namespace Xamarin.Test {
 
 		}
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/A", typeof (A));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/A", typeof (A));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/NormalMethods/Xamarin.Test.C.cs
+++ b/tests/generator-Tests/expected.ji/NormalMethods/Xamarin.Test.C.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Test {
 	[global::Java.Interop.JavaTypeParameters (new string [] {"T extends xamarin.test.C"})]
 	public partial class C : global::Java.Lang.Object {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/C", typeof (C));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/C", typeof (C));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/NormalMethods/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/NormalMethods/Xamarin.Test.SomeObject.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public partial class SomeObject : global::Java.Lang.Object {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/NormalProperties/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/NormalProperties/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/NormalProperties/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/NormalProperties/Xamarin.Test.SomeObject.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public abstract partial class SomeObject : global::Java.Lang.Object {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
@@ -156,7 +156,7 @@ namespace Xamarin.Test {
 
 		public SomeObjectInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObjectInvoker));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObjectInvoker));
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 			get { return _members; }

--- a/tests/generator-Tests/expected.ji/ParameterXPath/Java.Lang.Integer.cs
+++ b/tests/generator-Tests/expected.ji/ParameterXPath/Java.Lang.Integer.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Integer", DoNotGenerateAcw=true)]
 	public partial class Integer : global::Java.Lang.Object {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Integer", typeof (Integer));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Integer", typeof (Integer));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/ParameterXPath/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/ParameterXPath/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/ParameterXPath/Xamarin.Test.A.cs
+++ b/tests/generator-Tests/expected.ji/ParameterXPath/Xamarin.Test.A.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Test {
 	[global::Java.Interop.JavaTypeParameters (new string [] {"T extends java.lang.Object"})]
 	public partial class A : global::Java.Lang.Object {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/A", typeof (A));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/A", typeof (A));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/StaticFields/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/StaticFields/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/StaticFields/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/StaticFields/Xamarin.Test.SomeObject.cs
@@ -41,7 +41,7 @@ namespace Xamarin.Test {
 				}
 			}
 		}
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/StaticMethods/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/StaticMethods/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/StaticMethods/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/StaticMethods/Xamarin.Test.SomeObject.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public partial class SomeObject : global::Java.Lang.Object {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/StaticProperties/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/StaticProperties/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/StaticProperties/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/StaticProperties/Xamarin.Test.SomeObject.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public partial class SomeObject : global::Java.Lang.Object {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/Streams/Java.IO.FilterOutputStream.cs
+++ b/tests/generator-Tests/expected.ji/Streams/Java.IO.FilterOutputStream.cs
@@ -9,7 +9,7 @@ namespace Java.IO {
 	[global::Android.Runtime.Register ("java/io/FilterOutputStream", DoNotGenerateAcw=true)]
 	public partial class FilterOutputStream : global::Java.IO.OutputStream {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/io/FilterOutputStream", typeof (FilterOutputStream));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("java/io/FilterOutputStream", typeof (FilterOutputStream));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/Streams/Java.IO.IOException.cs
+++ b/tests/generator-Tests/expected.ji/Streams/Java.IO.IOException.cs
@@ -9,7 +9,7 @@ namespace Java.IO {
 	[global::Android.Runtime.Register ("java/io/IOException", DoNotGenerateAcw=true)]
 	public abstract partial class IOException : global::Java.Lang.Throwable {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/io/IOException", typeof (IOException));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("java/io/IOException", typeof (IOException));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
@@ -64,7 +64,7 @@ namespace Java.IO {
 
 		public IOExceptionInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/io/IOException", typeof (IOExceptionInvoker));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("java/io/IOException", typeof (IOExceptionInvoker));
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 			get { return _members; }

--- a/tests/generator-Tests/expected.ji/Streams/Java.IO.InputStream.cs
+++ b/tests/generator-Tests/expected.ji/Streams/Java.IO.InputStream.cs
@@ -9,7 +9,7 @@ namespace Java.IO {
 	[global::Android.Runtime.Register ("java/io/InputStream", DoNotGenerateAcw=true)]
 	public abstract partial class InputStream : global::Java.Lang.Object {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/io/InputStream", typeof (InputStream));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("java/io/InputStream", typeof (InputStream));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
@@ -324,7 +324,7 @@ namespace Java.IO {
 
 		public InputStreamInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/io/InputStream", typeof (InputStreamInvoker));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("java/io/InputStream", typeof (InputStreamInvoker));
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 			get { return _members; }

--- a/tests/generator-Tests/expected.ji/Streams/Java.IO.OutputStream.cs
+++ b/tests/generator-Tests/expected.ji/Streams/Java.IO.OutputStream.cs
@@ -9,7 +9,7 @@ namespace Java.IO {
 	[global::Android.Runtime.Register ("java/io/OutputStream", DoNotGenerateAcw=true)]
 	public abstract partial class OutputStream : global::Java.Lang.Object {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/io/OutputStream", typeof (OutputStream));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("java/io/OutputStream", typeof (OutputStream));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
@@ -205,7 +205,7 @@ namespace Java.IO {
 
 		public OutputStreamInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/io/OutputStream", typeof (OutputStreamInvoker));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("java/io/OutputStream", typeof (OutputStreamInvoker));
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 			get { return _members; }

--- a/tests/generator-Tests/expected.ji/Streams/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/Streams/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/Streams/Java.Lang.Throwable.cs
+++ b/tests/generator-Tests/expected.ji/Streams/Java.Lang.Throwable.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Throwable", DoNotGenerateAcw=true)]
 	public partial class Throwable  {
 
-		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Throwable", typeof (Throwable));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Throwable", typeof (Throwable));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/TestInterface/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/TestInterface/Java.Lang.String.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Java.Lang.String.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/String", DoNotGenerateAcw=true)]
 	public sealed partial class String : global::Java.Lang.Object {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/String", typeof (String));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/String", typeof (String));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericImplementation.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericImplementation.cs
@@ -9,7 +9,7 @@ namespace Test.ME {
 	[global::Android.Runtime.Register ("test/me/GenericImplementation", DoNotGenerateAcw=true)]
 	public partial class GenericImplementation : global::Java.Lang.Object, global::Test.ME.IGenericInterface {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("test/me/GenericImplementation", typeof (GenericImplementation));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("test/me/GenericImplementation", typeof (GenericImplementation));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericObjectPropertyImplementation.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericObjectPropertyImplementation.cs
@@ -9,7 +9,7 @@ namespace Test.ME {
 	[global::Android.Runtime.Register ("test/me/GenericObjectPropertyImplementation", DoNotGenerateAcw=true)]
 	public partial class GenericObjectPropertyImplementation : global::Java.Lang.Object, global::Test.ME.IGenericPropertyInterface {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("test/me/GenericObjectPropertyImplementation", typeof (GenericObjectPropertyImplementation));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("test/me/GenericObjectPropertyImplementation", typeof (GenericObjectPropertyImplementation));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericStringImplementation.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericStringImplementation.cs
@@ -9,7 +9,7 @@ namespace Test.ME {
 	[global::Android.Runtime.Register ("test/me/GenericStringImplementation", DoNotGenerateAcw=true)]
 	public partial class GenericStringImplementation : global::Java.Lang.Object, global::Test.ME.IGenericInterface {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("test/me/GenericStringImplementation", typeof (GenericStringImplementation));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("test/me/GenericStringImplementation", typeof (GenericStringImplementation));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericStringPropertyImplementation.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericStringPropertyImplementation.cs
@@ -9,7 +9,7 @@ namespace Test.ME {
 	[global::Android.Runtime.Register ("test/me/GenericStringPropertyImplementation", DoNotGenerateAcw=true)]
 	public partial class GenericStringPropertyImplementation : global::Java.Lang.Object, global::Test.ME.IGenericPropertyInterface {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("test/me/GenericStringPropertyImplementation", typeof (GenericStringPropertyImplementation));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("test/me/GenericStringPropertyImplementation", typeof (GenericStringPropertyImplementation));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/TestInterface/Test.ME.IGenericInterface.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Test.ME.IGenericInterface.cs
@@ -19,7 +19,7 @@ namespace Test.ME {
 	[global::Android.Runtime.Register ("test/me/GenericInterface", DoNotGenerateAcw=true)]
 	internal partial class IGenericInterfaceInvoker : global::Java.Lang.Object, IGenericInterface {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("test/me/GenericInterface", typeof (IGenericInterfaceInvoker));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("test/me/GenericInterface", typeof (IGenericInterfaceInvoker));
 
 		static IntPtr java_class_ref {
 			get { return _members.JniPeerType.PeerReference.Handle; }

--- a/tests/generator-Tests/expected.ji/TestInterface/Test.ME.IGenericPropertyInterface.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Test.ME.IGenericPropertyInterface.cs
@@ -22,7 +22,7 @@ namespace Test.ME {
 	[global::Android.Runtime.Register ("test/me/GenericPropertyInterface", DoNotGenerateAcw=true)]
 	internal partial class IGenericPropertyInterfaceInvoker : global::Java.Lang.Object, IGenericPropertyInterface {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("test/me/GenericPropertyInterface", typeof (IGenericPropertyInterfaceInvoker));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("test/me/GenericPropertyInterface", typeof (IGenericPropertyInterfaceInvoker));
 
 		static IntPtr java_class_ref {
 			get { return _members.JniPeerType.PeerReference.Handle; }

--- a/tests/generator-Tests/expected.ji/TestInterface/Test.ME.ITestInterface.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Test.ME.ITestInterface.cs
@@ -28,7 +28,7 @@ namespace Test.ME {
 			}
 		}
 
-		static new readonly JniPeerMembers _members = new JniPeerMembers ("test/me/TestInterface", typeof (TestInterface));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("test/me/TestInterface", typeof (TestInterface));
 	}
 
 	[Register ("test/me/TestInterface", DoNotGenerateAcw=true)]
@@ -80,7 +80,7 @@ namespace Test.ME {
 	[global::Android.Runtime.Register ("test/me/TestInterface", DoNotGenerateAcw=true)]
 	internal partial class ITestInterfaceInvoker : global::Java.Lang.Object, ITestInterface {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("test/me/TestInterface", typeof (ITestInterfaceInvoker));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("test/me/TestInterface", typeof (ITestInterfaceInvoker));
 
 		static IntPtr java_class_ref {
 			get { return _members.JniPeerType.PeerReference.Handle; }

--- a/tests/generator-Tests/expected.ji/TestInterface/Test.ME.TestInterfaceImplementation.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Test.ME.TestInterfaceImplementation.cs
@@ -31,7 +31,7 @@ namespace Test.ME {
 			}
 		}
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("test/me/TestInterfaceImplementation", typeof (TestInterfaceImplementation));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("test/me/TestInterfaceImplementation", typeof (TestInterfaceImplementation));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
@@ -158,7 +158,7 @@ namespace Test.ME {
 
 		public TestInterfaceImplementationInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("test/me/TestInterfaceImplementation", typeof (TestInterfaceImplementationInvoker));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("test/me/TestInterfaceImplementation", typeof (TestInterfaceImplementationInvoker));
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 			get { return _members; }

--- a/tests/generator-Tests/expected.ji/java.lang.Enum/Java.Lang.Enum.cs
+++ b/tests/generator-Tests/expected.ji/java.lang.Enum/Java.Lang.Enum.cs
@@ -10,7 +10,7 @@ namespace Java.Lang {
 	[global::Java.Interop.JavaTypeParameters (new string [] {"E extends java.lang.Enum<E>"})]
 	public abstract partial class Enum : global::Java.Lang.Object, global::Java.Lang.IComparable {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Enum", typeof (Enum));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Enum", typeof (Enum));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;
@@ -54,7 +54,7 @@ namespace Java.Lang {
 
 		public EnumInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Enum", typeof (EnumInvoker));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Enum", typeof (EnumInvoker));
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 			get { return _members; }

--- a/tests/generator-Tests/expected.ji/java.lang.Enum/Java.Lang.IComparable.cs
+++ b/tests/generator-Tests/expected.ji/java.lang.Enum/Java.Lang.IComparable.cs
@@ -19,7 +19,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Comparable", DoNotGenerateAcw=true)]
 	internal partial class IComparableInvoker : global::Java.Lang.Object, IComparable {
 
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Comparable", typeof (IComparableInvoker));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Comparable", typeof (IComparableInvoker));
 
 		static IntPtr java_class_ref {
 			get { return _members.JniPeerType.PeerReference.Handle; }

--- a/tests/generator-Tests/expected.ji/java.lang.Enum/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/java.lang.Enum/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/java.lang.Enum/Java.Lang.State.cs
+++ b/tests/generator-Tests/expected.ji/java.lang.Enum/Java.Lang.State.cs
@@ -81,7 +81,7 @@ namespace Java.Lang {
 				return global::Java.Lang.Object.GetObject<global::Java.Lang.State> (__v.Handle, JniHandleOwnership.TransferLocalRef);
 			}
 		}
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/State", typeof (State));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/State", typeof (State));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/java.lang.Object/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/java.lang.Object/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/java.util.List/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/java.util.List/Java.Lang.Object.cs
@@ -9,7 +9,7 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
 	public partial class Object  {
 
-		internal static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
 		internal static IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tests/generator-Tests/expected.ji/java.util.List/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/java.util.List/Xamarin.Test.SomeObject.cs
@@ -163,7 +163,7 @@ namespace Xamarin.Test {
 				}
 			}
 		}
-		internal static new readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 		internal static new IntPtr class_ref {
 			get {
 				return _members.JniPeerType.PeerReference.Handle;

--- a/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/JavaInteropCodeGenerator.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/JavaInteropCodeGenerator.cs
@@ -29,7 +29,7 @@ namespace MonoDroid.Generation {
 
 		internal override void WriteClassHandle (ClassGen type, string indent, bool requireNew)
 		{
-			WritePeerMembers (indent + '\t', true, requireNew, type.RawJniName, type.Name, false);
+			WritePeerMembers (indent + '\t', type.RawJniName, type.Name, false);
 
 			writer.WriteLine ("{0}\tinternal static {1}IntPtr class_ref {{", indent, requireNew ? "new " : string.Empty);
 			writer.WriteLine ("{0}\t\tget {{", indent);
@@ -55,12 +55,12 @@ namespace MonoDroid.Generation {
 
 		internal override void WriteClassHandle (InterfaceGen type, string indent, string declaringType)
 		{
-			WritePeerMembers (indent, false, true, type.RawJniName, declaringType, type.Name == declaringType);
+			WritePeerMembers (indent, type.RawJniName, declaringType, type.Name == declaringType);
 		}
 
 		internal override void WriteClassInvokerHandle (ClassGen type, string indent, string declaringType)
 		{
-			WritePeerMembers (indent, true, true, type.RawJniName, declaringType, false);
+			WritePeerMembers (indent, type.RawJniName, declaringType, false);
 
 			writer.WriteLine ();
 			writer.WriteLine ("{0}public override global::Java.Interop.JniPeerMembers JniPeerMembers {{", indent);
@@ -75,7 +75,7 @@ namespace MonoDroid.Generation {
 
 		internal override void WriteInterfaceInvokerHandle (InterfaceGen type, string indent, string declaringType)
 		{
-			WritePeerMembers (indent, true, true, type.RawJniName, declaringType, false);
+			WritePeerMembers (indent, type.RawJniName, declaringType, false);
 
 			writer.WriteLine ();
 			writer.WriteLine ("{0}static IntPtr java_class_ref {{", indent);
@@ -262,9 +262,9 @@ namespace MonoDroid.Generation {
 			writer.WriteLine ("{0}}}", indent);
 		}
 
-		void WritePeerMembers (string indent, bool isInternal, bool isNew, string rawJniType, string declaringType, bool isInterface)
+		void WritePeerMembers (string indent, string rawJniType, string declaringType, bool isInterface)
 		{
-			var signature = $"{(isInternal ? "internal " : "")}static {(isNew ? "new " : "")}readonly JniPeerMembers _members = ";
+			var signature = "static readonly JniPeerMembers _members = ";
 			var type = $"new {GetPeerMembersType ()} (\"{rawJniType}\", typeof ({declaringType}){(isInterface ? ", isInterface: true" : string.Empty)});";
 
 			writer.WriteLine ($"{indent}{signature}{type}");


### PR DESCRIPTION
Because the `JniPeerMembers _members` field is exposed via the `IJavaPeerable.JniPeerMembers` interface property, we no longer need the field to be `internal`, which means we no longer need to worry about when to add `new`.  This PR makes the `_members` field `private` which reduces the number of warnings that occur when building a binding project.

```
static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));

public override global::Java.Interop.JniPeerMembers JniPeerMembers {
	get { return _members; }
}
```