### PR TITLE
[Java.Interop] Revert removing public constructor from abstract class to appease api checker.

### DIFF
--- a/src/Java.Interop/GlobalSuppressions.cs
+++ b/src/Java.Interop/GlobalSuppressions.cs
@@ -8,6 +8,8 @@ using System.Diagnostics.CodeAnalysis;
 
 [assembly: SuppressMessage ("Design", "CA1008:Enums should have zero value", Justification = "No thanks", Scope = "type", Target = "~T:Java.Interop.JniVersion")]
 
+[assembly: SuppressMessage ("Design", "CA1012:Abstract types should not have constructors", Justification = "Public API checker in flux - Can change later", Scope = "type", Target = "~T:Java.Interop.JniRuntime.JniObjectReferenceManager")]
+
 [assembly: SuppressMessage ("Design", "CA1030:Use events where appropriate", Justification = "This isn't 'raising' an event; it's 'raising' a pending exception within the JVM.", Scope = "member", Target = "~M:Java.Interop.JniRuntime.RaisePendingException(System.Exception)")]
 
 [assembly: SuppressMessage ("Design", "CA1024:Use properties where appropriate", Justification = "<Pending>", Scope = "member", Target = "~M:Java.Interop.JniRuntime.GetRegisteredRuntimes()")]

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniObjectReferenceManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniObjectReferenceManager.cs
@@ -14,6 +14,10 @@ namespace Java.Interop {
 
 		public abstract class JniObjectReferenceManager : IDisposable, ISetRuntime {
 
+			public JniObjectReferenceManager ()
+			{
+			}
+
 			public  JniRuntime      Runtime { get; private set; }
 
 			public virtual void OnSetRuntime (JniRuntime runtime)


### PR DESCRIPTION
We removed the public constructor from abstract class `Java.Interop.JniRuntime.JniObjectReferenceManager` in https://github.com/xamarin/java.interop/pull/523.  This change is fine, but it triggered the API Compatibility check.

Because we are in the middle of replacing that check with something else it's easier to simply revert this change for now.