### PR TITLE
Fixing generator code to validate name collision between Methods and Fields

### DIFF
--- a/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/InterfaceMethodsConflict.xml
+++ b/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/InterfaceMethodsConflict.xml
@@ -13,10 +13,29 @@
 		<method abstract="true" deprecated="not deprecated" final="false" name="close" native="false" return="void" static="false" synchronized="false" visibility="public">
 		</method>
 	  </interface>
-	  <class abstract="true" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" 
+	  <class abstract="true" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object"
 	  		final="false" name="SomeObject" static="false" visibility="public">
 		<implements name="xamarin.test.I1" name-generic-aware="xamarin.test.I1" />
 		<implements name="xamarin.test.I2" name-generic-aware="xamarin.test.I2" />
+	  </class>
+    <class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="false" name="Color" static="false" visibility="public">
+      <constructor deprecated="not deprecated" final="false" name="Color" jni-signature="()V" bridge="false" static="false" type="android.graphics.Color" synthetic="false" visibility="public" />
+      <method abstract="false" deprecated="not deprecated" final="false" name="blue" bridge="false" native="false" return="float" static="false" synchronized="false" synthetic="false" visibility="public" />
+      <method abstract="false" deprecated="not deprecated" final="false" name="blue" bridge="false" native="false" return="float" static="true" synchronized="false" synthetic="false" visibility="public">
+        <parameter name="color" type="long"></parameter>
+      </method>
+      <field deprecated="not deprecated" final="true" name="BLACK" jni-signature="I" static="true" transient="false" type="int" type-generic-aware="int" value="-16777216" visibility="public" volatile="false"></field>
+      <field deprecated="not deprecated" final="true" name="BLUE" jni-signature="I" static="true" transient="false" type="int" type-generic-aware="int" value="-16776961" visibility="public" volatile="false"></field>
+    </class>
+    <class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" jni-extends="Ljava/lang/Object;" final="false" name="Action" static="true" visibility="public">
+      <method abstract="false" deprecated="not deprecated" final="false" name="getIcon" bridge="false" native="false" return="int" static="false" synchronized="false" synthetic="false" visibility="public" />
+      <field deprecated="not deprecated" final="false" name="icon" jni-signature="I" static="false" transient="false" type="int" type-generic-aware="int" visibility="public" volatile="false" deprecated-since="23"></field>
+      <field deprecated="not deprecated" final="true" name="SEMANTIC_ACTION_ARCHIVE" jni-signature="I" static="true" transient="false" type="int" type-generic-aware="int" value="5" visibility="public" volatile="false"></field>
+    </class>
+    <class abstract="true" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="false" name="Blues" static="false" visibility="public">
+      <field deprecated="not deprecated" final="true" name="BLUE" jni-signature="I" static="true" transient="false" type="int" type-generic-aware="int" value="-16776961" visibility="public" volatile="false"></field>
+      <field deprecated="not deprecated" final="true" name="blue" jni-signature="I" static="false" transient="false" type="int" type-generic-aware="int" value="10" visibility="public" volatile="false"></field>
+      <method abstract="false" deprecated="not deprecated" final="false" name="getBlue" native="false" return="int" static="true" synchronized="false" visibility="public" />
 	  </class>
 	</package>
 </api>

