### PR TITLE
[XAT.Bytecode] Add support for reading NotNull metadata into api.xml.

### DIFF
--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApi.XmlModel.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApi.XmlModel.cs
@@ -176,7 +176,8 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			: base (parent)
 		{
 		}
-		
+
+		public bool NotNull { get; set; }
 		public bool Transient { get; set; }
 		public string Type { get; set; }
 		public string TypeGeneric { get; set; }
@@ -248,6 +249,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		public bool Abstract { get; set; }
 		public bool Native { get; set; }
 		public string Return { get; set; }
+		public bool ReturnNotNull { get; set; }
 		public bool Synchronized { get; set; }
 
 		// Content of this value is not stable.
@@ -268,6 +270,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		public string Name { get; set; }
 		public string Type { get; set; }
 		public string JniType { get; set; }
+		public bool NotNull { get; set; }
 
 		// Content of this value is not stable.
 		public override string ToString ()

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiXmlGeneratorExtensions.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiXmlGeneratorExtensions.cs
@@ -160,12 +160,13 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 				null,
 				null,
 				null,
-				null);
+				null,
+				field.NotNull);
 		}
 		
 		static void Save (this JavaConstructor ctor, XmlWriter writer)
 		{
-			SaveCommon (ctor, writer, "constructor", null, null, null, null, null, ctor.Type ?? ctor.Parent.FullName, null, null, null, ctor.TypeParameters, ctor.Parameters, ctor.Exceptions, ctor.ExtendedBridge, ctor.ExtendedJniReturn, ctor.ExtendedSynthetic);
+			SaveCommon (ctor, writer, "constructor", null, null, null, null, null, ctor.Type ?? ctor.Parent.FullName, null, null, null, ctor.TypeParameters, ctor.Parameters, ctor.Exceptions, ctor.ExtendedBridge, ctor.ExtendedJniReturn, ctor.ExtendedSynthetic, null);
 		}
 		
 		static void Save (this JavaMethod method, XmlWriter writer)
@@ -217,7 +218,8 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 				method.Exceptions,
 				method.ExtendedBridge,
 				method.ExtendedJniReturn,
-				method.ExtendedSynthetic);
+				method.ExtendedSynthetic,
+				method.ReturnNotNull);
 		}
 		
 		static void SaveCommon (this JavaMember m, XmlWriter writer, string elementName,
@@ -227,7 +229,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 					JavaTypeParameters typeParameters,
 					IEnumerable<JavaParameter> parameters,
 					IEnumerable<JavaException> exceptions,
-					bool? extBridge, string jniReturn, bool? extSynthetic)
+					bool? extBridge, string jniReturn, bool? extSynthetic, bool? notNull)
 		{
 			// If any of the parameters contain reference to non-public type, it cannot be generated.
 			if (parameters != null && parameters.Any (p => p.ResolvedType.ReferencedType != null && string.IsNullOrEmpty (p.ResolvedType.ReferencedType.Visibility)))
@@ -248,6 +250,8 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 				writer.WriteAttributeString ("return", ret);
 			if (jniReturn != null)
 				writer.WriteAttributeString ("jni-return", jniReturn);
+			if (notNull.GetValueOrDefault ())
+				writer.WriteAttributeString (m is JavaField ? "not-null" : "return-not-null", "true");
 			writer.WriteAttributeString ("static", XmlConvert.ToString (m.Static));
 			if (sync != null)
 				writer.WriteAttributeString ("synchronized", sync);
@@ -275,6 +279,9 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 					writer.WriteAttributeString ("type", p.GetVisibleTypeName ());
 					if (!string.IsNullOrEmpty (p.JniType)) {
 						writer.WriteAttributeString ("jni-type", p.JniType);
+					}
+					if (p.NotNull == true) {
+						writer.WriteAttributeString ("not-null", "true");
 					}
 					writer.WriteString ("\n        ");
 					writer.WriteFullEndElement ();

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiXmlLoaderExtensions.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiXmlLoaderExtensions.cs
@@ -215,10 +215,11 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		{
 			field.LoadMemberAttributes (reader);
 			field.Transient = XmlConvert.ToBoolean (XmlUtil.GetRequiredAttribute (reader, "transient"));
-			field.Volatile = XmlConvert.ToBoolean (XmlUtil.GetRequiredAttribute (reader, "transient"));
+			field.Volatile = XmlConvert.ToBoolean (XmlUtil.GetRequiredAttribute (reader, "volatile"));
 			field.Type = XmlUtil.GetRequiredAttribute (reader, "type");
 			field.TypeGeneric = XmlUtil.GetRequiredAttribute (reader, "type-generic-aware");
 			field.Value = reader.GetAttribute ("value");
+			field.NotNull = reader.GetAttribute ("not-null") == "true";
 
 			reader.Skip ();
 		}
@@ -277,9 +278,10 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			method.Abstract = XmlConvert.ToBoolean (XmlUtil.GetRequiredAttribute (reader, "abstract"));
 			method.Native = XmlConvert.ToBoolean (XmlUtil.GetRequiredAttribute (reader, "native"));
 			method.Return = XmlUtil.GetRequiredAttribute (reader, "return");
+			method.ReturnNotNull = reader.GetAttribute ("return-not-null") == "true";
 			method.Synchronized = XmlConvert.ToBoolean (XmlUtil.GetRequiredAttribute (reader, "synchronized"));
 			XmlUtil.CheckExtraneousAttributes ("method", reader, "deprecated", "final", "name", "static", "visibility", "jni-signature", "jni-return", "synthetic", "bridge",
-				"abstract", "native", "return", "synchronized");
+				"abstract", "native", "return", "synchronized", "return-not-null");
 			method.LoadMethodBase ("method", reader);
 		}
 
