### PR TITLE
Fix missing constant fields

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,6 +17,32 @@
             "request": "attach",
             "address": "localhost",
             "port": 55555
+        },
+        {
+          "name": "Launch Generator",
+          "type": "mono",
+          "request": "launch",
+          "preLaunchTask": "Build Generator",
+          "program": "${workspaceRoot}/bin/TestDebug/generator.exe",
+          "args": [
+            "--public",
+            "--product-version=7",
+            "--api-level=29",
+            "-o=obj/Debug/android-29/mcw/",
+            "--codegen-target=XAJavaInterop1",
+            "--fixup=metadata",
+            "--preserve-enums",
+            "--enumflags=enumflags",
+            "--enumfields=map.csv",
+            "--enummethods=methodmap.csv",
+            "--enummetadata=obj/Debug/android-29/mcw/enummetadata",
+            "--apiversions=${env:HOME}/android-toolchain/sdk/platforms/android-29/data/api-versions.xml",
+            "--annotations=${env:HOME}/android-toolchain/sdk/platforms/android-29/data/annotations.zip",
+            "--type-map-report=obj/Debug/android-29/mcw/type-mapping.txt",
+            "--enumdir=obj/Debug/android-29/mcw",
+            "obj/Debug/android-29/mcw/api.xml"
+          ],
+          "cwd": "${workspaceRoot}/../xamarin-android/src/Mono.Android",
         }
     ]
 }

--- a/tests/generator-Tests/expected.ji/TestInterface/Mono.Android.projitems
+++ b/tests/generator-Tests/expected.ji/TestInterface/Mono.Android.projitems
@@ -16,7 +16,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Test.ME.GenericStringPropertyImplementation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Test.ME.IGenericInterface.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Test.ME.IGenericPropertyInterface.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Test.ME.IInputTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Test.ME.ITestInterface.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Test.ME.TestInputTestInterface.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Test.ME.TestInterfaceImplementation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)__NamespaceMapping__.cs" />
   </ItemGroup>

--- a/tests/generator-Tests/expected.ji/TestInterface/Test.ME.IInputTest.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Test.ME.IInputTest.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Test.ME {
+
+	[Register ("test/me/InputTest", DoNotGenerateAcw=true)]
+	public abstract class InputTest : Java.Lang.Object {
+
+		internal InputTest ()
+		{
+		}
+
+		// Metadata.xml XPath field reference: path="/api/package[@name='test.me']/interface[@name='InputTest']/field[@name='TYPE_CLASS_DATETIME']"
+		[Register ("TYPE_CLASS_DATETIME")]
+		public const int TypeClassDatetime = (int) 4;
+
+		// Metadata.xml XPath field reference: path="/api/package[@name='test.me']/interface[@name='InputTest']/field[@name='TYPE_CLASS_NUMBER']"
+		[Register ("TYPE_CLASS_NUMBER")]
+		public const int TypeClassNumber = (int) 2;
+	}
+
+	[Register ("test/me/InputTest", DoNotGenerateAcw=true)]
+	[global::System.Obsolete ("Use the 'InputTest' type. This type will be removed in a future release.", error: true)]
+	public abstract class InputTestConsts : InputTest {
+
+		private InputTestConsts ()
+		{
+		}
+	}
+
+	// Metadata.xml XPath interface reference: path="/api/package[@name='test.me']/interface[@name='InputTest']"
+	public partial interface IInputTest : IJavaObject, IJavaPeerable {
+
+	}
+
+}

