### PR TITLE
[build] Remove extraneous `nuget restore`s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,6 @@ NATIVE_EXT = .so
 DLLMAP_OS_NAME = linux
 endif
 
-PACKAGES = \
-	packages/NUnit.3.11.0/NUnit.3.11.0.nupkg \
-	packages/NUnit.Console.3.9.0/NUnit.Console.3.9.0.nupkg
-
 PREPARE_EXTERNAL_FILES  = \
 	external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj
 
@@ -38,8 +34,6 @@ PTESTS = \
 
 ATESTS = \
 	bin/Test$(CONFIGURATION)/Android.Interop-Tests.dll
-
-NUNIT_CONSOLE = packages/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe
 
 BUILD_PROPS = bin/Build$(CONFIGURATION)/JdkInfo.props bin/Build$(CONFIGURATION)/MonoInfo.props
 
@@ -68,9 +62,10 @@ bin/Build$(CONFIGURATION)/Java.Interop.BootstrapTasks.dll: build-tools/Java.Inte
 		$(wildcard build-tools/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks/*.cs)
 	$(MSBUILD) $(MSBUILD_FLAGS) /restore "$<"
 
-prepare-external $(PREPARE_EXTERNAL_FILES): $(PACKAGES) $(NUNIT_CONSOLE)
+prepare-external $(PREPARE_EXTERNAL_FILES):
 	git submodule update --init --recursive
 	(cd external/xamarin-android-tools && $(MAKE) prepare)
+	nuget restore
 
 clean:
 	-$(MSBUILD) $(MSBUILD_FLAGS) /t:Clean
@@ -79,9 +74,6 @@ clean:
 
 include build-tools/scripts/mono.mk
 include build-tools/scripts/jdk.mk
-
-$(PACKAGES) $(NUNIT_CONSOLE):
-	nuget restore
 
 JAVA_RUNTIME_ENVIRONMENT_DLLMAP_OVERRIDE = Java.Runtime.Environment.Override.dllmap
 ifeq ($(wildcard $(JAVA_RUNTIME_ENVIRONMENT_DLLMAP_OVERRIDE)),)


### PR DESCRIPTION
Ever since commit dec2e390, *every* **make**(1) target would result in
running `nuget restore`, e.g.:

	$ make run-tests TESTS=bin/TestDebug/Java.Interop.Tools.JavaSource-Tests.dll
	nuget restore
	...

The `nuget restore` was both time consuming and irrelevant, and meant
that `make` targets which *should* have been fast -- like `make all`,
which shouldn't do anything after the initial `make prepare all`,
would instead take multiple seconds to complete.

Why was `nuget restore` always being invoked?

	$ make -d -n run-tests
	...
	       Must remake target `packages/NUnit.3.11.0/NUnit.3.11.0.nupkg'.
	nuget restore

What happened is that commit dec2e390 changed various projects to be
Short-Form SDK projects, which in turn alters the `packages` directory
structure: instead of e.g.

	packages/NUnit.3.11.0/NUnit.3.11.0.nupkg

the file is instead:

	packages/nunit/3.11.0/nunit.3.11.0.nupkg

Note case and directory structure change, which in turn meant that the
rule dependencies were *never* satisfied (unless you happened to have
a `packages` directory from a pre-dec2e390 build…).

We *could* fix up the `$(PACKAGES)` and `$(NUNIT_CONSOLE)` variables
to use the new paths, but they're not actually *used* for anything
anymore, so just remove them.