@@ -288,6 +290,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			p.Name = XmlUtil.GetRequiredAttribute (reader, "name");
 			p.Type = XmlUtil.GetRequiredAttribute (reader, "type");
 			p.JniType = reader.GetAttribute ("jni-type");
+			p.NotNull = reader.GetAttribute ("not-null") == "true";
 			reader.Skip ();
 		}
 

--- a/src/Xamarin.Android.Tools.Bytecode/Annotation.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/Annotation.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace Xamarin.Android.Tools.Bytecode
@@ -46,6 +47,33 @@ namespace Xamarin.Android.Tools.Bytecode
 				values.Append (value.Key).Append (": ");
 				values.Append (value.Value);
 			}
+		}
+	}
+
+	public sealed class ParameterAnnotation
+	{
+		public int ParameterIndex { get; }
+		public IList<Annotation> Annotations { get; } = new List<Annotation> ();
+		public ConstantPool ConstantPool { get; }
+
+		public ParameterAnnotation (ConstantPool constantPool, Stream stream, int index)
+		{
+			ConstantPool = constantPool;
+
+			ParameterIndex = index;
+
+			var ann_count = stream.ReadNetworkUInt16 ();
+
+			for (var i = 0; i < ann_count; ++i) {
+				var a = new Annotation (constantPool, stream);
+				Annotations.Add (a);
+			}
+		}
+
+		public override string ToString ()
+		{
+			var annotations = string.Join (", ", Annotations.Select (v => v.ToString ()));
+			return $"Parameter{ParameterIndex}({annotations})";
 		}
 	}
 }

--- a/src/Xamarin.Android.Tools.Bytecode/AttributeInfo.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/AttributeInfo.cs
@@ -49,6 +49,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 		public  const   string  StackMapTable           = "StackMapTable";
 		public	const	string	RuntimeVisibleAnnotations	= "RuntimeVisibleAnnotations";
 		public	const	string	RuntimeInvisibleAnnotations	= "RuntimeInvisibleAnnotations";
+		public	const	string	RuntimeInvisibleParameterAnnotations = "RuntimeInvisibleParameterAnnotations";
 
 		ushort          nameIndex;
 
@@ -115,6 +116,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 			case MethodParameters:      return new MethodParametersAttribute (constantPool, nameIndex, stream);
 			case RuntimeVisibleAnnotations:		return new RuntimeVisibleAnnotationsAttribute (constantPool, nameIndex, stream);
 			case RuntimeInvisibleAnnotations:	return new RuntimeInvisibleAnnotationsAttribute (constantPool, nameIndex, stream);
+			case RuntimeInvisibleParameterAnnotations:	return new RuntimeInvisibleParameterAnnotationsAttribute (constantPool, nameIndex, stream);
 			case Signature:             return new SignatureAttribute (constantPool, nameIndex, stream);
 			case SourceFile:            return new SourceFileAttribute (constantPool, nameIndex, stream);
 			case StackMapTable:         return new StackMapTableAttribute (constantPool, nameIndex, stream);
