### PR TITLE
[generator] Support using DIM to nest interface types.

### DIFF
--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteNestedInterfaceTypes.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteNestedInterfaceTypes.txt
@@ -1,0 +1,179 @@
+// Metadata.xml XPath interface reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent']"
+[Register ("com/xamarin/android/Parent", "", "Com.Xamarin.Android.IParentInvoker")]
+public partial interface IParent : IJavaObject, IJavaPeerable {
+
+	int Bar {
+		// Metadata.xml XPath method reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent']/method[@name='getBar' and count(parameter)=0]"
+		[Register ("getBar", "()I", "GetGetBarHandler:Com.Xamarin.Android.IParentInvoker, MyAssembly")] get;
+	}
+
+	// Metadata.xml XPath interface reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent.Child']"
+	[Register ("com/xamarin/android/Parent$Child", "", "Com.Xamarin.Android.IParent/IChildInvoker")]
+	public partial interface IChild : IJavaObject, IJavaPeerable {
+
+		int Bar {
+			// Metadata.xml XPath method reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent.Child']/method[@name='getBar' and count(parameter)=0]"
+			[Register ("getBar", "()I", "GetGetBarHandler:Com.Xamarin.Android.IParent/IChildInvoker, MyAssembly")] get;
+		}
+
+	}
+
+	[global::Android.Runtime.Register ("com/xamarin/android/Parent$Child", DoNotGenerateAcw=true)]
+	internal partial class IChildInvoker : global::Java.Lang.Object, IChild {
+
+		static readonly JniPeerMembers _members = new JniPeerMembers ("com/xamarin/android/Parent$Child", typeof (IChildInvoker));
+
+		static IntPtr java_class_ref {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+		new IntPtr class_ref;
+
+		public static IChild GetObject (IntPtr handle, JniHandleOwnership transfer)
+		{
+			return global::Java.Lang.Object.GetObject<IChild> (handle, transfer);
+		}
+
+		static IntPtr Validate (IntPtr handle)
+		{
+			if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
+				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
+							JNIEnv.GetClassNameFromInstance (handle), "com.xamarin.android.Parent.Child"));
+			return handle;
+		}
+
+		protected override void Dispose (bool disposing)
+		{
+			if (this.class_ref != IntPtr.Zero)
+				JNIEnv.DeleteGlobalRef (this.class_ref);
+			this.class_ref = IntPtr.Zero;
+			base.Dispose (disposing);
+		}
+
+		public IChildInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
+		{
+			IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
+			this.class_ref = JNIEnv.NewGlobalRef (local_ref);
+			JNIEnv.DeleteLocalRef (local_ref);
+		}
+
+		static Delegate cb_getBar;
+#pragma warning disable 0169
+		static Delegate GetGetBarHandler ()
+		{
+			if (cb_getBar == null)
+				cb_getBar = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, int>) n_GetBar);
+			return cb_getBar;
+		}
+
+		static int n_GetBar (IntPtr jnienv, IntPtr native__this)
+		{
+			Com.Xamarin.Android.IParent.IChild __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent.IChild> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return __this.Bar;
+		}
+#pragma warning restore 0169
+
+		IntPtr id_getBar;
+		public unsafe int Bar {
+			get {
+				if (id_getBar == IntPtr.Zero)
+					id_getBar = JNIEnv.GetMethodID (class_ref, "getBar", "()I");
+				return JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getBar);
+			}
+		}
+
+	}
+
+
+}
+
+[global::Android.Runtime.Register ("com/xamarin/android/Parent", DoNotGenerateAcw=true)]
+internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
+
+	static readonly JniPeerMembers _members = new JniPeerMembers ("com/xamarin/android/Parent", typeof (IParentInvoker));
+
+	static IntPtr java_class_ref {
+		get { return _members.JniPeerType.PeerReference.Handle; }
+	}
+
+	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+		get { return _members; }
+	}
+
+	protected override IntPtr ThresholdClass {
+		get { return class_ref; }
+	}
+
+	protected override global::System.Type ThresholdType {
+		get { return _members.ManagedPeerType; }
+	}
+
+	new IntPtr class_ref;
+
+	public static IParent GetObject (IntPtr handle, JniHandleOwnership transfer)
+	{
+		return global::Java.Lang.Object.GetObject<IParent> (handle, transfer);
+	}
+
+	static IntPtr Validate (IntPtr handle)
+	{
+		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
+			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
+						JNIEnv.GetClassNameFromInstance (handle), "com.xamarin.android.Parent"));
+		return handle;
+	}
+
+	protected override void Dispose (bool disposing)
+	{
+		if (this.class_ref != IntPtr.Zero)
+			JNIEnv.DeleteGlobalRef (this.class_ref);
+		this.class_ref = IntPtr.Zero;
+		base.Dispose (disposing);
+	}
+
+	public IParentInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
+	{
+		IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
+		this.class_ref = JNIEnv.NewGlobalRef (local_ref);
+		JNIEnv.DeleteLocalRef (local_ref);
+	}
+
+	static Delegate cb_getBar;
+#pragma warning disable 0169
+	static Delegate GetGetBarHandler ()
+	{
+		if (cb_getBar == null)
+			cb_getBar = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, int>) n_GetBar);
+		return cb_getBar;
+	}
+
+	static int n_GetBar (IntPtr jnienv, IntPtr native__this)
+	{
+		Com.Xamarin.Android.IParent __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		return __this.Bar;
+	}
+#pragma warning restore 0169
+
+	IntPtr id_getBar;
+	public unsafe int Bar {
+		get {
+			if (id_getBar == IntPtr.Zero)
+				id_getBar = JNIEnv.GetMethodID (class_ref, "getBar", "()I");
+			return JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getBar);
+		}
+	}
+
+}
+

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteUnnestedInterfaceTypes.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteUnnestedInterfaceTypes.txt
@@ -1,0 +1,179 @@
+// Metadata.xml XPath interface reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent.Child']"
+[Register ("com/xamarin/android/Parent$Child", "", "Com.Xamarin.Android.IParentChildInvoker")]
+public partial interface IParentChild : IJavaObject, IJavaPeerable {
+
+	int Bar {
+		// Metadata.xml XPath method reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent.Child']/method[@name='getBar' and count(parameter)=0]"
+		[Register ("getBar", "()I", "GetGetBarHandler:Com.Xamarin.Android.IParentChildInvoker, MyAssembly")] get;
+	}
+
+}
+
+[global::Android.Runtime.Register ("com/xamarin/android/Parent$Child", DoNotGenerateAcw=true)]
+internal partial class IParentChildInvoker : global::Java.Lang.Object, IParentChild {
+
+	static readonly JniPeerMembers _members = new JniPeerMembers ("com/xamarin/android/Parent$Child", typeof (IParentChildInvoker));
+
+	static IntPtr java_class_ref {
+		get { return _members.JniPeerType.PeerReference.Handle; }
+	}
+
+	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+		get { return _members; }
+	}
+
+	protected override IntPtr ThresholdClass {
+		get { return class_ref; }
+	}
+
+	protected override global::System.Type ThresholdType {
+		get { return _members.ManagedPeerType; }
+	}
+
+	new IntPtr class_ref;
+
+	public static IParentChild GetObject (IntPtr handle, JniHandleOwnership transfer)
+	{
+		return global::Java.Lang.Object.GetObject<IParentChild> (handle, transfer);
+	}
+
+	static IntPtr Validate (IntPtr handle)
+	{
+		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
+			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
+						JNIEnv.GetClassNameFromInstance (handle), "com.xamarin.android.Parent.Child"));
+		return handle;
+	}
+
+	protected override void Dispose (bool disposing)
+	{
+		if (this.class_ref != IntPtr.Zero)
+			JNIEnv.DeleteGlobalRef (this.class_ref);
+		this.class_ref = IntPtr.Zero;
+		base.Dispose (disposing);
+	}
+
+	public IParentChildInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
+	{
+		IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
+		this.class_ref = JNIEnv.NewGlobalRef (local_ref);
+		JNIEnv.DeleteLocalRef (local_ref);
+	}
+
+	static Delegate cb_getBar;
+#pragma warning disable 0169
+	static Delegate GetGetBarHandler ()
+	{
+		if (cb_getBar == null)
+			cb_getBar = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, int>) n_GetBar);
+		return cb_getBar;
+	}
+
+	static int n_GetBar (IntPtr jnienv, IntPtr native__this)
+	{
+		Com.Xamarin.Android.IParentChild __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParentChild> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		return __this.Bar;
+	}
+#pragma warning restore 0169
+
+	IntPtr id_getBar;
+	public unsafe int Bar {
+		get {
+			if (id_getBar == IntPtr.Zero)
+				id_getBar = JNIEnv.GetMethodID (class_ref, "getBar", "()I");
+			return JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getBar);
+		}
+	}
+
+}
+
+
+// Metadata.xml XPath interface reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent']"
+[Register ("com/xamarin/android/Parent", "", "Com.Xamarin.Android.IParentInvoker")]
+public partial interface IParent : IJavaObject, IJavaPeerable {
+
+	int Bar {
+		// Metadata.xml XPath method reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent']/method[@name='getBar' and count(parameter)=0]"
+		[Register ("getBar", "()I", "GetGetBarHandler:Com.Xamarin.Android.IParentInvoker, MyAssembly")] get;
+	}
+
+}
+
+[global::Android.Runtime.Register ("com/xamarin/android/Parent", DoNotGenerateAcw=true)]
+internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
+
+	static readonly JniPeerMembers _members = new JniPeerMembers ("com/xamarin/android/Parent", typeof (IParentInvoker));
+
+	static IntPtr java_class_ref {
+		get { return _members.JniPeerType.PeerReference.Handle; }
+	}
+
+	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+		get { return _members; }
+	}
+
+	protected override IntPtr ThresholdClass {
+		get { return class_ref; }
+	}
+
+	protected override global::System.Type ThresholdType {
+		get { return _members.ManagedPeerType; }
+	}
+
+	new IntPtr class_ref;
+
+	public static IParent GetObject (IntPtr handle, JniHandleOwnership transfer)
+	{
+		return global::Java.Lang.Object.GetObject<IParent> (handle, transfer);
+	}
+
+	static IntPtr Validate (IntPtr handle)
+	{
+		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
+			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
+						JNIEnv.GetClassNameFromInstance (handle), "com.xamarin.android.Parent"));
+		return handle;
+	}
+
+	protected override void Dispose (bool disposing)
+	{
+		if (this.class_ref != IntPtr.Zero)
+			JNIEnv.DeleteGlobalRef (this.class_ref);
+		this.class_ref = IntPtr.Zero;
+		base.Dispose (disposing);
+	}
+
+	public IParentInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
+	{
+		IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
+		this.class_ref = JNIEnv.NewGlobalRef (local_ref);
+		JNIEnv.DeleteLocalRef (local_ref);
+	}
+
+	static Delegate cb_getBar;
+#pragma warning disable 0169
+	static Delegate GetGetBarHandler ()
+	{
+		if (cb_getBar == null)
+			cb_getBar = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, int>) n_GetBar);
+		return cb_getBar;
+	}
+
+	static int n_GetBar (IntPtr jnienv, IntPtr native__this)
+	{
+		Com.Xamarin.Android.IParent __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		return __this.Bar;
+	}
+#pragma warning restore 0169
+
+	IntPtr id_getBar;
+	public unsafe int Bar {
+		get {
+			if (id_getBar == IntPtr.Zero)
+				id_getBar = JNIEnv.GetMethodID (class_ref, "getBar", "()I");
+			return JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getBar);
+		}
+	}
+
+}
+

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceTypes.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceTypes.txt
@@ -1,0 +1,179 @@
+// Metadata.xml XPath interface reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent']"
+[Register ("com/xamarin/android/Parent", "", "Com.Xamarin.Android.IParentInvoker")]
+public partial interface IParent : IJavaObject, IJavaPeerable {
+
+	int Bar {
+		// Metadata.xml XPath method reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent']/method[@name='getBar' and count(parameter)=0]"
+		[Register ("getBar", "()I", "GetGetBarHandler:Com.Xamarin.Android.IParentInvoker, MyAssembly")] get;
+	}
+
+	// Metadata.xml XPath interface reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent.Child']"
+	[Register ("com/xamarin/android/Parent$Child", "", "Com.Xamarin.Android.IParent/IChildInvoker")]
+	public partial interface IChild : IJavaObject, IJavaPeerable {
+
+		int Bar {
+			// Metadata.xml XPath method reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent.Child']/method[@name='getBar' and count(parameter)=0]"
+			[Register ("getBar", "()I", "GetGetBarHandler:Com.Xamarin.Android.IParent/IChildInvoker, MyAssembly")] get;
+		}
+
+	}
+
+	[global::Android.Runtime.Register ("com/xamarin/android/Parent$Child", DoNotGenerateAcw=true)]
+	internal partial class IChildInvoker : global::Java.Lang.Object, IChild {
+
+		static readonly JniPeerMembers _members = new XAPeerMembers ("com/xamarin/android/Parent$Child", typeof (IChildInvoker));
+
+		static IntPtr java_class_ref {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+		new IntPtr class_ref;
+
+		public static IChild GetObject (IntPtr handle, JniHandleOwnership transfer)
+		{
+			return global::Java.Lang.Object.GetObject<IChild> (handle, transfer);
+		}
+
+		static IntPtr Validate (IntPtr handle)
+		{
+			if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
+				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
+							JNIEnv.GetClassNameFromInstance (handle), "com.xamarin.android.Parent.Child"));
+			return handle;
+		}
+
+		protected override void Dispose (bool disposing)
+		{
+			if (this.class_ref != IntPtr.Zero)
+				JNIEnv.DeleteGlobalRef (this.class_ref);
+			this.class_ref = IntPtr.Zero;
+			base.Dispose (disposing);
+		}
+
+		public IChildInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
+		{
+			IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
+			this.class_ref = JNIEnv.NewGlobalRef (local_ref);
+			JNIEnv.DeleteLocalRef (local_ref);
+		}
+
+		static Delegate cb_getBar;
+#pragma warning disable 0169
+		static Delegate GetGetBarHandler ()
+		{
+			if (cb_getBar == null)
+				cb_getBar = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, int>) n_GetBar);
+			return cb_getBar;
+		}
+
+		static int n_GetBar (IntPtr jnienv, IntPtr native__this)
+		{
+			Com.Xamarin.Android.IParent.IChild __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent.IChild> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return __this.Bar;
+		}
+#pragma warning restore 0169
+
+		IntPtr id_getBar;
+		public unsafe int Bar {
+			get {
+				if (id_getBar == IntPtr.Zero)
+					id_getBar = JNIEnv.GetMethodID (class_ref, "getBar", "()I");
+				return JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getBar);
+			}
+		}
+
+	}
+
+
+}
+
+[global::Android.Runtime.Register ("com/xamarin/android/Parent", DoNotGenerateAcw=true)]
+internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
+
+	static readonly JniPeerMembers _members = new XAPeerMembers ("com/xamarin/android/Parent", typeof (IParentInvoker));
+
+	static IntPtr java_class_ref {
+		get { return _members.JniPeerType.PeerReference.Handle; }
+	}
+
+	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+		get { return _members; }
+	}
+
+	protected override IntPtr ThresholdClass {
+		get { return class_ref; }
+	}
+
+	protected override global::System.Type ThresholdType {
+		get { return _members.ManagedPeerType; }
+	}
+
+	new IntPtr class_ref;
+
+	public static IParent GetObject (IntPtr handle, JniHandleOwnership transfer)
+	{
+		return global::Java.Lang.Object.GetObject<IParent> (handle, transfer);
+	}
+
+	static IntPtr Validate (IntPtr handle)
+	{
+		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
+			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
+						JNIEnv.GetClassNameFromInstance (handle), "com.xamarin.android.Parent"));
+		return handle;
+	}
+
+	protected override void Dispose (bool disposing)
+	{
+		if (this.class_ref != IntPtr.Zero)
+			JNIEnv.DeleteGlobalRef (this.class_ref);
+		this.class_ref = IntPtr.Zero;
+		base.Dispose (disposing);
+	}
+
+	public IParentInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
+	{
+		IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
+		this.class_ref = JNIEnv.NewGlobalRef (local_ref);
+		JNIEnv.DeleteLocalRef (local_ref);
+	}
+
+	static Delegate cb_getBar;
+#pragma warning disable 0169
+	static Delegate GetGetBarHandler ()
+	{
+		if (cb_getBar == null)
+			cb_getBar = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, int>) n_GetBar);
+		return cb_getBar;
+	}
+
+	static int n_GetBar (IntPtr jnienv, IntPtr native__this)
+	{
+		Com.Xamarin.Android.IParent __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		return __this.Bar;
+	}
+#pragma warning restore 0169
+
+	IntPtr id_getBar;
+	public unsafe int Bar {
+		get {
+			if (id_getBar == IntPtr.Zero)
+				id_getBar = JNIEnv.GetMethodID (class_ref, "getBar", "()I");
+			return JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getBar);
+		}
+	}
+
+}
+

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteUnnestedInterfaceTypes.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteUnnestedInterfaceTypes.txt
@@ -1,0 +1,179 @@
+// Metadata.xml XPath interface reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent.Child']"
+[Register ("com/xamarin/android/Parent$Child", "", "Com.Xamarin.Android.IParentChildInvoker")]
+public partial interface IParentChild : IJavaObject, IJavaPeerable {
+
+	int Bar {
+		// Metadata.xml XPath method reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent.Child']/method[@name='getBar' and count(parameter)=0]"
+		[Register ("getBar", "()I", "GetGetBarHandler:Com.Xamarin.Android.IParentChildInvoker, MyAssembly")] get;
+	}
+
+}
+
+[global::Android.Runtime.Register ("com/xamarin/android/Parent$Child", DoNotGenerateAcw=true)]
+internal partial class IParentChildInvoker : global::Java.Lang.Object, IParentChild {
+
+	static readonly JniPeerMembers _members = new XAPeerMembers ("com/xamarin/android/Parent$Child", typeof (IParentChildInvoker));
+
+	static IntPtr java_class_ref {
+		get { return _members.JniPeerType.PeerReference.Handle; }
+	}
+
+	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+		get { return _members; }
+	}
+
+	protected override IntPtr ThresholdClass {
+		get { return class_ref; }
+	}
+
+	protected override global::System.Type ThresholdType {
+		get { return _members.ManagedPeerType; }
+	}
+
+	new IntPtr class_ref;
+
+	public static IParentChild GetObject (IntPtr handle, JniHandleOwnership transfer)
+	{
+		return global::Java.Lang.Object.GetObject<IParentChild> (handle, transfer);
+	}
+
+	static IntPtr Validate (IntPtr handle)
+	{
+		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
+			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
+						JNIEnv.GetClassNameFromInstance (handle), "com.xamarin.android.Parent.Child"));
+		return handle;
+	}
+
+	protected override void Dispose (bool disposing)
+	{
+		if (this.class_ref != IntPtr.Zero)
+			JNIEnv.DeleteGlobalRef (this.class_ref);
+		this.class_ref = IntPtr.Zero;
+		base.Dispose (disposing);
+	}
+
+	public IParentChildInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
+	{
+		IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
+		this.class_ref = JNIEnv.NewGlobalRef (local_ref);
+		JNIEnv.DeleteLocalRef (local_ref);
+	}
+
+	static Delegate cb_getBar;
+#pragma warning disable 0169
+	static Delegate GetGetBarHandler ()
+	{
+		if (cb_getBar == null)
+			cb_getBar = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, int>) n_GetBar);
+		return cb_getBar;
+	}
+
+	static int n_GetBar (IntPtr jnienv, IntPtr native__this)
+	{
+		Com.Xamarin.Android.IParentChild __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParentChild> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		return __this.Bar;
+	}
+#pragma warning restore 0169
+
+	IntPtr id_getBar;
+	public unsafe int Bar {
+		get {
+			if (id_getBar == IntPtr.Zero)
+				id_getBar = JNIEnv.GetMethodID (class_ref, "getBar", "()I");
+			return JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getBar);
+		}
+	}
+
+}
+
+
+// Metadata.xml XPath interface reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent']"
+[Register ("com/xamarin/android/Parent", "", "Com.Xamarin.Android.IParentInvoker")]
+public partial interface IParent : IJavaObject, IJavaPeerable {
+
+	int Bar {
+		// Metadata.xml XPath method reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent']/method[@name='getBar' and count(parameter)=0]"
+		[Register ("getBar", "()I", "GetGetBarHandler:Com.Xamarin.Android.IParentInvoker, MyAssembly")] get;
+	}
+
+}
+
+[global::Android.Runtime.Register ("com/xamarin/android/Parent", DoNotGenerateAcw=true)]
+internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
+
+	static readonly JniPeerMembers _members = new XAPeerMembers ("com/xamarin/android/Parent", typeof (IParentInvoker));
+
+	static IntPtr java_class_ref {
+		get { return _members.JniPeerType.PeerReference.Handle; }
+	}
+
+	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+		get { return _members; }
+	}
+
+	protected override IntPtr ThresholdClass {
+		get { return class_ref; }
+	}
+
+	protected override global::System.Type ThresholdType {
+		get { return _members.ManagedPeerType; }
+	}
+
+	new IntPtr class_ref;
+
+	public static IParent GetObject (IntPtr handle, JniHandleOwnership transfer)
+	{
+		return global::Java.Lang.Object.GetObject<IParent> (handle, transfer);
+	}
+
+	static IntPtr Validate (IntPtr handle)
+	{
+		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
+			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
+						JNIEnv.GetClassNameFromInstance (handle), "com.xamarin.android.Parent"));
+		return handle;
+	}
+
+	protected override void Dispose (bool disposing)
+	{
+		if (this.class_ref != IntPtr.Zero)
+			JNIEnv.DeleteGlobalRef (this.class_ref);
+		this.class_ref = IntPtr.Zero;
+		base.Dispose (disposing);
+	}
+
+	public IParentInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
+	{
+		IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
+		this.class_ref = JNIEnv.NewGlobalRef (local_ref);
+		JNIEnv.DeleteLocalRef (local_ref);
+	}
+
+	static Delegate cb_getBar;
+#pragma warning disable 0169
+	static Delegate GetGetBarHandler ()
+	{
+		if (cb_getBar == null)
+			cb_getBar = JNINativeWrapper.CreateDelegate ((Func<IntPtr, IntPtr, int>) n_GetBar);
+		return cb_getBar;
+	}
+
+	static int n_GetBar (IntPtr jnienv, IntPtr native__this)
+	{
+		Com.Xamarin.Android.IParent __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		return __this.Bar;
+	}
+#pragma warning restore 0169
+
+	IntPtr id_getBar;
+	public unsafe int Bar {
+		get {
+			if (id_getBar == IntPtr.Zero)
+				id_getBar = JNIEnv.GetMethodID (class_ref, "getBar", "()I");
+			return JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getBar);
+		}
+	}
+
+}
+

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
@@ -511,7 +511,7 @@ namespace generatortests
 			var iface = SupportTypeBuilder.CreateInterface ("java.code.IMyInterface", options);
 
 			generator.Context.ContextTypes.Push (iface);
