### PR TITLE
[Java.Interop.Tools.JavaCallableWrappers] Renumber XA4213 to XA4217

### DIFF
--- a/src/Java.Interop.Tools.Diagnostics/Java.Interop.Tools.Diagnostics/Diagnostic.cs
+++ b/src/Java.Interop.Tools.Diagnostics/Java.Interop.Tools.Diagnostics/Diagnostic.cs
@@ -103,7 +103,7 @@ namespace Java.Interop.Tools.Diagnostics {
 	//					XA4210 "You need to add a reference to Mono.Android.Export.dll when you use ExportAttribute or ExportFieldAttribute."
 	//					XA4211  AndroidManifest.xml //uses-sdk/@android:targetSdkVersion '{0}' is less than $(TargetFrameworkVersion) '{1}'. Using API-{1} for ACW compilation.
 	//					XA4212  Type `{0}` implements `Android.Runtime.IJavaObject` but does not inherit `Java.Lang.Object` or `Java.Lang.Throwable`. This is not supported.
-	//					XA4213  Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin."
+	//					XA4217  Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin."
 	// XA5xxx	GCC and toolchain
 	//			XA32xx	.apk generation
 	//					XA4300  Unsupported $(AndroidSupportedAbis) value '{0}'; ignoring.

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
@@ -372,7 +372,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 				foreach (RegisterAttribute attr in GetRegisterAttributes (registeredMethod)) {
 					// Check for Kotlin-mangled methods that cannot be overridden
 					if (attr.Name.Contains ("-impl") || (attr.Name.Length > 7 && attr.Name[attr.Name.Length - 8] == '-'))
-						Diagnostic.Error (4213, LookupSource (implementedMethod), $"Cannot override Kotlin-generated method '{attr.Name}' because it is not a valid Java method name. This method can only be overridden from Kotlin.");
+						Diagnostic.Error (4217, LookupSource (implementedMethod), $"Cannot override Kotlin-generated method '{attr.Name}' because it is not a valid Java method name. This method can only be overridden from Kotlin.");
 
 					var msig = new Signature (implementedMethod, attr);
 					if (!registeredMethod.IsConstructor && !methods.Any (m => m.Name == msig.Name && m.Params == msig.Params))

--- a/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGeneratorTests.cs
+++ b/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGeneratorTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -38,7 +38,7 @@ namespace Java.Interop.Tools.JavaCallableWrappersTests
 			// Contains invalid [Register] name of "foo-impl"
 			var td = SupportDeclarations.GetTypeDefinition (typeof (KotlinInvalidImplRegisterName));
 			var e = Assert.Throws<XamarinAndroidException> (() => new JavaCallableWrapperGenerator (td, logger, cache: null));
-			Assert.AreEqual (4213, e.Code);
+			Assert.AreEqual (4217, e.Code);
 		}
 
 		[Test]
@@ -49,7 +49,7 @@ namespace Java.Interop.Tools.JavaCallableWrappersTests
 			// Contains invalid [Register] name of "foo-f8k2a13"
 			var td = SupportDeclarations.GetTypeDefinition (typeof (KotlinInvalidHashRegisterName));
 			var e = Assert.Throws<XamarinAndroidException> (() => new JavaCallableWrapperGenerator (td, logger, cache: null));
-			Assert.AreEqual (4213, e.Code);
+			Assert.AreEqual (4217, e.Code);
 		}
 
 		[Test]


### PR DESCRIPTION
Renumber XA4213 to XA4217 to remove a conflict with an earlier usage of
XA4213 in [xamarin-android][0].

[0]: https://github.com/xamarin/xamarin-android/blob/1a6fcff8a5a68bc2b53afa948176dea9681ff0d0/src/Xamarin.Android.Build.Tasks/Utilities/ManifestDocument.cs#L323