@@ -543,7 +545,32 @@ namespace Xamarin.Android.Tools.Bytecode {
 		public override string ToString ()
 		{
 			var annotations = string.Join (", ", Annotations.Select (v => v.ToString ()));
-			return $"RuntimeVisibleAnnotations({annotations})";
+			return $"RuntimeInvisibleAnnotations({annotations})";
+		}
+	}
+
+
+	// https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.7.19
+	public sealed class RuntimeInvisibleParameterAnnotationsAttribute : AttributeInfo
+	{
+		public IList<ParameterAnnotation> Annotations { get; } = new List<ParameterAnnotation> ();
+
+		public RuntimeInvisibleParameterAnnotationsAttribute (ConstantPool constantPool, ushort nameIndex, Stream stream)
+			: base (constantPool, nameIndex, stream)
+		{
+			var length = stream.ReadNetworkUInt32 ();
+			var param_count = stream.ReadNetworkByte ();
+
+			for (var i = 0; i < param_count; ++i) {
+				var a = new ParameterAnnotation (constantPool, stream, i);
+				Annotations.Add (a);
+			}
+		}
+
+		public override string ToString ()
+		{
+			var annotations = string.Join (", ", Annotations.Select (v => v.ToString ()));
+			return $"RuntimeInvisibleParameterAnnotationsAttribute({annotations})";
 		}
 	}
 

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/NullableAnnotationTests.cs
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/NullableAnnotationTests.cs
@@ -1,0 +1,68 @@
+using System;
+
+using Xamarin.Android.Tools.Bytecode;
+
+using NUnit.Framework;
+using System.Linq;
+
+namespace Xamarin.Android.Tools.BytecodeTests
+{
+	[TestFixture]
+	public class NullableAnnotationTests : ClassFileFixture
+	{
+		[Test]
+		public void RuntimeInvisibleAnnotations ()
+		{
+			var c = LoadClassFile ("NotNullClass.class");
+
+			// Method with no annotations
+			var null_method = c.Methods.First (m => m.Name == "nullFunc");
+
+			Assert.AreEqual (0, null_method.Attributes.OfType<RuntimeInvisibleAnnotationsAttribute> ().Count ());
+			Assert.AreEqual (0, null_method.Attributes.OfType<RuntimeInvisibleParameterAnnotationsAttribute> ().Count ());
+
+			// Method with not-null parameter and return value annotations
+			var notnull_method = c.Methods.First (m => m.Name == "notNullFunc");
+			var return_ann = notnull_method.Attributes.OfType<RuntimeInvisibleAnnotationsAttribute> ().FirstOrDefault ()?.Annotations;
+			var param_ann = notnull_method.Attributes.OfType<RuntimeInvisibleParameterAnnotationsAttribute> ().FirstOrDefault ()?.Annotations;
+
+			Assert.NotNull (return_ann);
+			Assert.IsTrue (return_ann.Any (a => a.Type == "Landroid/annotation/NonNull;"));
+
+			Assert.NotNull (param_ann);
+			Assert.IsTrue (param_ann.Any (a => a.ParameterIndex == 0 && a.Annotations[0].Type == "Landroid/annotation/NonNull;"));
+
+			// Field with no annotations
+			var null_field = c.Fields.First (f => f.Name == "nullField");
+
+			Assert.AreEqual (0, null_field.Attributes.OfType<RuntimeInvisibleAnnotationsAttribute> ().Count ());
+			Assert.AreEqual (0, null_field.Attributes.OfType<RuntimeInvisibleParameterAnnotationsAttribute> ().Count ());
+
+			// Field with not-null annotation
+			var notnull_field = c.Fields.First (f => f.Name == "notNullField");
+
+			var field_ann = notnull_method.Attributes.OfType<RuntimeInvisibleAnnotationsAttribute> ().FirstOrDefault ()?.Annotations;
+
+			Assert.NotNull (field_ann);
+			Assert.IsTrue (field_ann.Any (a => a.Type == "Landroid/annotation/NonNull;"));
+		}
+
+		[Test]
+		public void NullableAnnotationOutput ()
+		{
+			var c = LoadClassFile ("NotNullClass.class");
+			var builder = new XmlClassDeclarationBuilder (c);
+			var xml = builder.ToXElement ();
+
+			var method = xml.Elements ("method").First (m => m.Attribute ("name").Value == "notNullFunc");
+			Assert.AreEqual ("true", method.Attribute ("return-not-null").Value);
+
+			var parameter = method.Element ("parameter");
+			Assert.AreEqual ("true", parameter.Attribute ("not-null").Value);
+
+			var field = xml.Elements ("field").First (f => f.Attribute ("name").Value == "notNullField");
+			Assert.AreEqual ("true", field.Attribute ("not-null").Value);
+		}
+	}
+}
+

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj
@@ -31,6 +31,7 @@
     <EmbeddedResource Include="Resources\*" />
     <EmbeddedResource Include="kotlin\**\*.class" />
 
