### PR TITLE
[tests] Convert to Unix style line endings

### DIFF
--- a/tests/Java.Interop-Tests/Java.Interop/JniValueMarshalerContractTests.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JniValueMarshalerContractTests.cs
@@ -260,9 +260,13 @@ namespace Java.InteropTests {
 				: (Expression) Expression.Empty ();
 			var expr    = Expression.TryFinally (body, cleanup);
 			var block   = Expression.Block (context.LocalVariables, expr);
+			// Convert line endings to Unix style to support building and running on different OS types.
+			string blockCSharp = block.ToCSharpCode ();
+			blockCSharp = blockCSharp.Replace ("\r\n", "\n");
+			expected = expected.Replace ("\r\n", "\n");
 			Console.WriteLine ("# jonp: expected: {0}", GetType ().Name);
-			Console.WriteLine (block.ToCSharpCode ());
-			Assert.AreEqual (expected, block.ToCSharpCode ());
+			Console.WriteLine (blockCSharp);
+			Assert.AreEqual (expected, blockCSharp);
 		}
 
 		protected static string GetTypeName (Type type)


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/commit/130905e1612f1c3f41b6b233056cae2753270630
Context: https://github.com/xamarin/QualityAssurance/pull/3478

We've recently started running `Java.Interop` tests on an Android target
as part of the `Mono.Android-Tests` suite. This has introduced some
seemingly harmless failures[0] when building this suite on Windows and
then running it on Android. We can fix this by converting line endings
before comparing strings.

[0]:

    01-02 16:18:11.949 I/NUnit   (23743): Failed tests:
    01-02 16:18:11.949 I/NUnit   (23743): 1) Java.InteropTests.JniValueMarshaler_Boolean_ContractTests.JniValueMarshalerContractTests`1.CreateReturnValueFromManagedExpression (Java.Interop-Tests)
    01-02 16:18:11.949 I/NUnit   (23743):   Expected string length 111 but was 99. Strings differ at index 1.
    01-02 16:18:11.949 I/NUnit   (23743):   Expected: "{\r\n\tJniRuntime __jvm;\r\n\tbool __value;\r\n\r\n\ttry\r\n\t{\r\n\t\treturn _..."
    01-02 16:18:11.949 I/NUnit   (23743):   But was:  "{\n\tJniRuntime __jvm;\n\tbool __value;\n\n\ttry\n\t{\n\t\treturn __value..."
    01-02 16:18:11.949 I/NUnit   (23743):   -------------^
    01-02 16:18:11.949 I/NUnit   (23743):
    01-02 16:18:11.949 I/NUnit   (23743):   at Java.InteropTests.JniValueMarshalerContractTests`1[T].CheckExpression (Java.Interop.Expressions.JniValueMarshalerContext context, System.String expected, System.Linq.Expressions.Expression ret) [0x00083] in <59a94475f2544934836dac1b5c1cf1e1>:0

    01-02 16:18:11.949 I/NUnit   (23743): 2) Java.InteropTests.JniValueMarshaler_Char_ContractTests.JniValueMarshalerContractTests`1.CreateReturnValueFromManagedExpression (Java.Interop-Tests)
    01-02 16:18:11.949 I/NUnit   (23743):   Expected string length 111 but was 99. Strings differ at index 1.
    01-02 16:18:11.949 I/NUnit   (23743):   Expected: "{\r\n\tJniRuntime __jvm;\r\n\tchar __value;\r\n\r\n\ttry\r\n\t{\r\n\t\treturn _..."
    01-02 16:18:11.949 I/NUnit   (23743):   But was:  "{\n\tJniRuntime __jvm;\n\tchar __value;\n\n\ttry\n\t{\n\t\treturn __value..."
    01-02 16:18:11.949 I/NUnit   (23743):   -------------^
    01-02 16:18:11.949 I/NUnit   (23743):
    01-02 16:18:11.949 I/NUnit   (23743):   at Java.InteropTests.JniValueMarshalerContractTests`1[T].CheckExpression (Java.Interop.Expressions.JniValueMarshalerContext context, System.String expected, System.Linq.Expressions.Expression ret) [0x00083] in <59a94475f2544934836dac1b5c1cf1e1>:0