--- a/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.Action.cs
+++ b/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.Action.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Xamarin.Test {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='Action']"
+	[global::Android.Runtime.Register ("xamarin/test/Action", DoNotGenerateAcw=true)]
+	public partial class Action : global::Java.Lang.Object {
+
+
+
+		// Metadata.xml XPath field reference: path="/api/package[@name='xamarin.test']/class[@name='Action']/field[@name='icon']"
+		[Register ("icon")]
+		public int Icon_ {
+			get {
+				const string __id = "icon.I";
+
+				var __v = _members.InstanceFields.GetInt32Value (__id, this);
+				return __v;
+			}
+			set {
+				const string __id = "icon.I";
+
+				try {
+					_members.InstanceFields.SetValue (__id, this, value);
+				} finally {
+				}
+			}
+		}
+
+		// Metadata.xml XPath field reference: path="/api/package[@name='xamarin.test']/class[@name='Action']/field[@name='SEMANTIC_ACTION_ARCHIVE']"
+		[Register ("SEMANTIC_ACTION_ARCHIVE")]
+		public const int SemanticActionArchive = (int) 5;
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/Action", typeof (Action));
+		internal static new IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+		protected Action (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		static Delegate cb_getIcon;
+#pragma warning disable 0169
+		static Delegate GetGetIconHandler ()
+		{
+			if (cb_getIcon == null)
+				cb_getIcon = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, int>) n_GetIcon);
+			return cb_getIcon;
+		}
+
+		static int n_GetIcon (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Xamarin.Test.Action __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.Action> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return __this.Icon;
+		}
+#pragma warning restore 0169
+
+		public virtual unsafe int Icon {
+			// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='Action']/method[@name='getIcon' and count(parameter)=0]"
+			[Register ("getIcon", "()I", "GetGetIconHandler")]
+			get {
+				const string __id = "getIcon.()I";
+				try {
+					var __rm = _members.InstanceMethods.InvokeVirtualInt32Method (__id, this, null);
+					return __rm;
+				} finally {
+				}
+			}
+		}
+
+	}
+}

--- a/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.Blues.cs
+++ b/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.Blues.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Xamarin.Test {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='Blues']"
+	[global::Android.Runtime.Register ("xamarin/test/Blues", DoNotGenerateAcw=true)]
+	public abstract partial class Blues : global::Java.Lang.Object {
+
+
+		// Metadata.xml XPath field reference: path="/api/package[@name='xamarin.test']/class[@name='Blues']/field[@name='BLUE']"
+		[Register ("BLUE")]
+		public const int Blue__ = (int) -16776961;
+
+
+		// Metadata.xml XPath field reference: path="/api/package[@name='xamarin.test']/class[@name='Blues']/field[@name='blue']"
+		[Register ("blue")]
+		public int Blue_ {
+			get {
+				const string __id = "blue.I";
+
+				var __v = _members.InstanceFields.GetInt32Value (__id, this);
+				return __v;
+			}
+			set {
+				const string __id = "blue.I";
+
+				try {
+					_members.InstanceFields.SetValue (__id, this, value);
+				} finally {
+				}
+			}
+		}
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/Blues", typeof (Blues));
+		internal static new IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+		protected Blues (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		public static unsafe int Blue {
+			// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='Blues']/method[@name='getBlue' and count(parameter)=0]"
+			[Register ("getBlue", "()I", "")]
+			get {
+				const string __id = "getBlue.()I";
+				try {
+					var __rm = _members.StaticMethods.InvokeInt32Method (__id, null);
+					return __rm;
+				} finally {
+				}
+			}
+		}
+
+	}
+
+	[global::Android.Runtime.Register ("xamarin/test/Blues", DoNotGenerateAcw=true)]
+	internal partial class BluesInvoker : Blues {
+
+		public BluesInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
+
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/Blues", typeof (BluesInvoker));
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+	}
+
+}

