### PR TITLE
Consume Mono.Linq.Expressions as a NuGet instead of a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "lib/mono.linq.expressions"]
-	path = lib/mono.linq.expressions
-	url = https://github.com/jbevain/mono.linq.expressions.git
-	branch = master
 [submodule "external/cecil"]
 	path = external/cecil
 	url = https://github.com/mono/cecil.git

--- a/Java.Interop.sln
+++ b/Java.Interop.sln
@@ -5,8 +5,6 @@ VisualStudioVersion = 16.0.29424.173
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tools", "Tools", "{C8F58966-94BF-407F-914A-8654F8B8AE3B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mono.Linq.Expressions", "lib\mono.linq.expressions\Mono.Linq.Expressions.csproj", "{0C001D50-4176-45AE-BDC8-BA626508B0CC}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Android.Tools.JniMarshalMethodGenerator", "tools\jnimarshalmethod-gen\Xamarin.Android.Tools.JniMarshalMethodGenerator.csproj", "{D1295A8F-4F42-461D-A046-564476C10002}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "logcat-parse", "tools\logcat-parse\logcat-parse.csproj", "{7387E151-48E3-4885-B2CA-A74434A34045}"
@@ -98,10 +96,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{0C001D50-4176-45AE-BDC8-BA626508B0CC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0C001D50-4176-45AE-BDC8-BA626508B0CC}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0C001D50-4176-45AE-BDC8-BA626508B0CC}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0C001D50-4176-45AE-BDC8-BA626508B0CC}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D1295A8F-4F42-461D-A046-564476C10002}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D1295A8F-4F42-461D-A046-564476C10002}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D1295A8F-4F42-461D-A046-564476C10002}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -243,7 +237,6 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
-		{0C001D50-4176-45AE-BDC8-BA626508B0CC} = {C8F58966-94BF-407F-914A-8654F8B8AE3B}
 		{D1295A8F-4F42-461D-A046-564476C10002} = {C8F58966-94BF-407F-914A-8654F8B8AE3B}
 		{7387E151-48E3-4885-B2CA-A74434A34045} = {C8F58966-94BF-407F-914A-8654F8B8AE3B}
 		{38C762AB-8FD1-44DE-9855-26AAE7129DC3} = {C8F58966-94BF-407F-914A-8654F8B8AE3B}

--- a/src/Java.Interop.Dynamic/Java.Interop.Dynamic.csproj
+++ b/src/Java.Interop.Dynamic/Java.Interop.Dynamic.csproj
@@ -22,9 +22,5 @@
       <Project>{94BD81F7-B06F-4295-9636-F8A3B6BDC762}</Project>
       <Name>Java.Interop</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\lib\mono.linq.expressions\Mono.Linq.Expressions.csproj">
-      <Project>{0C001D50-4176-45AE-BDC8-BA626508B0CC}</Project>
-      <Name>Mono.Linq.Expressions</Name>
-    </ProjectReference>
   </ItemGroup>
 </Project>

--- a/src/Java.Interop.Dynamic/Java.Interop.Dynamic/DynamicJavaClass.cs
+++ b/src/Java.Interop.Dynamic/Java.Interop.Dynamic/DynamicJavaClass.cs
@@ -9,8 +9,6 @@ using System.Text;
 
 using Java.Interop;
 