-			generator.WriteInterfaceDeclaration (iface, string.Empty);
+			generator.WriteInterfaceDeclaration (iface, string.Empty, new GenerationInfo (null, null, null));
 			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteInterfaceDeclaration)), writer.ToString ().NormalizeLineEndings ());

--- a/tests/generator-Tests/Unit-Tests/InterfaceConstantsTests.cs
+++ b/tests/generator-Tests/Unit-Tests/InterfaceConstantsTests.cs
@@ -39,7 +39,7 @@ namespace generatortests
 			iface.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ());
 
 			generator.Context.ContextTypes.Push (iface);
-			generator.WriteInterfaceDeclaration (iface, string.Empty);
+			generator.WriteInterfaceDeclaration (iface, string.Empty, new GenerationInfo (null, null, null));
 			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteInterfaceFields)), writer.ToString ().NormalizeLineEndings ());
@@ -64,7 +64,7 @@ namespace generatortests
 			iface.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ());
 
 			generator.Context.ContextTypes.Push (iface);
-			generator.WriteInterfaceDeclaration (iface, string.Empty);
+			generator.WriteInterfaceDeclaration (iface, string.Empty, new GenerationInfo (null, null, null));
 			generator.Context.ContextTypes.Pop ();
 
 			Assert.AreEqual (GetTargetedExpected (nameof (WriteConstSugarInterfaceFields)), writer.ToString ().NormalizeLineEndings ());