+    <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\xamarin\NotNullClass.class" />
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\xamarin\IJavaInterface.class" />
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\xamarin\IParameterInterface.class" />
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\xamarin\JavaAnnotation.class" />
@@ -51,14 +52,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <TestJar Include="java\**\*.java" Exclude="java\java\util\Collection.java" />
+    <TestJar Include="java\**\*.java" Exclude="java\java\util\Collection.java,java\android\annotation\NonNull.java" />
     <TestJarNoParameters Include="java\java\util\Collection.java" />
     <TestKotlinJar Include="kotlin\**\*.kt" />
   </ItemGroup>
 
   <Target Name="BuildClasses" BeforeTargets="BeforeBuild" Inputs="@(TestJar)" Outputs="@(TestJar->'$(IntermediateOutputPath)classes\%(RecursiveDir)%(Filename).class')">
     <MakeDir Directories="$(IntermediateOutputPath)classes" />
-    <Exec Command="&quot;$(JavaCPath)&quot; -parameters $(_JavacSourceOptions) -g -d &quot;$(IntermediateOutputPath)classes&quot; @(TestJar->'%(Identity)', ' ')" />
+    <Exec Command="&quot;$(JavaCPath)&quot; -parameters $(_JavacSourceOptions) -g -d &quot;$(IntermediateOutputPath)classes&quot; java\android\annotation\NonNull.java @(TestJar->'%(Identity)', ' ')" />
     <Exec Command="&quot;$(JavaCPath)&quot; $(_JavacSourceOptions) -g -d &quot;$(IntermediateOutputPath)classes&quot; @(TestJarNoParameters->'%(Identity)', ' ')" />
   </Target>
 

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/java/android/annotation/NonNull.java
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/java/android/annotation/NonNull.java
@@ -1,0 +1,7 @@
+package android.annotation;
+
+import java.lang.annotation.*;  
+import java.lang.reflect.*;  
+  
+public @interface NonNull {  
+}

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/java/com/xamarin/NotNullClass.java
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/java/com/xamarin/NotNullClass.java
@@ -1,0 +1,18 @@
+package com.xamarin;
+
+import android.annotation.NonNull;
+
+public class NotNullClass {
+
+	public void nullFunc (String value) {
+	}
+
+	@NonNull
+	public void notNullFunc (@NonNull String value) {
+	}
+
+	public String nullField;
+
+	@NonNull
+	public String notNullField;
+}


### PR DESCRIPTION
First part of https://github.com/xamarin/java.interop/issues/468.

This adds support for reading `@NotNull/@NonNull` annotations from Java and putting them into `api.xml`.  It does not add logic to consume them.

Adds `not-null` attribute to `api.xml` for Fields and Parameters:

```
<field 
  deprecated="not deprecated" 
  final="true" 
  name="CREATOR" 
  jni-signature="Landroid/os/Parcelable$Creator;" 
  not-null="true" 
  static="true" 
  transient="false" 
  type="android.os.Parcelable.Creator" 
  type-generic-aware="android.os.Parcelable.Creator&lt;android.app.DirectAction&gt;" 
  visibility="public" 
  volatile="false" />

<parameter 
  name="handler" 
  type="android.os.Handler" 
  jni-type="Landroid/os/Handler;" 
  not-null="true" />
```

Adds `return-not-null` attribute to `api.xml` for Methods:

```
<method 
  abstract="false" 
  deprecated="not deprecated" 
  final="true" 
  name="getContext" 
  jni-signature="()Landroid/content/Context;" 
  bridge="false" 
  native="false" 
  return="android.content.Context" 
  jni-return="Landroid/content/Context;" 
  static="false" 
  synchronized="false" 
  synthetic="false" 
  visibility="public" 
  return-not-null="true" />
```

We look for the following annotations:

```
Android:
android/annotation/NonNull
androidx/annotation/RecentlyNonNull

Java:
javax/validation/constraints/NotNull
edu/umd/cs/findbugs/annotations/NonNull
javax/annotation/Nonnull
org/jetbrains/annotations/NotNull
lombok/NonNull
android/support/annotation/NonNull
org/eclipse/jdt/annotation/NonNull
```

List partially taken from https://stackoverflow.com/questions/4963300/which-notnull-java-annotation-should-i-use.