### PR TITLE
Marking constant fields that will be removed in the next version as Obsolete error

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,22 +1,48 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Launch",
-            "type": "mono",
-            "request": "launch",
-            "program": "${workspaceRoot}/packages/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe ${workspaceRoot}/bin/TestDebug/generator-Tests.dll",
-            "cwd": "${workspaceRoot}bin/TestDebug/"
-        },
-        {
-            "name": "Attach",
-            "type": "mono",
-            "request": "attach",
-            "address": "localhost",
-            "port": 55555
-        }
-    ]
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch",
+      "type": "mono",
+      "request": "launch",
+      "program": "${workspaceRoot}/packages/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe ${workspaceRoot}/bin/TestDebug/generator-Tests.dll",
+      "cwd": "${workspaceRoot}bin/TestDebug/"
+    },
+    {
+      "name": "Attach",
+      "type": "mono",
+      "request": "attach",
+      "address": "localhost",
+      "port": 55555
+    },
+    {
+      "name": "Launch Generator",
+      "type": "mono",
+      "request": "launch",
+      "preLaunchTask": "Build Generator",
+      "program": "${workspaceRoot}/bin/TestDebug/generator.exe",
+      "args": [
+        "--public",
+        "--product-version=7",
+        "--api-level=29",
+        "-o=obj/Debug/android-29/mcw/",
+        "--codegen-target=XAJavaInterop1",
+        "--fixup=metadata",
+        "--preserve-enums",
+        "--enumflags=enumflags",
+        "--enumfields=map.csv",
+        "--enummethods=methodmap.csv",
+        "--enummetadata=obj/Debug/android-29/mcw/enummetadata",
+        "--apiversions=${env:HOME}/android-toolchain/sdk/platforms/android-29/data/api-versions.xml",
+        "--annotations=${env:HOME}/android-toolchain/sdk/platforms/android-29/data/annotations.zip",
+        "--type-map-report=obj/Debug/android-29/mcw/type-mapping.txt",
+        "--enumdir=obj/Debug/android-29/mcw",
+        "obj/Debug/android-29/mcw/api.xml"
+      ],
+      "cwd": "${workspaceRoot}/../xamarin-android/src/Mono.Android",
+    }
+  ]
 }

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
@@ -346,11 +346,11 @@ namespace generatortests
 		{
 			var comment = "Don't use this!";
 			var @class = new TestClass ("java.lang.Object", "com.mypackage.foo");
-			var field = new TestField ("int", "bar").SetConstant ("1234").SetDeprecated (comment);
+			var field = new TestField ("int", "bar").SetConstant ("1234").SetDeprecated (comment, true);
 			Assert.IsTrue (field.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "field.Validate failed!");
 			generator.WriteField (field, string.Empty, @class);
 
-			StringAssert.Contains ($"[Obsolete (\"{comment}\")]", builder.ToString (), "Should contain ObsoleteAttribute!");
+			StringAssert.Contains ($"[Obsolete (\"{comment}\", error: true)]", builder.ToString (), "Should contain ObsoleteAttribute!");
 		}
 
 		[Test]
@@ -535,7 +535,7 @@ namespace generatortests
 			var iface = SupportTypeBuilder.CreateInterface ("java.code.IMyInterface", options);
 
 			generator.Context.ContextTypes.Push (iface);
-			generator.WriteInterfaceEventArgs (iface, iface.Methods[0], string.Empty);
+			generator.WriteInterfaceEventArgs (iface, iface.Methods [0], string.Empty);
 			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetExpected (nameof (WriteInterfaceEventArgs)), writer.ToString ().NormalizeLineEndings ());
@@ -572,7 +572,7 @@ namespace generatortests
 			var handlers = new List<string> ();
 
 			generator.Context.ContextTypes.Push (iface);
-			generator.WriteInterfaceEventHandlerImplContent (iface, iface.Methods[0], string.Empty, true, string.Empty, handlers);
+			generator.WriteInterfaceEventHandlerImplContent (iface, iface.Methods [0], string.Empty, true, string.Empty, handlers);
 			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (1, handlers.Count);

--- a/tests/generator-Tests/Unit-Tests/SupportTypes.cs
+++ b/tests/generator-Tests/Unit-Tests/SupportTypes.cs
@@ -64,9 +64,10 @@ namespace generatortests
 			return this;
 		}
 
-		public TestField SetDeprecated (string comment = null)
+		public TestField SetDeprecated (string comment = null, bool error = false)
 		{
 			IsDeprecated = true;
+			IsDeprecatedError = error;
 			DeprecatedComment = comment;
 			return this;
 		}
@@ -280,7 +281,7 @@ namespace generatortests
 			return iface;
 		}
 
