### PR TITLE
[Java.Interop] remove Type.GetTypeInfo() calls

### DIFF
--- a/src/Java.Interop/Java.Interop/JavaArray.cs
+++ b/src/Java.Interop/Java.Interop/JavaArray.cs
@@ -102,7 +102,7 @@ namespace Java.Interop
 		{
 			if (TargetTypeIsCurrentType (targetType))
 				return this;
-			if (targetType == typeof (T[]) || targetType.GetTypeInfo ().IsAssignableFrom (typeof (IList<T>).GetTypeInfo ())) {
+			if (targetType == typeof (T[]) || targetType.IsAssignableFrom (typeof (IList<T>))) {
 				try {
 					return ToArray ();
 				} finally {

--- a/src/Java.Interop/Java.Interop/JniPeerMembers.cs
+++ b/src/Java.Interop/Java.Interop/JniPeerMembers.cs
@@ -19,7 +19,7 @@ namespace Java.Interop {
 		{
 			if (managedPeerType == null)
 				throw new ArgumentNullException (nameof (managedPeerType));
-			if (!typeof (IJavaPeerable).GetTypeInfo ().IsAssignableFrom (managedPeerType.GetTypeInfo ()))
+			if (!typeof (IJavaPeerable).IsAssignableFrom (managedPeerType))
 				throw new ArgumentException ("'managedPeerType' must implement the IJavaPeerable interface.", nameof (managedPeerType));
 
 #if !XA_INTEGRATION
@@ -42,7 +42,7 @@ namespace Java.Interop {
 			if (checkManagedPeerType) {
 				if (managedPeerType == null)
 					throw new ArgumentNullException (nameof (managedPeerType));
-				if (!typeof (IJavaPeerable).GetTypeInfo ().IsAssignableFrom (managedPeerType.GetTypeInfo ()))
+				if (!typeof (IJavaPeerable).IsAssignableFrom (managedPeerType))
 					throw new ArgumentException ("'managedPeerType' must implement the IJavaPeerable interface.", nameof (managedPeerType));
 
 #if !XA_INTEGRATION

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
@@ -226,8 +226,8 @@ namespace Java.Interop {
 
 			static bool TryLoadJniMarshalMethods (JniType nativeClass, Type type, string methods)
 			{
-				var marshalType = type.GetTypeInfo ()?.GetDeclaredNestedType ("__<$>_jni_marshal_methods")?.AsType ();
-				if (marshalType == null || !(marshalType is Type))
+				var marshalType = type?.GetNestedType ("__<$>_jni_marshal_methods", BindingFlags.NonPublic);
+				if (marshalType == null)
 					return false;
 
 				var registerMethod = marshalType.GetRuntimeMethod ("__RegisterNativeMembers", registerMethodParameters);

--- a/src/Java.Interop/Java.Interop/JniRuntime.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.cs
@@ -277,8 +277,7 @@ namespace Java.Interop
 
 		public virtual void FailFast (string message)
 		{
-			var t = typeof (Environment).GetTypeInfo ();
-			var m = t.DeclaredMethods.FirstOrDefault (x => x.Name == "FailFast");
+			var m = typeof (Environment).GetMethod ("FailFast");
 			m.Invoke (null, new object[]{ message });
 		}
 

--- a/src/Java.Interop/Java.Interop/JniValueMarshalerAttribute.cs
+++ b/src/Java.Interop/Java.Interop/JniValueMarshalerAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reflection;
 
 namespace Java.Interop {
@@ -15,7 +15,7 @@ namespace Java.Interop {
 		{
 			if (marshalerType == null)
 				throw new ArgumentNullException (nameof (marshalerType));
-			if (!typeof (JniValueMarshaler).GetTypeInfo ().IsAssignableFrom (marshalerType.GetTypeInfo ()))
+			if (!typeof (JniValueMarshaler).IsAssignableFrom (marshalerType))
 				throw new ArgumentException (
 						string.Format ("`{0}` must inherit from JniValueMarshaler!", marshalerType.FullName),
 						nameof (marshalerType));

--- a/src/Java.Interop/Java.Interop/ManagedPeer.cs
+++ b/src/Java.Interop/Java.Interop/ManagedPeer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
@@ -83,8 +83,7 @@ namespace Java.Interop {
 				}
 
 				var type    = Type.GetType (JniEnvironment.Strings.ToString (n_assemblyQualifiedName), throwOnError: true);
-				var info    = type.GetTypeInfo ();
-				if (info.IsGenericTypeDefinition) {
+				if (type.IsGenericTypeDefinition) {
 					throw new NotSupportedException (
 							"Constructing instances of generic types from Java is not supported, as the type parameters cannot be determined.",
 							CreateJniLocationException ());
@@ -92,8 +91,8 @@ namespace Java.Interop {
 
 				var ptypes  = GetParameterTypes (JniEnvironment.Strings.ToString (n_constructorSignature));
 				var pvalues = GetValues (runtime, new JniObjectReference (n_constructorArguments), ptypes);
-				var ctor    = info.DeclaredConstructors
-					.FirstOrDefault (c => !c.IsStatic &&
+				var ctor    = type.GetConstructors (BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+					.FirstOrDefault (c =>
 						c.GetParameters ().Select (p => p.ParameterType).SequenceEqual (ptypes));
 				if (ctor == null) {
 					throw CreateMissingConstructorException (type, ptypes);


### PR DESCRIPTION
Java.Interop used to be a PCL, but is now a netstandard 2.0 library.

We make use of `IntrospectionExtensions.GetTypeInfo`:

https://github.com/mono/mono/blob/c5b88ec4f323f2bdb7c7d0a595ece28dae66579c/mcs/class/referencesource/mscorlib/system/reflection/introspectionextensions.cs#L24
https://github.com/mono/mono/blob/c5b88ec4f323f2bdb7c7d0a595ece28dae66579c/mcs/class/corlib/ReferenceSources/RuntimeType.cs

This is a "compat layer", because some of the System.Reflection APIs
are different for PCLs and netstandard 1.x.

If we remove these calls, and just use the regular `System.Type` APIs
the code is simpler and makes less method calls.

API differences to mention:

* `TypeInfo.GetDeclaredNestedType` is equivalent to
  `Type.GetNestedTypes(BindingFlags.Public | BindingFlags.NonPublic)`
* `TypeInfo.DeclaredConstructors` is equivalent to
  `Type.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static)`
  Places checking `IsStatic` can drop `BindingFlags.Static`.

## Results ##

Testing a Release build of the Xamarin.Forms integration project in
xamarin-android:

    Before:
    01-09 16:21:41.904  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +756ms
    01-09 16:21:45.886  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +749ms
    01-09 16:21:49.851  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +758ms
    01-09 16:21:53.818  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +757ms
    01-09 16:21:57.785  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +747ms
    01-09 16:22:01.783  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +763ms
    01-09 16:22:05.832  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +756ms
    01-09 16:22:09.782  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +754ms
    01-09 16:22:13.798  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +757ms
    01-09 16:22:17.798  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +757ms
    Average(ms): 755.4
    Std Err(ms): 1.43913554299486
    Std Dev(ms): 4.55094617756694
    After:
    01-09 17:07:41.164  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +757ms
    01-09 17:07:45.148  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +758ms
    01-09 17:07:49.113  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +747ms
    01-09 17:07:53.096  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +748ms
    01-09 17:07:57.062  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +747ms
    01-09 17:08:01.045  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +756ms
    01-09 17:08:05.012  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +745ms
    01-09 17:08:08.994  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +753ms
    01-09 17:08:13.011  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +765ms
    01-09 17:08:17.026  1473  1503 I ActivityTaskManager: Displayed Xamarin.Forms_Performance_Integration/xamarin.forms.performance.integration.MainActivity: +752ms
    Average(ms): 752.8
    Std Err(ms): 1.98774020211674
    Std Dev(ms): 6.28578643537236

This might save ~3ms on startup?

Comparing the number of calls:

       Method call summary
       Total(ms) Self(ms)      Calls Method name
       -      4        3       3457 System.Reflection.IntrospectionExtensions:GetTypeInfo (System.Type)
       +      3        2       3020 System.Reflection.IntrospectionExtensions:GetTypeInfo (System.Type)

This reduced ~437 calls. Xamarin.Forms still supports netstandard 1.x,
so that is where some of the remaining calls are coming from.