### PR TITLE
Remove <Imports> now covered by Directory.Build.props.

### DIFF
--- a/src/java-interop/java-interop.csproj
+++ b/src/java-interop/java-interop.csproj
@@ -27,8 +27,6 @@
     <DefineSymbols>JI_DLL_EXPORT MONODEVELOP MONO_DLL_EXPORT</DefineSymbols>
     <SourceDirectory>.</SourceDirectory>
   </PropertyGroup>
-  <Import Project="$(JNIEnvGenPath)\JdkInfo.props" Condition="Exists('$(JNIEnvGenPath)\JdkInfo.props')" />
-  <Import Project="$(JNIEnvGenPath)\MonoInfo.props" Condition="Exists('$(JNIEnvGenPath)\MonoInfo.props')" />
   <ItemGroup>
     <ClInclude Include="java-interop.h" />
     <ClInclude Include="java-interop-gc-bridge.h" />

--- a/tests/Java.Interop-PerformanceTests/Java.Interop-PerformanceTests.csproj
+++ b/tests/Java.Interop-PerformanceTests/Java.Interop-PerformanceTests.csproj
@@ -25,8 +25,6 @@
     <ProjectReference Include="..\TestJVM\TestJVM.csproj" />
   </ItemGroup>
 
-  <Import Condition="Exists('$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\JdkInfo.props')" Project="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\JdkInfo.props" />
-
   <ItemGroup>
     <JavaPerformanceTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\performance\JavaTiming.java" />
   </ItemGroup>

--- a/tests/Java.Interop-Tests/Java.Interop-Tests.csproj
+++ b/tests/Java.Interop-Tests/Java.Interop-Tests.csproj
@@ -30,8 +30,6 @@
     <ProjectReference Include="..\TestJVM\TestJVM.csproj" />
   </ItemGroup>
 
-  <Import Condition="Exists('$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\JdkInfo.props')" Project="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\JdkInfo.props" />
-
   <ItemGroup>
     <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\CrossReferenceBridge.java" />
     <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\CallNonvirtualBase.java" />

--- a/tests/Java.Interop.Export-Tests/Java.Interop.Export-Tests.csproj
+++ b/tests/Java.Interop.Export-Tests/Java.Interop.Export-Tests.csproj
@@ -25,8 +25,6 @@
     <ProjectReference Include="..\..\src\Java.Runtime.Environment\Java.Runtime.Environment.csproj" />
     <ProjectReference Include="..\TestJVM\TestJVM.csproj" />
   </ItemGroup>
-
-  <Import Condition="Exists('$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\JdkInfo.props')" Project="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\JdkInfo.props" />
   
   <ItemGroup>
     <JavaExportTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\export\ExportType.java" />


### PR DESCRIPTION
In https://github.com/xamarin/java.interop/pull/605, we created a `Directory.Build.props` file which automatically imports several things for all projects.  The projects that are still manually importing these same files are creating duplicate warnings like:

```
tests\Java.Interop-Tests\Java.Interop-Tests.csproj(33,3): 
Warning MSB4011: "d:\a\1\s\bin\BuildRelease\JdkInfo.props" cannot be imported again. It was already imported at "d:\a\1\s\Directory.Build.props (13,3)". This is most likely a build authoring error. This subsequent import will be ignored. 
```

This doesn't fix the `jnienv-gen.csproj` warnings, they will be fixed when the project is converted to sdk-style.