### PR TITLE
Remove obj/ from Compile in Java.Interop-MonoAndroid.csproj

### DIFF
--- a/src/Java.Interop/Java.Interop-MonoAndroid.csproj
+++ b/src/Java.Interop/Java.Interop-MonoAndroid.csproj
@@ -52,6 +52,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="**\*.cs" />
+    <Compile Remove="obj\**\*.cs" />
     <Compile Remove="Tests\**\*.cs" />
     <Compile Remove="Java.Interop\JniLocationException.cs" />
   </ItemGroup>


### PR DESCRIPTION
After https://github.com/xamarin/java.interop/commit/95712a2fc58a9c52ee0f53eea5bbd29d12f21385 we now hit the opposite condition.

The SDK-style build of Java.Interop.csproj generates "obj/Release/netstandard2.0/.NETStandard,Version=v2.0.AssemblyAttributes.cs" which is now included by the `<Compile Include="**\*.cs" />` in Java.Interop-MonoAndroid.csproj.

Changing the `BaseIntermediateOutputPath` is more complicated for SDK-style projects due to the way the common targets are imported: https://github.com/microsoft/msbuild/issues/1603. The easiest fix is adding back the removal of .cs files in obj/.