--- a/tests/generator-Tests/expected.ji/TestInterface/Test.ME.TestInputTestInterface.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Test.ME.TestInputTestInterface.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Test.ME {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='test.me']/class[@name='TestInputTestInterface']"
+	[global::Android.Runtime.Register ("test/me/TestInputTestInterface", DoNotGenerateAcw=true)]
+	public partial class TestInputTestInterface : global::Java.Lang.Object, global::Test.ME.IInputTest {
+
+
+		public static class InterfaceConsts {
+
+			// The following are fields from: test.me.InputTest
+
+			// Metadata.xml XPath field reference: path="/api/package[@name='test.me']/interface[@name='InputTest']/field[@name='TYPE_CLASS_DATETIME']"
+			[Register ("TYPE_CLASS_DATETIME")]
+			public const int TypeClassDatetime = (int) 4;
+
+			// Metadata.xml XPath field reference: path="/api/package[@name='test.me']/interface[@name='InputTest']/field[@name='TYPE_CLASS_NUMBER']"
+			[Register ("TYPE_CLASS_NUMBER")]
+			public const int TypeClassNumber = (int) 2;
+		}
+
+		static readonly JniPeerMembers _members = new JniPeerMembers ("test/me/TestInputTestInterface", typeof (TestInputTestInterface));
+		internal static new IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+		protected TestInputTestInterface (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		// Metadata.xml XPath constructor reference: path="/api/package[@name='test.me']/class[@name='TestInputTestInterface']/constructor[@name='TestInputTestInterface' and count(parameter)=0]"
+		[Register (".ctor", "()V", "")]
+		public unsafe TestInputTestInterface ()
+			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		{
+			const string __id = "()V";
+
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+				return;
+
+			try {
+				var __r = _members.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), null);
+				SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
+				_members.InstanceMethods.FinishCreateInstance (__id, this, null);
+			} finally {
+			}
+		}
+
+		static Delegate cb_describeContents;
+#pragma warning disable 0169
+		static Delegate GetDescribeContentsHandler ()
+		{
+			if (cb_describeContents == null)
+				cb_describeContents = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, int>) n_DescribeContents);
+			return cb_describeContents;
+		}
+
+		static int n_DescribeContents (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Test.ME.TestInputTestInterface __this = global::Java.Lang.Object.GetObject<global::Test.ME.TestInputTestInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return __this.DescribeContents ();
+		}
+#pragma warning restore 0169
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='test.me']/class[@name='TestInputTestInterface']/method[@name='describeContents' and count(parameter)=0]"
+		[Register ("describeContents", "()I", "GetDescribeContentsHandler")]
+		public virtual unsafe int DescribeContents ()
+		{
+			const string __id = "describeContents.()I";
+			try {
+				var __rm = _members.InstanceMethods.InvokeVirtualInt32Method (__id, this, null);
+				return __rm;
+			} finally {
+			}
+		}
+
+	}
+}

--- a/tests/generator-Tests/expected/TestInterface/Test.ME.IInputTest.cs
+++ b/tests/generator-Tests/expected/TestInterface/Test.ME.IInputTest.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Test.ME {
+
+	[Register ("test/me/InputTest", DoNotGenerateAcw=true)]
+	public abstract class InputTest : Java.Lang.Object {
+
+		internal InputTest ()
+		{
+		}
+
+		// Metadata.xml XPath field reference: path="/api/package[@name='test.me']/interface[@name='InputTest']/field[@name='TYPE_CLASS_DATETIME']"
+		[Register ("TYPE_CLASS_DATETIME")]
+		public const int TypeClassDatetime = (int) 4;
+
+		// Metadata.xml XPath field reference: path="/api/package[@name='test.me']/interface[@name='InputTest']/field[@name='TYPE_CLASS_NUMBER']"
+		[Register ("TYPE_CLASS_NUMBER")]
+		public const int TypeClassNumber = (int) 2;
+	}
+
+	[Register ("test/me/InputTest", DoNotGenerateAcw=true)]
+	[global::System.Obsolete ("Use the 'InputTest' type. This type will be removed in a future release.", error: true)]
+	public abstract class InputTestConsts : InputTest {
+
+		private InputTestConsts ()
+		{
+		}
+	}
+
+	// Metadata.xml XPath interface reference: path="/api/package[@name='test.me']/interface[@name='InputTest']"
+	public partial interface IInputTest : IJavaObject {
+
+	}
+
+}

