### PR TITLE
[Java.Interop.Tools.TypeNameMappings] remove Assembly.GetName().Name usage

### DIFF
--- a/src/Java.Interop.Tools.TypeNameMappings/Java.Interop.Tools.TypeNameMappings/JavaNativeTypeManager.cs
+++ b/src/Java.Interop.Tools.TypeNameMappings/Java.Interop.Tools.TypeNameMappings/JavaNativeTypeManager.cs
@@ -191,7 +191,7 @@ namespace Java.Interop.Tools.TypeNameMappings
 
 		public static string GetPackageName (Type type)
 		{
-			string assemblyName = type.Assembly.GetName ().Name;
+			string assemblyName = GetAssemblyName (type.Assembly);
 			if (IsPackageNamePreservedForAssembly (assemblyName))
 				return type.Namespace.ToLowerInvariant ();
 			switch (PackageNamingPolicy) {
@@ -205,6 +205,19 @@ namespace Java.Interop.Tools.TypeNameMappings
 			default:
 					throw new NotSupportedException ($"PackageNamingPolicy.{PackageNamingPolicy} is no longer supported.");
 			}
+		}
+
+		/// <summary>
+		/// A more performant equivalent of `Assembly.GetName().Name`
+		/// </summary>
+		static string GetAssemblyName (Assembly assembly)
+		{
+			var name = assembly.FullName;
+			int index = name.IndexOf (',');
+			if (index != -1) {
+				return name.Substring (0, index);
+			}
+			return name;
 		}
 
 		public static int GetArrayInfo (Type type, out Type elementType)


### PR DESCRIPTION
Context: https://github.com/jonathanpeppers/Benchmarks/blob/cc3f2fb1c8f34c30b5b89b2a2b7e327ab7743bb1/Benchmarks/FullyQualifiedName.cs

I found `Assembly.GetName().Name` is somewhat slow compared to using
`Assembly.FullName` and a `Substring`.

It was an order of magnitude faster on .NET framework on Windows:

    Intel Core i9-9900K CPU 3.60GHz, 1 CPU, 16 logical and 8 physical cores
      [Host]     : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.8.4075.0
              Method |      Mean |     Error |    StdDev | Gen 0/1k Op | Allocated Memory/Op |
    ---------------- |----------:|----------:|----------:|------------:|--------------------:|
           Substring |  92.05 ns | 0.1823 ns | 0.1616 ns |      0.0168 |                88 B |
     AssemblyGetName | 949.68 ns | 1.9551 ns | 1.8288 ns |      0.0896 |               473 B |

But still quite faster on Mono on macOS:

    Intel Core i7-6567U CPU 3.30GHz (Skylake), 1 CPU, 4 logical and 2 physical cores
      [Host]     : Mono 6.6.0.155 (2019-08/296a9afdb24 Thu), 64bit
              Method |     Mean |     Error |    StdDev | Gen 0/1k Op |
    ---------------- |---------:|----------:|----------:|------------:|
           Substring | 1.596 us | 0.0040 us | 0.0035 us |      0.0687 |
     AssemblyGetName | 2.182 us | 0.0110 us | 0.0097 us |      0.2289 |

*NOTE: macOS is displaying us (microseconds) and Windows ns (nanoseconds)

I suspect the reason is that `AssemblyName` splits the string parsing
the `Version`, `PublicKeyToken`, etc. We don't need those values in
some cases.

`JavaNativeTypeManager.GetPackageName` is heavily used during the
build in `<GenerateJavaStubs/>`:

* When generating Java stubs
* When generating `AndroidManifest.xml`
* For the `acwmap.txt` and other typemaps

It is also used at runtime by the Android designer.

After making the change, I could see a small improvement when building
the Xamarin.Forms integration project:

      Before:
      386 ms  GenerateJavaStubs                          1 calls
      After:
      361 ms  GenerateJavaStubs                          1 calls

This seems like it will save ~25ms on builds when
`<GenerateJavaStubs/>` runs.

I have seen `<GenerateJavaStubs/>` take over a second with some larger
projects, so it is probably worth making this change.