### PR TITLE
[generator] Don't process duplicate reference assemblies.

### DIFF
--- a/tools/generator/CodeGenerator.cs
+++ b/tools/generator/CodeGenerator.cs
@@ -94,7 +94,7 @@ namespace Xamarin.Android.Binder
 			// every type to be fully populated.
 			opt.UseShallowReferencedTypes = apiSourceAttr != "class-parse";
 
-			foreach (var reference in references) {
+			foreach (var reference in references.Distinct ()) {
 				try {
 					Report.Verbose (0, "resolving assembly {0}.", reference);
 					var assembly    = resolver.Load (reference);


### PR DESCRIPTION
When a binding project references another binding project, the list of references assemblies can contain duplicates, particularly `mscorlib`:

```
    [0]: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Preview\\Common7\\IDE\\ReferenceAssemblies\\Microsoft\\Framework\\MonoAndroid\\v1.0\\mscorlib.dll"
    [1]: "C:\\code\\XamarinComponents\\Android\\BetterPickers\\source\\AndroidSwitchBackport\\bin\\Debug\\AndroidSwitchBackport.dll"
    [2]: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Preview\\Common7\\IDE\\ReferenceAssemblies\\Microsoft\\Framework\\MonoAndroid\\v1.0\\Java.Interop.dll"
    [3]: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Preview\\Common7\\IDE\\ReferenceAssemblies\\Microsoft\\Framework\\MonoAndroid\\v9.0\\Mono.Android.dll"
    [4]: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Preview\\Common7\\IDE\\ReferenceAssemblies\\Microsoft\\Framework\\MonoAndroid\\v1.0\\mscorlib.dll"
    [5]: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Preview\\Common7\\IDE\\ReferenceAssemblies\\Microsoft\\Framework\\MonoAndroid\\v1.0\\System.Core.dll"
    [6]: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Preview\\Common7\\IDE\\ReferenceAssemblies\\Microsoft\\Framework\\MonoAndroid\\v1.0\\System.dll"
    [7]: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Preview\\Common7\\IDE\\ReferenceAssemblies\\Microsoft\\Framework\\MonoAndroid\\v1.0\\Facades\\System.Runtime.dll"
    [8]: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Preview\\Common7\\IDE\\ReferenceAssemblies\\Microsoft\\Framework\\MonoAndroid\\v1.0\\System.Xml.dll"
```

There is no reason to scan any duplicate assemblies a second time, so add a `Distinct()` to prevent duplicates.