--- a/tests/generator-Tests/Unit-Tests/KotlinFixupsTests.cs
+++ b/tests/generator-Tests/Unit-Tests/KotlinFixupsTests.cs
@@ -14,7 +14,7 @@ namespace generatortests
 		public void CreateMethod_EnsureKotlinImplFix ()
 		{
 			var xml = XDocument.Parse ("<package name=\"com.example.test\" jni-name=\"com/example/test\"><class name=\"test\"><method name=\"add-impl\" final=\"false\" /></class></package>");
-			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"));
+			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), new CodeGenerationOptions ());
 
 			KotlinFixups.Fixup (new [] { (GenBase)klass }.ToList ());
 
@@ -27,7 +27,7 @@ namespace generatortests
 		public void CreateMethod_EnsureKotlinHashcodeFix ()
 		{
 			var xml = XDocument.Parse ("<package name=\"com.example.test\" jni-name=\"com/example/test\"><class name=\"test\"><method name=\"add-h-_1V8i\" final=\"false\" /></class></package>");
-			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"));
+			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), new CodeGenerationOptions ());
 
 			KotlinFixups.Fixup (new [] { (GenBase) klass }.ToList ());
 

--- a/tests/generator-Tests/Unit-Tests/XmlApiImporterTests.cs
+++ b/tests/generator-Tests/Unit-Tests/XmlApiImporterTests.cs
@@ -8,11 +8,13 @@ namespace generatortests
 	[TestFixture]
 	public class XmlApiImporterTests
 	{
+		CodeGenerationOptions opt = new CodeGenerationOptions ();
+
 		[Test]
 		public void CreateClass_EnsureValidName ()
 		{
 			var xml = XDocument.Parse ("<package name=\"com.example.test\" jni-name=\"com/example/test\"><class name=\"$3\" /></package>");
-			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"));
+			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), opt);
 
 			Assert.AreEqual ("_3", klass.Name);
 		}