--- a/tests/generator-Tests/expected/TestInterface/Test.ME.TestInputTestInterface.cs
+++ b/tests/generator-Tests/expected/TestInterface/Test.ME.TestInputTestInterface.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Test.ME {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='test.me']/class[@name='TestInputTestInterface']"
+	[global::Android.Runtime.Register ("test/me/TestInputTestInterface", DoNotGenerateAcw=true)]
+	public partial class TestInputTestInterface : global::Java.Lang.Object, global::Test.ME.IInputTest {
+
+
+		public static class InterfaceConsts {
+
+			// The following are fields from: test.me.InputTest
+
+			// Metadata.xml XPath field reference: path="/api/package[@name='test.me']/interface[@name='InputTest']/field[@name='TYPE_CLASS_DATETIME']"
+			[Register ("TYPE_CLASS_DATETIME")]
+			public const int TypeClassDatetime = (int) 4;
+
+			// Metadata.xml XPath field reference: path="/api/package[@name='test.me']/interface[@name='InputTest']/field[@name='TYPE_CLASS_NUMBER']"
+			[Register ("TYPE_CLASS_NUMBER")]
+			public const int TypeClassNumber = (int) 2;
+		}
+
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("test/me/TestInputTestInterface", ref java_class_handle);
+			}
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (TestInputTestInterface); }
+		}
+
+		protected TestInputTestInterface (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		static IntPtr id_ctor;
+		// Metadata.xml XPath constructor reference: path="/api/package[@name='test.me']/class[@name='TestInputTestInterface']/constructor[@name='TestInputTestInterface' and count(parameter)=0]"
+		[Register (".ctor", "()V", "")]
+		public unsafe TestInputTestInterface ()
+			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		{
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+				return;
+
+			try {
+				if (((object) this).GetType () != typeof (TestInputTestInterface)) {
+					SetHandle (
+							global::Android.Runtime.JNIEnv.StartCreateInstance (((object) this).GetType (), "()V"),
+							JniHandleOwnership.TransferLocalRef);
+					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "()V");
+					return;
+				}
+
+				if (id_ctor == IntPtr.Zero)
+					id_ctor = JNIEnv.GetMethodID (class_ref, "<init>", "()V");
+				SetHandle (
+						global::Android.Runtime.JNIEnv.StartCreateInstance (class_ref, id_ctor),
+						JniHandleOwnership.TransferLocalRef);
+				JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, class_ref, id_ctor);
+			} finally {
+			}
+		}
+
+		static Delegate cb_describeContents;
+#pragma warning disable 0169
+		static Delegate GetDescribeContentsHandler ()
+		{
+			if (cb_describeContents == null)
+				cb_describeContents = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, int>) n_DescribeContents);
+			return cb_describeContents;
+		}
+
+		static int n_DescribeContents (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Test.ME.TestInputTestInterface __this = global::Java.Lang.Object.GetObject<global::Test.ME.TestInputTestInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return __this.DescribeContents ();
+		}
+#pragma warning restore 0169
+
+		static IntPtr id_describeContents;
+		// Metadata.xml XPath method reference: path="/api/package[@name='test.me']/class[@name='TestInputTestInterface']/method[@name='describeContents' and count(parameter)=0]"
+		[Register ("describeContents", "()I", "GetDescribeContentsHandler")]
+		public virtual unsafe int DescribeContents ()
+		{
+			if (id_describeContents == IntPtr.Zero)
+				id_describeContents = JNIEnv.GetMethodID (class_ref, "describeContents", "()I");
+			try {
+
+				if (((object) this).GetType () == ThresholdType)
+					return JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_describeContents);
+				else
+					return JNIEnv.CallNonvirtualIntMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "describeContents", "()I"));
+			} finally {
+			}
+		}
+
+	}
+}

