### PR TITLE
Force looking for the [JniAddNativeMethodRegistration] attribute

### DIFF
--- a/tests/TestJVM/TestJVM.cs
+++ b/tests/TestJVM/TestJVM.cs
@@ -16,6 +16,7 @@ namespace Java.InteropTests
 			var dir = Path.GetDirectoryName (typeof (TestJVM).Assembly.Location);
 			var builder = new JreRuntimeOptions () {
 				JvmLibraryPath              = Environment.GetEnvironmentVariable ("JI_JVM_PATH"),
+				JniAddNativeMethodRegistrationAttributePresent = true,
 			};
 			if (jars != null) {
 				foreach (var jar in jars)


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/4302
Context: https://github.com/xamarin/java.interop/pull/582

Java.Interop tests use their own runtime which doesn't know about the
results of Xamarin.Android's build process scanning for the presence of
the `JniAddNativeMethodRegistration` custom attribute. In addition,
Java.Interop's Java type scanner (for typemaps) does not include in its
results the types in `Java.Interop-Tests` which derive from
`Java.Interop.JavaObject` (which is **functionally** equivalent to
Xamarin.Android's `Java.Lang.Object`) and, thus, the scan doesn't notice
that the custom attribute mentioned above is used by a few test classes.
In effect, two tests fail with a similar exception:

    Java.Lang.LinkageError : No implementation found for void com.xamarin.interop.CallVirtualFromConstructorDerived.calledFromConstructor(int) (tried Java_com_xamarin_interop_CallVirtualFromConstructorDerived_calledFromConstructor and Java_com_xamarin_interop_CallVirtualFromConstructorDerived_calledFromConstructor__I)
      at Java.Interop.JniEnvironment+InstanceMethods.CallNonvirtualVoidMethod (Java.Interop.JniObjectReference instance, Java.Interop.JniObjectReference type, Java.Interop.JniMethodInfo method, Java.Interop.JniArgumentValue* args) [0x0008e] in <d30c11568ddc48d5aff8f2d4b2eaa867>:0
      at Java.Interop.GenericMarshaler.JniPeerInstanceMethodsExtensions._InvokeConstructor[T] (Java.Interop.JniPeerMembers+JniInstanceMethods peer, System.String constructorSignature, Java.Interop.IJavaPeerable self, T value) [0x00059] in <f6f553d46eb149a29e6542964ef27aaa>:0
      at Java.Interop.GenericMarshaler.JniPeerInstanceMethodsExtensions.FinishGenericCreateInstance[T] (Java.Interop.JniPeerMembers+JniInstanceMethods peer, System.String constructorSignature, Java.Interop.IJavaPeerable self, T value) [0x00029] in <f6f553d46eb149a29e6542964ef27aaa>:0
      at Java.InteropTests.CallVirtualFromConstructorBase..ctor (System.Int32 value) [0x0004e] in <d39267c627f54df3bc31406b36effb6c>:0
      at Java.InteropTests.CallVirtualFromConstructorDerived..ctor (System.Int32 value) [0x00000] in <d39267c627f54df3bc31406b36effb6c>:0
      at Java.InteropTests.InvokeVirtualFromConstructorTests.InvokeVirtualFromConstructor () [0x00000] in <d39267c627f54df3bc31406b36effb6c>:0
      at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
      at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in <26b1d17e27e54492bd3e4105b16bfc7e>:0
      --- End of managed Java.Lang.LinkageError stack trace ---
    java.lang.UnsatisfiedLinkError: No implementation found for void com.xamarin.interop.CallVirtualFromConstructorDerived.calledFromConstructor(int) (tried Java_com_xamarin_interop_CallVirtualFromConstructorDerived_calledFromConstructor and Java_com_xamarin_interop_CallVirtualFromConstructorDerived_calledFromConstructor__I)
      at com.xamarin.interop.CallVirtualFromConstructorDerived.calledFromConstructor(Native Method)
      at com.xamarin.interop.CallVirtualFromConstructorBase.<init>(Unknown Source:35)
      at com.xamarin.interop.CallVirtualFromConstructorDerived.<init>(Unknown Source:2)
      at crc64f295cabbf85394f5.TestSuiteInstrumentation.n_onStart(Native Method)
      at crc64f295cabbf85394f5.TestSuiteInstrumentation.onStart(Unknown Source:0)
      at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:2189)

Force the tests to always assume the custom attribute is present, thus
restoring the default behavior from before Java.Interop PR582