@@ -21,7 +23,7 @@ namespace generatortests
 		public void CreateCtor_EnsureValidName ()
 		{
 			var xml = XDocument.Parse ("<package name=\"com.example.test\" jni-name=\"com/example/test\"><class name=\"test\"><constructor name=\"$3\" /></class></package>");
-			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"));
+			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), opt);
 
 			Assert.AreEqual ("_3", klass.Ctors[0].Name);
 		}
@@ -66,7 +68,7 @@ namespace generatortests
 		public void CreateInterface_EnsureValidName ()
 		{
 			var xml = XDocument.Parse ("<package name=\"com.example.test\" jni-name=\"com/example/test\"><interface name=\"$3\" /></package>");
-			var iface = XmlApiImporter.CreateInterface (xml.Root, xml.Root.Element ("interface"));
+			var iface = XmlApiImporter.CreateInterface (xml.Root, xml.Root.Element ("interface"), opt);
 
 			Assert.AreEqual ("I_3", iface.Name);
 		}
@@ -75,7 +77,7 @@ namespace generatortests
 		public void CreateMethod_EnsureValidName ()
 		{
 			var xml = XDocument.Parse ("<package name=\"com.example.test\" jni-name=\"com/example/test\"><class name=\"test\"><method name=\"$3\" /></class></package>");
-			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"));
+			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), opt);
 
 			Assert.AreEqual ("_3", klass.Methods [0].Name);
 		}