--- a/tests/generator-Tests/expected/TestInterface/TestInterface.xml
+++ b/tests/generator-Tests/expected/TestInterface/TestInterface.xml
@@ -1,14 +1,23 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <api>
-	<package name="java.lang">
-		<class abstract="false" deprecated="not deprecated" final="false" name="Object" static="false" visibility="public">
-		</class>
-		<class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object"
-			final="true" name="String" static="false" visibility="public">
-		</class>
-	</package>
-	<package name="test.me">
-		<!--
+  <package name="java.lang">
+    <class abstract="false" deprecated="not deprecated" final="false" name="Object" static="false" visibility="public">
+    </class>
+    <class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="true" name="String" static="false" visibility="public">
+    </class>
+  </package>
+  <package name="test.me">
+    <interface abstract="true" deprecated="not deprecated" final="false" name="InputTest" static="false" visibility="public">
+      <field deprecated="not deprecated" final="true" name="TYPE_CLASS_DATETIME" static="true" transient="false" type="int" type-generic-aware="int" value="4" visibility="public" volatile="false"></field>
+      <field deprecated="not deprecated" final="true" name="TYPE_CLASS_NUMBER" static="true" transient="false" type="int" type-generic-aware="int" value="2" visibility="public" volatile="false"></field>
+    </interface>
+    <class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" jni-extends="Ljava/lang/Object;" final="false" name="TestInputTestInterface" static="false" visibility="public">
+      <implements name="android.text.InputTest" name-generic-aware="test.me.InputTest"></implements>
+      <constructor deprecated="not deprecated" final="false" name="TestInputTestInterface" jni-signature="()V" bridge="false" static="false" type="test.me.TestInputTestInterface" synthetic="false" visibility="public" />
+      <method abstract="false" deprecated="not deprecated" final="false" name="describeContents" jni-signature="()I" bridge="false" native="false" return="int" jni-return="I" static="false" synchronized="false" synthetic="false" visibility="public" />
+    </class>
+
+    <!--
 			public interface TestInterface {
 				public static final int SPAN_COMPOSING = 256;
 				public static final java.lang.Object DEFAULT_FOO = new ...;
@@ -23,87 +32,87 @@
 				CharSequence identity(CharSequence value);
 			}
 		-->
-		<interface abstract="true" deprecated="not deprecated" final="false" name="TestInterface" static="false" visibility="public">
-			<method abstract="false" deprecated="not deprecated" final="false" name="defaultInterfaceMethod" native="false" return="void" static="false" synchronized="false" visibility="public">
-			</method>
-			<method abstract="true" deprecated="not deprecated" final="false" name="getSpanFlags" native="false" return="int" static="false" synchronized="false" visibility="public">
-				<parameter name="tag" type="java.lang.Object">
-				</parameter>
-			</method>
-			<field deprecated="not deprecated" final="true" name="SPAN_COMPOSING" static="true" transient="false" type="int" type-generic-aware="int" value="256" visibility="public" volatile="false">
-			</field>
-			<field deprecated="not deprecated" final="true" name="DEFAULT_FOO" static="true" transient="false" type="java.lang.Object" type-generic-aware="java.lang.Object" visibility="public" volatile="false">
-			</field>
-			<method abstract="true" deprecated="not deprecated" final="false" name="append" native="false" return="void" static="false" synchronized="false" visibility="public">
-				<parameter name="value" type="java.lang.CharSequence" />
-			</method>
-			<method abstract="true" deprecated="not deprecated" final="false" name="identity" native="false" return="java.lang.CharSequence" static="false" synchronized="false" visibility="public">
-				<parameter name="value" type="java.lang.CharSequence" />
-			</method>
-		</interface>
-		<!--
+    <interface abstract="true" deprecated="not deprecated" final="false" name="TestInterface" static="false" visibility="public">
+      <method abstract="false" deprecated="not deprecated" final="false" name="defaultInterfaceMethod" native="false" return="void" static="false" synchronized="false" visibility="public">
+      </method>
+      <method abstract="true" deprecated="not deprecated" final="false" name="getSpanFlags" native="false" return="int" static="false" synchronized="false" visibility="public">
+        <parameter name="tag" type="java.lang.Object">
+        </parameter>
+      </method>
+      <field deprecated="not deprecated" final="true" name="SPAN_COMPOSING" static="true" transient="false" type="int" type-generic-aware="int" value="256" visibility="public" volatile="false">
+      </field>
+      <field deprecated="not deprecated" final="true" name="DEFAULT_FOO" static="true" transient="false" type="java.lang.Object" type-generic-aware="java.lang.Object" visibility="public" volatile="false">
+      </field>
+      <method abstract="true" deprecated="not deprecated" final="false" name="append" native="false" return="void" static="false" synchronized="false" visibility="public">
+        <parameter name="value" type="java.lang.CharSequence" />
+      </method>
+      <method abstract="true" deprecated="not deprecated" final="false" name="identity" native="false" return="java.lang.CharSequence" static="false" synchronized="false" visibility="public">
+        <parameter name="value" type="java.lang.CharSequence" />
+      </method>
+    </interface>
+    <!--
 			public abstract class TestInterfaceImplementation implements TestInterface {
 				// does NOT declare getSpanFlags(); it's implicitly included via `implements`
 			}
 		-->
