### PR TITLE
[build] Build additional `$(TargetFramework)` values.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,10 +18,22 @@
       Project="$(_OutputPath)MonoInfo.props"
       Condition="Exists('$(_OutputPath)MonoInfo.props')"
   />
+  <PropertyGroup Condition=" '$(TargetFramework)' != '' And $(TargetFramework.StartsWith ('netcoreapp')) ">
+    <BuildToolOutputFullPath>$(MSBuildThisFileDirectory)bin\Build$(_Configuration)-$(TargetFramework)\</BuildToolOutputFullPath>
+    <ToolOutputFullPath>$(MSBuildThisFileDirectory)bin\$(_Configuration)-$(TargetFramework)\</ToolOutputFullPath>
+    <TestOutputFullPath>$(MSBuildThisFileDirectory)bin\Test$(_Configuration)-$(TargetFramework)\</TestOutputFullPath>
+    <UtilityOutputFullPath Condition=" '$(UtilityOutputFullPathCoreApps)' != '' ">$(UtilityOutputFullPathCoreApps)</UtilityOutputFullPath>
+    <UtilityOutputFullPath Condition=" '$(UtilityOutputFullPathCoreApps)' == '' ">$(ToolOutputFullPath)</UtilityOutputFullPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == '' Or !$(TargetFramework.StartsWith ('netcoreapp')) ">
+    <BuildToolOutputFullPath>$(MSBuildThisFileDirectory)bin\Build$(_Configuration)\</BuildToolOutputFullPath>
+    <ToolOutputFullPath>$(MSBuildThisFileDirectory)bin\$(_Configuration)\</ToolOutputFullPath>
+    <TestOutputFullPath>$(MSBuildThisFileDirectory)bin\Test$(_Configuration)\</TestOutputFullPath>
+    <UtilityOutputFullPath Condition=" '$(UtilityOutputFullPath)' == '' ">$(ToolOutputFullPath)</UtilityOutputFullPath>
+  </PropertyGroup>
   <PropertyGroup>
     <CecilRestoreConfiguration Condition=" '$(CecilRestoreConfiguration)' == '' ">$(Configuration)</CecilRestoreConfiguration>
     <CecilSourceDirectory   Condition=" '$(CecilSourceDirectory)' == '' ">$(MSBuildThisFileDirectory)external\cecil</CecilSourceDirectory>
-    <UtilityOutputFullPath  Condition=" '$(UtilityOutputFullPath)' == '' ">$(MSBuildThisFileDirectory)bin\$(_Configuration)\</UtilityOutputFullPath>
     <XamarinAndroidToolsDirectory   Condition=" '$(XamarinAndroidToolsDirectory)' == '' ">$(MSBuildThisFileDirectory)external\xamarin-android-tools</XamarinAndroidToolsDirectory>
   </PropertyGroup>
   <PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ MSbuild properties may be placed into the file `Configuration.Override.props`,
 which can be copied from
 [`Configuration.Override.props.in`](Configuration.Override.props.in).
 The `Configuration.Override.props` file is `<Import/>`ed by
-[`Configuration.props`](Configuration.props); there is no need to `<Import/>`
-it within other project files.
+[`Directory.Build.props`](Directory.Build.props); there is no need to
+`<Import/>` it within other project files.
 
 Overridable MSBuild properties include:
 

--- a/build-tools/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks.csproj
+++ b/build-tools/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks.csproj
@@ -11,7 +11,6 @@
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
-  <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
     <DebugType>Full</DebugType>

--- a/build-tools/jnienv-gen/jnienv-gen.csproj
+++ b/build-tools/jnienv-gen/jnienv-gen.csproj
@@ -11,11 +11,12 @@
     <AssemblyName>jnienv-gen</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
   </PropertyGroup>
