### PR TITLE
[Java.Interop, jnienv-gen] Add netcoreapp3.1 support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,13 +18,16 @@
       Condition="Exists('$(_OutputPath)MonoInfo.props')"
   />
   <PropertyGroup Condition=" '$(TargetFramework)' != '' And $(TargetFramework.StartsWith ('netcoreapp')) ">
+    <JIBuildingForNetCoreApp>True</JIBuildingForNetCoreApp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(JIBuildingForNetCoreApp)' == 'True' ">
     <BuildToolOutputFullPath>$(MSBuildThisFileDirectory)bin\Build$(Configuration)-$(TargetFramework)\</BuildToolOutputFullPath>
     <ToolOutputFullPath>$(MSBuildThisFileDirectory)bin\$(Configuration)-$(TargetFramework)\</ToolOutputFullPath>
     <TestOutputFullPath>$(MSBuildThisFileDirectory)bin\Test$(Configuration)-$(TargetFramework)\</TestOutputFullPath>
     <UtilityOutputFullPath Condition=" '$(UtilityOutputFullPathCoreApps)' != '' ">$(UtilityOutputFullPathCoreApps)</UtilityOutputFullPath>
     <UtilityOutputFullPath Condition=" '$(UtilityOutputFullPathCoreApps)' == '' ">$(ToolOutputFullPath)</UtilityOutputFullPath>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == '' Or !$(TargetFramework.StartsWith ('netcoreapp')) ">
+  <PropertyGroup Condition=" '$(JIBuildingForNetCoreApp)' != 'True' ">
     <BuildToolOutputFullPath>$(MSBuildThisFileDirectory)bin\Build$(Configuration)\</BuildToolOutputFullPath>
     <ToolOutputFullPath>$(MSBuildThisFileDirectory)bin\$(Configuration)\</ToolOutputFullPath>
     <TestOutputFullPath>$(MSBuildThisFileDirectory)bin\Test$(Configuration)\</TestOutputFullPath>

--- a/build-tools/jnienv-gen/jnienv-gen.csproj
+++ b/build-tools/jnienv-gen/jnienv-gen.csproj
@@ -2,9 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(Configuration)\$(TargetFramework.ToLowerInvariant())\</IntermediateOutputPath>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Java.Interop/Directory.Build.targets
+++ b/src/Java.Interop/Directory.Build.targets
@@ -2,6 +2,10 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Runtime Condition="'$(OS)' != 'Windows_NT'">mono</Runtime>
+    <_JNIEnvGenPath Condition=" '$(JIBuildingForNetCoreApp)' == 'True' ">$(BuildToolOutputFullPath)jnienv-gen.dll</_JNIEnvGenPath>
+    <_JNIEnvGenPath Condition=" '$(JIBuildingForNetCoreApp)' != 'True' ">$(BuildToolOutputFullPath)jnienv-gen.exe</_JNIEnvGenPath>
+    <_RunJNIEnvGen Condition=" '$(JIBuildingForNetCoreApp)' == 'True' ">dotnet "$(_JNIEnvGenPath)"</_RunJNIEnvGen>
+    <_RunJNIEnvGen Condition=" '$(JIBuildingForNetCoreApp)' != 'True' ">$(Runtime) "$(_JNIEnvGenPath)"</_RunJNIEnvGen>
   </PropertyGroup>
   <ItemGroup>
     <CompileJavaInteropJar Include="java\com\xamarin\java_interop\internal\JavaProxyObject.java" />
@@ -16,14 +20,14 @@
   </ItemGroup>
   <Target Name="BuildJniEnvironment_g_cs"
       BeforeTargets="BeforeCompile"
-      Inputs="$(JNIEnvGenPath)\jnienv-gen.exe"
+      Inputs="$(_JNIEnvGenPath)"
       Outputs="Java.Interop\JniEnvironment.g.cs;$(IntermediateOutputPath)\jni.c">
     <MakeDir Directories="$(IntermediateOutputPath)" />
     <PropertyGroup>
       <_AddCompile Condition=" !Exists('Java.Interop\JniEnvironment.g.cs') ">True</_AddCompile>
     </PropertyGroup>
     <Exec
-        Command="$(Runtime) &quot;$(JNIEnvGenPath)\jnienv-gen.exe&quot; Java.Interop\JniEnvironment.g.cs $(IntermediateOutputPath)\jni.c"
+        Command="$(_RunJNIEnvGen) Java.Interop\JniEnvironment.g.cs $(IntermediateOutputPath)\jni.c"
     />
     <ItemGroup>
       <Compile Include="Java.Interop\JniEnvironment.g.cs" Condition=" '$(_AddCompile)' == 'True' " />