-		<class abstract="true" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="false" name="TestInterfaceImplementation" static="false" visibility="public">
-			<implements name="test.me.TestInterface" name-generic-aware="test.me.TestInterface" />
-			<constructor deprecated="not deprecated" final="false" name="TestInterfaceImplementation" static="false" visibility="public" />
-		</class>
-		<!--
+    <class abstract="true" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="false" name="TestInterfaceImplementation" static="false" visibility="public">
+      <implements name="test.me.TestInterface" name-generic-aware="test.me.TestInterface" />
+      <constructor deprecated="not deprecated" final="false" name="TestInterfaceImplementation" static="false" visibility="public" />
+    </class>
+    <!--
 			public interface GenericInterface<T> {
 				void SetObject(T item);
 			}
 		-->
-		<interface abstract="true" deprecated="not deprecated" final="false" name="GenericInterface" static="false" visibility="public">
-			<typeParameters>
-				<typeParameter name="T" classBound="java.lang.Object" interfaceBounds="" />
-			</typeParameters>
-			<method abstract="true" deprecated="not deprecated" final="false" name="SetObject" native="false" return="void" static="false" synchronized="false" visibility="public">
-				<parameter name="value" type="T" />
-			</method>
-		</interface>
-		<!--
+    <interface abstract="true" deprecated="not deprecated" final="false" name="GenericInterface" static="false" visibility="public">
+      <typeParameters>
+        <typeParameter name="T" classBound="java.lang.Object" interfaceBounds="" />
+      </typeParameters>
+      <method abstract="true" deprecated="not deprecated" final="false" name="SetObject" native="false" return="void" static="false" synchronized="false" visibility="public">
+        <parameter name="value" type="T" />
+      </method>
+    </interface>
+    <!--
 			public class GenericImplementation implements GenericInterface<byte[]> {
 				public void SetObject(byte[] item);
 			}
 		-->
-		<class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="false" name="GenericImplementation" static="false" visibility="public">
-			<implements name="test.me.GenericInterface" name-generic-aware="test.me.GenericInterface&lt;byte[]&gt;" />
-			<constructor deprecated="not deprecated" final="false" name="GenericImplementation" static="false" visibility="public" />
-			<method abstract="false" deprecated="not deprecated" final="false" name="SetObject" native="false" return="void" static="false" synchronized="false" visibility="public">
-				<parameter name="value" type="byte[]" />
-			</method>
-		</class>
-		<!--
+    <class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="false" name="GenericImplementation" static="false" visibility="public">
+      <implements name="test.me.GenericInterface" name-generic-aware="test.me.GenericInterface&lt;byte[]&gt;" />
+      <constructor deprecated="not deprecated" final="false" name="GenericImplementation" static="false" visibility="public" />
+      <method abstract="false" deprecated="not deprecated" final="false" name="SetObject" native="false" return="void" static="false" synchronized="false" visibility="public">
+        <parameter name="value" type="byte[]" />
+      </method>
+    </class>
+    <!--
 			public class GenericStringImplementation implements GenericInterface<java.lang.String> {
 				public void SetObject(java.lang.String[] item);
 			}
 		-->