+  <Import Project="..\..\Directory.Build.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' Or '$(Configuration)|$(Platform)' == 'Gendarme|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\bin\BuildDebug</OutputPath>
+    <OutputPath>$(BuildToolOutputFullPath)</OutputPath>
     <DefineConstants>DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -24,7 +25,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>full</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\..\bin\BuildRelease</OutputPath>
+    <OutputPath>$(BuildToolOutputFullPath)</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Externalconsole>true</Externalconsole>

--- a/build-tools/scripts/PrepareWindows.targets
+++ b/build-tools/scripts/PrepareWindows.targets
@@ -7,7 +7,6 @@
     <_NuGetPath>$(_TopDir)\.nuget</_NuGetPath>
     <_NuGet>$(_NuGetPath)\NuGet.exe</_NuGet>
   </PropertyGroup>
-  <Import Project="$(_TopDir)\Configuration.props" />
   <UsingTask AssemblyFile="$(_TopDir)\bin\Build$(Configuration)\Java.Interop.BootstrapTasks.dll" TaskName="Java.Interop.BootstrapTasks.JdkInfo" />
   <UsingTask AssemblyFile="$(_TopDir)\bin\Build$(Configuration)\Java.Interop.BootstrapTasks.dll" TaskName="Java.Interop.BootstrapTasks.DownloadUri" />
   <Target Name="Prepare">

--- a/samples/Hello/Hello.csproj
+++ b/samples/Hello/Hello.csproj
@@ -8,6 +8,10 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <OutputPath>$(TestOutputFullPath)</OutputPath>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Java.Interop\Java.Interop.csproj" />
     <ProjectReference Include="..\..\src\Java.Runtime.Environment\Java.Runtime.Environment.csproj" />

--- a/src/Java.Interop.Dynamic/Java.Interop.Dynamic.csproj
+++ b/src/Java.Interop.Dynamic/Java.Interop.Dynamic.csproj
@@ -12,11 +12,8 @@
     <AssemblyVersion>0.1.0.0</AssemblyVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <OutputPath>..\..\bin\Debug</OutputPath>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <OutputPath>..\..\bin\Release</OutputPath>
+  <PropertyGroup>
+    <OutputPath>$(ToolOutputFullPath)</OutputPath>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Java.Interop\Java.Interop.csproj">

--- a/src/Java.Interop.Export/Java.Interop.Export.csproj
+++ b/src/Java.Interop.Export/Java.Interop.Export.csproj
@@ -11,11 +11,8 @@
     <AssemblyVersion>0.1.0.0</AssemblyVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <OutputPath>..\..\bin\Debug</OutputPath>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <OutputPath>..\..\bin\Release</OutputPath>
+  <PropertyGroup>
+    <OutputPath>$(ToolOutputFullPath)</OutputPath>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Java.Interop\Java.Interop.csproj">

--- a/src/Java.Interop.GenericMarshaler/Java.Interop.GenericMarshaler.csproj
+++ b/src/Java.Interop.GenericMarshaler/Java.Interop.GenericMarshaler.csproj
@@ -12,11 +12,8 @@
     <AssemblyVersion>0.1.0.0</AssemblyVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <OutputPath>..\..\bin\Debug</OutputPath>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <OutputPath>..\..\bin\Release</OutputPath>
+  <PropertyGroup>
+    <OutputPath>$(ToolOutputFullPath)</OutputPath>
   </PropertyGroup>
   <ItemGroup>
     <None Include="Java.Interop.GenericMarshaler\JniPeerInstanceMethodsExtensions.tt">

