### PR TITLE
[generator] Add api flag "no-alternatives" to skip generating interface member alternatives.

### DIFF
--- a/tests/generator-Tests/Unit-Tests/DefaultInterfaceMethodsTests.cs
+++ b/tests/generator-Tests/Unit-Tests/DefaultInterfaceMethodsTests.cs
@@ -363,5 +363,38 @@ namespace generatortests
 
 			Assert.AreEqual (GetTargetedExpected (nameof (ObsoleteInterfaceAlternativeClass)), writer.ToString ().NormalizeLineEndings ());
 		}
+
+		[Test]
+		public void RespectNoAlternativesForInterfaces ()
+		{
+			// If an interface is marked with no-alternatives='true', do
+			// not generate any legacy alternative classes for it
+			options.SupportInterfaceConstants = true;
+
+			var xml = @"<api>
+			  <package name='java.lang' jni-name='java/lang'>
+			    <class abstract='false' deprecated='not deprecated' final='false' name='Object' static='false' visibility='public' jni-signature='Ljava/lang/EmptyOverrideClass;' />
+			  </package>
+			  <package name='com.xamarin.android' jni-name='com/xamarin/android'>
+			    <interface no-alternatives='true' abstract='true' deprecated='not deprecated' final='false' name='Parent' static='false' visibility='public' jni-signature='Lcom/xamarin/android/Parent;'>
+			      <field deprecated='not deprecated' final='true' name='ACCEPT_HANDOVER' jni-signature='Ljava/lang/String;' static='true' transient='false' type='java.lang.String' type-generic-aware='java.lang.String' value='&quot;android.permission.ACCEPT_HANDOVER&quot;' visibility='public' volatile='false'></field>
+			      <field deprecated='deprecated' final='true' name='ALREADY_OBSOLETE' jni-signature='Ljava/lang/String;' static='true' transient='false' type='java.lang.String' type-generic-aware='java.lang.String' value='&quot;android.permission.ACCEPT_HANDOVER&quot;' visibility='public' volatile='false'></field>
+			      <field deprecated='not deprecated' final='true' name='API_NAME' jni-signature='Ljava/lang/String;' static='true' transient='false' type='java.lang.String' type-generic-aware='java.lang.String' visibility='public' volatile='false'></field>
+			      <method abstract='false' deprecated='not deprecated' final='false' name='comparing' jni-signature='()I' bridge='false' native='false' return='int' jni-return='I' static='true' synchronized='false' synthetic='false' visibility='public' />
+			      <method abstract='false' deprecated='deprecated' final='false' name='comparingOld' jni-signature='()I' bridge='false' native='false' return='int' jni-return='I' static='true' synchronized='false' synthetic='false' visibility='public' />
+			    </interface>
+			  </package>
+			</api>";
+
+			var gens = ParseApiDefinition (xml);
+			var iface = gens.OfType<InterfaceGen> ().Single ();
+
+			iface.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ());
+
+			generator.WriteInterface (iface, string.Empty, new GenerationInfo (string.Empty, string.Empty, "MyAssembly"));
+
+			Assert.False (writer.ToString ().Contains ("class ParentConsts"));
+			Assert.False (writer.ToString ().Contains ("class Parent"));
+		}
 	}
 }

--- a/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/CodeGenerator.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/CodeGenerator.cs
@@ -732,6 +732,11 @@ namespace MonoDroid.Generation
 			// in order to maintain backward compatibility.
 			// If we're creating a binding that supports DIM, we remove the XXXConsts class as they've been
 			// [Obsolete:iserror] for a long time, and we add [Obsolete] to the interface "class".
+
+			// Bail if requested we not produce alternative classes for this interface
+			if (@interface.NoAlternatives)
+				return;
+
 			var staticMethods = @interface.Methods.Where (m => m.IsStatic);
 			var should_obsolete = opt.SupportInterfaceConstants && opt.SupportDefaultInterfaceMethods;
 

--- a/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
@@ -197,6 +197,7 @@ namespace MonoDroid.Generation
 			var iface = new InterfaceGen (CreateGenBaseSupport (pkg, elem, true)) {
 				ArgsType = elem.XGetAttribute ("argsType"),
 				HasManagedName = elem.Attribute ("managedName") != null,
+				NoAlternatives = elem.XGetAttribute ("no-alternatives") == "true",
 				// Only use an explicitly set XML attribute
 				Unnest = elem.XGetAttribute ("unnest") == "true" ? true :
 					 elem.XGetAttribute ("unnest") == "false" ? false :

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/InterfaceGen.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/InterfaceGen.cs
@@ -186,6 +186,10 @@ namespace MonoDroid.Generation
 		internal bool NeedsSender =>
 			Methods.Any (m => (m.RetVal.IsVoid && !m.Parameters.HasSender) || (m.IsEventHandlerWithHandledProperty && !m.Parameters.HasSender));
 
+		// If true, we will no longer generate the "interface alternative" legacy classes
+		// used to hold interface constants/static methods before we had C#8
+		public bool NoAlternatives { get; set; }
+
 		protected override bool OnValidate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params, CodeGeneratorContext context)
 		{
 			if (validated)


### PR DESCRIPTION
Context: #509 

In #600 we began cleaning up our existing "alternative" hacks for bindings that use the new C#8 DIM features.  However, as we add new API interfaces we will continue to generate new `[Obsolete]` "alternative" classes.  We do not need to add new already-obsolete API to our bindings.

This PR creates a new attribute for `<interface>` elements called `@no-alternatives`.  When this attribute is set to `true` we will not generate the alternative classes for this interface.

This will be used in `Mono.Android.dll` like this:
```
<attr api-since="30" path="/api/package/interface[contains(@merge.SourceFile,'api-30.xml.in')]" name="no-alternatives">true</attr>
```

This will keep any new interfaces added in API-30 from creating `[Obsolete]` alternative classes.

This diff https://gist.github.com/jpobst/27f4109aceb8d74b257cefa773704cac shows the difference between `Mono.Android.dll` `master - API-R` and what this PR will do.  Note the diff is reversed to work around an issue in `mono-api-html`.  Basically it shows that we will keep 3 new alternative classes in API-R from being created.