--- a/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.Color.cs
+++ b/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.Color.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Xamarin.Test {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='Color']"
+	[global::Android.Runtime.Register ("xamarin/test/Color", DoNotGenerateAcw=true)]
+	public partial class Color : global::Java.Lang.Object {
+
+
+		// Metadata.xml XPath field reference: path="/api/package[@name='xamarin.test']/class[@name='Color']/field[@name='BLACK']"
+		[Register ("BLACK")]
+		public const int Black = (int) -16777216;
+
+		// Metadata.xml XPath field reference: path="/api/package[@name='xamarin.test']/class[@name='Color']/field[@name='BLUE']"
+		[Register ("BLUE")]
+		public const int Blue__ = (int) -16776961;
+		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/Color", typeof (Color));
+		internal static new IntPtr class_ref {
+			get {
+				return _members.JniPeerType.PeerReference.Handle;
+			}
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+		protected Color (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		// Metadata.xml XPath constructor reference: path="/api/package[@name='xamarin.test']/class[@name='Color']/constructor[@name='Color' and count(parameter)=0]"
+		[Register (".ctor", "()V", "")]
+		public unsafe Color ()
+			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		{
+			const string __id = "()V";
+
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+				return;
+
+			try {
+				var __r = _members.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), null);
+				SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
+				_members.InstanceMethods.FinishCreateInstance (__id, this, null);
+			} finally {
+			}
+		}
+
+		static Delegate cb_blue;
+#pragma warning disable 0169
+		static Delegate GetBlueHandler ()
+		{
+			if (cb_blue == null)
+				cb_blue = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, float>) n_Blue);
+			return cb_blue;
+		}
+
+		static float n_Blue (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Xamarin.Test.Color __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.Color> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return __this.Blue ();
+		}
+#pragma warning restore 0169
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='Color']/method[@name='blue' and count(parameter)=0]"
+		[Register ("blue", "()F", "GetBlueHandler")]
+		public virtual unsafe float Blue ()
+		{
+			const string __id = "blue.()F";
+			try {
+				var __rm = _members.InstanceMethods.InvokeVirtualSingleMethod (__id, this, null);
+				return __rm;
+			} finally {
+			}
+		}
+
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='Color']/method[@name='blue' and count(parameter)=1 and parameter[1][@type='long']]"
+		[Register ("blue", "(J)F", "")]
+		public static unsafe float Blue (long color)
+		{
+			const string __id = "blue.(J)F";
+			try {
+				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+				__args [0] = new JniArgumentValue (color);
+				var __rm = _members.StaticMethods.InvokeSingleMethod (__id, __args);
+				return __rm;
+			} finally {
+			}
+		}
+
+	}
+}

--- a/tests/generator-Tests/expected/InterfaceMethodsConflict/InterfaceMethodsConflict.xml
+++ b/tests/generator-Tests/expected/InterfaceMethodsConflict/InterfaceMethodsConflict.xml
@@ -13,20 +13,39 @@
 		<method abstract="true" deprecated="not deprecated" final="false" name="close" native="false" return="void" static="false" synchronized="false" visibility="public">
 		</method>
 	  </interface>
-	  <class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" 
+	  <class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object"
 	  		final="false" name="SomeObject" static="false" visibility="public">
 		<implements name="xamarin.test.I1" name-generic-aware="xamarin.test.I1" />
 		<implements name="xamarin.test.I2" name-generic-aware="xamarin.test.I2" />
 		<method abstract="false" deprecated="not deprecated" final="false" name="close" native="false" return="void" static="false" synchronized="false" visibility="public">
 		</method>
 	  </class>
-	  <class abstract="true" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" 
+	  <class abstract="true" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object"
 	  		final="false" name="SomeObject2" static="false" visibility="public">
 		<implements name="xamarin.test.I1" name-generic-aware="xamarin.test.I1" />
 		<implements name="xamarin.test.I2" name-generic-aware="xamarin.test.I2" />
 		<!-- FIXME: this should not be required, but generator has an issue that when there is no member in the declaring class, "class_ref" is not generated and then the generated code does not compile because those invoker implementations depend on it. -->
 		<method abstract="false" deprecated="not deprecated" final="false" name="irrelevant" native="false" return="void" static="false" synchronized="false" visibility="public">
 		</method>
