### PR TITLE
[JCW] Throw error if user tries to override a Kotlin name-mangled method. (#534)

### DIFF
--- a/src/Java.Interop.Tools.Diagnostics/Java.Interop.Tools.Diagnostics/Diagnostic.cs
+++ b/src/Java.Interop.Tools.Diagnostics/Java.Interop.Tools.Diagnostics/Diagnostic.cs
@@ -103,6 +103,7 @@ namespace Java.Interop.Tools.Diagnostics {
 	//					XA4210 "You need to add a reference to Mono.Android.Export.dll when you use ExportAttribute or ExportFieldAttribute."
 	//					XA4211  AndroidManifest.xml //uses-sdk/@android:targetSdkVersion '{0}' is less than $(TargetFrameworkVersion) '{1}'. Using API-{1} for ACW compilation.
 	//					XA4212  Type `{0}` implements `Android.Runtime.IJavaObject` but does not inherit `Java.Lang.Object` or `Java.Lang.Throwable`. This is not supported.
+	//					XA4213  Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin."
 	// XA5xxx	GCC and toolchain
 	//			XA32xx	.apk generation
 	//					XA4300  Unsupported $(AndroidSupportedAbis) value '{0}'; ignoring.

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
@@ -362,6 +362,10 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 		{
 			if (registeredMethod != null)
 				foreach (RegisterAttribute attr in GetRegisterAttributes (registeredMethod)) {
+					// Check for Kotlin-mangled methods that cannot be overridden
+					if (attr.Name.Contains ("-impl") || (attr.Name.Length > 7 && attr.Name[attr.Name.Length - 8] == '-'))
+						Diagnostic.Error (4213, LookupSource (implementedMethod), $"Cannot override Kotlin-generated method '{attr.Name}' because it is not a valid Java method name. This method can only be overridden from Kotlin.");
+
 					var msig = new Signature (implementedMethod, attr);
 					if (!registeredMethod.IsConstructor && !methods.Any (m => m.Name == msig.Name && m.Params == msig.Params))
 						methods.Add (msig);

--- a/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGeneratorTests.cs
+++ b/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGeneratorTests.cs
@@ -31,6 +31,28 @@ namespace Java.Interop.Tools.JavaCallableWrappersTests
 		}
 
 		[Test]
+		public void KotlinInvalidImplRegisterName ()
+		{
+			Action<string, object []> logger = (f, o) => { };
+
+			// Contains invalid [Register] name of "foo-impl"
+			var td = SupportDeclarations.GetTypeDefinition (typeof (KotlinInvalidImplRegisterName));
+			var e = Assert.Throws<XamarinAndroidException> (() => new JavaCallableWrapperGenerator (td, logger));
+			Assert.AreEqual (4213, e.Code);
+		}
+
+		[Test]
+		public void KotlinInvalidHashRegisterName ()
+		{
+			Action<string, object []> logger = (f, o) => { };
+
+			// Contains invalid [Register] name of "foo-f8k2a13"
+			var td = SupportDeclarations.GetTypeDefinition (typeof (KotlinInvalidHashRegisterName));
+			var e = Assert.Throws<XamarinAndroidException> (() => new JavaCallableWrapperGenerator (td, logger));
+			Assert.AreEqual (4213, e.Code);
+		}
+
+		[Test]
 		public void GenerateApplication (
 				[Values (null, "android.app.Application", "android.support.multidex.MultiDexApplication")] string applicationJavaClass
 		)

--- a/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/SupportDeclarations.cs
+++ b/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/SupportDeclarations.cs
@@ -227,6 +227,34 @@ namespace Xamarin.Android.ToolsTests {
 		}
 	}
 
+	[Register ("Kotlin.InvalidRegisterName")]
+	class KotlinInvalidRegisterName : Java.Lang.Object
+	{
+		[Register ("foo-impl")]
+		public virtual void Foo ()
+		{
+		}
+
+		[Register ("foo-f8k2a13")]
+		public virtual void Bar ()
+		{
+		}
+	}
+
+	[Register ("Kotlin.InvalidRegisterNameSubclass")]
+	class KotlinInvalidImplRegisterName : KotlinInvalidRegisterName
+	{
+		[Register ("foo-impl")]
+		public override void Foo () => base.Foo ();
+	}
+
+	[Register ("Kotlin.InvalidRegisterNameSubclass")]
+	class KotlinInvalidHashRegisterName : KotlinInvalidRegisterName
+	{
+		[Register ("foo-f8k2a13")]
+		public override void Bar () => base.Foo ();
+	}
+
 	[Service (Name = "service.Name")]
 	class ServiceName : Java.Lang.Object
 	{


### PR DESCRIPTION
Context: #534 

There are cases where Kotlin generates Java methods that are not allowed Java identifier names:

```
abstract class Bar {
    abstract void foo-WZ4Q5Ns(int);
}

interface IBar {
    void foo-WZ4Q5Ns(int);
}
```

In this case we cannot allow the user to implement the class as the mangled method cannot be implemented.  We still need the class to be bound because there might be a Kotlin-created subclass
that needs the base class to exist.

There's no foolproof way to mark these as "not implementable".  The best we can do for now is to detect if the user implements them in `GenerateJavaStubs` and give an informative error at that point.

This PR adds this error:
```
 error XA4213: Cannot override Kotlin-generated method 'foo-WZ4Q5Ns' because it 
 is not a valid Java method name. This method can only be overridden from Kotlin.
```