### PR TITLE
[Java.Interop] Alter $(BaseIntermediateOutputPath) for x-a

### DIFF
--- a/src/Java.Interop/Java.Interop-MonoAndroid.csproj
+++ b/src/Java.Interop/Java.Interop-MonoAndroid.csproj
@@ -14,7 +14,6 @@
     <NoWarn>1591</NoWarn>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
-    <BaseIntermediateOutputPath>obj-MonoAndroid\</BaseIntermediateOutputPath>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <Import Project="..\..\Configuration.props" />
@@ -49,11 +48,11 @@
     <NoStdLib Condition=" '$(XAInstallPrefix)' != '' ">true</NoStdLib>
     <OutputPath>..\..\bin\$(Configuration)Net45</OutputPath>
     <DocumentationFile>$(OutputPath)\Java.Interop.xml</DocumentationFile>
+    <BaseIntermediateOutputPath>..\..\bin\Build$(Configuration)\Java.Interop-MonoAndroid\</BaseIntermediateOutputPath>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="**\*.cs" />
     <Compile Remove="Tests\**\*.cs" />
-    <Compile Remove="obj*\**\*.cs" />
     <Compile Remove="Java.Interop\JniLocationException.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
Context: https://github.com/microsoft/msbuild/commit/67991edee76d433b744ceb593f554e2bbeb6b9a0
Context: https://github.com/xamarin/xamarin-android/pull/4219
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3497481&view=logs&s=1afc3bfe-122c-538b-e9ad-2a86c2efcfef&j=96fd57f5-f69e-53c7-3d47-f67e6cf9b93e

A "funny" thing happened in xamarin/xamarin-android#4219 in trying to
use the latest mono/2020-02 branch: the build failed:

	"…/xamarin-android/external/Java.Interop/src/Java.Interop/Java.Interop.csproj" (default target) (25:3) ->
	(CoreCompile target) ->
	  obj/Release/netstandard2.0/.NETStandard,Version=v2.0.AssemblyAttributes.cs(4,12):
	  error CS0579: Duplicate 'global::System.Runtime.Versioning.TargetFrameworkAttribute' attribute

`Java.Interop.csproj` failed to build, because of a CS0579!

It appears that [MSBuild altered behavior][0]: previously, it would
create an `*AssemblyAttributes.cs` file placed in some temporary
directory, but as of microsoft/msbuild@67991ede the
`*AssemblyAttributes.cs` file is instead placed into
`$(IntermediateOutputPath)`.

Which sounds fine, except that there are two overlapping builds:
`Java.Interop.csproj` and `Java.Interop-MonoAndroid.csproj` (85be94f3).
The latter overrides `$(BaseIntermediateOutputPath)` to
`obj-MonoAndroid\` so that it wouldn't "step on" the .NETStandard
`Java.Interop.csproj` build, and then we later updated
`Java.Interop.csproj` so that it would exclude `obj-*` (d37ec491).

So long as MSBuild didn't create new files in
`$(IntermediateOutputPath)`, things worked, but with the updated
MSBuild what happens is:

 1. `Java.Interop-MonoAndroid.csproj` is built, creating the file
    `obj-MonoAndroid/Release/MonoAndroid,Version=v1.0.AssemblyAttributes.cs`
    then later

 2. `Java.Interop.csproj` is built, creating the file
    `obj/Release/netstandard2.0/.NETStandard,Version=v2.0.AssemblyAttributes.c`
    then later

 3. The "Short-Form SDK project" semantics of "include `**\*.cs`"
    comes in, causing the `Java.Interop.csproj` build to *also*
    compile the `MonoAndroid,Version=v1.0.AssemblyAttributes.cs` in (1).

which results in the CS0579.

The fix?  Ensure that `Java.Interop.csproj` and
`Java.Interop-MonoAndroid.csproj` have *entirely non-overlapping*
`$(IntermediateOutputPath)` values, by having
`Java.Interop-MonoAndroid.csproj` set `$(BaseIntermediateOutputPath)`
to `..\..\bin\Build$(Configuration)\Java.Interop-MonoAndroid\`.  This
should ensure that `Java.Interop.csproj` *cannot possibly see* files
produced by the `Java.Interop-MonoAndroid.csproj` build, and thus
restoring sanity.

[0]: https://github.com/microsoft/msbuild/commit/67991edee76d433b744ceb593f554e2bbeb6b9a0