+	  </class>
+    <class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="false" name="Color" static="false" visibility="public">
+      <constructor deprecated="not deprecated" final="false" name="Color" jni-signature="()V" bridge="false" static="false" type="android.graphics.Color" synthetic="false" visibility="public" />
+      <method abstract="false" deprecated="not deprecated" final="false" name="blue" bridge="false" native="false" return="float" static="false" synchronized="false" synthetic="false" visibility="public" />
+      <method abstract="false" deprecated="not deprecated" final="false" name="blue" bridge="false" native="false" return="float" static="true" synchronized="false" synthetic="false" visibility="public">
+        <parameter name="color" type="long"></parameter>
+      </method>
+      <field deprecated="not deprecated" final="true" name="BLACK" jni-signature="I" static="true" transient="false" type="int" type-generic-aware="int" value="-16777216" visibility="public" volatile="false"></field>
+      <field deprecated="not deprecated" final="true" name="BLUE" jni-signature="I" static="true" transient="false" type="int" type-generic-aware="int" value="-16776961" visibility="public" volatile="false"></field>
+    </class>
+    <class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" jni-extends="Ljava/lang/Object;" final="false" name="Action" static="true" visibility="public">
+      <method abstract="false" deprecated="not deprecated" final="false" name="getIcon" bridge="false" native="false" return="int" static="false" synchronized="false" synthetic="false" visibility="public" />
+      <field deprecated="not deprecated" final="false" name="icon" jni-signature="I" static="false" transient="false" type="int" type-generic-aware="int" visibility="public" volatile="false" deprecated-since="23"></field>
+      <field deprecated="not deprecated" final="true" name="SEMANTIC_ACTION_ARCHIVE" jni-signature="I" static="true" transient="false" type="int" type-generic-aware="int" value="5" visibility="public" volatile="false"></field>
+    </class>
+    <class abstract="true" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="false" name="Blues" static="false" visibility="public">
+      <field deprecated="not deprecated" final="true" name="BLUE" jni-signature="I" static="true" transient="false" type="int" type-generic-aware="int" value="-16776961" visibility="public" volatile="false"></field>
+      <field deprecated="not deprecated" final="true" name="blue" jni-signature="I" static="false" transient="false" type="int" type-generic-aware="int" value="10" visibility="public" volatile="false"></field>
+      <method abstract="false" deprecated="not deprecated" final="false" name="getBlue" native="false" return="int" static="true" synchronized="false" visibility="public" />
 	  </class>
 	</package>
 </api>

--- a/tests/generator-Tests/expected/InterfaceMethodsConflict/Xamarin.Test.Action.cs
+++ b/tests/generator-Tests/expected/InterfaceMethodsConflict/Xamarin.Test.Action.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Xamarin.Test {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='Action']"
+	[global::Android.Runtime.Register ("xamarin/test/Action", DoNotGenerateAcw=true)]
+	public partial class Action : global::Java.Lang.Object {
+
+
+		static IntPtr icon_jfieldId;
+
+		// Metadata.xml XPath field reference: path="/api/package[@name='xamarin.test']/class[@name='Action']/field[@name='icon']"
+		[Register ("icon")]
+		public int Icon_ {
+			get {
+				if (icon_jfieldId == IntPtr.Zero)
+					icon_jfieldId = JNIEnv.GetFieldID (class_ref, "icon", "I");
+				return JNIEnv.GetIntField (((global::Java.Lang.Object) this).Handle, icon_jfieldId);
+			}
+			set {
+				if (icon_jfieldId == IntPtr.Zero)
+					icon_jfieldId = JNIEnv.GetFieldID (class_ref, "icon", "I");
+				try {
+					JNIEnv.SetField (((global::Java.Lang.Object) this).Handle, icon_jfieldId, value);
+				} finally {
+				}
+			}
+		}
+
+		// Metadata.xml XPath field reference: path="/api/package[@name='xamarin.test']/class[@name='Action']/field[@name='SEMANTIC_ACTION_ARCHIVE']"
+		[Register ("SEMANTIC_ACTION_ARCHIVE")]
+		public const int SemanticActionArchive = (int) 5;
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("xamarin/test/Action", ref java_class_handle);
+			}
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (Action); }
+		}
+
+		protected Action (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		static Delegate cb_getIcon;
+#pragma warning disable 0169
+		static Delegate GetGetIconHandler ()
+		{
+			if (cb_getIcon == null)
+				cb_getIcon = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, int>) n_GetIcon);
+			return cb_getIcon;
+		}
+
+		static int n_GetIcon (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Xamarin.Test.Action __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.Action> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return __this.Icon;
+		}
+#pragma warning restore 0169
+
+		static IntPtr id_getIcon;
+		public virtual unsafe int Icon {
+			// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='Action']/method[@name='getIcon' and count(parameter)=0]"
+			[Register ("getIcon", "()I", "GetGetIconHandler")]
+			get {
+				if (id_getIcon == IntPtr.Zero)
+					id_getIcon = JNIEnv.GetMethodID (class_ref, "getIcon", "()I");
+				try {
+
+					if (((object) this).GetType () == ThresholdType)
+						return JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getIcon);
+					else
+						return JNIEnv.CallNonvirtualIntMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "getIcon", "()I"));
+				} finally {
+				}
+			}
+		}
+
+	}
+}