-using Mono.Linq.Expressions;
-
 namespace Java.Interop.Dynamic {
 
 	public class DynamicJavaClass : IDynamicMetaObjectProvider, IDisposable

--- a/src/Java.Interop.Dynamic/Java.Interop.Dynamic/DynamicJavaInstance.cs
+++ b/src/Java.Interop.Dynamic/Java.Interop.Dynamic/DynamicJavaInstance.cs
@@ -9,8 +9,6 @@ using System.Text;
 
 using Java.Interop;
 
-using Mono.Linq.Expressions;
-
 
 namespace Java.Interop.Dynamic {
 

--- a/src/Java.Interop.Dynamic/Java.Interop.Dynamic/JavaClassInfo.cs
+++ b/src/Java.Interop.Dynamic/Java.Interop.Dynamic/JavaClassInfo.cs
@@ -9,8 +9,6 @@ using System.Reflection;
 using System.Threading;
 using System.Text;
 
-using Mono.Linq.Expressions;
-
 using Java.Interop;
 
 namespace Java.Interop.Dynamic {

--- a/src/Java.Interop.Dynamic/Java.Interop.Dynamic/JavaConstructorInfo.cs
+++ b/src/Java.Interop.Dynamic/Java.Interop.Dynamic/JavaConstructorInfo.cs
@@ -9,8 +9,6 @@ using System.Reflection;
 using System.Threading;
 using System.Text;
 
-using Mono.Linq.Expressions;
-
 using Java.Interop;
 
 namespace Java.Interop.Dynamic {

--- a/src/Java.Interop.Dynamic/Java.Interop.Dynamic/JavaFieldInfo.cs
+++ b/src/Java.Interop.Dynamic/Java.Interop.Dynamic/JavaFieldInfo.cs
@@ -9,8 +9,6 @@ using System.Reflection;
 using System.Threading;
 using System.Text;
 
-using Mono.Linq.Expressions;
-
 using Java.Interop;
 
 namespace Java.Interop.Dynamic {

--- a/src/Java.Interop.Dynamic/Java.Interop.Dynamic/JavaInstanceProxy.cs
+++ b/src/Java.Interop.Dynamic/Java.Interop.Dynamic/JavaInstanceProxy.cs
@@ -9,8 +9,6 @@ using System.Reflection;
 using System.Threading;
 using System.Text;
 
-using Mono.Linq.Expressions;
-
 using Java.Interop;
 
 namespace Java.Interop.Dynamic {

--- a/src/Java.Interop.Dynamic/Java.Interop.Dynamic/JavaMethodBase.cs
+++ b/src/Java.Interop.Dynamic/Java.Interop.Dynamic/JavaMethodBase.cs
@@ -9,8 +9,6 @@ using System.Reflection;
 using System.Threading;
 using System.Text;
 
-using Mono.Linq.Expressions;
-
 using Java.Interop;
 
 namespace Java.Interop.Dynamic {

--- a/src/Java.Interop.Dynamic/Java.Interop.Dynamic/JavaMethodInfo.cs
+++ b/src/Java.Interop.Dynamic/Java.Interop.Dynamic/JavaMethodInfo.cs
@@ -9,8 +9,6 @@ using System.Reflection;
 using System.Threading;
 using System.Text;
 
-using Mono.Linq.Expressions;
-
 using Java.Interop;
 
 namespace Java.Interop.Dynamic {

--- a/src/Java.Interop.Dynamic/Java.Interop.Dynamic/JniMetaObject.cs
+++ b/src/Java.Interop.Dynamic/Java.Interop.Dynamic/JniMetaObject.cs
@@ -9,8 +9,6 @@ using System.Reflection;
 using System.Threading;
 using System.Text;
 
-using Mono.Linq.Expressions;
-
 using Java.Interop;
 
 namespace Java.Interop.Dynamic {

--- a/tests/Java.Interop-Tests/Java.Interop-Tests.csproj
+++ b/tests/Java.Interop-Tests/Java.Interop-Tests.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Mono.Linq.Expressions" Version="2.0.0" />
     <PackageReference Include="nunit" Version="3.11.0" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.9.0" GeneratePathProperty="true" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
@@ -31,7 +32,6 @@
     <ProjectReference Include="..\..\src\Java.Interop.GenericMarshaler\Java.Interop.GenericMarshaler.csproj" />
     <ProjectReference Include="..\..\src\Java.Runtime.Environment\Java.Runtime.Environment.csproj" />
     <ProjectReference Include="..\TestJVM\TestJVM.csproj" />
-    <ProjectReference Include="..\..\lib\mono.linq.expressions\Mono.Linq.Expressions.csproj" />
   </ItemGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\JdkInfo.props" />

--- a/tests/Java.Interop.Dynamic-Tests/Java.Interop.Dynamic-Tests.csproj
+++ b/tests/Java.Interop.Dynamic-Tests/Java.Interop.Dynamic-Tests.csproj
@@ -31,7 +31,6 @@
     <ProjectReference Include="..\..\src\Java.Interop.Dynamic\Java.Interop.Dynamic.csproj" />
     <ProjectReference Include="..\..\src\Java.Runtime.Environment\Java.Runtime.Environment.csproj" />
     <ProjectReference Include="..\TestJVM\TestJVM.csproj" />
-    <ProjectReference Include="..\..\lib\mono.linq.expressions\Mono.Linq.Expressions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Java.Interop.Dynamic-Tests/Java.Interop/DynamicJavaClassTests.cs
+++ b/tests/Java.Interop.Dynamic-Tests/Java.Interop/DynamicJavaClassTests.cs
@@ -7,8 +7,6 @@ using System.Threading;
 using Java.Interop;
 using Java.Interop.Dynamic;
 
-using Mono.Linq.Expressions;
-
 using NUnit.Framework;
 
 namespace Java.Interop.DynamicTests {

--- a/tests/Java.Interop.Dynamic-Tests/Java.Interop/DynamicJavaInstanceTests.cs
+++ b/tests/Java.Interop.Dynamic-Tests/Java.Interop/DynamicJavaInstanceTests.cs
@@ -7,8 +7,6 @@ using System.Threading;
 using Java.Interop;
 using Java.Interop.Dynamic;
 
-using Mono.Linq.Expressions;
-
 using NUnit.Framework;
 
 namespace Java.Interop.DynamicTests {

--- a/tests/Java.Interop.Export-Tests/Java.Interop.Export-Tests.csproj
+++ b/tests/Java.Interop.Export-Tests/Java.Interop.Export-Tests.csproj
@@ -16,6 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Mono.Linq.Expressions" Version="2.0.0" />
     <PackageReference Include="nunit" Version="3.11.0" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
@@ -27,7 +28,6 @@
     <ProjectReference Include="..\..\src\Java.Interop.Export\Java.Interop.Export.csproj" />
     <ProjectReference Include="..\..\src\Java.Runtime.Environment\Java.Runtime.Environment.csproj" />
     <ProjectReference Include="..\TestJVM\TestJVM.csproj" />
-    <ProjectReference Include="..\..\lib\mono.linq.expressions\Mono.Linq.Expressions.csproj" />
   </ItemGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\JdkInfo.props" />


### PR DESCRIPTION
`Mono.Linq.Expressions` is available as `netstandard2.0` NuGet package.  Since we only use it for tests and it hasn't changed in 3+ years it seems more reasonable to use the NuGet package instead of a git submodule.