### PR TITLE
[build] target .NET Core 3.1.100

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -6,7 +6,7 @@ trigger:
 
 # Global variables
 variables:
-  DotNetCoreVersion: 3.1.x
+  DotNetCoreVersion: 3.1.100
   HostedMac: Hosted Mac Internal
   HostedWinVS2019: Hosted Windows 2019 with VS2019
 


### PR DESCRIPTION
Context: https://feedback.devdiv.io/922217
Context: https://build.azdo.io/3484060

.NET Core 3.1.102 dropped yesterday and broke the build with:

    Download URL for .Net Core sdk version 3.1.102 could not be found for the following OS platforms (rid): osx-x64,osx-x64

It appears using `3.1.x` broke...

We don't know how long this will be broken, so let's use what
xamarin-android is using, which appears to be working:

https://github.com/xamarin/xamarin-android/blob/87ee20c59a09ba4314f4226e1c77ee2331c3f09f/build-tools/automation/azure-pipelines.yaml#L51