--- a/tests/generator-Tests/expected/InterfaceMethodsConflict/Xamarin.Test.Blues.cs
+++ b/tests/generator-Tests/expected/InterfaceMethodsConflict/Xamarin.Test.Blues.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Xamarin.Test {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='Blues']"
+	[global::Android.Runtime.Register ("xamarin/test/Blues", DoNotGenerateAcw=true)]
+	public abstract partial class Blues : global::Java.Lang.Object {
+
+
+		// Metadata.xml XPath field reference: path="/api/package[@name='xamarin.test']/class[@name='Blues']/field[@name='BLUE']"
+		[Register ("BLUE")]
+		public const int Blue__ = (int) -16776961;
+
+		static IntPtr blue_jfieldId;
+
+		// Metadata.xml XPath field reference: path="/api/package[@name='xamarin.test']/class[@name='Blues']/field[@name='blue']"
+		[Register ("blue")]
+		public int Blue_ {
+			get {
+				if (blue_jfieldId == IntPtr.Zero)
+					blue_jfieldId = JNIEnv.GetFieldID (class_ref, "blue", "I");
+				return JNIEnv.GetIntField (((global::Java.Lang.Object) this).Handle, blue_jfieldId);
+			}
+			set {
+				if (blue_jfieldId == IntPtr.Zero)
+					blue_jfieldId = JNIEnv.GetFieldID (class_ref, "blue", "I");
+				try {
+					JNIEnv.SetField (((global::Java.Lang.Object) this).Handle, blue_jfieldId, value);
+				} finally {
+				}
+			}
+		}
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("xamarin/test/Blues", ref java_class_handle);
+			}
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (Blues); }
+		}
+
+		protected Blues (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		static IntPtr id_getBlue;
+		public static unsafe int Blue {
+			// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='Blues']/method[@name='getBlue' and count(parameter)=0]"
+			[Register ("getBlue", "()I", "")]
+			get {
+				if (id_getBlue == IntPtr.Zero)
+					id_getBlue = JNIEnv.GetStaticMethodID (class_ref, "getBlue", "()I");
+				try {
+					return JNIEnv.CallStaticIntMethod  (class_ref, id_getBlue);
+				} finally {
+				}
+			}
+		}
+
+	}
+
+	[global::Android.Runtime.Register ("xamarin/test/Blues", DoNotGenerateAcw=true)]
+	internal partial class BluesInvoker : Blues {
+
+		public BluesInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (BluesInvoker); }
+		}
+
+	}
+
+}