-		<class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="false" name="GenericStringImplementation" static="false" visibility="public">
-			<implements name="test.me.GenericInterface" name-generic-aware="test.me.GenericInterface&lt;java.lang.String[]&gt;" />
-			<constructor deprecated="not deprecated" final="false" name="GenericImplementation" static="false" visibility="public" />
-			<method abstract="false" deprecated="not deprecated" final="false" name="SetObject" native="false" return="void" static="false" synchronized="false" visibility="public">
-				<parameter name="value" type="java.lang.String[]" />
-			</method>
-		</class>
-		<!--
+    <class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="false" name="GenericStringImplementation" static="false" visibility="public">
+      <implements name="test.me.GenericInterface" name-generic-aware="test.me.GenericInterface&lt;java.lang.String[]&gt;" />
+      <constructor deprecated="not deprecated" final="false" name="GenericImplementation" static="false" visibility="public" />
+      <method abstract="false" deprecated="not deprecated" final="false" name="SetObject" native="false" return="void" static="false" synchronized="false" visibility="public">
+        <parameter name="value" type="java.lang.String[]" />
+      </method>
+    </class>
+    <!--
 			public interface GenericPropertyInterface<T> {
 				T getObject();
 				void setObject(T value);
 			}
 		-->
-		<interface abstract="true" deprecated="not deprecated" final="false" name="GenericPropertyInterface" static="false" visibility="public">
-			<typeParameters>
-				<typeParameter name="T" classBound="java.lang.Object" interfaceBounds="" />
-			</typeParameters>
-			<method abstract="true" deprecated="not deprecated" final="false" name="getObject" native="false" return="T" static="false" synchronized="false" visibility="public">
-			</method>
-			<method abstract="true" deprecated="not deprecated" final="false" name="setObject" native="false" return="void" static="false" synchronized="false" visibility="public">
-				<parameter name="value" type="T" />
-			</method>
-		</interface>
-		<!--
+    <interface abstract="true" deprecated="not deprecated" final="false" name="GenericPropertyInterface" static="false" visibility="public">
+      <typeParameters>
+        <typeParameter name="T" classBound="java.lang.Object" interfaceBounds="" />
+      </typeParameters>
+      <method abstract="true" deprecated="not deprecated" final="false" name="getObject" native="false" return="T" static="false" synchronized="false" visibility="public">
+      </method>
+      <method abstract="true" deprecated="not deprecated" final="false" name="setObject" native="false" return="void" static="false" synchronized="false" visibility="public">
+        <parameter name="value" type="T" />
+      </method>
+    </interface>
+    <!--
 			public class GenericObjectPropertyImplementation implements GenericPropertyInterface<java.lang.Object> {
 				@Override
 				Object getObject();
@@ -111,16 +120,16 @@
 				void setObject(Object value);
 			}
 		-->
-		<class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="false" name="GenericObjectPropertyImplementation" static="false" visibility="public">
-			<implements name="test.me.GenericPropertyInterface" name-generic-aware="test.me.GenericPropertyInterface&lt;java.lang.Object&gt;" />
-			<constructor deprecated="not deprecated" final="false" name="GenericObjectPropertyImplementation" static="false" visibility="public" />
-			<method abstract="false" deprecated="not deprecated" final="false" name="getObject" native="false" return="java.lang.Object" static="false" synchronized="false" visibility="public">
-			</method>
-			<method abstract="false" deprecated="not deprecated" final="false" name="setObject" native="false" return="void" static="false" synchronized="false" visibility="public">
-				<parameter name="value" type="java.lang.Object" />
-			</method>
-		</class>
-		<!--
+    <class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="false" name="GenericObjectPropertyImplementation" static="false" visibility="public">
+      <implements name="test.me.GenericPropertyInterface" name-generic-aware="test.me.GenericPropertyInterface&lt;java.lang.Object&gt;" />
+      <constructor deprecated="not deprecated" final="false" name="GenericObjectPropertyImplementation" static="false" visibility="public" />
+      <method abstract="false" deprecated="not deprecated" final="false" name="getObject" native="false" return="java.lang.Object" static="false" synchronized="false" visibility="public">
+      </method>
+      <method abstract="false" deprecated="not deprecated" final="false" name="setObject" native="false" return="void" static="false" synchronized="false" visibility="public">
+        <parameter name="value" type="java.lang.Object" />
+      </method>
+    </class>
+    <!--
 			public class GenericStringPropertyImplementation implements GenericPropertyInterface<java.lang.String> {
 				@Override
 				String getObject();
@@ -128,23 +137,23 @@
 				void setObject(String value);
 			}
 		-->
