### PR TITLE
[Java.Interop.Tools.Cecil] cache TypeReference.Resolve() calls

### DIFF
--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/TypeDefinitionCache.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/TypeDefinitionCache.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using Mono.Cecil;
+
+namespace Java.Interop.Tools.Cecil
+{
+	/// <summary>
+	/// A class for caching lookups from TypeReference -> TypeDefinition.
+	/// Generally its lifetime should match an AssemblyResolver instance.
+	/// </summary>
+	public class TypeDefinitionCache
+	{
+		readonly Dictionary<TypeReference, TypeDefinition> cache = new Dictionary<TypeReference, TypeDefinition> ();
+
+		public virtual TypeDefinition Resolve (TypeReference typeReference)
+		{
+			if (cache.TryGetValue (typeReference, out var typeDefinition))
+				return typeDefinition;
+			return cache [typeReference] = typeReference.Resolve ();
+		}
+	}
+}

--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/TypeDefinitionRocks.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/TypeDefinitionRocks.cs
@@ -8,54 +8,82 @@ namespace Java.Interop.Tools.Cecil {
 
 	public static class TypeDefinitionRocks {
 
-		public static TypeDefinition GetBaseType (this TypeDefinition type)
+		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
+		public static TypeDefinition GetBaseType (this TypeDefinition type) =>
+			GetBaseType (type, cache: null);
+
+		public static TypeDefinition GetBaseType (this TypeDefinition type, TypeDefinitionCache cache)
 		{
 			var bt = type.BaseType;
-			return bt == null ? null : bt.Resolve ();
+			if (bt == null)
+				return null;
+			if (cache != null)
+				return cache.Resolve (bt);
+			return bt.Resolve ();
 		}
 
-		public static IEnumerable<TypeDefinition> GetTypeAndBaseTypes (this TypeDefinition type)
+		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
+		public static IEnumerable<TypeDefinition> GetTypeAndBaseTypes (this TypeDefinition type) =>
+			GetTypeAndBaseTypes (type, cache: null);
+
+		public static IEnumerable<TypeDefinition> GetTypeAndBaseTypes (this TypeDefinition type, TypeDefinitionCache cache)
 		{
 			while (type != null) {
 				yield return type;
-				type = type.GetBaseType ();
+				type = type.GetBaseType (cache);
 			}
 		}
 
-		public static IEnumerable<TypeDefinition> GetBaseTypes (this TypeDefinition type)
+		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
+		public static IEnumerable<TypeDefinition> GetBaseTypes (this TypeDefinition type) =>
+			GetBaseTypes (type, cache: null);
+
+		public static IEnumerable<TypeDefinition> GetBaseTypes (this TypeDefinition type, TypeDefinitionCache cache)
 		{
-			while ((type = type.GetBaseType ()) != null) {
+			while ((type = type.GetBaseType (cache)) != null) {
 				yield return type;
 			}
 		}
 
-		public static bool IsAssignableFrom (this TypeReference type, TypeReference c)
+		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
+		public static bool IsAssignableFrom (this TypeReference type, TypeReference c) =>
+			IsAssignableFrom (type, c, cache: null);
+
+		public static bool IsAssignableFrom (this TypeReference type, TypeReference c, TypeDefinitionCache cache)
 		{
 			if (type.FullName == c.FullName)
 				return true;
 			var d = c.Resolve ();
 			if (d == null)
 				return false;
-			foreach (var t in d.GetTypeAndBaseTypes ()) {
+			foreach (var t in d.GetTypeAndBaseTypes (cache)) {
 				if (type.FullName == t.FullName)
 					return true;
 				foreach (var ifaceImpl in t.Interfaces) {
 					var i   = ifaceImpl.InterfaceType;
-					if (IsAssignableFrom (type, i))
+					if (IsAssignableFrom (type, i, cache))
 						return true;
 				}
 			}
 			return false;
 		}
 
-		public static bool IsSubclassOf (this TypeDefinition type, string typeName)
+		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
+		public static bool IsSubclassOf (this TypeDefinition type, string typeName) =>
+			IsSubclassOf (type, typeName, cache: null);
+
+		public static bool IsSubclassOf (this TypeDefinition type, string typeName, TypeDefinitionCache cache)
 		{
-			return type.GetTypeAndBaseTypes ().Any (t => t.FullName == typeName);
+			return type.GetTypeAndBaseTypes (cache).Any (t => t.FullName == typeName);
 		}
 
-		public static bool ImplementsInterface (this TypeDefinition type, string interfaceName)
+		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
+		public static bool ImplementsInterface (this TypeDefinition type, string interfaceName) =>
+			ImplementsInterface (type, interfaceName, cache: null);
+
+		public static bool ImplementsInterface (this TypeDefinition type, string interfaceName, TypeDefinitionCache cache)
 		{
-			foreach (var t in type.GetTypeAndBaseTypes ()) {
+			foreach (var t in type.GetTypeAndBaseTypes (cache)) {
 				foreach (var i in t.Interfaces) {
 					if (i.InterfaceType.FullName == interfaceName) {
 						return true;
@@ -65,24 +93,36 @@ namespace Java.Interop.Tools.Cecil {
 			return false;
 		}
 
-		public static string GetPartialAssemblyName (this TypeReference type)
+		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
+		public static string GetPartialAssemblyName (this TypeReference type) =>
+			GetPartialAssemblyName (type, cache: null);
+
+		public static string GetPartialAssemblyName (this TypeReference type, TypeDefinitionCache cache)
 		{
-			TypeDefinition def = type.Resolve ();
+			TypeDefinition def = cache != null ? cache.Resolve (type) : type.Resolve ();
 			return (def ?? type).Module.Assembly.Name.Name;
 		}
 
-		public static string GetPartialAssemblyQualifiedName (this TypeReference type)
+		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
+		public static string GetPartialAssemblyQualifiedName (this TypeReference type) =>
+			GetPartialAssemblyQualifiedName (type, cache: null);
+
+		public static string GetPartialAssemblyQualifiedName (this TypeReference type, TypeDefinitionCache cache)
 		{
 			return string.Format ("{0}, {1}",
 					// Cecil likes to use '/' as the nested type separator, while
 					// Reflection uses '+' as the nested type separator. Use Reflection.
 					type.FullName.Replace ('/', '+'),
-					type.GetPartialAssemblyName ());
+					type.GetPartialAssemblyName (cache));
 		}
 
-		public static string GetAssemblyQualifiedName (this TypeReference type)
+		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
+		public static string GetAssemblyQualifiedName (this TypeReference type) =>
+			GetAssemblyQualifiedName (type, cache: null);
+
+		public static string GetAssemblyQualifiedName (this TypeReference type, TypeDefinitionCache cache)
 		{
-			TypeDefinition def = type.Resolve ();
+			TypeDefinition def = cache != null ? cache.Resolve (type) : type.Resolve ();
 			return string.Format ("{0}, {1}",
 					// Cecil likes to use '/' as the nested type separator, while
 					// Reflection uses '+' as the nested type separator. Use Reflection.

--- a/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGeneratorTests.cs
+++ b/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGeneratorTests.cs
@@ -26,7 +26,7 @@ namespace Java.Interop.Tools.JavaCallableWrappersTests
 
 			// structs aren't supported
 			var td  = SupportDeclarations.GetTypeDefinition (typeof (int));
-			var e   = Assert.Throws<XamarinAndroidException> (() => new JavaCallableWrapperGenerator (td, logger));
+			var e   = Assert.Throws<XamarinAndroidException> (() => new JavaCallableWrapperGenerator (td, logger, cache: null));
 			Assert.AreEqual (4200, e.Code);
 		}
 
@@ -37,7 +37,7 @@ namespace Java.Interop.Tools.JavaCallableWrappersTests
 
 			// Contains invalid [Register] name of "foo-impl"
 			var td = SupportDeclarations.GetTypeDefinition (typeof (KotlinInvalidImplRegisterName));
-			var e = Assert.Throws<XamarinAndroidException> (() => new JavaCallableWrapperGenerator (td, logger));
+			var e = Assert.Throws<XamarinAndroidException> (() => new JavaCallableWrapperGenerator (td, logger, cache: null));
 			Assert.AreEqual (4213, e.Code);
 		}
 
@@ -48,7 +48,7 @@ namespace Java.Interop.Tools.JavaCallableWrappersTests
 
 			// Contains invalid [Register] name of "foo-f8k2a13"
 			var td = SupportDeclarations.GetTypeDefinition (typeof (KotlinInvalidHashRegisterName));
-			var e = Assert.Throws<XamarinAndroidException> (() => new JavaCallableWrapperGenerator (td, logger));
+			var e = Assert.Throws<XamarinAndroidException> (() => new JavaCallableWrapperGenerator (td, logger, cache: null));
 			Assert.AreEqual (4213, e.Code);
 		}
 
@@ -105,7 +105,7 @@ public class Name
 		static string Generate (Type type, string applicationJavaClass = null, string monoRuntimeInit = null)
 		{
 			var td  = SupportDeclarations.GetTypeDefinition (type);
-			var g   = new JavaCallableWrapperGenerator (td, null) {
+			var g   = new JavaCallableWrapperGenerator (td, log: null, cache: null) {
 				ApplicationJavaClass        = applicationJavaClass,
 				GenerateOnCreateOverrides   = true,
 				MonoRuntimeInitialization   = monoRuntimeInit,

--- a/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/TypeNameMapGeneratorTests.cs
+++ b/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/TypeNameMapGeneratorTests.cs
@@ -29,11 +29,11 @@ namespace Xamarin.Android.ToolsTests
 			Action<string, object []> nullLogger = null;
 			Action<TraceLevel, string> levelLogger = (l, v) => { };
 			Action<TraceLevel, string> nullLevelLogger = null;
+#pragma warning disable 0618
 			Assert.Throws<ArgumentNullException> (() => new TypeNameMapGenerator ((string []) null, levelLogger));
 			Assert.Throws<ArgumentNullException> (() => new TypeNameMapGenerator ((TypeDefinition []) null, levelLogger));
 			Assert.Throws<ArgumentNullException> (() => new TypeNameMapGenerator (new string [0], nullLevelLogger));
 			Assert.Throws<ArgumentNullException> (() => new TypeNameMapGenerator (new TypeDefinition [0], nullLevelLogger));
-#pragma warning disable 0618
 			Assert.Throws<ArgumentNullException> (() => new TypeNameMapGenerator ((string []) null, logger));
 			Assert.Throws<ArgumentNullException> (() => new TypeNameMapGenerator ((TypeDefinition []) null, logger));
 			Assert.Throws<ArgumentNullException> (() => new TypeNameMapGenerator (new string [0], nullLogger));
@@ -45,7 +45,7 @@ namespace Xamarin.Android.ToolsTests
 		public void WriteJavaToManaged ()
 		{
 			var types = SupportDeclarations.GetTestTypeDefinitions ();
-			var v = new TypeNameMapGenerator (types, logger: Diagnostic.CreateConsoleLogger ());
+			var v = new TypeNameMapGenerator (types, logger: Diagnostic.CreateConsoleLogger (), cache: null);
 			var o = new MemoryStream ();
 			v.WriteJavaToManaged (o);
 			var a = ToArray (o);
@@ -112,7 +112,7 @@ namespace Xamarin.Android.ToolsTests
 		[Test]
 		public void WriteManagedToJavaWithNoTypes ()
 		{
-			var v = new TypeNameMapGenerator (new string[0], logger: Diagnostic.CreateConsoleLogger ());
+			var v = new TypeNameMapGenerator (new string[0], logger: Diagnostic.CreateConsoleLogger (), cache: null);
 			var o = new MemoryStream ();
 			v.WriteManagedToJava (o);
 			var a = ToArray (o);
@@ -123,7 +123,7 @@ namespace Xamarin.Android.ToolsTests
 		public void WriteManagedToJava ()
 		{
 			var types = SupportDeclarations.GetTestTypeDefinitions ();
-			var v = new TypeNameMapGenerator (types, logger: Diagnostic.CreateConsoleLogger ());
+			var v = new TypeNameMapGenerator (types, logger: Diagnostic.CreateConsoleLogger (), cache: null);
 			var o = new MemoryStream ();
 			v.WriteManagedToJava (o);
 			var a = ToArray (o);

--- a/tools/generator/CodeGenerator.cs
+++ b/tools/generator/CodeGenerator.cs
@@ -69,6 +69,7 @@ namespace Xamarin.Android.Binder
 				SupportInterfaceConstants = options.SupportInterfaceConstants,
 				SupportDefaultInterfaceMethods = options.SupportDefaultInterfaceMethods,
 			};
+			var resolverCache       = new TypeDefinitionCache ();
 
 			// Load reference libraries
 
@@ -106,7 +107,7 @@ namespace Xamarin.Android.Binder
 							var nonGenericOverload  = td.HasGenericParameters
 								? md.GetType (td.FullName.Substring (0, td.FullName.IndexOf ('`')))
 								: null;
-							if (BindSameType (td, nonGenericOverload))
+							if (BindSameType (td, nonGenericOverload, resolverCache))
 								continue;
 							ProcessReferencedType (td, opt);
 						}
@@ -209,11 +210,11 @@ namespace Xamarin.Android.Binder
 				AddTypeToTable (opt, nt);
 		}
 
-		static bool BindSameType (TypeDefinition a, TypeDefinition b)
+		static bool BindSameType (TypeDefinition a, TypeDefinition b, TypeDefinitionCache cache)
 		{
 			if (a == null || b == null)
 				return false;
-			if (!a.ImplementsInterface ("Android.Runtime.IJavaObject") || !b.ImplementsInterface ("Android.Runtime.IJavaObject"))
+			if (!a.ImplementsInterface ("Android.Runtime.IJavaObject", cache) || !b.ImplementsInterface ("Android.Runtime.IJavaObject", cache))
 				return false;
 			return JavaNativeTypeManager.ToJniName (a) == JavaNativeTypeManager.ToJniName (b);
 		}

--- a/tools/jcw-gen/App.cs
+++ b/tools/jcw-gen/App.cs
@@ -43,7 +43,8 @@ namespace Java.Interop.Tools
 				  "Show this message and exit",
 				  v => help = v != null },
 			};
-			var scanner = new JavaTypeScanner (Diagnostic.CreateConsoleLogger ());
+			var cache = new TypeDefinitionCache ();
+			var scanner = new JavaTypeScanner (Diagnostic.CreateConsoleLogger (), cache);
 			try {
 				var assemblies = options.Parse (args);
 				if (assemblies.Count == 0 || outputPath == null || help) {
@@ -64,9 +65,9 @@ namespace Java.Interop.Tools
 					resolver.Load (assembly);
 				}
 				var types = scanner.GetJavaTypes (assemblies, resolver)
-					.Where (td => !JavaTypeScanner.ShouldSkipJavaCallableWrapperGeneration (td));
+					.Where (td => !JavaTypeScanner.ShouldSkipJavaCallableWrapperGeneration (td, cache));
 				foreach (var type in types) {
-					GenerateJavaCallableWrapper (type, outputPath);
+					GenerateJavaCallableWrapper (type, outputPath, cache);
 				}
 				return 0;
 			}
@@ -79,9 +80,9 @@ namespace Java.Interop.Tools
 			}
 		}
 
-		static void GenerateJavaCallableWrapper (TypeDefinition type, string outputPath)
+		static void GenerateJavaCallableWrapper (TypeDefinition type, string outputPath, TypeDefinitionCache cache)
 		{
-			var generator = new JavaCallableWrapperGenerator (type, log: Console.WriteLine) {
+			var generator = new JavaCallableWrapperGenerator (type, log: Console.WriteLine, cache) {
 			};
 			generator.Generate (outputPath);
 		}

--- a/tools/jnimarshalmethod-gen/TypeMover.cs
+++ b/tools/jnimarshalmethod-gen/TypeMover.cs
@@ -17,13 +17,15 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator
 		Dictionary<string, System.Reflection.Emit.TypeBuilder> Types { get; }
 
 		MethodReference consoleWriteLine;
+		TypeDefinitionCache cache;
 
-		public TypeMover (AssemblyDefinition source, AssemblyDefinition destination, string destinationPath, Dictionary<string, System.Reflection.Emit.TypeBuilder> types, DirectoryAssemblyResolver resolver)
+		public TypeMover (AssemblyDefinition source, AssemblyDefinition destination, string destinationPath, Dictionary<string, System.Reflection.Emit.TypeBuilder> types, DirectoryAssemblyResolver resolver, TypeDefinitionCache cache)
 		{
 			Source = source;
 			Destination = destination;
 			DestinationPath = destinationPath;
 			Types = types;
+			this.cache = cache;
 
 			if (App.Debug) {
 				consoleWriteLine = GetSingleParameterMethod (resolver, Destination.MainModule, "mscorlib", "System.Console", "WriteLine", "System.String");
@@ -83,7 +85,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator
 
 			if (toRemove != null) {
 				foreach (var t in toRemove) {
-					App.ColorWriteLine ($"Removing original '{t.GetAssemblyQualifiedName ()}' type. (forced)", ConsoleColor.Cyan);
+					App.ColorWriteLine ($"Removing original '{t.GetAssemblyQualifiedName (cache)}' type. (forced)", ConsoleColor.Cyan);
 					typeDst.NestedTypes.Remove (t);
 				}
 			}


### PR DESCRIPTION
I was profiling builds with the Mono profiler and noticed:

    Method call summary
    Total(ms) Self(ms)      Calls Method name
        70862       97      89713 Java.Interop.Tools.Cecil.DirectoryAssemblyResolver:Resolve (Mono.Cecil.AssemblyNameReference,Mono.Cecil.ReaderParameters)

Almost 90K calls? What is that coming from???

    61422 calls from:
        Java.Interop.Tools.Cecil.TypeDefinitionRocks/<GetTypeAndBaseTypes>d__1:MoveNext ()
        Java.Interop.Tools.Cecil.TypeDefinitionRocks:GetBaseType (Mono.Cecil.TypeDefinition)
        Mono.Cecil.TypeReference:Resolve ()
        Mono.Cecil.ModuleDefinition:Resolve (Mono.Cecil.TypeReference)
        Mono.Cecil.MetadataResolver:Resolve (Mono.Cecil.TypeReference)
        Java.Interop.Tools.Cecil.DirectoryAssemblyResolver:Resolve (Mono.Cecil.AssemblyNameReference)

Ok, this jogged my memory. Stephane Delcroix had mentioned one of the
big wins for XamlC in Xamarin.Forms was to cache any time
`TypeReference.Resolve()` was called:

https://github.com/xamarin/Xamarin.Forms/blob/1b9c22b4b9b1c1354a3a5c35ad445a2738c6f6c3/Xamarin.Forms.Build.Tasks/TypeReferenceExtensions.cs#L437-L443

XamlC was able to use `static` here, because it's using a feature of
MSBuild to run in a separate `AppDomain`:

https://github.com/xamarin/Xamarin.Forms/blob/1b9c22b4b9b1c1354a3a5c35ad445a2738c6f6c3/Xamarin.Forms.Build.Tasks/XamlTask.cs#L20-L21

However, I think we can simply add a new non-static
`TypeDefinitionCache` class that would allow callers to control the
caching strategy. Callers will need to control the scope of the
`TypeDefinitionCache` so it matches any `DirectoryAssemblyResolver`
being used. Right now most Xamarin.Android builds will open assemblies
with Mono.Cecil twice: once for `<GenerateJavaStubs/>` and once for
the linker.

So for example, we can add caching in an API-compatible way:

    [Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
    public static TypeDefinition GetBaseType (this TypeDefinition type) =>
        GetBaseType (type, cache: null);

    public static TypeDefinition GetBaseType (this TypeDefinition type, TypeDefinitionCache cache)
    {
        if (bt == null)
            return null;
        if (cache != null)
            return cache.Resolve (bt);
        return bt.Resolve ();
    }

We just need to ensure `cache: null` is valid. I took this approach
for any `public` APIs and made any `private` or `internal` APIs
*require* a `TypeDefinitionCache`.

I fixed every instance where `[Obsolete]` would cause a warning here
in Java.Interop. We'll probably see a small improvement in `generator`
and `jnimarshalmethod-gen`.

Downstream in xamarin-android, I fixed all the `[Obsolete]` warnings
that were called in `<GenerateJavaStubs/>`. I can make more changes
for the linker in a future PR.

## Results ##

The reduced calls to `DirectoryAssemblyResolver.Resolve`:

    Method call summary
    Total(ms) Self(ms)      Calls Method name
    Before;
        70862       97      89713 Java.Interop.Tools.Cecil.DirectoryAssemblyResolver:Resolve (Mono.Cecil.AssemblyNameReference,Mono.Cecil.ReaderParameters)
    After:
        68830       35      26315 Java.Interop.Tools.Cecil.DirectoryAssemblyResolver:Resolve (Mono.Cecil.AssemblyNameReference,Mono.Cecil.ReaderParameters)

~63,398 less calls.

In a build of the Xamarin.Forms integration project on macOS / Mono:

    Before:
       1365 ms  GenerateJavaStubs                          1 calls
    After:
        862 ms  GenerateJavaStubs                          1 calls

It is almost a 40% improvement, around ~500ms better.