--- a/tests/generator-Tests/expected/InterfaceMethodsConflict/Xamarin.Test.Color.cs
+++ b/tests/generator-Tests/expected/InterfaceMethodsConflict/Xamarin.Test.Color.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Xamarin.Test {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='Color']"
+	[global::Android.Runtime.Register ("xamarin/test/Color", DoNotGenerateAcw=true)]
+	public partial class Color : global::Java.Lang.Object {
+
+
+		// Metadata.xml XPath field reference: path="/api/package[@name='xamarin.test']/class[@name='Color']/field[@name='BLACK']"
+		[Register ("BLACK")]
+		public const int Black = (int) -16777216;
+
+		// Metadata.xml XPath field reference: path="/api/package[@name='xamarin.test']/class[@name='Color']/field[@name='BLUE']"
+		[Register ("BLUE")]
+		public const int Blue__ = (int) -16776961;
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("xamarin/test/Color", ref java_class_handle);
+			}
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (Color); }
+		}
+
+		protected Color (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+		static IntPtr id_ctor;
+		// Metadata.xml XPath constructor reference: path="/api/package[@name='xamarin.test']/class[@name='Color']/constructor[@name='Color' and count(parameter)=0]"
+		[Register (".ctor", "()V", "")]
+		public unsafe Color ()
+			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		{
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+				return;
+
+			try {
+				if (((object) this).GetType () != typeof (Color)) {
+					SetHandle (
+							global::Android.Runtime.JNIEnv.StartCreateInstance (((object) this).GetType (), "()V"),
+							JniHandleOwnership.TransferLocalRef);
+					global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "()V");
+					return;
+				}
+
+				if (id_ctor == IntPtr.Zero)
+					id_ctor = JNIEnv.GetMethodID (class_ref, "<init>", "()V");
+				SetHandle (
+						global::Android.Runtime.JNIEnv.StartCreateInstance (class_ref, id_ctor),
+						JniHandleOwnership.TransferLocalRef);
+				JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, class_ref, id_ctor);
+			} finally {
+			}
+		}
+
+		static Delegate cb_blue;
+#pragma warning disable 0169
+		static Delegate GetBlueHandler ()
+		{
+			if (cb_blue == null)
+				cb_blue = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, float>) n_Blue);
+			return cb_blue;
+		}
+
+		static float n_Blue (IntPtr jnienv, IntPtr native__this)
+		{
+			global::Xamarin.Test.Color __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.Color> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return __this.Blue ();
+		}
+#pragma warning restore 0169
+
+		static IntPtr id_blue;
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='Color']/method[@name='blue' and count(parameter)=0]"
+		[Register ("blue", "()F", "GetBlueHandler")]
+		public virtual unsafe float Blue ()
+		{
+			if (id_blue == IntPtr.Zero)
+				id_blue = JNIEnv.GetMethodID (class_ref, "blue", "()F");
+			try {
+
+				if (((object) this).GetType () == ThresholdType)
+					return JNIEnv.CallFloatMethod (((global::Java.Lang.Object) this).Handle, id_blue);
+				else
+					return JNIEnv.CallNonvirtualFloatMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "blue", "()F"));
+			} finally {
+			}
+		}
+
+		static IntPtr id_blue_J;
+		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='Color']/method[@name='blue' and count(parameter)=1 and parameter[1][@type='long']]"
+		[Register ("blue", "(J)F", "")]
+		public static unsafe float Blue (long color)
+		{
+			if (id_blue_J == IntPtr.Zero)
+				id_blue_J = JNIEnv.GetStaticMethodID (class_ref, "blue", "(J)F");
+			try {
+				JValue* __args = stackalloc JValue [1];
+				__args [0] = new JValue (color);
+				return JNIEnv.CallStaticFloatMethod  (class_ref, id_blue_J, __args);
+			} finally {
+			}
+		}
+
+	}
+}


### PR DESCRIPTION
We currently remove fields that have name collision with methods that start with Get/Set or even methods that have the same name as the field.

i.e.:
public int blue;
public Color GetBlue()
public void Blue()

The above examples will cause the int field to not be generated, preventing developers to access the original field.
See: https://github.com/xamarin/xamarin-android/issues/3632

The fix, renames the original field to contain an extra "_" (underscore) on the name.

i.e.:
public int blue; => public int blue_; 

Tests were added to cover the scenario.