-		<class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="false" name="GenericStringPropertyImplementation" static="false" visibility="public">
-			<implements name="test.me.GenericPropertyInterface" name-generic-aware="test.me.GenericPropertyInterface&lt;java.lang.String&gt;" />
-			<constructor deprecated="not deprecated" final="false" name="GenericStringPropertyImplementation" static="false" visibility="public" />
-			<method abstract="false" deprecated="not deprecated" final="false" name="getObject" native="false" return="java.lang.String" static="false" synchronized="false" visibility="public">
-			</method>
-			<method abstract="false" deprecated="not deprecated" final="false" name="SetObject" native="false" return="void" static="false" synchronized="false" visibility="public">
-				<parameter name="value" type="java.lang.String" />
-			</method>
-		</class>
-	</package>
+    <class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="false" name="GenericStringPropertyImplementation" static="false" visibility="public">
+      <implements name="test.me.GenericPropertyInterface" name-generic-aware="test.me.GenericPropertyInterface&lt;java.lang.String&gt;" />
+      <constructor deprecated="not deprecated" final="false" name="GenericStringPropertyImplementation" static="false" visibility="public" />
+      <method abstract="false" deprecated="not deprecated" final="false" name="getObject" native="false" return="java.lang.String" static="false" synchronized="false" visibility="public">
+      </method>
+      <method abstract="false" deprecated="not deprecated" final="false" name="SetObject" native="false" return="void" static="false" synchronized="false" visibility="public">
+        <parameter name="value" type="java.lang.String" />
+      </method>
+    </class>
+  </package>
   <package name="">
     <interface abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="false" name="InterfaceWithoutNamespace" static="false" visibility="public">
       <method abstract="true" deprecated="not deprecated" final="false" name="Foo" native="false" return="void" static="false" synchronized="false" visibility="public" />
-		</interface>
+    </interface>
     <class abstract="true" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="false" name="ClassWithoutNamespace" static="false" visibility="public">
-			<implements name="InterfaceWithoutNamespace" name-generic-aware="InterfaceWithoutNamespace" />
-			<constructor deprecated="not deprecated" final="false" name="ClassWithoutNamespace" static="false" visibility="public" />
-		</class>
-	</package>
+      <implements name="InterfaceWithoutNamespace" name-generic-aware="InterfaceWithoutNamespace" />
+      <constructor deprecated="not deprecated" final="false" name="ClassWithoutNamespace" static="false" visibility="public" />
+    </class>
+  </package>
 </api>

--- a/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/CodeGenerator.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/CodeGenerator.cs
@@ -54,7 +54,7 @@ namespace MonoDroid.Generation
 			foreach (ISymbol isym in @class.Interfaces) {
 				GenericSymbol gs = isym as GenericSymbol;
 				InterfaceGen gen = (gs == null ? isym : gs.Gen) as InterfaceGen;
-				if (gen != null && (gen.IsConstSugar || gen.RawVisibility != "public"))
+				if (gen != null && (gen.RawVisibility != "public"))
 					continue;
 				if (sb.Length > 0)
 					sb.Append (", ");
@@ -459,11 +459,6 @@ namespace MonoDroid.Generation
 
 			WriteInterfaceImplementedMembersAlternative (@interface, indent);
 
-			// If this interface is just fields and we can't generate any of them
-			// then we don't need to write the interface
-			if (@interface.IsConstSugar && @interface.GetGeneratableFields (opt).Count () == 0)
-				return;
-
 			WriteInterfaceDeclaration (@interface, indent);
 
 			// If this interface is just constant fields we don't need to write all the invoker bits
@@ -533,7 +528,7 @@ namespace MonoDroid.Generation
 			if (@interface.TypeParameters != null && @interface.TypeParameters.Any ())
 				writer.WriteLine ("{0}{1}", indent, @interface.TypeParameters.ToGeneratedAttributeString ());
 			writer.WriteLine ("{0}{1} partial interface {2}{3} {{", indent, @interface.Visibility, @interface.Name,
-				@interface.IsConstSugar ? string.Empty : @interface.Interfaces.Count == 0 || sb.Length == 0 ? " : " + GetAllInterfaceImplements () : " : " + sb.ToString ());
+				@interface.Interfaces.Count == 0 || sb.Length == 0 ? " : " + GetAllInterfaceImplements () : " : " + sb.ToString ());
 
 			if (opt.SupportDefaultInterfaceMethods && (@interface.HasDefaultMethods || @interface.HasStaticMethods))
 				WriteClassHandle (@interface, indent + "\t", @interface.Name);