--- a/src/Java.Interop/Java.Interop-MonoAndroid.csproj
+++ b/src/Java.Interop/Java.Interop-MonoAndroid.csproj
@@ -76,7 +76,7 @@
       <Private>False</Private>
     </Reference>
   </ItemGroup>
-  <Import Project="Java.Interop.targets" />
+  <Import Project="Directory.Build.targets" />
   <PropertyGroup>
     <BuildDependsOn>
       BuildJniEnvironment_g_cs;

--- a/src/Java.Interop/Java.Interop.csproj
+++ b/src/Java.Interop/Java.Interop.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <NoWarn>1591</NoWarn>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
@@ -9,26 +9,19 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(Configuration)\$(TargetFramework.ToLowerInvariant())\</IntermediateOutputPath>
+    <OutputPath>$(ToolOutputFullPath)</OutputPath>
+    <DocumentationFile>$(ToolOutputFullPath)Java.Interop.xml</DocumentationFile>
+    <JNIEnvGenPath>$(BuildToolOutputFullPath)</JNIEnvGenPath>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <OutputPath>..\..\bin\Debug</OutputPath>
-    <DocumentationFile>..\..\bin\Debug\Java.Interop.xml</DocumentationFile>
-    <JNIEnvGenPath>..\..\bin\BuildDebug</JNIEnvGenPath>
-    <DefineConstants>$(DefineConstants);DEBUG;NETSTANDARD;NETSTANDARD2_0</DefineConstants>
-    <LangVersion>8.0</LangVersion>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <OutputPath>..\..\bin\Release</OutputPath>
-    <DocumentationFile>..\..\bin\Release\Java.Interop.xml</DocumentationFile>
-    <JNIEnvGenPath>..\..\bin\BuildRelease</JNIEnvGenPath>
-    <LangVersion>8.0</LangVersion>
-    <Nullable>enable</Nullable>
+    <DefineConstants>DEBUG;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Java.Interop\JniLocationException.cs" />
   </ItemGroup>
-  <Import Project="Java.Interop.targets" />
   <PropertyGroup>
     <BuildDependsOn>
       BuildJniEnvironment_g_cs;
@@ -60,7 +53,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <ProjectReference Include="..\..\build-tools\jnienv-gen\jnienv-gen.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" />
+    <ProjectReference Include="..\..\build-tools\jnienv-gen\jnienv-gen.csproj"
+        ReferenceOutputAssembly="false"
+    />
   </ItemGroup>
   <ItemGroup>
     <Compile Condition=" '$(EnableDefaultCompileItems)' == 'true' " Update="Java.Interop\JavaPrimitiveArrays.cs">


### PR DESCRIPTION
`Java.Interop.dll` is already a .NET Standard 2.0 library, which is
already compatible with .NETCoreApp,Version=3.1.  Why does it need to
be built against `netcoreapp3.1` framework?

Consistent Assembly References.

`Java.Interop.dll` was originally a PCL, and before it became a
.NET Standard 2.0 library in commit 85be94f3, we added support to
build `Java.Interop.dll` as a `MonoAndroid`-profile assembly in commit
893562cb, as doing so reduced the assemblies referenced from the PCL
version from 15 assemblies (`System.Runtime`, `System.Collections`, …)
down to *3* assemblies: `mscorlib`, `System`, `System.Core`.  Reducing
the number of assemblies referenced improved build and deploy times.

In the .NET Standard 2.0 world order, `Java.Interop.dll` now has *one*
assembly reference: `netstandard`.

However, within Xamarin.Android, `netstandard.dll` has 16 assembly
references (as of mono/2020-02), which *might* matter, but very likely
doesn't matter *that* much, as any large app will probably be pulling
in .NET Standard libraries anyway.

Why add `netcoreapp3.1` support to `Java.Interop.csproj`?  While it's
not strictly *needed*, it does increase consistency, replacing the
`netstandard` assembly reference with "real" references which will be
consistent with the [equivalent `Mono.Android.dll`][0].

To build `Java.Interop.dll` for `netcoreapp3.1`, also begin building
`jnienv-gen` for netcoreapp3.1, and add the appropriate build system
voodoo so that it can be executed.

[0]: https://github.com/xamarin/xamarin-android/commit/e2854ee71961d4a9910944e5b2aa7107cdf2349c