--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil.csproj
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil.csproj
@@ -5,12 +5,8 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\bin\Debug</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\bin\Release</OutputPath>
+  <PropertyGroup>
+    <OutputPath>$(ToolOutputFullPath)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Java.Interop.Tools.Diagnostics/Java.Interop.Tools.Diagnostics.csproj
+++ b/src/Java.Interop.Tools.Diagnostics/Java.Interop.Tools.Diagnostics.csproj
@@ -4,12 +4,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\bin\Debug</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\bin\Release</OutputPath>
+  <PropertyGroup>
+    <OutputPath>$(ToolOutputFullPath)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers.csproj
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers.csproj
@@ -5,13 +5,15 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <OutputPath>$(ToolOutputFullPath)</OutputPath>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\bin\Debug</OutputPath>
     <DefineConstants>DEBUG;JCW_ONLY_TYPE_NAMES;HAVE_CECIL</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\bin\Release</OutputPath>
     <DefineConstants>JCW_ONLY_TYPE_NAMES;HAVE_CECIL</DefineConstants>
   </PropertyGroup>
 

--- a/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource.csproj
+++ b/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource.csproj
@@ -8,11 +8,8 @@
     <Copyright>Microsoft Corporation</Copyright>
     <AssemblyVersion>0.1.0.0</AssemblyVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <OutputPath>..\..\bin\Debug</OutputPath>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <OutputPath>..\..\bin\Release</OutputPath>
+  <PropertyGroup>
+    <OutputPath>$(ToolOutputFullPath)</OutputPath>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Irony" Version="1.1.0" />

--- a/src/Java.Interop/Java.Interop-MonoAndroid.csproj
+++ b/src/Java.Interop/Java.Interop-MonoAndroid.csproj
@@ -16,7 +16,7 @@
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
-  <Import Project="..\..\Configuration.props" />
+  <Import Project="..\..\Directory.Build.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>

--- a/src/Java.Interop/Java.Interop.csproj
+++ b/src/Java.Interop/Java.Interop.csproj
@@ -28,7 +28,6 @@
   <ItemGroup>
     <Compile Remove="Java.Interop\JniLocationException.cs" />
   </ItemGroup>
-  <Import Project="..\..\Configuration.props" />
   <Import Project="Java.Interop.targets" />
   <PropertyGroup>
     <BuildDependsOn>

--- a/src/Java.Runtime.Environment/Java.Runtime.Environment.csproj
+++ b/src/Java.Runtime.Environment/Java.Runtime.Environment.csproj
@@ -8,12 +8,8 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\bin\Debug</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\bin\Release</OutputPath>
+  <PropertyGroup>
+    <OutputPath>$(TestOutputFullPath)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Xamarin.Android.Cecil/Xamarin.Android.Cecil.Mdb.csproj
+++ b/src/Xamarin.Android.Cecil/Xamarin.Android.Cecil.Mdb.csproj
@@ -11,7 +11,6 @@
     <AssemblyName>Xamarin.Android.Cecil.Mdb</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
   </PropertyGroup>
-  <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>

--- a/src/Xamarin.Android.Cecil/Xamarin.Android.Cecil.csproj
+++ b/src/Xamarin.Android.Cecil/Xamarin.Android.Cecil.csproj
@@ -11,7 +11,6 @@
     <AssemblyName>Xamarin.Android.Cecil</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
   </PropertyGroup>
-  <Import Project="..\..\Configuration.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>

--- a/src/Xamarin.Android.Tools.AnnotationSupport.Cecil/Xamarin.Android.Tools.AnnotationSupport.Cecil.csproj
+++ b/src/Xamarin.Android.Tools.AnnotationSupport.Cecil/Xamarin.Android.Tools.AnnotationSupport.Cecil.csproj
@@ -5,12 +5,8 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\bin\Debug</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\bin\Release</OutputPath>
+  <PropertyGroup>
+    <OutputPath>$(TestOutputFullPath)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Xamarin.Android.Tools.AnnotationSupport/Xamarin.Android.Tools.AnnotationSupport.csproj
+++ b/src/Xamarin.Android.Tools.AnnotationSupport/Xamarin.Android.Tools.AnnotationSupport.csproj
@@ -5,12 +5,8 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\bin\Debug</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\bin\Release</OutputPath>
+  <PropertyGroup>
+    <OutputPath>$(TestOutputFullPath)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/Xamarin.Android.Tools.ApiXmlAdjuster.csproj
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/Xamarin.Android.Tools.ApiXmlAdjuster.csproj
@@ -4,12 +4,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\bin\Debug</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\bin\Release</OutputPath>
+  <PropertyGroup>
+    <OutputPath>$(TestOutputFullPath)</OutputPath>
   </PropertyGroup>
 
 </Project>

