### PR TITLE
[generator] Do not generate bindings for package-private nested types [#572]

### DIFF
--- a/tests/generator-Tests/expected/AccessModifiers/AccessModifiers.xml
+++ b/tests/generator-Tests/expected/AccessModifiers/AccessModifiers.xml
@@ -18,6 +18,11 @@
 			public class PublicClass extends PackageClass {
 				@Override
 				public void foo();
+				
+				// This nested type should not be generated because it is package-private
+				/* package */ static interface OnPressedChangeListener {
+				  void onPressedChanged ();
+				}
 			}
 		-->
 		<class abstract="false" deprecated="not deprecated" extends="xamarin.test.PackageClass" extends-generic-aware="xamarin.test.PackageClass" final="false" name="PublicClass" static="false" visibility="public">
@@ -25,6 +30,9 @@
 			<method abstract="false" deprecated="not deprecated" final="false" name="foo" native="false" return="void" static="false" synchronized="false" visibility="public">
 			</method>
 		</class>
+		<interface abstract="true" deprecated="not deprecated" final="false" name="PublicClass.OnPressedChangeListener" static="true" visibility="" >
+			<method abstract="true" deprecated="not deprecated" final="false" name="onPressedChanged" jni-signature="V" bridge="false" native="false" return="void" jni-return="V" static="false" synchronized="false" synthetic="false" visibility="public" />
+		</interface>
 		<!-- 
 			/* package */ abstract class ExtendPackageClass extends PackageClass {
 			}

--- a/tools/generator/CodeGenerator.cs
+++ b/tools/generator/CodeGenerator.cs
@@ -231,6 +231,8 @@ namespace Xamarin.Android.Binder
 		{
 			//int cycle = 1;
 			List<GenBase> removed = new List<GenBase> ();
+			var nested_removes = new List<GenBase> ();
+
 			// This loop is required because we cannot really split type validation and member
 			// validation apart (unlike C# compiler), because invalidated members will result
 			// in the entire interface invalidation (since we cannot implement it), and use of
@@ -252,6 +254,22 @@ namespace Xamarin.Android.Binder
 						}
 						removed.Add (gen);
 					}
+
+				// Remove any nested types that are package-private
+				foreach (var gen in gens) {
+					foreach (var nest in gen.NestedTypes)
+						if (opt.IgnoreNonPublicType && (nest.RawVisibility != "public" && nest.RawVisibility != "internal")) {
+							// We still add it to "removed" even though the removal
+							// code later won't work, so that it triggers a new cycle
+							removed.Add (nest);
+							nested_removes.Add (nest);
+						}
+
+					foreach (var nest in nested_removes)
+						gen.NestedTypes.Remove (nest);
+
+					nested_removes.Clear ();
+				}
 
 				foreach (GenBase gen in removed)
 					gens.Remove (gen);


### PR DESCRIPTION
Fixes #572.

Do not generate bindings for `package-private` nested types to match logic for top level classes.