### PR TITLE
[generator] Call explicit unsigned NewArray methods. (#556)

### DIFF
--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteKotlinUnsignedArrayTypeMethodsClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteKotlinUnsignedArrayTypeMethodsClass.txt
@@ -16,7 +16,7 @@ public partial class MyClass  {
 	public unsafe uint[] Echo (uint[] value)
 	{
 		const string __id = "Echo.([I)[I";
-		IntPtr native_value = JNIEnv.NewArray ((int[])(object)value);
+		IntPtr native_value = JNIEnv.NewArray (value);
 		try {
 			JniArgumentValue* __args = stackalloc JniArgumentValue [1];
 			__args [0] = new JniArgumentValue (native_value);
@@ -35,7 +35,7 @@ public partial class MyClass  {
 	public unsafe ushort[] Echo (ushort[] value)
 	{
 		const string __id = "Echo.([S)[S";
-		IntPtr native_value = JNIEnv.NewArray ((short[])(object)value);
+		IntPtr native_value = JNIEnv.NewArray (value);
 		try {
 			JniArgumentValue* __args = stackalloc JniArgumentValue [1];
 			__args [0] = new JniArgumentValue (native_value);
@@ -54,7 +54,7 @@ public partial class MyClass  {
 	public unsafe ulong[] Echo (ulong[] value)
 	{
 		const string __id = "Echo.([J)[J";
-		IntPtr native_value = JNIEnv.NewArray ((long[])(object)value);
+		IntPtr native_value = JNIEnv.NewArray (value);
 		try {
 			JniArgumentValue* __args = stackalloc JniArgumentValue [1];
 			__args [0] = new JniArgumentValue (native_value);

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteKotlinUnsignedArrayTypePropertiesClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteKotlinUnsignedArrayTypePropertiesClass.txt
@@ -26,7 +26,7 @@ public partial class MyClass  {
 		[Register ("set_UIntProp", "([I)V", "")]
 		set {
 			const string __id = "set_UIntProp.([I)V";
-			IntPtr native_value = JNIEnv.NewArray ((int[])(object)value);
+			IntPtr native_value = JNIEnv.NewArray (value);
 			try {
 				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
 				__args [0] = new JniArgumentValue (native_value);
@@ -55,7 +55,7 @@ public partial class MyClass  {
 		[Register ("set_UShortProp", "([S)V", "")]
 		set {
 			const string __id = "set_UShortProp.([S)V";
-			IntPtr native_value = JNIEnv.NewArray ((short[])(object)value);
+			IntPtr native_value = JNIEnv.NewArray (value);
 			try {
 				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
 				__args [0] = new JniArgumentValue (native_value);
@@ -84,7 +84,7 @@ public partial class MyClass  {
 		[Register ("set_ULongProp", "([J)V", "")]
 		set {
 			const string __id = "set_ULongProp.([J)V";
-			IntPtr native_value = JNIEnv.NewArray ((long[])(object)value);
+			IntPtr native_value = JNIEnv.NewArray (value);
 			try {
 				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
 				__args [0] = new JniArgumentValue (native_value);

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/ArraySymbol.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/ArraySymbol.cs
@@ -122,25 +122,10 @@ namespace MonoDroid.Generation {
 
 		public string[] PreCall (CodeGenerationOptions opt, string var_name)
 		{
-
-			return new string[] { String.Format ("IntPtr {0} = JNIEnv.NewArray ({2}{1});", opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name)), opt.GetSafeIdentifier (var_name), GetPreCallCast ()) };
+			return new string[] { String.Format ("IntPtr {0} = JNIEnv.NewArray ({1});", opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name)), opt.GetSafeIdentifier (var_name)) };
 		}
 
 		public bool NeedsPrep { get { return true; } }
-
-		string GetPreCallCast ()
-		{
-			switch (sym.FullName) {
-				case "uint":
-					return "(int[])(object)";
-				case "ushort":
-					return "(short[])(object)";
-				case "ulong":
-					return "(long[])(object)";
-				default:
-					return string.Empty;
-			}
-		}
 	}
 }
 


### PR DESCRIPTION
Context: #556 
Companion XA PR: https://github.com/xamarin/xamarin-android/pull/4119

Call new `JNIEnv.NewArray (...)` overloads that explicitly take unsigned types instead of doing `JNIEnv.NewArray ((int[])(object)value`.  This allows users to get a linker time error if they are using an older Java.Interop.dll that does not support unsigned types instead of a runtime error.