--- a/src/Xamarin.Android.Tools.Bytecode/Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj
+++ b/src/Xamarin.Android.Tools.Bytecode/Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\packages\NUnit.3.11.0\build\NUnit.props" Condition="Exists('..\..\..\packages\NUnit.3.11.0\build\NUnit.props')" />
-  <Import Project="..\..\..\Configuration.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -17,7 +16,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\..\bin\TestDebug</OutputPath>
+    <OutputPath>$(ToolOutputFullPath)</OutputPath>
     <DefineConstants>DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -26,7 +25,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>full</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\..\..\bin\TestRelease</OutputPath>
+    <OutputPath>$(ToolOutputFullPath)</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>

--- a/src/Xamarin.Android.Tools.Bytecode/Xamarin.Android.Tools.Bytecode.csproj
+++ b/src/Xamarin.Android.Tools.Bytecode/Xamarin.Android.Tools.Bytecode.csproj
@@ -5,12 +5,8 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\bin\Debug</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\bin\Release</OutputPath>
+  <PropertyGroup>
+    <OutputPath>$(TestOutputFullPath)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/java-interop/java-interop.csproj
+++ b/src/java-interop/java-interop.csproj
@@ -8,19 +8,20 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{BB0AB9F7-0979-41A7-B7A9-877260655F94}</ProjectGuid>
   </PropertyGroup>
+  <Import Project="..\..\Directory.Build.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>..\..\bin\Debug</OutputPath>
-    <JNIEnvGenPath>..\..\bin\BuildDebug</JNIEnvGenPath>
+    <OutputPath>$(ToolOutputFullPath)</OutputPath>
+    <JNIEnvGenPath>$(BuildToolOutputFullPath)</JNIEnvGenPath>
     <OutputName>java-interop</OutputName>
     <CompileTarget>SharedLibrary</CompileTarget>
     <DefineSymbols>DEBUG JI_DLL_EXPORT MONODEVELOP MONO_DLL_EXPORT</DefineSymbols>
     <SourceDirectory>.</SourceDirectory>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <OutputPath>..\..\bin\Release</OutputPath>
+    <OutputPath>$(ToolOutputFullPath)</OutputPath>
     <OutputName>java-interop</OutputName>
-    <JNIEnvGenPath>..\..\bin\BuildRelease</JNIEnvGenPath>
+    <JNIEnvGenPath>$(BuildToolOutputFullPath)</JNIEnvGenPath>
     <CompileTarget>SharedLibrary</CompileTarget>
     <OptimizationLevel>3</OptimizationLevel>
     <DefineSymbols>JI_DLL_EXPORT MONODEVELOP MONO_DLL_EXPORT</DefineSymbols>

