### PR TITLE
[generator] Allow multiple `generator --apiversions`

### DIFF
--- a/tools/generator/CodeGenerator.cs
+++ b/tools/generator/CodeGenerator.cs
@@ -53,7 +53,6 @@ namespace Xamarin.Android.Binder
 			string enum_flags       = options.EnumFlagsFile;
 			string enum_methods_map = options.EnumMethodsMapFile;
 			var fixups              = options.FixupFiles;
-			string api_versions_xml = options.ApiVersionsXmlFile;
 			var annotations_zips    = options.AnnotationsZipFiles;
 			string filename         = options.ApiDescriptionFile;
 			string mapping_file     = options.MappingReportFile;
@@ -157,8 +156,9 @@ namespace Xamarin.Android.Binder
 
 			Validate (gens, opt, new CodeGeneratorContext ());
 
-			if (api_versions_xml != null)
+			foreach (var api_versions_xml in options.ApiVersionsXmlFiles) {
 				ApiVersionsSupport.AssignApiLevels (gens, api_versions_xml);
+			}
 
 			foreach (GenBase gen in gens)
 				gen.FillProperties ();

--- a/tools/generator/CodeGeneratorOptions.cs
+++ b/tools/generator/CodeGeneratorOptions.cs
@@ -10,6 +10,7 @@ namespace Xamarin.Android.Binder
 	{
 		public CodeGeneratorOptions ()
 		{
+			ApiVersionsXmlFiles = new Collection<string> ();
 			AssemblyReferences  = new Collection<string> ();
 			FixupFiles          = new Collection<string> ();
 			LibraryPaths        = new Collection<string> ();
@@ -26,7 +27,9 @@ namespace Xamarin.Android.Binder
 		public bool                 GlobalTypeNames {get; set;}
 		public bool                 OnlyBindPublicTypes {get; set;}
 		public string               ApiDescriptionFile {get; set;}
+		[Obsolete ("Use ApiVersionsXmlFiles")]
 		public string               ApiVersionsXmlFile {get; set;}
+		public Collection<string>   ApiVersionsXmlFiles {get; set;}
 		public Collection<string>   AnnotationsZipFiles {get; set;}
 		public string               EnumFieldsMapFile {get; set;}
 		public string               EnumFlagsFile {get; set;}
@@ -138,7 +141,7 @@ namespace Xamarin.Android.Binder
 					v => opts.EnumMethodsMapFile = v },
 				{ "apiversions=",
 					"For internal use.",
-					v => opts.ApiVersionsXmlFile = v },
+					v => opts.ApiVersionsXmlFiles.Add (v) },
 				{ "annotations=",
 					"For internal use.",
 					v => opts.AnnotationsZipFiles.Add (v) },


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/4356#issuecomment-594990011

A "funny" thing was found with API-R: the Android SDK
`platforms/android-R/data/api-versions.xml` file is *missing* members
present in previous API versions, e.g.
`java.lang.StringBuilder.trimToSize()` is not mentioned in API-R,
while it *is* mentioned in API-29 and the "global"
`platform-tools/api/api-versions.xml`.

Try to improve sanity for this conundrum by allowing
`generator --apiversions` to be specified multiple times, e.g. this
diff to apply to xamarin-android:

	diff --git a/src/Mono.Android/Mono.Android.targets b/src/Mono.Android/Mono.Android.targets
	index 8735c2ae..baae759b 100644
	--- a/src/Mono.Android/Mono.Android.targets
	+++ b/src/Mono.Android/Mono.Android.targets
	@@ -78,10 +78,13 @@
	       Inputs="metadata;enumflags;map.csv;methodmap.csv;$(IntermediateOutputPath)mcw\api.xml"
	       Outputs="$(IntermediateOutputPath)mcw\Mono.Android.projitems">
	     <MakeDir Directories="$(IntermediateOutputPath)mcw" />
	-    <PropertyGroup>
	-      <_ApiVersions Condition="Exists('$(AndroidSdkDirectory)\platforms\android-$(AndroidPlatformId)\data\api-versions.xml')">"$(AndroidSdkDirectory)\platforms\android-$(AndroidPlatformId)\data\api-versions.xml"</_ApiVersions>
	-      <_ApiVersions Condition="'$(_ApiVersions)'==''">"$(AndroidSdkDirectory)\platform-tools\api\api-versions.xml"</_ApiVersions>
	-    </PropertyGroup>
	+    <ItemGroup>
	+      <_ApiVersion Include="$(AndroidSdkDirectory)\platform-tools\api\api-versions.xml" />
	+      <_ApiVersion
	+          Condition="Exists('$(AndroidSdkDirectory)\platforms\android-$(AndroidPlatformId)\data\api-versions.xml')"
	+          Include="$(AndroidSdkDirectory)\platforms\android-$(AndroidPlatformId)\data\api-versions.xml"
	+      />
	+    </ItemGroup>
	     <PropertyGroup>
	       <Generator>"$(XAInstallPrefix)xbuild\Xamarin\Android\generator.exe"</Generator>
	       <_GenFlags>--public --product-version=7</_GenFlags>
	@@ -91,7 +94,7 @@
	       <_Fixup>--fixup=metadata</_Fixup>
	       <_Enums1>--preserve-enums --enumflags=enumflags --enumfields=map.csv --enummethods=methodmap.csv</_Enums1>
	       <_Enums2>--enummetadata=$(IntermediateOutputPath)mcw\enummetadata</_Enums2>
	-      <_Versions>--apiversions=$(_ApiVersions)</_Versions>
	+      <_Versions>@(_ApiVersion->'--apiversions="%(Identity)"', ' ')</_Versions>
	       <_Annotations>--annotations="$(AndroidSdkDirectory)\platform-tools\api\annotations.zip"</_Annotations>
	       <_Assembly>--assembly="Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"</_Assembly>
	       <_TypeMap>--type-map-report=$(IntermediateOutputPath)mcw\type-mapping.txt</_TypeMap>

The `generator --apiversions` files are applied in order, with *later*
versions overriding/replacing earlier versions.  This is why
`platform-tools/api/api-versions.xml` is present *first*.