-		public static TestMethod CreateMethod (GenBase parent, string methodName, CodeGenerationOptions options, string returnType = "void", bool isStatic = false, bool isAbstract = false, params Parameter[] parameters)
+		public static TestMethod CreateMethod (GenBase parent, string methodName, CodeGenerationOptions options, string returnType = "void", bool isStatic = false, bool isAbstract = false, params Parameter [] parameters)
 		{
 			var method = new TestMethod (parent, methodName, returnType);
 

--- a/tests/generator-Tests/expected/EnumerationFixup/EnumerationFixup.xml
+++ b/tests/generator-Tests/expected/EnumerationFixup/EnumerationFixup.xml
@@ -5,7 +5,7 @@
 	    </class>
 	  </package>
 	<package name="xamarin.test">
-	  <class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" 
+	  <class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object"
 	  		final="false" name="SomeObject" static="false" visibility="public">
 	  		<field deprecated="not deprecated" final="true" name="SOME_VALUE" static="false" transient="false" type="Xamarin.Test.SomeValues" type-generic-aware="int" visibility="public" volatile="false">
 	        </field>
@@ -18,7 +18,7 @@
         	   </parameter>
       		</method>
 	    </class>
-		<class abstract="false" deprecated="not deprecated" extends="xamarin.test.SomeObject" extends-generic-aware="xamarin.test.SomeObject" 
+		<class abstract="false" deprecated="not deprecated" extends="xamarin.test.SomeObject" extends-generic-aware="xamarin.test.SomeObject"
 	  		final="false" name="SomeObject2" static="false" visibility="public">
 	  		<method abstract="false" deprecated="not deprecated" final="false" name="getSomeObjectProperty" native="false" return="int" enumReturn="Xamarin.Test.SomeValues" static="false" synchronized="false" visibility="public">
 	  		</method>
@@ -33,6 +33,9 @@
         	   </parameter>
       		</method>
 	  	</class>
+      <class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="false" name="DeprecatedItems" static="false" visibility="public">
+        <field deprecated="Field is deprecated" deprecated-error="true" final="true" name="My_Test_Field" jni-signature="I" static="true" transient="false" type="int" type-generic-aware="int" value="1" visibility="public" volatile="false" />
+      </class>
 	</package>
 	<enum name="Xamarin.Test.SomeValues"/>
 </api>

--- a/tests/generator-Tests/expected/EnumerationFixup/Xamarin.Test.DeprecatedItems.cs
+++ b/tests/generator-Tests/expected/EnumerationFixup/Xamarin.Test.DeprecatedItems.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Xamarin.Test {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='DeprecatedItems']"
+	[global::Android.Runtime.Register ("xamarin/test/DeprecatedItems", DoNotGenerateAcw=true)]
+	public partial class DeprecatedItems : global::Java.Lang.Object {
+
+
+		// Metadata.xml XPath field reference: path="/api/package[@name='xamarin.test']/class[@name='DeprecatedItems']/field[@name='My_Test_Field']"
+		[Register ("My_Test_Field")]
+		[Obsolete ("Field is deprecated", error: true)]
+		public const int MyTestField = (int) 1;
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("xamarin/test/DeprecatedItems", ref java_class_handle);
+			}
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (DeprecatedItems); }
+		}
+
+		protected DeprecatedItems (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+	}
+}

--- a/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/CodeGenerator.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/CodeGenerator.cs
@@ -437,8 +437,10 @@ namespace MonoDroid.Generation
 			} else {
 				writer.WriteLine ("{0}// Metadata.xml XPath field reference: path=\"{1}/field[@name='{2}']\"", indent, type.MetadataXPathReference, field.JavaName);
 				writer.WriteLine ("{0}[Register (\"{1}\"{2})]", indent, field.JavaName, field.AdditionalAttributeString ());
-				if (field.IsDeprecated)
-					writer.WriteLine ("{0}[Obsolete (\"{1}\")]", indent, field.DeprecatedComment);
+				if (field.IsDeprecated) {
+					var deprecatedError = field.IsDeprecatedError ? ", error: true" : string.Empty;
+					writer.WriteLine ("{0}[Obsolete (\"{1}\"{2})]", indent, field.DeprecatedComment, deprecatedError);
+				}
 				if (field.Annotation != null)
 					writer.WriteLine ("{0}{1}", indent, field.Annotation);
 

--- a/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
@@ -95,6 +95,7 @@ namespace MonoDroid.Generation
 				DeprecatedComment = elem.XGetAttribute ("deprecated"),
 				IsAcw = true,
 				IsDeprecated = elem.XGetAttribute ("deprecated") != "not deprecated",
+				IsDeprecatedError = elem.XGetAttribute ("deprecated-error") == "true",
 				IsFinal = elem.XGetAttribute ("final") == "true",
 				IsStatic = elem.XGetAttribute ("static") == "true",
 				JavaName = elem.XGetAttribute ("name"),

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Field.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Field.cs
@@ -11,6 +11,7 @@ namespace MonoDroid.Generation
 		public string DeprecatedComment { get; set; }
 		public bool IsAcw { get; set; }
 		public bool IsDeprecated { get; set; }
+		public bool IsDeprecatedError { get; set; }
 		public bool IsEnumified { get; set; }
 		public bool IsFinal { get; set; }
 		public bool IsStatic { get; set; }

--- a/tools/generator/Java.Interop.Tools.Generator.Transformation/EnumMap.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Transformation/EnumMap.cs
@@ -24,9 +24,9 @@ namespace MonoDroid.Generation
 			fix_constants_instead_of_removing = fixConstantsInsteadOfRemove;
 		}
 
