### PR TITLE
[build] Provide a default $(Configuration) value

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,9 +2,8 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Note: MUST be imported *after* $(Configuration) is set! -->
   <PropertyGroup>
-    <_Configuration Condition=" '$(Configuration)' != 'Gendarme' ">$(Configuration)</_Configuration>
-    <_Configuration Condition=" '$(Configuration)' == 'Gendarme' ">Debug</_Configuration>
-    <_OutputPath>$(MSBuildThisFileDirectory)bin\Build$(_Configuration)\</_OutputPath>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <_OutputPath>$(MSBuildThisFileDirectory)bin\Build$(Configuration)\</_OutputPath>
   </PropertyGroup>
   <Import
       Project="$(MSBuildThisFileDirectory)Configuration.Override.props"
@@ -19,16 +18,16 @@
       Condition="Exists('$(_OutputPath)MonoInfo.props')"
   />
   <PropertyGroup Condition=" '$(TargetFramework)' != '' And $(TargetFramework.StartsWith ('netcoreapp')) ">
-    <BuildToolOutputFullPath>$(MSBuildThisFileDirectory)bin\Build$(_Configuration)-$(TargetFramework)\</BuildToolOutputFullPath>
-    <ToolOutputFullPath>$(MSBuildThisFileDirectory)bin\$(_Configuration)-$(TargetFramework)\</ToolOutputFullPath>
-    <TestOutputFullPath>$(MSBuildThisFileDirectory)bin\Test$(_Configuration)-$(TargetFramework)\</TestOutputFullPath>
+    <BuildToolOutputFullPath>$(MSBuildThisFileDirectory)bin\Build$(Configuration)-$(TargetFramework)\</BuildToolOutputFullPath>
+    <ToolOutputFullPath>$(MSBuildThisFileDirectory)bin\$(Configuration)-$(TargetFramework)\</ToolOutputFullPath>
+    <TestOutputFullPath>$(MSBuildThisFileDirectory)bin\Test$(Configuration)-$(TargetFramework)\</TestOutputFullPath>
     <UtilityOutputFullPath Condition=" '$(UtilityOutputFullPathCoreApps)' != '' ">$(UtilityOutputFullPathCoreApps)</UtilityOutputFullPath>
     <UtilityOutputFullPath Condition=" '$(UtilityOutputFullPathCoreApps)' == '' ">$(ToolOutputFullPath)</UtilityOutputFullPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == '' Or !$(TargetFramework.StartsWith ('netcoreapp')) ">
-    <BuildToolOutputFullPath>$(MSBuildThisFileDirectory)bin\Build$(_Configuration)\</BuildToolOutputFullPath>
-    <ToolOutputFullPath>$(MSBuildThisFileDirectory)bin\$(_Configuration)\</ToolOutputFullPath>
-    <TestOutputFullPath>$(MSBuildThisFileDirectory)bin\Test$(_Configuration)\</TestOutputFullPath>
+    <BuildToolOutputFullPath>$(MSBuildThisFileDirectory)bin\Build$(Configuration)\</BuildToolOutputFullPath>
+    <ToolOutputFullPath>$(MSBuildThisFileDirectory)bin\$(Configuration)\</ToolOutputFullPath>
+    <TestOutputFullPath>$(MSBuildThisFileDirectory)bin\Test$(Configuration)\</TestOutputFullPath>
     <UtilityOutputFullPath Condition=" '$(UtilityOutputFullPath)' == '' ">$(ToolOutputFullPath)</UtilityOutputFullPath>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
When `Directory.Build.props` is imported by MSBuild, the
`$(Configuration)` property will only be defined if it was excplitily
provided on the command line.  As such, when building the repo when
using **make**(1), it builds:

        $ make prepare
        $ make all
        # works!

After `make all`, if we attempt to manually build a single `.csproj`,
it may fail:

        $ msbuild tests/Java.Interop-Tests/Java.Interop-Tests.csproj
        ...
        BuildInteropTestJar:
          "" -source 1.6 -target 1.6 -bootclasspath "" -d "obj/Debug/it-classes" -classpath …
        …: error MSB3073: The command """ -source 1.6 -target 1.6 …" exited with code 127.

Building a single `.csproj` works if the `Configuration` property is
explicitly provided:

        $ msbuild tests/Java.Interop-Tests/Java.Interop-Tests.csproj /p:Configuration=Debug
        # no error

Update `Directory.Build.props` so that if no `$(Configuration)` is
provided we default to the Debug configuration.  This allows all the
relevant `$(Configuration)`-dependent properties to have correct and
consistent values, which allows projects to build as intended:

        $ msbuild tests/Java.Interop-Tests/Java.Interop-Tests.csproj
        # no errors