### PR TITLE
[PrepareWindows] Use an updated version of NuGet.exe.

### DIFF
--- a/build-tools/scripts/PrepareWindows.targets
+++ b/build-tools/scripts/PrepareWindows.targets
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <_TopDir>$(MSBuildThisFileDirectory)..\..</_TopDir>
-    <_NuGetUri>https://dist.nuget.org/win-x86-commandline/v4.7.1/nuget.exe</_NuGetUri>
+    <_NuGetUri>https://dist.nuget.org/win-x86-commandline/v5.4.0/nuget.exe</_NuGetUri>
     <_NuGetPath>$(_TopDir)\.nuget</_NuGetPath>
     <_NuGet>$(_NuGetPath)\NuGet.exe</_NuGet>
   </PropertyGroup>


### PR DESCRIPTION
The version of `NuGet.exe` that is downloaded during `msbuild Java.Interop /t:Prepare` on Windows is unable to load all the needed assemblies in order to complete a restore:

```
C:\code\xamarin-android\external\Java.Interop\build-tools\scripts\..\..\.nuget\NuGet.exe restore Java.Interop.sln
  MSBuild auto-detection: using msbuild version '16.6.0.15501' from 'C:\Program Files (x86)\Microsoft Visual Studio\201  9\Preview\MSBuild\Current\bin'.
  Error parsing solution file at C:\code\xamarin-android\external\Java.Interop\Java.Interop.sln: Exception has been thrown by the target of an invocation.  The project file could not be loaded. Could not load file or assembly 'Microsoft.Build.Framework, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. The system cannot find the file specified.  C:\code\xamarin-android\external\Java.Interop\Java.Interop.sln
```

This is fixed by updating to a newer version of NuGet: 5.4.