### PR TITLE
[generator] Fix issue where generic types couldn't be found in SymbolTable (#543)

### DIFF
--- a/tests/generator-Tests/Unit-Tests/SymbolTableTests.cs
+++ b/tests/generator-Tests/Unit-Tests/SymbolTableTests.cs
@@ -28,11 +28,13 @@ namespace generatortests
 
 			table.AddType (dict);
 
-			Assert.NotNull (table.Lookup ("System.Collections.Generic.IList<Java.Util.Locale.LanguageRange>"));
-			Assert.NotNull (table.Lookup ("System.Collections.Generic.IList<List<Java.Util.Locale.LanguageRange>>"));
+			Assert.AreEqual ("System.Collections.Generic.IList`1", table.Lookup ("System.Collections.Generic.IList<Java.Util.Locale.LanguageRange>").FullName);
+			Assert.AreEqual ("System.Collections.Generic.IList`1", table.Lookup ("System.Collections.Generic.IList<List<Java.Util.Locale.LanguageRange>>").FullName);
 
-			Assert.NotNull (table.Lookup ("System.Collections.Generic.IDictionary<string, Java.Util.Locale.LanguageRange>"));
-			Assert.NotNull (table.Lookup ("System.Collections.Generic.IDictionary<string, List<Java.Util.Locale.LanguageRange>>"));
+			Assert.AreEqual ("System.Collections.Generic.IDictionary`2", table.Lookup ("System.Collections.Generic.IDictionary<string, Java.Util.Locale.LanguageRange>").FullName);
+			Assert.AreEqual ("System.Collections.Generic.IDictionary`2", table.Lookup ("System.Collections.Generic.IDictionary<string, List<Java.Util.Locale.LanguageRange>>").FullName);
+
+			Assert.AreEqual ("System.Collections.Generic.IList`1", table.Lookup ("System.Collections.Generic.IList<Dictionary<string, Java.Util.Locale.LanguageRange>>").FullName);
 		}
 	}
 }

--- a/tests/generator-Tests/Unit-Tests/SymbolTableTests.cs
+++ b/tests/generator-Tests/Unit-Tests/SymbolTableTests.cs
@@ -1,0 +1,38 @@
+using System;
+using MonoDroid.Generation;
+using NUnit.Framework;
+
+namespace generatortests
+{
+	[TestFixture]
+	public class SymbolTableTests
+	{
+		[Test]
+		public void FindGenericTypes ()
+		{
+			var table = new SymbolTable ();
+
+			var list = new InterfaceGen (new GenBaseSupport {
+				Name = "System.Collections.Generic.IList`1",
+				FullName = "System.Collections.Generic.IList`1",
+				JavaSimpleName = "System.Collections.Generic.IList`1"
+			});
+
+			table.AddType (list);
+
+			var dict = new InterfaceGen (new GenBaseSupport {
+				Name = "System.Collections.Generic.IDictionary`2",
+				FullName = "System.Collections.Generic.IDictionary`2",
+				JavaSimpleName = "System.Collections.Generic.IDictionary`2"
+			});
+
+			table.AddType (dict);
+
+			Assert.NotNull (table.Lookup ("System.Collections.Generic.IList<Java.Util.Locale.LanguageRange>"));
+			Assert.NotNull (table.Lookup ("System.Collections.Generic.IList<List<Java.Util.Locale.LanguageRange>>"));
+
+			Assert.NotNull (table.Lookup ("System.Collections.Generic.IDictionary<string, Java.Util.Locale.LanguageRange>"));
+			Assert.NotNull (table.Lookup ("System.Collections.Generic.IDictionary<string, List<Java.Util.Locale.LanguageRange>>"));
+		}
+	}
+}

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/SymbolTable.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/SymbolTable.cs
@@ -311,21 +311,13 @@ namespace MonoDroid.Generation {
 			typeParams = typeParams.Substring (1, typeParams.Length - 2);
 
 			foreach (var c in typeParams) {
-				if (nested_count > 0) {
-					if (c == '>') {
-						nested_count--;
-						continue;
-					}
+				if (c == '>')
+					nested_count--;
 
-					if (c == '<') {
-						nested_count++;
-						continue;
-					}
+				if (c == '<')
+					nested_count++;
 
-					continue;
-				}
-
-				if (c == ',')
+				if (nested_count == 0 && c == ',')
 					arity++;
 			}
 

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/SymbolTable.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/SymbolTable.cs
@@ -260,7 +260,15 @@ namespace MonoDroid.Generation {
 					if (all_symbols_cache == null)
 						all_symbols_cache = new ConcurrentDictionary<string, ISymbol> (symbols.Values.SelectMany (v => v).GroupBy (s => s.FullName).ToDictionary (s => s.Key, s => s.FirstOrDefault ()));
 
-					all_symbols_cache.TryGetValue (key, out sym);
+					if (!all_symbols_cache.TryGetValue (key, out sym)) {
+						// We may be looking for a type like:
+						// - System.Collections.Generic.IList<Java.Util.Locale.LanguageRange>
+						// Our key is "System.Collections.Generic.IList", but it's stored in
+						// the symbol table with the arity so we need to look for
+						// "System.Collections.Generic.IList`1" to find a match
+						key = AddArity (key, type_params);
+						all_symbols_cache.TryGetValue (key, out sym);
+					}
 				}
 			}
 			ISymbol result;
@@ -290,7 +298,40 @@ namespace MonoDroid.Generation {
 
 			return result;
 		}
-		
+
+		private string AddArity (string key, string typeParams)
+		{
+			if (string.IsNullOrWhiteSpace (typeParams) || !typeParams.StartsWith ("<") || !typeParams.EndsWith (">"))
+				return key;
+
+			var nested_count = 0;
+			var arity = 1;
+
+			// Remove the outer <>
+			typeParams = typeParams.Substring (1, typeParams.Length - 2);
+
+			foreach (var c in typeParams) {
+				if (nested_count > 0) {
+					if (c == '>') {
+						nested_count--;
+						continue;
+					}
+
+					if (c == '<') {
+						nested_count++;
+						continue;
+					}
+
+					continue;
+				}
+
+				if (c == ',')
+					arity++;
+			}
+
+			return $"{key}`{arity}";
+		}
+
 		public void Dump ()
 		{
 			foreach (var p in symbols) {


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/issues/543

In https://github.com/xamarin/java.interop/pull/450 we began stripping the arity from Cecil imported types so that we wouldn't write invalid types like `System.Collections.Generic.IList'1<string>`, resulting in the correctly formed `System.Collections.Generic.IList<string>`.

However when we try to resolve these types in the SymbolTable we only look at the type name, ignoring the generic types.  In this case we are looking for `System.Collections.Generic.IList` but the type is stored in the symbol table with the arity to disambiguate types like `Action'1` and `Action'2`.  Therefore our lookup fails because the table key is `System.Collections.Generic.IList'1`.

With this PR, if the type is not found in the table and there are generic type parameters, calculate the arity from the generic type parameters and look in the table again.

That is, `System.Collections.Generic.IList<string>` is rechecked as `System.Collections.Generic.IList'1`, which allows the type to be found.

This is a relatively rare case because it comes from reference assemblies read in via Cecil, and there aren't many generics used in binding libraries.  The only case in `Mono.Android.dll` is:

```
warning BG8800: Unknown parameter type System.Collections.Generic.IList<Java.Util.Locale.LanguageRange> in method Filter in managed type Java.Util.Locale.
```