### PR TITLE
[generator] Bind protected nested types.

### DIFF
--- a/tests/generator-Tests/expected.ji/AccessModifiers/Xamarin.Test.PublicClass.cs
+++ b/tests/generator-Tests/expected.ji/AccessModifiers/Xamarin.Test.PublicClass.cs
@@ -9,6 +9,94 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/PublicClass", DoNotGenerateAcw=true)]
 	public partial class PublicClass : global::Java.Lang.Object {
 
+		// Metadata.xml XPath interface reference: path="/api/package[@name='xamarin.test']/interface[@name='PublicClass.ProtectedInterface']"
+		[Register ("xamarin/test/PublicClass$ProtectedInterface", "", "Xamarin.Test.PublicClass/IProtectedInterfaceInvoker")]
+		protected internal partial interface IProtectedInterface : IJavaObject, IJavaPeerable {
+
+			// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/interface[@name='PublicClass.ProtectedInterface']/method[@name='foo' and count(parameter)=0]"
+			[Register ("foo", "()V", "GetFooHandler:Xamarin.Test.PublicClass/IProtectedInterfaceInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
+			void Foo ();
+
+		}
+
+		[global::Android.Runtime.Register ("xamarin/test/PublicClass$ProtectedInterface", DoNotGenerateAcw=true)]
+		internal partial class IProtectedInterfaceInvoker : global::Java.Lang.Object, IProtectedInterface {
+
+			static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/PublicClass$ProtectedInterface", typeof (IProtectedInterfaceInvoker));
+
+			static IntPtr java_class_ref {
+				get { return _members.JniPeerType.PeerReference.Handle; }
+			}
+
+			public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+				get { return _members; }
+			}
+
+			protected override IntPtr ThresholdClass {
+				get { return class_ref; }
+			}
+
+			protected override global::System.Type ThresholdType {
+				get { return _members.ManagedPeerType; }
+			}
+
+			new IntPtr class_ref;
+
+			public static IProtectedInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
+			{
+				return global::Java.Lang.Object.GetObject<IProtectedInterface> (handle, transfer);
+			}
+
+			static IntPtr Validate (IntPtr handle)
+			{
+				if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
+					throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
+								JNIEnv.GetClassNameFromInstance (handle), "xamarin.test.PublicClass.ProtectedInterface"));
+				return handle;
+			}
+
+			protected override void Dispose (bool disposing)
+			{
+				if (this.class_ref != IntPtr.Zero)
+					JNIEnv.DeleteGlobalRef (this.class_ref);
+				this.class_ref = IntPtr.Zero;
+				base.Dispose (disposing);
+			}
+
+			public IProtectedInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
+			{
+				IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
+				this.class_ref = JNIEnv.NewGlobalRef (local_ref);
+				JNIEnv.DeleteLocalRef (local_ref);
+			}
+
+			static Delegate cb_foo;
+#pragma warning disable 0169
+			static Delegate GetFooHandler ()
+			{
+				if (cb_foo == null)
+					cb_foo = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr>) n_Foo);
+				return cb_foo;
+			}
+
+			static void n_Foo (IntPtr jnienv, IntPtr native__this)
+			{
+				global::Xamarin.Test.PublicClass.IProtectedInterface __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.PublicClass.IProtectedInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				__this.Foo ();
+			}
+#pragma warning restore 0169
+
+			IntPtr id_foo;
+			public unsafe void Foo ()
+			{
+				if (id_foo == IntPtr.Zero)
+					id_foo = JNIEnv.GetMethodID (class_ref, "foo", "()V");
+				JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_foo);
+			}
+
+		}
+
+
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/PublicClass", typeof (PublicClass));
 		internal static new IntPtr class_ref {
 			get {

--- a/tests/generator-Tests/expected/AccessModifiers/AccessModifiers.xml
+++ b/tests/generator-Tests/expected/AccessModifiers/AccessModifiers.xml
@@ -23,6 +23,11 @@
 				/* package */ static interface OnPressedChangeListener {
 				  void onPressedChanged ();
 				}
+				
+				// This nested type should be generated because it is protected
+				protected interface ProtectedInterface {
+				  void foo ();
+				}
 			}
 		-->
 		<class abstract="false" deprecated="not deprecated" extends="xamarin.test.PackageClass" extends-generic-aware="xamarin.test.PackageClass" final="false" name="PublicClass" static="false" visibility="public">
@@ -32,6 +37,9 @@
 		</class>
 		<interface abstract="true" deprecated="not deprecated" final="false" name="PublicClass.OnPressedChangeListener" static="true" visibility="" >
 			<method abstract="true" deprecated="not deprecated" final="false" name="onPressedChanged" jni-signature="V" bridge="false" native="false" return="void" jni-return="V" static="false" synchronized="false" synthetic="false" visibility="public" />
+		</interface>
+		<interface abstract="true" deprecated="not deprecated" final="false" name="PublicClass.ProtectedInterface" static="true" visibility="protected" >
+			<method abstract="true" deprecated="not deprecated" final="false" name="foo" jni-signature="V" bridge="false" native="false" return="void" jni-return="V" static="false" synchronized="false" synthetic="false" visibility="public" />
 		</interface>
 		<!-- 
 			/* package */ abstract class ExtendPackageClass extends PackageClass {

--- a/tests/generator-Tests/expected/AccessModifiers/Xamarin.Test.PublicClass.cs
+++ b/tests/generator-Tests/expected/AccessModifiers/Xamarin.Test.PublicClass.cs
@@ -8,6 +8,86 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/PublicClass", DoNotGenerateAcw=true)]
 	public partial class PublicClass : global::Java.Lang.Object {
 
+		// Metadata.xml XPath interface reference: path="/api/package[@name='xamarin.test']/interface[@name='PublicClass.ProtectedInterface']"
+		[Register ("xamarin/test/PublicClass$ProtectedInterface", "", "Xamarin.Test.PublicClass/IProtectedInterfaceInvoker")]
+		protected internal partial interface IProtectedInterface : IJavaObject {
+
+			// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/interface[@name='PublicClass.ProtectedInterface']/method[@name='foo' and count(parameter)=0]"
+			[Register ("foo", "()V", "GetFooHandler:Xamarin.Test.PublicClass/IProtectedInterfaceInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
+			void Foo ();
+
+		}
+
+		[global::Android.Runtime.Register ("xamarin/test/PublicClass$ProtectedInterface", DoNotGenerateAcw=true)]
+		internal partial class IProtectedInterfaceInvoker : global::Java.Lang.Object, IProtectedInterface {
+
+			static IntPtr java_class_ref = JNIEnv.FindClass ("xamarin/test/PublicClass$ProtectedInterface");
+
+			protected override IntPtr ThresholdClass {
+				get { return class_ref; }
+			}
+
+			protected override global::System.Type ThresholdType {
+				get { return typeof (IProtectedInterfaceInvoker); }
+			}
+
+			new IntPtr class_ref;
+
+			public static IProtectedInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
+			{
+				return global::Java.Lang.Object.GetObject<IProtectedInterface> (handle, transfer);
+			}
+
+			static IntPtr Validate (IntPtr handle)
+			{
+				if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
+					throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
+								JNIEnv.GetClassNameFromInstance (handle), "xamarin.test.PublicClass.ProtectedInterface"));
+				return handle;
+			}
+
+			protected override void Dispose (bool disposing)
+			{
+				if (this.class_ref != IntPtr.Zero)
+					JNIEnv.DeleteGlobalRef (this.class_ref);
+				this.class_ref = IntPtr.Zero;
+				base.Dispose (disposing);
+			}
+
+			public IProtectedInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
+			{
+				IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
+				this.class_ref = JNIEnv.NewGlobalRef (local_ref);
+				JNIEnv.DeleteLocalRef (local_ref);
+			}
+
+			static Delegate cb_foo;
+#pragma warning disable 0169
+			static Delegate GetFooHandler ()
+			{
+				if (cb_foo == null)
+					cb_foo = JNINativeWrapper.CreateDelegate ((Action<IntPtr, IntPtr>) n_Foo);
+				return cb_foo;
+			}
+
+			static void n_Foo (IntPtr jnienv, IntPtr native__this)
+			{
+				global::Xamarin.Test.PublicClass.IProtectedInterface __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.PublicClass.IProtectedInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				__this.Foo ();
+			}
+#pragma warning restore 0169
+
+			IntPtr id_foo;
+			public unsafe void Foo ()
+			{
+				if (id_foo == IntPtr.Zero)
+					id_foo = JNIEnv.GetMethodID (class_ref, "foo", "()V");
+				JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_foo);
+			}
+
+		}
+
+
 		internal static new IntPtr java_class_handle;
 		internal static new IntPtr class_ref {
 			get {

--- a/tools/generator/CodeGenerator.cs
+++ b/tools/generator/CodeGenerator.cs
@@ -259,7 +259,7 @@ namespace Xamarin.Android.Binder
 				// Remove any nested types that are package-private
 				foreach (var gen in gens) {
 					foreach (var nest in gen.NestedTypes)
-						if (opt.IgnoreNonPublicType && (nest.RawVisibility != "public" && nest.RawVisibility != "internal")) {
+						if (opt.IgnoreNonPublicType && (nest.RawVisibility != "public" && nest.RawVisibility != "internal" && nest.RawVisibility != "protected internal")) {
 							// We still add it to "removed" even though the removal
 							// code later won't work, so that it triggers a new cycle
 							removed.Add (nest);


### PR DESCRIPTION
In #575, we stopped binding nested types that are **not** `public` or `internal`, however we also need to bind nested types that are `protected`.

Note that internally `protected` is stored as `protected internal` due to:

https://github.com/xamarin/java.interop/blob/master/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs#L143-L144