@@ -84,7 +86,7 @@ namespace generatortests
 		public void CreateMethod_EnsureValidNameHyphen ()
 		{
 			var xml = XDocument.Parse ("<package name=\"com.example.test\" jni-name=\"com/example/test\"><class name=\"test\"><method name=\"-3\" /></class></package>");
-			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"));
+			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), opt);
 
 			Assert.AreEqual ("_3", klass.Methods [0].Name);
 		}

--- a/tests/generator-Tests/Unit-Tests/XmlTests.cs
+++ b/tests/generator-Tests/Unit-Tests/XmlTests.cs
@@ -52,7 +52,7 @@ namespace generatortests
 			options = new CodeGenerationOptions ();
 			var javaLang = xml.Element ("api").Element ("package");
 			foreach (var type in javaLang.Elements("class")) {
-				var @class = XmlApiImporter.CreateClass (javaLang, type);
+				var @class = XmlApiImporter.CreateClass (javaLang, type, options);
 				Assert.IsTrue (@class.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "@class.Validate failed!");
 				options.SymbolTable.AddType (@class);
 			}
@@ -64,7 +64,7 @@ namespace generatortests
 		public void Class ()
 		{
 			var element = package.Element ("class");
-			var @class = XmlApiImporter.CreateClass (package, element);
+			var @class = XmlApiImporter.CreateClass (package, element, options);
 			Assert.IsTrue (@class.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "@class.Validate failed!");
 
 			Assert.AreEqual ("public", @class.Visibility);
@@ -81,7 +81,7 @@ namespace generatortests
 		public void Method ()
 		{
 			var element = package.Element ("class");
-			var @class = XmlApiImporter.CreateClass (package, element);
+			var @class = XmlApiImporter.CreateClass (package, element, options);
 			var method = XmlApiImporter.CreateMethod (@class, element.Element ("method"));
 			Assert.IsTrue (method.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "method.Validate failed!");
 
@@ -101,7 +101,7 @@ namespace generatortests
 		public void Method_Matches_True ()
 		{
 			var element = package.Element ("class");
-			var @class = XmlApiImporter.CreateClass (package, element);
+			var @class = XmlApiImporter.CreateClass (package, element, options);
 			var unknownTypes = element.Elements ("method").Where (e => e.Attribute ("name").Value == "unknownTypes").First ();
 			var methodA = XmlApiImporter.CreateMethod (@class, unknownTypes);
 			var methodB = XmlApiImporter.CreateMethod (@class, unknownTypes);
@@ -112,7 +112,7 @@ namespace generatortests
 		public void Method_Matches_False ()
 		{
 			var element = package.Element ("class");
-			var @class = XmlApiImporter.CreateClass (package, element);
+			var @class = XmlApiImporter.CreateClass (package, element, options);
 			var unknownTypesA = element.Elements ("method").Where (e => e.Attribute ("name").Value == "unknownTypes").First ();
 			var unknownTypesB = element.Elements ("method").Where (e => e.Attribute ("name").Value == "unknownTypesReturn").First ();
 			unknownTypesB.Attribute ("name").Value = "unknownTypes";
@@ -126,7 +126,7 @@ namespace generatortests
 		public void MethodWithParameters ()
 		{
 			var element = package.Element ("class");
-			var @class = XmlApiImporter.CreateClass (package, element);
+			var @class = XmlApiImporter.CreateClass (package, element, options);
 			var method = XmlApiImporter.CreateMethod (@class, element.Elements ("method").Where (e => e.Attribute ("name").Value == "barWithParams").First ());
 			Assert.IsTrue (method.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "method.Validate failed!");
 			Assert.AreEqual ("(ZID)Ljava/lang/String;", method.JniSignature);
@@ -156,7 +156,7 @@ namespace generatortests
 		public void Ctor ()
 		{
 			var element = package.Element ("class");
-			var @class = XmlApiImporter.CreateClass (package, element);
+			var @class = XmlApiImporter.CreateClass (package, element, options);
 			var ctor = XmlApiImporter.CreateCtor (@class, element.Element ("constructor"));
 			Assert.IsTrue (ctor.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "ctor.Validate failed!");
 
@@ -170,7 +170,7 @@ namespace generatortests
 		public void Field ()
 		{
 			var element = package.Element ("class");
-			var @class = XmlApiImporter.CreateClass (package, element);
+			var @class = XmlApiImporter.CreateClass (package, element, options);
 			var field = XmlApiImporter.CreateField (element.Element ("field"));
 			Assert.IsTrue (field.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "field.Validate failed!");
 
@@ -186,7 +186,7 @@ namespace generatortests
 		public void Interface ()
 		{
 			var element = package.Element ("interface");
-			var @interface = XmlApiImporter.CreateInterface (package, element);
+			var @interface = XmlApiImporter.CreateInterface (package, element, options);
 			Assert.IsTrue (@interface.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "interface.Validate failed!");
 
 			Assert.AreEqual ("public", @interface.Visibility);

--- a/tools/generator/CodeGenerationOptions.cs
+++ b/tools/generator/CodeGenerationOptions.cs
@@ -49,6 +49,7 @@ namespace MonoDroid.Generation
 		public int ProductVersion { get; set; }
 		public bool SupportInterfaceConstants { get; set; }
 		public bool SupportDefaultInterfaceMethods { get; set; }
+		public bool SupportNestedInterfaceTypes { get; set; }
 		public bool UseShallowReferencedTypes { get; set; }
 
 		bool? buildingCoreAssembly;

--- a/tools/generator/CodeGenerator.cs
+++ b/tools/generator/CodeGenerator.cs
@@ -68,6 +68,7 @@ namespace Xamarin.Android.Binder
 				ProductVersion        = options.ProductVersion,
 				SupportInterfaceConstants = options.SupportInterfaceConstants,
 				SupportDefaultInterfaceMethods = options.SupportDefaultInterfaceMethods,
+				SupportNestedInterfaceTypes = options.SupportNestedInterfaceTypes,
 			};
 			var resolverCache       = new TypeDefinitionCache ();
 

--- a/tools/generator/CodeGeneratorOptions.cs
+++ b/tools/generator/CodeGeneratorOptions.cs
@@ -41,6 +41,7 @@ namespace Xamarin.Android.Binder
 		public string               ApiXmlAdjusterOutput { get; set; }
 		public bool                 SupportInterfaceConstants { get; set; }
 		public bool		    SupportDefaultInterfaceMethods { get; set; }
+		public bool		    SupportNestedInterfaceTypes { get; set; }
 
 		public static CodeGeneratorOptions Parse (string[] args)
 		{
@@ -92,6 +93,7 @@ namespace Xamarin.Android.Binder
 					v => {
 						opts.SupportInterfaceConstants = v?.Contains ("interface-constants") == true;
 						opts.SupportDefaultInterfaceMethods = v?.Contains ("default-interface-methods") == true;
+						opts.SupportNestedInterfaceTypes = v?.Contains ("nested-interface-types") == true;
 						}},
 				{ "preserve-enums",
 					"For internal use.",

--- a/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/CodeGenerator.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/CodeGenerator.cs
@@ -453,8 +453,8 @@ namespace MonoDroid.Generation
 		{
 			Context.ContextTypes.Push (@interface);
 
-			// interfaces don't nest, so generate as siblings
-			foreach (GenBase nest in @interface.NestedTypes) {
+			// Generate sibling types for nested types we don't want to nest
+			foreach (var nest in @interface.NestedTypes.Where (t => t.Unnest)) {
 				WriteType (nest, indent, gen_info);
 				writer.WriteLine ();
 			}
@@ -466,7 +466,7 @@ namespace MonoDroid.Generation
 			if (@interface.IsConstSugar && @interface.GetGeneratableFields (opt).Count () == 0)
 				return;
 
-			WriteInterfaceDeclaration (@interface, indent);
+			WriteInterfaceDeclaration (@interface, indent, gen_info);
 
 			// If this interface is just constant fields we don't need to write all the invoker bits
 			if (@interface.IsConstSugar)
@@ -507,7 +507,7 @@ namespace MonoDroid.Generation
 			}
 		}
 
-		public void WriteInterfaceDeclaration (InterfaceGen @interface, string indent)
+		public void WriteInterfaceDeclaration (InterfaceGen @interface, string indent, GenerationInfo gen_info)
 		{
 			StringBuilder sb = new StringBuilder ();
 			foreach (ISymbol isym in @interface.Interfaces) {
@@ -544,6 +544,13 @@ namespace MonoDroid.Generation
 			writer.WriteLine ();
 			WriteInterfaceProperties (@interface, indent + "\t");
 			WriteInterfaceMethods (@interface, indent + "\t");
+
+			// Generate nested types for supported nested types
+			foreach (var nest in @interface.NestedTypes.Where (t => !t.Unnest)) {
+				WriteType (nest, indent + "\t", gen_info);
+				writer.WriteLine ();
+			}
+
 			writer.WriteLine (indent + "}");
 			writer.WriteLine ();
 		}

--- a/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
@@ -12,13 +12,17 @@ namespace MonoDroid.Generation
 	{
 		static readonly Regex api_level = new Regex (@"api-(\d+).xml");
 
-		public static ClassGen CreateClass (XElement pkg, XElement elem)
+		public static ClassGen CreateClass (XElement pkg, XElement elem, CodeGenerationOptions options)
 		{
 			var klass = new ClassGen (CreateGenBaseSupport (pkg, elem, false)) {
 				BaseType = elem.XGetAttribute ("extends"),
 				FromXml = true,
 				IsAbstract = elem.XGetAttribute ("abstract") == "true",
-				IsFinal = elem.XGetAttribute ("final") == "true"
+				IsFinal = elem.XGetAttribute ("final") == "true",
+				// Only use an explicitly set XML attribute
+				Unnest = elem.XGetAttribute ("unnest") == "true" ? true :
+					 elem.XGetAttribute ("unnest") == "false" ? false :
+					 !options.SupportNestedInterfaceTypes
 			};
 
 			foreach (var child in elem.Elements ()) {
@@ -188,11 +192,15 @@ namespace MonoDroid.Generation
 			return support;
 		}
 
-		public static InterfaceGen CreateInterface (XElement pkg, XElement elem)
+		public static InterfaceGen CreateInterface (XElement pkg, XElement elem, CodeGenerationOptions options)
 		{
 			var iface = new InterfaceGen (CreateGenBaseSupport (pkg, elem, true)) {
 				ArgsType = elem.XGetAttribute ("argsType"),
-				HasManagedName = elem.Attribute ("managedName") != null
+				HasManagedName = elem.Attribute ("managedName") != null,
+				// Only use an explicitly set XML attribute
+				Unnest = elem.XGetAttribute ("unnest") == "true" ? true :
+					 elem.XGetAttribute ("unnest") == "false" ? false :
+					 !options.SupportNestedInterfaceTypes
 			};
 
 			foreach (var child in elem.Elements ()) {

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
@@ -817,6 +817,12 @@ namespace MonoDroid.Generation
 
 		public GenericParameterDefinitionList TypeParameters => support.TypeParameters;
 
+		// Prior to DIM, interfaces could not contain nested types so we generated them
+		// as sibling types.  When DIM is enabled we can now generate them properly nested.
+		// However this is an API break for existing bindings.  Setting this property
+		// to true opts this interface into the sibling compatibility behavior.
+		public bool Unnest { get; set; }
+
 		public virtual void UpdateEnums (CodeGenerationOptions opt, AncestorDescendantCache cache)
 		{
 			if (enum_updated || !IsGeneratable)

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/InterfaceGen.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/InterfaceGen.cs
@@ -21,6 +21,15 @@ namespace MonoDroid.Generation
 
 			if (nest_name.IndexOf (".") < 0) {
 				if (gen is InterfaceGen) {
+
+					// We don't need to mangle the name if we support nested interface types
+					// ex: my.namespace.IParent.IChild
+					if (!gen.Unnest) {
+						gen.FullName = FullName + "." + gen.Name;
+						return;
+					}
+
+					// ex: my.namespace.IParentChild
 					gen.FullName = FullName + gen.Name.Substring (1);
 					gen.Name = Name + gen.Name.Substring (1);
 				} else {

--- a/tools/generator/Java.Interop.Tools.Generator.Transformation/Parser.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Transformation/Parser.cs
@@ -105,12 +105,12 @@ namespace MonoDroid.Generation
 				case "class":
 					if (elem.XGetAttribute ("obfuscated") == "true")
 						continue;
-					gen = XmlApiImporter.CreateClass (ns, elem);
+					gen = XmlApiImporter.CreateClass (ns, elem, opt);
 					break;
 				case "interface":
 					if (elem.XGetAttribute ("obfuscated") == "true")
 						continue;
-					gen = XmlApiImporter.CreateInterface (ns, elem);
+					gen = XmlApiImporter.CreateInterface (ns, elem, opt);
 					break;
 				default:
 					Report.Warning (0, Report.WarningParser + 3, "Unexpected node in package element: {0}.", elem.Name);


### PR DESCRIPTION
Traditionally we have not been able to support types nested inside an interface, as C# did not allow it.  Cases like this:
```
My.Namespace.IParent.IChild
```
had to be bound as:
```
My.Namespace.IParentChild
```

With the addition of DIM in C#8, interfaces can now created with nested types.  However this is a breaking changes if you've already been generating the old style types.  

Therefore we add a new flag `--lang-features=nested-interface-types` that defaults to `false` to preserve compatibility.  Opting in to this flag will nest all interface types.

### Mixing Nested and Unnested
Additionally, users may have bindings that need to mix nested and unnested interface types.  For example, `Mono.Android.dll` contains a decade of APIs that cannot be broken, however **new** APIs can be nested correctly, producing a binding that more closely mirrors its Java counterpart.

To support this there is a new attribute available for `interface` and `class` nodes in `api.xml` called `unnest`.  This attribute is not set by tooling such as `class-parse`, but can be modified via `metadata` to force an interface-nested type to override the default setting.  If the attribute is omitted, the default is used.

Example:
```
<!-- Do not nest type (legacy style) -->
<attr path="/api/package[@name='my.namespace']/interface[@name='parent']/interface[@name='child']" name="unnest">true</attr>

<!-- Nest type (new style) -->
<attr path="/api/package[@name='my.namespace']/interface[@name='parent']/interface[@name='child']" name="unnest">false</attr>
```