### PR TITLE
[vs-code] Recommend the zbecknell.t4-support extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,5 +5,6 @@
       "ms-vscode.mono-debug",
       "wghats.vscode-nxunit-test-adapter",
       "visualstudioexptteam.vscodeintellicode",
+      "zbecknell.t4-support",
     ]
 }


### PR DESCRIPTION
The [T4 Support][0] Visual Studio Code extension provides syntax
highlighting for T4 files, such as
`src/Java.Interop/Java.Interop/JavaPrimitiveArrays.tt` and other T4
files included within the repo.

[0]: https://marketplace.visualstudio.com/items?itemName=zbecknell.t4-support