-		internal Dictionary<string,EnumDescription> Process (string fieldMap, string flagsFile, string methodMap)
+		internal Dictionary<string, EnumDescription> Process (string fieldMap, string flagsFile, string methodMap)
 		{
-			remove_nodes = new List<KeyValuePair<string,string>> ();
+			remove_nodes = new List<KeyValuePair<string, string>> ();
 			var enums = (fieldMap ?? "").EndsWith (".csv")
 				? ParseFieldMappings (fieldMap, flagsFile, version, remove_nodes)
 				: ParseXmlFieldMappings (fieldMap, version, remove_nodes);
@@ -48,12 +48,12 @@ namespace MonoDroid.Generation
 					FixOldConstants (sw);
 				else
 					RemoveOldConstants (sw);
-				
+
 				sw.WriteLine ("</metadata>");
 			}
 			return enums;
 		}
-		
+
 		//  <remove-node path="/api/package[@name='java.lang']/class[@name='Float']/field[@name='MAX_VALUE']" />
 		void RemoveOldConstants (StreamWriter sw)
 		{
@@ -81,14 +81,16 @@ namespace MonoDroid.Generation
 
 				if (pair.Value != null) {
 					sw.WriteLine ("  <attr path=\"/api/package[@name='{0}']/{3}[@name='{1}']/field[@name='{2}']\" name=\"type\">{4}</attr>",
-					              package, type, member, enu.StartsWith ("I:") ? "interface" : "class", pair.Value);
+						      package, type, member, enu.StartsWith ("I:") ? "interface" : "class", pair.Value);
 					sw.WriteLine ("  <attr path=\"/api/package[@name='{0}']/{3}[@name='{1}']/field[@name='{2}']\" name=\"deprecated\">This constant will be removed in the future version. Use {4} enum directly instead of this field.</attr>",
-					              package, type, member, enu.StartsWith ("I:") ? "interface" : "class", pair.Value);
+						      package, type, member, enu.StartsWith ("I:") ? "interface" : "class", pair.Value);
+					sw.WriteLine ("  <attr path=\"/api/package[@name='{0}']/{3}[@name='{1}']/field[@name='{2}']\" name=\"deprecated-error\">true</attr>",
+						      package, type, member, enu.StartsWith ("I:") ? "interface" : "class", pair.Value);
 					continue;
 				}
 				try {
 					sw.WriteLine ("  <remove-node path=\"/api/package[@name='{0}']/{3}[@name='{1}']/field[@name='{2}']\" />",
-					              package, type, member, enu.StartsWith ("I:") ? "interface" : "class");
+						      package, type, member, enu.StartsWith ("I:") ? "interface" : "class");
 				} catch (Exception) {
 					Console.Error.WriteLine ("ERROR: failed to remove old comments: " + enu);
 					throw;

--- a/tools/generator/generator.sln
+++ b/tools/generator/generator.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "generator", "generator.csproj", "{D14A1B5C-2060-4930-92BE-F7190256C735}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "generator-Tests", "Tests\generator-Tests.csproj", "{4EEAB1A7-99C1-4302-9C18-01A7B481409B}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "generator-Tests", "..\..\tests\generator-Tests\generator-Tests.csproj", "{4EEAB1A7-99C1-4302-9C18-01A7B481409B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
We are generating fields that have been marked as obsolete for a long time.
In the effort to remove all fields that now we believe should not be part of our API, we are marking then as obsolete Error=True so we can remove them in the next release.

Here are some scenarios these changes are addressing:

We should [Obsolete(error:true)] "interface proxy" types such as Android.Content.ComponentCallbacks2, which contains fields for the android.content.ComponentCallbacks2 interface and lives "alongside" the Android.Content.IComponentCallbacks2 interface. Additionally, all of these fields should be moved into the appropriate C# interface, e.g. every field within Android.Content.ComponentCallbacks2 should reside in the Android.Content.IComponentCallbacks2 type, using C#8 default interface members.
We should also [Obsolete(error:true)] all of the nested InterfaceConsts types, such as Android.OS.Binder.InterfaceConsts.
We should also [Obsolete(error:true)] all members which are already [Obsolete].

This PR should be combined with XA PR: https://github.com/xamarin/xamarin-android/pull/4248