--- a/tests/Java.Interop-PerformanceTests/Java.Interop-PerformanceTests.csproj
+++ b/tests/Java.Interop-PerformanceTests/Java.Interop-PerformanceTests.csproj
@@ -7,12 +7,8 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\bin\TestDebug</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\bin\TestRelease</OutputPath>
+  <PropertyGroup>
+    <OutputPath>$(TestOutputFullPath)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Java.Interop-Tests/Java.Interop-Tests.csproj
+++ b/tests/Java.Interop-Tests/Java.Interop-Tests.csproj
@@ -7,12 +7,8 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\bin\TestDebug</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\bin\TestRelease</OutputPath>
+  <PropertyGroup>
+    <OutputPath>$(TestOutputFullPath)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Java.Interop.Dynamic-Tests/Java.Interop.Dynamic-Tests.csproj
+++ b/tests/Java.Interop.Dynamic-Tests/Java.Interop.Dynamic-Tests.csproj
@@ -7,12 +7,8 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\bin\TestDebug</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\bin\TestRelease</OutputPath>
+  <PropertyGroup>
+    <OutputPath>$(TestOutputFullPath)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Java.Interop.Export-Tests/Java.Interop.Export-Tests.csproj
+++ b/tests/Java.Interop.Export-Tests/Java.Interop.Export-Tests.csproj
@@ -7,12 +7,8 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\bin\TestDebug</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\bin\TestRelease</OutputPath>
+  <PropertyGroup>
+    <OutputPath>$(TestOutputFullPath)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers-Tests.csproj
+++ b/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers-Tests.csproj
@@ -7,12 +7,8 @@
     <DefineConstants>$(DefineConstants);HAVE_CECIL;JCW_ONLY_TYPE_NAMES</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\bin\TestDebug</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\bin\TestRelease</OutputPath>
+  <PropertyGroup>
+    <OutputPath>$(TestOutputFullPath)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Java.Interop.Tools.JavaSource-Tests/Java.Interop.Tools.JavaSource-Tests.csproj
+++ b/tests/Java.Interop.Tools.JavaSource-Tests/Java.Interop.Tools.JavaSource-Tests.csproj
@@ -4,11 +4,8 @@
     <IsPackable>False</IsPackable>
     <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\bin\TestDebug</OutputPath>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\bin\TestRelease</OutputPath>
+  <PropertyGroup>
+    <OutputPath>$(TestOutputFullPath)</OutputPath>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="nunit" Version="3.11.0" />

--- a/tests/TestJVM/TestJVM.csproj
+++ b/tests/TestJVM/TestJVM.csproj
@@ -6,12 +6,8 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\bin\TestDebug</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\bin\TestRelease</OutputPath>
+  <PropertyGroup>
+    <OutputPath>$(TestOutputFullPath)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Xamarin.Android.Tools.ApiXmlAdjuster-Tests/Xamarin.Android.Tools.ApiXmlAdjuster-Tests.csproj
+++ b/tests/Xamarin.Android.Tools.ApiXmlAdjuster-Tests/Xamarin.Android.Tools.ApiXmlAdjuster-Tests.csproj
@@ -6,12 +6,8 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\bin\TestDebug</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\bin\TestRelease</OutputPath>
+  <PropertyGroup>
+    <OutputPath>$(TestOutputFullPath)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj
@@ -1,19 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="..\..\Configuration.props" />
-  
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <IsPackable>false</IsPackable>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\bin\TestDebug</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\bin\TestRelease</OutputPath>
+  <PropertyGroup>
+    <OutputPath>$(TestOutputFullPath)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/generator-Tests/generator-Tests.csproj
+++ b/tests/generator-Tests/generator-Tests.csproj
@@ -7,12 +7,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\bin\TestDebug</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\bin\TestRelease</OutputPath>
+  <PropertyGroup>
+    <OutputPath>$(TestOutputFullPath)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/logcat-parse-Tests/logcat-parse-Tests.csproj
+++ b/tests/logcat-parse-Tests/logcat-parse-Tests.csproj
@@ -6,12 +6,8 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\..\bin\TestDebug</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\bin\TestRelease</OutputPath>
+  <PropertyGroup>
+    <OutputPath>$(TestOutputFullPath)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/class-parse/class-parse.csproj
+++ b/tools/class-parse/class-parse.csproj
@@ -1,12 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
-
-  <Import Project="..\..\Configuration.props" />
 
   <PropertyGroup>
     <OutputPath>$(UtilityOutputFullPath)</OutputPath>

--- a/tools/generator/generator.csproj
+++ b/tools/generator/generator.csproj
@@ -7,8 +7,6 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
-  <Import Project="..\..\Configuration.props" />
-
   <PropertyGroup>
     <OutputPath>$(UtilityOutputFullPath)</OutputPath>
   </PropertyGroup>

