### PR TITLE
[Java.Interop] remove IEnumerable iterators called at startup

### DIFF
--- a/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace Java.Interop {
@@ -32,6 +33,7 @@ namespace Java.Interop {
 				disposed    = true;
 			}
 
+			[MethodImpl (MethodImplOptions.AggressiveInlining)]
 			void AssertValid ()
 			{
 				if (!disposed)
@@ -39,41 +41,72 @@ namespace Java.Interop {
 				throw new ObjectDisposedException (nameof (JniTypeManager));
 			}
 
+			// NOTE: This method needs to be kept in sync with GetTypeSignatures()
+			// This version of the method has removed IEnumerable for performance reasons.
 			public JniTypeSignature GetTypeSignature (Type type)
 			{
 				AssertValid ();
 
-				return GetTypeSignatures (type).FirstOrDefault ();
+				if (type == null)
+					throw new ArgumentNullException (nameof (type));
+				if (type.ContainsGenericParameters)
+					throw new ArgumentException ($"'{type}' contains a generic type definition. This is not supported.", nameof (type));
+
+				type = GetUnderlyingType (type, out int rank);
+
+				foreach (var mapping in JniBuiltinTypeNameMappings.Value) {
+					if (mapping.Key == type) {
+						var r = mapping.Value;
+						return r.AddArrayRank (rank);
+					}
+				}
+
+				foreach (var mapping in JniBuiltinArrayMappings.Value) {
+					if (mapping.Key == type) {
+						var r = mapping.Value;
+						return r.AddArrayRank (rank);
+					}
+				}
+
+				var name = type.GetCustomAttribute<JniTypeSignatureAttribute> (inherit: false);
+				if (name != null) {
+					return new JniTypeSignature (name.SimpleReference, name.ArrayRank + rank, name.IsKeyword);
+				}
+
+				var isGeneric = type.IsGenericType;
+				var genericDef = isGeneric ? type.GetGenericTypeDefinition () : type;
+				if (isGeneric) {
+					if (genericDef == typeof (JavaArray<>) || genericDef == typeof (JavaObjectArray<>)) {
+						var r = GetTypeSignature (type.GenericTypeArguments [0]);
+						return r.AddArrayRank (rank + 1);
+					}
+				}
+
+				var simpleRef = GetSimpleReference (type);
+				if (simpleRef != null)
+					return new JniTypeSignature (simpleRef, rank, false);
+
+				if (isGeneric) {
+					simpleRef = GetSimpleReference (genericDef);
+					if (simpleRef != null)
+						return new JniTypeSignature (simpleRef, rank, false);
+				}
+
+				return default;
 			}
 
+			// NOTE: This method needs to be kept in sync with GetTypeSignature()
 			public IEnumerable<JniTypeSignature> GetTypeSignatures (Type type)
 			{
 				AssertValid ();
 
 				if (type == null)
 					throw new ArgumentNullException (nameof (type));
-				if (type.GetTypeInfo ().ContainsGenericParameters)
-					throw new ArgumentException ("Generic type definitions are not supported.", nameof (type));
+				if (type.ContainsGenericParameters)
+					throw new ArgumentException ($"'{type}' contains a generic type definition. This is not supported.", nameof (type));
 
-				return CreateGetTypeSignaturesEnumerator (type);
-			}
+				type = GetUnderlyingType (type, out int rank);
 
-			IEnumerable<JniTypeSignature> CreateGetTypeSignaturesEnumerator (Type type)
-			{
-				var originalType    = type;
-				int rank            = 0;
-				while (type.IsArray) {
-					if (type.IsArray && type.GetArrayRank () > 1)
-						throw new ArgumentException ("Multidimensional array '" + originalType.FullName + "' is not supported.", nameof (type));
-					rank++;
-					type    = type.GetElementType ();
-				}
-
-				var info    = type.GetTypeInfo ();
-				if (info.IsEnum)
-					type = Enum.GetUnderlyingType (type);
-
-#if !XA_INTEGRATION
 				foreach (var mapping in JniBuiltinTypeNameMappings.Value) {
 					if (mapping.Key == type) {
 						var r = mapping.Value;
@@ -87,23 +120,21 @@ namespace Java.Interop {
 						yield return r.AddArrayRank (rank);
 					}
 				}
-#endif  // !XA_INTEGRATION
 
-				var name = info.GetCustomAttribute<JniTypeSignatureAttribute> (inherit: false);
+				var name = type.GetCustomAttribute<JniTypeSignatureAttribute> (inherit: false);
 				if (name != null) {
 					yield return new JniTypeSignature (name.SimpleReference, name.ArrayRank + rank, name.IsKeyword);
 				}
 
-				var isGeneric   = info.IsGenericType;
-				var genericDef  = isGeneric ? info.GetGenericTypeDefinition () : type;
-#if !XA_INTEGRATION
+				var isGeneric   = type.IsGenericType;
+				var genericDef  = isGeneric ? type.GetGenericTypeDefinition () : type;
 				if (isGeneric) {
 					if (genericDef == typeof(JavaArray<>) || genericDef == typeof(JavaObjectArray<>)) {
-						var r = GetTypeSignature (info.GenericTypeArguments [0]);
+						var r = GetTypeSignature (type.GenericTypeArguments [0]);
 						yield return r.AddArrayRank (rank + 1);
 					}
 				}
-#endif  // !XA_INTEGRATION
+
 				foreach (var simpleRef in GetSimpleReferences (type)) {
 					if (simpleRef == null)
 						continue;
@@ -119,6 +150,40 @@ namespace Java.Interop {
 				}
 			}
 
+			static Type GetUnderlyingType (Type type, out int rank)
+			{
+				rank = 0;
+				var originalType = type;
+				while (type.IsArray) {
+					if (type.IsArray && type.GetArrayRank () > 1)
+						throw new ArgumentException ("Multidimensional array '" + originalType.FullName + "' is not supported.", nameof (type));
+					rank++;
+					type = type.GetElementType ();
+				}
+
+				if (type.IsEnum)
+					type = Enum.GetUnderlyingType (type);
+
+				return type;
+			}
+
+
+			// NOTE: This method needs to be kept in sync with GetSimpleReferences()
+			// This version of the method has removed IEnumerable for performance reasons.
+			// `type` will NOT be an array type.
+			protected virtual string GetSimpleReference (Type type)
+			{
+				AssertValid ();
+
+				if (type == null)
+					throw new ArgumentNullException (nameof (type));
+				if (type.IsArray)
+					throw new ArgumentException ("Array type '" + type.FullName + "' is not supported.", nameof (type));
+
+				return null;
+			}
+
+			// NOTE: This method needs to be kept in sync with GetSimpleReference()
 			// `type` will NOT be an array type.
 			protected virtual IEnumerable<string> GetSimpleReferences (Type type)
 			{

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
@@ -167,23 +167,12 @@ namespace Java.Interop {
 				return type;
 			}
 
-
-			// NOTE: This method needs to be kept in sync with GetSimpleReferences()
-			// This version of the method has removed IEnumerable for performance reasons.
 			// `type` will NOT be an array type.
 			protected virtual string GetSimpleReference (Type type)
 			{
-				AssertValid ();
-
-				if (type == null)
-					throw new ArgumentNullException (nameof (type));
-				if (type.IsArray)
-					throw new ArgumentException ("Array type '" + type.FullName + "' is not supported.", nameof (type));
-
-				return null;
+				return GetSimpleReferences (type).FirstOrDefault ();
 			}
 
-			// NOTE: This method needs to be kept in sync with GetSimpleReference()
 			// `type` will NOT be an array type.
 			protected virtual IEnumerable<string> GetSimpleReferences (Type type)
 			{

--- a/tests/TestJVM/TestJVM.cs
+++ b/tests/TestJVM/TestJVM.cs
@@ -47,6 +47,21 @@ namespace Java.InteropTests
 					yield return target;
 			}
 
+			protected override string GetSimpleReference (Type type)
+			{
+				var simpleRef = base.GetSimpleReference (type);
+				if (simpleRef != null)
+					return simpleRef;
+				var mappings = ((TestJVM) Runtime).typeMappings;
+				if (mappings == null)
+					return null;
+				foreach (var e in mappings) {
+					if (e.Value == type)
+						return e.Key;
+				}
+				return null;
+			}
+
 			protected override IEnumerable<string> GetSimpleReferences (Type type)
 			{
 				return base.GetSimpleReferences (type)

--- a/tests/TestJVM/TestJVM.cs
+++ b/tests/TestJVM/TestJVM.cs
@@ -47,21 +47,6 @@ namespace Java.InteropTests
 					yield return target;
 			}
 
-			protected override string GetSimpleReference (Type type)
-			{
-				var simpleRef = base.GetSimpleReference (type);
-				if (simpleRef != null)
-					return simpleRef;
-				var mappings = ((TestJVM) Runtime).typeMappings;
-				if (mappings == null)
-					return null;
-				foreach (var e in mappings) {
-					if (e.Value == type)
-						return e.Key;
-				}
-				return null;
-			}
-
 			protected override IEnumerable<string> GetSimpleReferences (Type type)
 			{
 				return base.GetSimpleReferences (type)


### PR DESCRIPTION
When profiling with `adb setprop debug.mono.profile log:alloc`, I
noticed the following allocations:

    Allocation summary
         Bytes      Count  Average Type name
         84840        505      168 Java.Interop.JniRuntime.JniTypeManager.<CreateGetTypeSignaturesEnumerator>d__11
         24096        502       48 Android.Runtime.AndroidTypeManager.<GetSimpleReferences>d__1

This was using the Xamarin.Forms integration project in xamarin-android:

https://github.com/xamarin/xamarin-android/tree/master/tests/Xamarin.Forms-Performance-Integration

100K of memory allocations are a bit much, so seemed like it might help
to reduce these.

I made a version of both `JniTypeManager.CreateTypeSignatures` and
`AndroidTypeManager.GetSimpleReferences` that return a single value
instead of an `IEnumerable` and `yield return`.

Other general performance changes:

* Added `[MethodImpl (MethodImplOptions.AggressiveInlining)]` to
  `JniTypeManager.AssertValid`. It is called quite frequently.

* Removed a call to `.GetTypeInfo()`, as this was not needed. It wraps
  `System.Type` in another type that was probably originally used for
  netstandard 1.x compatibility.

See: https://github.com/mono/mono/blob/c5b88ec4f323f2bdb7c7d0a595ece28dae66579c/mcs/class/referencesource/mscorlib/system/reflection/introspectionextensions.cs#L24

Changes had to be made in both java.interop and xamarin-android for
this to work.

## Results ##

I was able to see a startup improvement in a Release build of the
Xamarin.Forms integration project on a Pixel 3 XL:

    Before:
    01-08 14:53:34.926  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +779ms
    01-08 14:53:38.892  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +764ms
    01-08 14:53:42.859  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +753ms
    01-08 14:53:46.795  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +748ms
    01-08 14:53:50.792  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +764ms
    01-08 14:53:54.759  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +756ms
    01-08 14:53:58.726  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +764ms
    01-08 14:54:02.675  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +749ms
    01-08 14:54:06.691  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +759ms
    01-08 14:54:10.641  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +749ms
    Average(ms): 758.5
    Std Err(ms): 3.0523215208537
    Std Dev(ms): 9.65228815704684
    After:
    01-08 14:55:56.972  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +772ms
    01-08 14:56:00.906  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +741ms
    01-08 14:56:05.006  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +741ms
    01-08 14:56:08.940  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +748ms
    01-08 14:56:12.890  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +747ms
    01-08 14:56:16.839  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +753ms
    01-08 14:56:20.824  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +757ms
    01-08 14:56:24.775  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +746ms
    01-08 14:56:28.776  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +747ms
    01-08 14:56:32.740  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +748ms
    Average(ms): 750
    Std Err(ms): 2.87904305089189
    Std Dev(ms): 9.10433352249844

It seems like this might save ~8ms on startup?

There is also a good improvement to memory usage/allocations.

Looking at Mono's memory summary:

    Before:
        Mono System:
        Working Set                    : 71008256
        Private Bytes                  : 601202688
        Virtual Bytes                  : 1306873856
    After:
        Mono System:
        Working Set                    : 70774784
        Private Bytes                  : 552910848
        Virtual Bytes                  : 1302822912

Then the total GC summary:

    Before:
    Event: GC allocations          : 9340
    After:
    Event: GC allocations          : 8867