### PR TITLE
[generator] Change protected members in sealed classes to private.

### DIFF
--- a/tests/generator-Tests/Unit-Tests/SealedProtectedFixupsTests.cs
+++ b/tests/generator-Tests/Unit-Tests/SealedProtectedFixupsTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Linq;
+using System.Xml.Linq;
+using Java.Interop.Tools.Generator.Transformation;
+using MonoDroid.Generation;
+using NUnit.Framework;
+
+namespace generatortests
+{
+	[TestFixture]
+	public class SealedProtectedFixupsTests
+	{
+		private CodeGenerationOptions options = new CodeGenerationOptions ();
+
+		[Test]
+		public void FixProtectedMethod ()
+		{
+			var klass = CreateSealedClass ();
+
+			var method = SupportTypeBuilder.CreateMethod (klass, "ToString", options);
+
+			klass.Methods.Add (method);
+
+			method.Visibility = "protected";
+			method.IsOverride = false;
+
+			SealedProtectedFixups.Fixup (new [] { (GenBase)klass }.ToList ());
+
+			Assert.AreEqual ("private", method.Visibility);
+		}
+
+		[Test]
+		public void FixProtectedProperty ()
+		{
+			var klass = CreateSealedClass ();
+
+			var method = SupportTypeBuilder.CreateProperty (klass, "Handle", "int", options);
+
+			klass.Properties.Add (method);
+
+			method.Getter.Visibility = "protected";
+			method.Getter.IsOverride = false;
+
+			method.Setter.Visibility = "protected";
+			method.Setter.IsOverride = false;
+
+			SealedProtectedFixups.Fixup (new [] { (GenBase) klass }.ToList ());
+
+			Assert.AreEqual ("private", method.Getter.Visibility);
+			Assert.AreEqual ("private", method.Setter.Visibility);
+		}
+
+		[Test]
+		public void FixProtectedField ()
+		{
+			var klass = CreateSealedClass ();
+
+			var field = new Field {
+				Name = "MyConstant",
+				TypeName = "int",
+				Visibility = "protected"
+			};
+
+			klass.Fields.Add (field);
+
+			SealedProtectedFixups.Fixup (new [] { (GenBase) klass }.ToList ());
+
+			Assert.AreEqual ("private", field.Visibility);
+		}
+
+		private ClassGen CreateSealedClass ()
+		{
+			var klass = SupportTypeBuilder.CreateClass ("my.example.class", options);
+			klass.IsFinal = true;
+			return klass;
+		}
+	}
+}

--- a/tools/generator/CodeGenerator.cs
+++ b/tools/generator/CodeGenerator.cs
@@ -172,6 +172,8 @@ namespace Xamarin.Android.Binder
 			foreach (GenBase gen in gens)
 				gen.FixupExplicitImplementation ();
 
+			SealedProtectedFixups.Fixup (gens);
+
 			GenerateAnnotationAttributes (gens, annotations_zips);
 
 			//SymbolTable.Dump ();

--- a/tools/generator/Java.Interop.Tools.Generator.Transformation/SealedProtectedFixups.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Transformation/SealedProtectedFixups.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MonoDroid.Generation;
+
+namespace Java.Interop.Tools.Generator.Transformation
+{
+	public static class SealedProtectedFixups
+	{
+		public static void Fixup (List<GenBase> gens)
+		{
+			foreach (var c in gens.OfType<ClassGen> ().Where (c => c.IsFinal)) {
+				foreach (var m in c.Methods.Where (m => m.Visibility == "protected" && !m.IsOverride))
+					m.Visibility = "private";
+
+				foreach (var p in c.Properties.Where (p => p.Getter?.Visibility == "protected" && !p.Getter.IsOverride))
+					p.Getter.Visibility = "private";
+
+				foreach (var p in c.Properties.Where (p => p.Setter?.Visibility == "protected" && !p.Setter.IsOverride))
+					p.Setter.Visibility = "private";
+
+				foreach (var p in c.Fields.Where (f => f.Visibility == "protected"))
+					p.Visibility = "private";
+			}
+		}
+	}
+}

--- a/tools/generator/generator.csproj
+++ b/tools/generator/generator.csproj
@@ -104,6 +104,7 @@
     <Compile Include="Java.Interop.Tools.Generator.ObjectModel\NamespaceMapping.cs" />
     <Compile Include="Java.Interop.Tools.Generator.ObjectModel\Parameter.cs" />
     <Compile Include="Java.Interop.Tools.Generator.ObjectModel\ParameterList.cs" />
+    <Compile Include="Java.Interop.Tools.Generator.Transformation\SealedProtectedFixups.cs" />
     <Compile Include="Java.Interop.Tools.Generator.Transformation\KotlinFixups.cs" />
     <Compile Include="Java.Interop.Tools.Generator.Transformation\Parser.cs" />
     <Compile Include="Utilities\AncestorDescendantCache.cs" />


### PR DESCRIPTION
When generating API-29 `Mono.Android.dll` we get ~12 warnings that we are declaring a new `protected` member in a `sealed` class:

```
warning CS0628: 'HttpHost.Hostname': new protected member declared in sealed class
```

The C# compiler makes these members `private` anyways, so we can change `generator` to make them `private` to eliminate the warning without being a breaking change.  The value in continuing to bind them as `private` as opposed to removing them is that they could be used by custom code in `partial` classes.