--- a/tools/generator/Java.Interop.Tools.Generator.Transformation/EnumMap.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Transformation/EnumMap.cs
@@ -24,9 +24,9 @@ namespace MonoDroid.Generation
 			fix_constants_instead_of_removing = fixConstantsInsteadOfRemove;
 		}
 
-		internal Dictionary<string,EnumDescription> Process (string fieldMap, string flagsFile, string methodMap)
+		internal Dictionary<string, EnumDescription> Process (string fieldMap, string flagsFile, string methodMap)
 		{
-			remove_nodes = new List<KeyValuePair<string,string>> ();
+			remove_nodes = new List<KeyValuePair<string, string>> ();
 			var enums = (fieldMap ?? "").EndsWith (".csv")
 				? ParseFieldMappings (fieldMap, flagsFile, version, remove_nodes)
 				: ParseXmlFieldMappings (fieldMap, version, remove_nodes);
@@ -48,12 +48,12 @@ namespace MonoDroid.Generation
 					FixOldConstants (sw);
 				else
 					RemoveOldConstants (sw);
-				
+
 				sw.WriteLine ("</metadata>");
 			}
 			return enums;
 		}
-		
+
 		//  <remove-node path="/api/package[@name='java.lang']/class[@name='Float']/field[@name='MAX_VALUE']" />
 		void RemoveOldConstants (StreamWriter sw)
 		{
@@ -81,17 +81,10 @@ namespace MonoDroid.Generation
 
 				if (pair.Value != null) {
 					sw.WriteLine ("  <attr path=\"/api/package[@name='{0}']/{3}[@name='{1}']/field[@name='{2}']\" name=\"type\">{4}</attr>",
-					              package, type, member, enu.StartsWith ("I:") ? "interface" : "class", pair.Value);
+						      package, type, member, enu.StartsWith ("I:") ? "interface" : "class", pair.Value);
 					sw.WriteLine ("  <attr path=\"/api/package[@name='{0}']/{3}[@name='{1}']/field[@name='{2}']\" name=\"deprecated\">This constant will be removed in the future version. Use {4} enum directly instead of this field.</attr>",
-					              package, type, member, enu.StartsWith ("I:") ? "interface" : "class", pair.Value);
+						      package, type, member, enu.StartsWith ("I:") ? "interface" : "class", pair.Value);
 					continue;
-				}
-				try {
-					sw.WriteLine ("  <remove-node path=\"/api/package[@name='{0}']/{3}[@name='{1}']/field[@name='{2}']\" />",
-					              package, type, member, enu.StartsWith ("I:") ? "interface" : "class");
-				} catch (Exception) {
-					Console.Error.WriteLine ("ERROR: failed to remove old comments: " + enu);
-					throw;
 				}
 			}
 		}

--- a/tools/generator/generator.sln
+++ b/tools/generator/generator.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "generator", "generator.csproj", "{D14A1B5C-2060-4930-92BE-F7190256C735}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "generator-Tests", "Tests\generator-Tests.csproj", "{4EEAB1A7-99C1-4302-9C18-01A7B481409B}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "generator-Tests", "..\..\tests\generator-Tests\generator-Tests.csproj", "{4EEAB1A7-99C1-4302-9C18-01A7B481409B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
Generator has a wrong logic where we remove all constant fields in case they are part of an enum considered "NON TRANSIENT". Currently We have about 4500 constant fields missing due to this bug. We should not prevent the developer form using the original constant fields.

Method FixOldConstants forcibly removes the field. The fix is removing the code block that removes the field.

Also fixing the  generator solution to point to the correct location of the test project and updating launch.json so we can easily debug generator using vscode. Also auto fixing some code style issues caught by .editorconfig file

This PR depends on PR: https://github.com/xamarin/xamarin-android/pull/4213