--- a/tools/jcw-gen/jcw-gen.csproj
+++ b/tools/jcw-gen/jcw-gen.csproj
@@ -1,12 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
-
-  <Import Project="..\..\Configuration.props" />
 
   <PropertyGroup>
     <OutputPath>$(UtilityOutputFullPath)</OutputPath>

--- a/tools/jnimarshalmethod-gen/Xamarin.Android.Tools.JniMarshalMethodGenerator.csproj
+++ b/tools/jnimarshalmethod-gen/Xamarin.Android.Tools.JniMarshalMethodGenerator.csproj
@@ -7,7 +7,6 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
-  <Import Project="..\..\Configuration.props" />
   <Import Project="..\..\src\Java.Interop.NamingCustomAttributes\Java.Interop.NamingCustomAttributes.projitems" Label="Shared" Condition="Exists('..\..\src\Java.Interop.NamingCustomAttributes\Java.Interop.NamingCustomAttributes.projitems')" />
 
   <PropertyGroup>

--- a/tools/logcat-parse/logcat-parse.csproj
+++ b/tools/logcat-parse/logcat-parse.csproj
@@ -1,12 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
-
-  <Import Project="..\..\Configuration.props" />
 
   <PropertyGroup>
     <OutputPath>$(UtilityOutputFullPath)</OutputPath>

--- a/tools/param-name-importer/param-name-importer.csproj
+++ b/tools/param-name-importer/param-name-importer.csproj
@@ -1,10 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
-  <Import Project="..\..\Configuration.props" />
   <PropertyGroup>
     <OutputPath>$(UtilityOutputFullPath)</OutputPath>
   </PropertyGroup>


### PR DESCRIPTION
Now that most projects are Short-Form projects (cedf4d04), we can use
MSBuild multitargeting and the [`$(TargetFrameworks)`][0] MSBuild
property to build for multiple target frameworks at once.

This in turn will allow us to determine which apps can be built
against the `.NETCoreApp,Version=v3.1` framework, which is our current
"stepping stone" to eventual .NET 5 compatibility.

Rename `Configuration.props` to `Directory.Build.props`, so that it
doesn't need to be explicitly `<Import/>`ed everywhere.

Update all projects so that `$(OutputPath)` is in turn a variable
defined in `Directory.Build.props`:

  * `$(BuildToolOutputFullPath)`: Build-time utilities, e.g. files
    that belong in `bin/BuildDebug`.
  * `$(ToolOutputFullPath)`: "Normal" output, e.g. `bin/Debug`.
  * `$(TestOutputFullPath)`: Test-related artifacts, e.g.
    `bin/TestDebug`.
  * `$(UtilityOutputFullPath)`: "Normal" output that is shared with
    xamarin-android and needs an alternate installation location when
    built from xamarin-android.

Of note is that when `$(TargetFramework)` starts with `netcoreapp`,
the above properties are changed to have a `-$(TargetFramework)`
suffix.

Update a few tools projects so that they build for both `net472` and
`netcoreapp3.1` frameworks, e.g. `tools/logcat-parse` now produces:

  * `bin/Debug-netcoreapp3.1/logcat-parse.deps.json`
  * `bin/Debug-netcoreapp3.1/logcat-parse.dll`
  * `bin/Debug-netcoreapp3.1/logcat-parse.pdb`
  * `bin/Debug-netcoreapp3.1/logcat-parse.runtimeconfig.dev.json`
  * `bin/Debug-netcoreapp3.1/logcat-parse.runtimeconfig.json`
  * `bin/Debug/logcat-parse.exe`
  * `bin/Debug/logcat-parse.exe.config`
  * `bin/Debug/logcat-parse.pdb`

Some projects fail when building for `netcoreapp3.1`.  These projects
will be fixed separately.

[0]: https://docs.microsoft.com/en-us/dotnet/standard/frameworks