### PR TITLE
[generator] Use 'var' when possible in generated code to reduce nullability annotations.

### DIFF
--- a/tests/generator-Tests/Tests-Core/expected.cp/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/Tests-Core/expected.cp/Java.Interop.__TypeRegistrations.cs
@@ -27,7 +27,7 @@ namespace Java.Interop {
 
 		static Type Lookup (string[] mappings, string javaType)
 		{
-			string managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
+			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
 			if (managedType == null)
 				return null;
 			return Type.GetType (managedType);

--- a/tests/generator-Tests/Tests-Core/expected.ji/Android.Text.ISpannable.cs
+++ b/tests/generator-Tests/Tests-Core/expected.ji/Android.Text.ISpannable.cs
@@ -73,8 +73,8 @@ namespace Android.Text {
 
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_tag)
 		{
-			Android.Text.ISpannable __this = global::Java.Lang.Object.GetObject<Android.Text.ISpannable> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			Java.Lang.Object tag = global::Java.Lang.Object.GetObject<Java.Lang.Object> (native_tag, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<Android.Text.ISpannable> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var tag = global::Java.Lang.Object.GetObject<Java.Lang.Object> (native_tag, JniHandleOwnership.DoNotTransfer);
 			int __ret = (int) __this.GetSpanFlags (tag);
 			return __ret;
 		}
@@ -87,7 +87,7 @@ namespace Android.Text {
 				id_getSpanFlags_Ljava_lang_Object_ = JNIEnv.GetMethodID (class_ref, "getSpanFlags", "(Ljava/lang/Object;)I");
 			JValue* __args = stackalloc JValue [1];
 			__args [0] = new JValue ((tag == null) ? IntPtr.Zero : ((global::Java.Lang.Object) tag).Handle);
-			Android.Text.SpanTypes __ret = (Android.Text.SpanTypes) JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getSpanFlags_Ljava_lang_Object_, __args);
+			var __ret = (Android.Text.SpanTypes) JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getSpanFlags_Ljava_lang_Object_, __args);
 			return __ret;
 		}
 

--- a/tests/generator-Tests/Tests-Core/expected.ji/Android.Text.ISpanned.cs
+++ b/tests/generator-Tests/Tests-Core/expected.ji/Android.Text.ISpanned.cs
@@ -78,8 +78,8 @@ namespace Android.Text {
 
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_tag)
 		{
-			Android.Text.ISpanned __this = global::Java.Lang.Object.GetObject<Android.Text.ISpanned> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			Java.Lang.Object tag = global::Java.Lang.Object.GetObject<Java.Lang.Object> (native_tag, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<Android.Text.ISpanned> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var tag = global::Java.Lang.Object.GetObject<Java.Lang.Object> (native_tag, JniHandleOwnership.DoNotTransfer);
 			int __ret = (int) __this.GetSpanFlags (tag);
 			return __ret;
 		}
@@ -92,7 +92,7 @@ namespace Android.Text {
 				id_getSpanFlags_Ljava_lang_Object_ = JNIEnv.GetMethodID (class_ref, "getSpanFlags", "(Ljava/lang/Object;)I");
 			JValue* __args = stackalloc JValue [1];
 			__args [0] = new JValue ((tag == null) ? IntPtr.Zero : ((global::Java.Lang.Object) tag).Handle);
-			Android.Text.SpanTypes __ret = (Android.Text.SpanTypes) JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getSpanFlags_Ljava_lang_Object_, __args);
+			var __ret = (Android.Text.SpanTypes) JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getSpanFlags_Ljava_lang_Object_, __args);
 			return __ret;
 		}
 

--- a/tests/generator-Tests/Tests-Core/expected.ji/Android.Text.SpannableString.cs
+++ b/tests/generator-Tests/Tests-Core/expected.ji/Android.Text.SpannableString.cs
@@ -84,8 +84,8 @@ namespace Android.Text {
 
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_what)
 		{
-			Android.Text.SpannableString __this = global::Java.Lang.Object.GetObject<Android.Text.SpannableString> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			Java.Lang.Object what = global::Java.Lang.Object.GetObject<Java.Lang.Object> (native_what, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<Android.Text.SpannableString> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var what = global::Java.Lang.Object.GetObject<Java.Lang.Object> (native_what, JniHandleOwnership.DoNotTransfer);
 			int __ret = (int) __this.GetSpanFlags (what);
 			return __ret;
 		}

--- a/tests/generator-Tests/Tests-Core/expected.ji/Android.Text.SpannableStringInternal.cs
+++ b/tests/generator-Tests/Tests-Core/expected.ji/Android.Text.SpannableStringInternal.cs
@@ -41,8 +41,8 @@ namespace Android.Text {
 
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
 		{
-			Android.Text.SpannableStringInternal __this = global::Java.Lang.Object.GetObject<Android.Text.SpannableStringInternal> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			Java.Lang.Object p0 = global::Java.Lang.Object.GetObject<Java.Lang.Object> (native_p0, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<Android.Text.SpannableStringInternal> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var p0 = global::Java.Lang.Object.GetObject<Java.Lang.Object> (native_p0, JniHandleOwnership.DoNotTransfer);
 			int __ret = (int) __this.GetSpanFlags (p0);
 			return __ret;
 		}

--- a/tests/generator-Tests/Tests-Core/expected.ji/Android.Views.View.cs
+++ b/tests/generator-Tests/Tests-Core/expected.ji/Android.Views.View.cs
@@ -81,8 +81,8 @@ namespace Android.Views {
 
 			static void n_OnClick_Landroid_view_View_ (IntPtr jnienv, IntPtr native__this, IntPtr native_v)
 			{
-				Android.Views.View.IOnClickListener __this = global::Java.Lang.Object.GetObject<Android.Views.View.IOnClickListener> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-				Android.Views.View v = global::Java.Lang.Object.GetObject<Android.Views.View> (native_v, JniHandleOwnership.DoNotTransfer);
+				var __this = global::Java.Lang.Object.GetObject<Android.Views.View.IOnClickListener> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var v = global::Java.Lang.Object.GetObject<Android.Views.View> (native_v, JniHandleOwnership.DoNotTransfer);
 				__this.OnClick (v);
 			}
 #pragma warning restore 0169
@@ -160,8 +160,8 @@ namespace Android.Views {
 
 		static void n_SetOnClickListener_Landroid_view_View_OnClickListener_ (IntPtr jnienv, IntPtr native__this, IntPtr native_l)
 		{
-			Android.Views.View __this = global::Java.Lang.Object.GetObject<Android.Views.View> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			Android.Views.View.IOnClickListener l = (Android.Views.View.IOnClickListener)global::Java.Lang.Object.GetObject<Android.Views.View.IOnClickListener> (native_l, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<Android.Views.View> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var l = (Android.Views.View.IOnClickListener)global::Java.Lang.Object.GetObject<Android.Views.View.IOnClickListener> (native_l, JniHandleOwnership.DoNotTransfer);
 			__this.SetOnClickListener (l);
 		}
 #pragma warning restore 0169
@@ -190,8 +190,8 @@ namespace Android.Views {
 
 		static void n_SetOn123Listener_Landroid_view_View_OnClickListener_ (IntPtr jnienv, IntPtr native__this, IntPtr native_l)
 		{
-			Android.Views.View __this = global::Java.Lang.Object.GetObject<Android.Views.View> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			Android.Views.View.IOnClickListener l = (Android.Views.View.IOnClickListener)global::Java.Lang.Object.GetObject<Android.Views.View.IOnClickListener> (native_l, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<Android.Views.View> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var l = (Android.Views.View.IOnClickListener)global::Java.Lang.Object.GetObject<Android.Views.View.IOnClickListener> (native_l, JniHandleOwnership.DoNotTransfer);
 			__this.SetOn123Listener (l);
 		}
 #pragma warning restore 0169
@@ -220,7 +220,7 @@ namespace Android.Views {
 
 		static void n_AddTouchables_Ljava_util_ArrayList_ (IntPtr jnienv, IntPtr native__this, IntPtr native_views)
 		{
-			Android.Views.View __this = global::Java.Lang.Object.GetObject<Android.Views.View> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<Android.Views.View> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			var views = Android.Runtime.JavaList<Android.Views.View>.FromJniHandle (native_views, JniHandleOwnership.DoNotTransfer);
 			__this.AddTouchables (views);
 		}

--- a/tests/generator-Tests/Tests-Core/expected.ji/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/Tests-Core/expected.ji/Java.Interop.__TypeRegistrations.cs
@@ -27,7 +27,7 @@ namespace Java.Interop {
 
 		static Type Lookup (string[] mappings, string javaType)
 		{
-			string managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
+			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
 			if (managedType == null)
 				return null;
 			return Type.GetType (managedType);

--- a/tests/generator-Tests/Tests-Core/expected/Android.Text.ISpannable.cs
+++ b/tests/generator-Tests/Tests-Core/expected/Android.Text.ISpannable.cs
@@ -64,8 +64,8 @@ namespace Android.Text {
 
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_tag)
 		{
-			Android.Text.ISpannable __this = global::Java.Lang.Object.GetObject<Android.Text.ISpannable> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			Java.Lang.Object tag = global::Java.Lang.Object.GetObject<Java.Lang.Object> (native_tag, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<Android.Text.ISpannable> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var tag = global::Java.Lang.Object.GetObject<Java.Lang.Object> (native_tag, JniHandleOwnership.DoNotTransfer);
 			int __ret = (int) __this.GetSpanFlags (tag);
 			return __ret;
 		}
@@ -78,7 +78,7 @@ namespace Android.Text {
 				id_getSpanFlags_Ljava_lang_Object_ = JNIEnv.GetMethodID (class_ref, "getSpanFlags", "(Ljava/lang/Object;)I");
 			JValue* __args = stackalloc JValue [1];
 			__args [0] = new JValue (tag);
-			Android.Text.SpanTypes __ret = (Android.Text.SpanTypes) JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getSpanFlags_Ljava_lang_Object_, __args);
+			var __ret = (Android.Text.SpanTypes) JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getSpanFlags_Ljava_lang_Object_, __args);
 			return __ret;
 		}
 

--- a/tests/generator-Tests/Tests-Core/expected/Android.Text.ISpanned.cs
+++ b/tests/generator-Tests/Tests-Core/expected/Android.Text.ISpanned.cs
@@ -69,8 +69,8 @@ namespace Android.Text {
 
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_tag)
 		{
-			Android.Text.ISpanned __this = global::Java.Lang.Object.GetObject<Android.Text.ISpanned> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			Java.Lang.Object tag = global::Java.Lang.Object.GetObject<Java.Lang.Object> (native_tag, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<Android.Text.ISpanned> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var tag = global::Java.Lang.Object.GetObject<Java.Lang.Object> (native_tag, JniHandleOwnership.DoNotTransfer);
 			int __ret = (int) __this.GetSpanFlags (tag);
 			return __ret;
 		}
@@ -83,7 +83,7 @@ namespace Android.Text {
 				id_getSpanFlags_Ljava_lang_Object_ = JNIEnv.GetMethodID (class_ref, "getSpanFlags", "(Ljava/lang/Object;)I");
 			JValue* __args = stackalloc JValue [1];
 			__args [0] = new JValue (tag);
-			Android.Text.SpanTypes __ret = (Android.Text.SpanTypes) JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getSpanFlags_Ljava_lang_Object_, __args);
+			var __ret = (Android.Text.SpanTypes) JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getSpanFlags_Ljava_lang_Object_, __args);
 			return __ret;
 		}
 

--- a/tests/generator-Tests/Tests-Core/expected/Android.Text.SpannableString.cs
+++ b/tests/generator-Tests/Tests-Core/expected/Android.Text.SpannableString.cs
@@ -98,8 +98,8 @@ namespace Android.Text {
 
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_what)
 		{
-			Android.Text.SpannableString __this = global::Java.Lang.Object.GetObject<Android.Text.SpannableString> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			Java.Lang.Object what = global::Java.Lang.Object.GetObject<Java.Lang.Object> (native_what, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<Android.Text.SpannableString> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var what = global::Java.Lang.Object.GetObject<Java.Lang.Object> (native_what, JniHandleOwnership.DoNotTransfer);
 			int __ret = (int) __this.GetSpanFlags (what);
 			return __ret;
 		}

--- a/tests/generator-Tests/Tests-Core/expected/Android.Text.SpannableStringInternal.cs
+++ b/tests/generator-Tests/Tests-Core/expected/Android.Text.SpannableStringInternal.cs
@@ -36,8 +36,8 @@ namespace Android.Text {
 
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
 		{
-			Android.Text.SpannableStringInternal __this = global::Java.Lang.Object.GetObject<Android.Text.SpannableStringInternal> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			Java.Lang.Object p0 = global::Java.Lang.Object.GetObject<Java.Lang.Object> (native_p0, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<Android.Text.SpannableStringInternal> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var p0 = global::Java.Lang.Object.GetObject<Java.Lang.Object> (native_p0, JniHandleOwnership.DoNotTransfer);
 			int __ret = (int) __this.GetSpanFlags (p0);
 			return __ret;
 		}

--- a/tests/generator-Tests/Tests-Core/expected/Android.Views.View.cs
+++ b/tests/generator-Tests/Tests-Core/expected/Android.Views.View.cs
@@ -72,8 +72,8 @@ namespace Android.Views {
 
 			static void n_OnClick_Landroid_view_View_ (IntPtr jnienv, IntPtr native__this, IntPtr native_v)
 			{
-				Android.Views.View.IOnClickListener __this = global::Java.Lang.Object.GetObject<Android.Views.View.IOnClickListener> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-				Android.Views.View v = global::Java.Lang.Object.GetObject<Android.Views.View> (native_v, JniHandleOwnership.DoNotTransfer);
+				var __this = global::Java.Lang.Object.GetObject<Android.Views.View.IOnClickListener> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var v = global::Java.Lang.Object.GetObject<Android.Views.View> (native_v, JniHandleOwnership.DoNotTransfer);
 				__this.OnClick (v);
 			}
 #pragma warning restore 0169
@@ -147,8 +147,8 @@ namespace Android.Views {
 
 		static void n_SetOnClickListener_Landroid_view_View_OnClickListener_ (IntPtr jnienv, IntPtr native__this, IntPtr native_l)
 		{
-			Android.Views.View __this = global::Java.Lang.Object.GetObject<Android.Views.View> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			Android.Views.View.IOnClickListener l = (Android.Views.View.IOnClickListener)global::Java.Lang.Object.GetObject<Android.Views.View.IOnClickListener> (native_l, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<Android.Views.View> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var l = (Android.Views.View.IOnClickListener)global::Java.Lang.Object.GetObject<Android.Views.View.IOnClickListener> (native_l, JniHandleOwnership.DoNotTransfer);
 			__this.SetOnClickListener (l);
 		}
 #pragma warning restore 0169
@@ -183,8 +183,8 @@ namespace Android.Views {
 
 		static void n_SetOn123Listener_Landroid_view_View_OnClickListener_ (IntPtr jnienv, IntPtr native__this, IntPtr native_l)
 		{
-			Android.Views.View __this = global::Java.Lang.Object.GetObject<Android.Views.View> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			Android.Views.View.IOnClickListener l = (Android.Views.View.IOnClickListener)global::Java.Lang.Object.GetObject<Android.Views.View.IOnClickListener> (native_l, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<Android.Views.View> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var l = (Android.Views.View.IOnClickListener)global::Java.Lang.Object.GetObject<Android.Views.View.IOnClickListener> (native_l, JniHandleOwnership.DoNotTransfer);
 			__this.SetOn123Listener (l);
 		}
 #pragma warning restore 0169
@@ -219,7 +219,7 @@ namespace Android.Views {
 
 		static void n_AddTouchables_Ljava_util_ArrayList_ (IntPtr jnienv, IntPtr native__this, IntPtr native_views)
 		{
-			Android.Views.View __this = global::Java.Lang.Object.GetObject<Android.Views.View> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<Android.Views.View> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			var views = Android.Runtime.JavaList<Android.Views.View>.FromJniHandle (native_views, JniHandleOwnership.DoNotTransfer);
 			__this.AddTouchables (views);
 		}

--- a/tests/generator-Tests/Tests-Core/expected/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/Tests-Core/expected/Java.Interop.__TypeRegistrations.cs
@@ -27,7 +27,7 @@ namespace Java.Interop {
 
 		static Type Lookup (string[] mappings, string javaType)
 		{
-			string managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
+			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
 			if (managedType == null)
 				return null;
 			return Type.GetType (managedType);

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteInterfaceMethodInvokers.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteInterfaceMethodInvokers.txt
@@ -9,8 +9,8 @@ static Delegate GetGetCountForKey_Ljava_lang_String_Handler ()
 
 static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
 {
-	java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-	string key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
 	int __ret = __this.GetCountForKey (key);
 	return __ret;
 }
@@ -24,7 +24,7 @@ public unsafe int GetCountForKey (string key)
 	IntPtr native_key = JNIEnv.NewString (key);
 	JValue* __args = stackalloc JValue [1];
 	__args [0] = new JValue (native_key);
-	int __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_GetCountForKey_Ljava_lang_String_, __args);
+	var __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_GetCountForKey_Ljava_lang_String_, __args);
 	JNIEnv.DeleteLocalRef (native_key);
 	return __ret;
 }
@@ -40,7 +40,7 @@ static Delegate GetKeyHandler ()
 
 static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
 {
-	java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	return JNIEnv.NewString (__this.Key ());
 }
 #pragma warning restore 0169
@@ -64,7 +64,7 @@ static Delegate GetAbstractMethodHandler ()
 
 static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)
 {
-	java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	__this.AbstractMethod ();
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteInterfaceMethodInvokersWithSkips.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteInterfaceMethodInvokersWithSkips.txt
@@ -9,8 +9,8 @@ static Delegate GetGetCountForKey_Ljava_lang_String_Handler ()
 
 static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
 {
-	java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-	string key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
 	int __ret = __this.GetCountForKey (key);
 	return __ret;
 }
@@ -24,7 +24,7 @@ public unsafe int GetCountForKey (string key)
 	IntPtr native_key = JNIEnv.NewString (key);
 	JValue* __args = stackalloc JValue [1];
 	__args [0] = new JValue (native_key);
-	int __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_GetCountForKey_Ljava_lang_String_, __args);
+	var __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_GetCountForKey_Ljava_lang_String_, __args);
 	JNIEnv.DeleteLocalRef (native_key);
 	return __ret;
 }
@@ -40,7 +40,7 @@ static Delegate GetKeyHandler ()
 
 static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
 {
-	java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	return JNIEnv.NewString (__this.Key ());
 }
 #pragma warning restore 0169
@@ -64,7 +64,7 @@ static Delegate GetAbstractMethodHandler ()
 
 static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)
 {
-	java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	__this.AbstractMethod ();
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteInterfacePropertyInvokers.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteInterfacePropertyInvokers.txt
@@ -9,7 +9,7 @@ static Delegate Getget_CountHandler ()
 
 static int n_get_Count (IntPtr jnienv, IntPtr native__this)
 {
-	java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	return __this.Count;
 }
 #pragma warning restore 0169
@@ -25,7 +25,7 @@ static Delegate Getset_Count_IHandler ()
 
 static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
 {
-	java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	__this.Count = value;
 }
 #pragma warning restore 0169
@@ -58,7 +58,7 @@ static Delegate Getget_KeyHandler ()
 
 static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
 {
-	java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	return JNIEnv.NewString (__this.Key);
 }
 #pragma warning restore 0169
@@ -74,8 +74,8 @@ static Delegate Getset_Key_Ljava_lang_String_Handler ()
 
 static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 {
-	java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-	string value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
 	__this.Key = value;
 }
 #pragma warning restore 0169
@@ -110,7 +110,7 @@ static Delegate Getget_StaticCountHandler ()
 
 static int n_get_StaticCount (IntPtr jnienv, IntPtr native__this)
 {
-	java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	return __this.StaticCount;
 }
 #pragma warning restore 0169
@@ -126,7 +126,7 @@ static Delegate Getset_StaticCount_IHandler ()
 
 static void n_set_StaticCount_I (IntPtr jnienv, IntPtr native__this, int value)
 {
-	java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	__this.StaticCount = value;
 }
 #pragma warning restore 0169
@@ -159,7 +159,7 @@ static Delegate Getget_AbstractCountHandler ()
 
 static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
 {
-	java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	return __this.AbstractCount;
 }
 #pragma warning restore 0169
@@ -175,7 +175,7 @@ static Delegate Getset_AbstractCount_IHandler ()
 
 static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
 {
-	java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	__this.AbstractCount = value;
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteInterfacePropertyInvokersWithSkips.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteInterfacePropertyInvokersWithSkips.txt
@@ -9,7 +9,7 @@ static Delegate Getget_KeyHandler ()
 
 static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
 {
-	java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	return JNIEnv.NewString (__this.Key);
 }
 #pragma warning restore 0169
@@ -25,8 +25,8 @@ static Delegate Getset_Key_Ljava_lang_String_Handler ()
 
 static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 {
-	java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-	string value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
 	__this.Key = value;
 }
 #pragma warning restore 0169
@@ -61,7 +61,7 @@ static Delegate Getget_StaticCountHandler ()
 
 static int n_get_StaticCount (IntPtr jnienv, IntPtr native__this)
 {
-	java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	return __this.StaticCount;
 }
 #pragma warning restore 0169
@@ -77,7 +77,7 @@ static Delegate Getset_StaticCount_IHandler ()
 
 static void n_set_StaticCount_I (IntPtr jnienv, IntPtr native__this, int value)
 {
-	java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	__this.StaticCount = value;
 }
 #pragma warning restore 0169
@@ -110,7 +110,7 @@ static Delegate Getget_AbstractCountHandler ()
 
 static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
 {
-	java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	return __this.AbstractCount;
 }
 #pragma warning restore 0169
@@ -126,7 +126,7 @@ static Delegate Getset_AbstractCount_IHandler ()
 
 static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
 {
-	java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	__this.AbstractCount = value;
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WritePropertyAbstractDeclaration.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WritePropertyAbstractDeclaration.txt
@@ -9,7 +9,7 @@ static Delegate Getget_MyPropertyHandler ()
 
 static int n_get_MyProperty (IntPtr jnienv, IntPtr native__this)
 {
-	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	return __this.MyProperty;
 }
 #pragma warning restore 0169
@@ -25,7 +25,7 @@ static Delegate Getset_MyProperty_IHandler ()
 
 static void n_set_MyProperty_I (IntPtr jnienv, IntPtr native__this, int value)
 {
-	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	__this.MyProperty = value;
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WritePropertyCallbacks.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WritePropertyCallbacks.txt
@@ -9,7 +9,7 @@ static Delegate Getget_MyPropertyHandler ()
 
 static int n_get_MyProperty (IntPtr jnienv, IntPtr native__this)
 {
-	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	return __this.MyProperty;
 }
 #pragma warning restore 0169
@@ -25,7 +25,7 @@ static Delegate Getset_MyProperty_IHandler ()
 
 static void n_set_MyProperty_I (IntPtr jnienv, IntPtr native__this, int value)
 {
-	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	__this.MyProperty = value;
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WritePropertyInvoker.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WritePropertyInvoker.txt
@@ -9,7 +9,7 @@ static Delegate Getget_MyPropertyHandler ()
 
 static int n_get_MyProperty (IntPtr jnienv, IntPtr native__this)
 {
-	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	return __this.MyProperty;
 }
 #pragma warning restore 0169
@@ -25,7 +25,7 @@ static Delegate Getset_MyProperty_IHandler ()
 
 static void n_set_MyProperty_I (IntPtr jnienv, IntPtr native__this, int value)
 {
-	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	__this.MyProperty = value;
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WritePropertyStringVariant.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WritePropertyStringVariant.txt
@@ -1,7 +1,7 @@
 public string MyProperty {
 	get { return MyProperty == null ? null : MyProperty.ToString (); }
 	set {
-		global::Java.Lang.String jls = value == null ? null : new global::Java.Lang.String (value);
+		var jls = value == null ? null : new global::Java.Lang.String (value);
 		MyProperty = jls;
 		if (jls != null) jls.Dispose ();
 	}

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteClass.txt
@@ -62,7 +62,7 @@ public partial class MyClass  {
 
 	static int n_get_Count (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return __this.Count;
 	}
 #pragma warning restore 0169
@@ -78,7 +78,7 @@ public partial class MyClass  {
 
 	static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.Count = value;
 	}
 #pragma warning restore 0169
@@ -118,7 +118,7 @@ public partial class MyClass  {
 
 	static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return JNIEnv.NewString (__this.Key);
 	}
 #pragma warning restore 0169
@@ -134,8 +134,8 @@ public partial class MyClass  {
 
 	static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 	{
-		java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		string value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
 		__this.Key = value;
 	}
 #pragma warning restore 0169
@@ -201,7 +201,7 @@ public partial class MyClass  {
 
 	static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return __this.AbstractCount;
 	}
 #pragma warning restore 0169
@@ -217,7 +217,7 @@ public partial class MyClass  {
 
 	static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.AbstractCount = value;
 	}
 #pragma warning restore 0169
@@ -240,8 +240,8 @@ public partial class MyClass  {
 
 	static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
 	{
-		java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		string key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
 		int __ret = __this.GetCountForKey (key);
 		return __ret;
 	}
@@ -274,7 +274,7 @@ public partial class MyClass  {
 
 	static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return JNIEnv.NewString (__this.Key ());
 	}
 #pragma warning restore 0169
@@ -313,7 +313,7 @@ public partial class MyClass  {
 
 	static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.AbstractMethod ();
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteClassMethods.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteClassMethods.txt
@@ -9,8 +9,8 @@ static Delegate GetGetCountForKey_Ljava_lang_String_Handler ()
 
 static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
 {
-	java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-	string key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
 	int __ret = __this.GetCountForKey (key);
 	return __ret;
 }
@@ -43,7 +43,7 @@ static Delegate GetKeyHandler ()
 
 static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
 {
-	java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	return JNIEnv.NewString (__this.Key ());
 }
 #pragma warning restore 0169
@@ -82,7 +82,7 @@ static Delegate GetAbstractMethodHandler ()
 
 static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)
 {
-	java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	__this.AbstractMethod ();
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteClassProperties.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteClassProperties.txt
@@ -9,7 +9,7 @@ static Delegate Getget_CountHandler ()
 
 static int n_get_Count (IntPtr jnienv, IntPtr native__this)
 {
-	java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	return __this.Count;
 }
 #pragma warning restore 0169
@@ -25,7 +25,7 @@ static Delegate Getset_Count_IHandler ()
 
 static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
 {
-	java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	__this.Count = value;
 }
 #pragma warning restore 0169
@@ -65,7 +65,7 @@ static Delegate Getget_KeyHandler ()
 
 static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
 {
-	java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	return JNIEnv.NewString (__this.Key);
 }
 #pragma warning restore 0169
@@ -81,8 +81,8 @@ static Delegate Getset_Key_Ljava_lang_String_Handler ()
 
 static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 {
-	java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-	string value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
 	__this.Key = value;
 }
 #pragma warning restore 0169
@@ -148,7 +148,7 @@ static Delegate Getget_AbstractCountHandler ()
 
 static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
 {
-	java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	return __this.AbstractCount;
 }
 #pragma warning restore 0169
@@ -164,7 +164,7 @@ static Delegate Getset_AbstractCount_IHandler ()
 
 static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
 {
-	java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	__this.AbstractCount = value;
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteDefaultInterfaceMethodInvoker.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteDefaultInterfaceMethodInvoker.txt
@@ -60,7 +60,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static void n_DoDeclaration (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.DoDeclaration ();
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterface.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterface.txt
@@ -129,7 +129,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static int n_get_Count (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return __this.Count;
 	}
 #pragma warning restore 0169
@@ -145,7 +145,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.Count = value;
 	}
 #pragma warning restore 0169
@@ -178,7 +178,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return JNIEnv.NewString (__this.Key);
 	}
 #pragma warning restore 0169
@@ -194,8 +194,8 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		string value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
 		__this.Key = value;
 	}
 #pragma warning restore 0169
@@ -230,7 +230,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return __this.AbstractCount;
 	}
 #pragma warning restore 0169
@@ -246,7 +246,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.AbstractCount = value;
 	}
 #pragma warning restore 0169
@@ -279,8 +279,8 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		string key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
 		int __ret = __this.GetCountForKey (key);
 		return __ret;
 	}
@@ -294,7 +294,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		IntPtr native_key = JNIEnv.NewString (key);
 		JValue* __args = stackalloc JValue [1];
 		__args [0] = new JValue (native_key);
-		int __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_GetCountForKey_Ljava_lang_String_, __args);
+		var __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_GetCountForKey_Ljava_lang_String_, __args);
 		JNIEnv.DeleteLocalRef (native_key);
 		return __ret;
 	}
@@ -310,7 +310,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return JNIEnv.NewString (__this.Key ());
 	}
 #pragma warning restore 0169
@@ -334,7 +334,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.AbstractMethod ();
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterfaceDefaultMethod.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterfaceDefaultMethod.txt
@@ -14,7 +14,7 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 
 	private static void n_DoSomething (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.DoSomething ();
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterfaceDefaultProperty.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterfaceDefaultProperty.txt
@@ -14,7 +14,7 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 
 	private static int n_get_Value (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return __this.Value;
 	}
 #pragma warning restore 0169
@@ -30,7 +30,7 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 
 	private static void n_set_Value_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.Value = value;
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterfaceDefaultPropertyGetterOnly.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterfaceDefaultPropertyGetterOnly.txt
@@ -14,7 +14,7 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 
 	private static int n_get_Value (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return __this.Value;
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterfaceInvoker.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterfaceInvoker.txt
@@ -60,7 +60,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static int n_get_Count (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return __this.Count;
 	}
 #pragma warning restore 0169
@@ -76,7 +76,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.Count = value;
 	}
 #pragma warning restore 0169
@@ -109,7 +109,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return JNIEnv.NewString (__this.Key);
 	}
 #pragma warning restore 0169
@@ -125,8 +125,8 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		string value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
 		__this.Key = value;
 	}
 #pragma warning restore 0169
@@ -161,7 +161,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return __this.AbstractCount;
 	}
 #pragma warning restore 0169
@@ -177,7 +177,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.AbstractCount = value;
 	}
 #pragma warning restore 0169
@@ -210,8 +210,8 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		string key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
 		int __ret = __this.GetCountForKey (key);
 		return __ret;
 	}
@@ -225,7 +225,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		IntPtr native_key = JNIEnv.NewString (key);
 		JValue* __args = stackalloc JValue [1];
 		__args [0] = new JValue (native_key);
-		int __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_GetCountForKey_Ljava_lang_String_, __args);
+		var __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_GetCountForKey_Ljava_lang_String_, __args);
 		JNIEnv.DeleteLocalRef (native_key);
 		return __ret;
 	}
@@ -241,7 +241,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return JNIEnv.NewString (__this.Key ());
 	}
 #pragma warning restore 0169
@@ -265,7 +265,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.AbstractMethod ();
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteMethodAbstractWithVoidReturn.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteMethodAbstractWithVoidReturn.txt
@@ -9,7 +9,7 @@ static Delegate GetbarHandler ()
 
 static void n_bar (IntPtr jnienv, IntPtr native__this)
 {
-	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	__this.bar ();
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteMethodAsyncifiedWithIntReturn.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteMethodAsyncifiedWithIntReturn.txt
@@ -9,7 +9,7 @@ static Delegate GetbarHandler ()
 
 static int n_bar (IntPtr jnienv, IntPtr native__this)
 {
-	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	return __this.bar ();
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteMethodAsyncifiedWithVoidReturn.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteMethodAsyncifiedWithVoidReturn.txt
@@ -9,7 +9,7 @@ static Delegate GetbarHandler ()
 
 static void n_bar (IntPtr jnienv, IntPtr native__this)
 {
-	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	__this.bar ();
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteMethodProtected.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteMethodProtected.txt
@@ -9,7 +9,7 @@ static Delegate GetbarHandler ()
 
 static void n_bar (IntPtr jnienv, IntPtr native__this)
 {
-	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	__this.bar ();
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteMethodWithIntReturn.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteMethodWithIntReturn.txt
@@ -9,7 +9,7 @@ static Delegate GetbarHandler ()
 
 static int n_bar (IntPtr jnienv, IntPtr native__this)
 {
-	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	return __this.bar ();
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteMethodWithStringReturn.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteMethodWithStringReturn.txt
@@ -9,7 +9,7 @@ static Delegate GetbarHandler ()
 
 static IntPtr n_bar (IntPtr jnienv, IntPtr native__this)
 {
-	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	return JNIEnv.NewString (__this.bar ());
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteMethodWithVoidReturn.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteMethodWithVoidReturn.txt
@@ -9,7 +9,7 @@ static Delegate GetbarHandler ()
 
 static void n_bar (IntPtr jnienv, IntPtr native__this)
 {
-	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	__this.bar ();
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteNestedInterfaceClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteNestedInterfaceClass.txt
@@ -98,7 +98,7 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 
 	static int n_GetBar (IntPtr jnienv, IntPtr native__this)
 	{
-		Com.Xamarin.Android.IParent __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return __this.Bar;
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteNestedInterfaceTypes.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteNestedInterfaceTypes.txt
@@ -80,7 +80,7 @@ public partial interface IParent : IJavaObject, IJavaPeerable {
 
 		static int n_GetBar (IntPtr jnienv, IntPtr native__this)
 		{
-			Com.Xamarin.Android.IParent.IChild __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent.IChild> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent.IChild> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.Bar;
 		}
 #pragma warning restore 0169
@@ -161,7 +161,7 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 
 	static int n_GetBar (IntPtr jnienv, IntPtr native__this)
 	{
-		Com.Xamarin.Android.IParent __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return __this.Bar;
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteProperty.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteProperty.txt
@@ -9,7 +9,7 @@ static Delegate Getget_MyPropertyHandler ()
 
 static int n_get_MyProperty (IntPtr jnienv, IntPtr native__this)
 {
-	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	return __this.MyProperty;
 }
 #pragma warning restore 0169
@@ -25,7 +25,7 @@ static Delegate Getset_MyProperty_IHandler ()
 
 static void n_set_MyProperty_I (IntPtr jnienv, IntPtr native__this, int value)
 {
-	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	__this.MyProperty = value;
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteUnnestedInterfaceTypes.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteUnnestedInterfaceTypes.txt
@@ -71,7 +71,7 @@ internal partial class IParentChildInvoker : global::Java.Lang.Object, IParentCh
 
 	static int n_GetBar (IntPtr jnienv, IntPtr native__this)
 	{
-		Com.Xamarin.Android.IParentChild __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParentChild> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParentChild> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return __this.Bar;
 	}
 #pragma warning restore 0169
@@ -161,7 +161,7 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 
 	static int n_GetBar (IntPtr jnienv, IntPtr native__this)
 	{
-		Com.Xamarin.Android.IParent __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return __this.Bar;
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClass.txt
@@ -62,7 +62,7 @@ public partial class MyClass  {
 
 	static int n_get_Count (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return __this.Count;
 	}
 #pragma warning restore 0169
@@ -78,7 +78,7 @@ public partial class MyClass  {
 
 	static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.Count = value;
 	}
 #pragma warning restore 0169
@@ -118,7 +118,7 @@ public partial class MyClass  {
 
 	static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return JNIEnv.NewString (__this.Key);
 	}
 #pragma warning restore 0169
@@ -134,8 +134,8 @@ public partial class MyClass  {
 
 	static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 	{
-		java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		string value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
 		__this.Key = value;
 	}
 #pragma warning restore 0169
@@ -201,7 +201,7 @@ public partial class MyClass  {
 
 	static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return __this.AbstractCount;
 	}
 #pragma warning restore 0169
@@ -217,7 +217,7 @@ public partial class MyClass  {
 
 	static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.AbstractCount = value;
 	}
 #pragma warning restore 0169
@@ -240,8 +240,8 @@ public partial class MyClass  {
 
 	static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
 	{
-		java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		string key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
 		int __ret = __this.GetCountForKey (key);
 		return __ret;
 	}
@@ -274,7 +274,7 @@ public partial class MyClass  {
 
 	static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return JNIEnv.NewString (__this.Key ());
 	}
 #pragma warning restore 0169
@@ -313,7 +313,7 @@ public partial class MyClass  {
 
 	static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.AbstractMethod ();
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClassMethods.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClassMethods.txt
@@ -9,8 +9,8 @@ static Delegate GetGetCountForKey_Ljava_lang_String_Handler ()
 
 static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
 {
-	java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-	string key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
 	int __ret = __this.GetCountForKey (key);
 	return __ret;
 }
@@ -43,7 +43,7 @@ static Delegate GetKeyHandler ()
 
 static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
 {
-	java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	return JNIEnv.NewString (__this.Key ());
 }
 #pragma warning restore 0169
@@ -82,7 +82,7 @@ static Delegate GetAbstractMethodHandler ()
 
 static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)
 {
-	java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	__this.AbstractMethod ();
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClassProperties.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClassProperties.txt
@@ -9,7 +9,7 @@ static Delegate Getget_CountHandler ()
 
 static int n_get_Count (IntPtr jnienv, IntPtr native__this)
 {
-	java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	return __this.Count;
 }
 #pragma warning restore 0169
@@ -25,7 +25,7 @@ static Delegate Getset_Count_IHandler ()
 
 static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
 {
-	java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	__this.Count = value;
 }
 #pragma warning restore 0169
@@ -65,7 +65,7 @@ static Delegate Getget_KeyHandler ()
 
 static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
 {
-	java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	return JNIEnv.NewString (__this.Key);
 }
 #pragma warning restore 0169
@@ -81,8 +81,8 @@ static Delegate Getset_Key_Ljava_lang_String_Handler ()
 
 static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 {
-	java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-	string value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
 	__this.Key = value;
 }
 #pragma warning restore 0169
@@ -148,7 +148,7 @@ static Delegate Getget_AbstractCountHandler ()
 
 static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
 {
-	java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	return __this.AbstractCount;
 }
 #pragma warning restore 0169
@@ -164,7 +164,7 @@ static Delegate Getset_AbstractCount_IHandler ()
 
 static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
 {
-	java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	__this.AbstractCount = value;
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteDefaultInterfaceMethodInvoker.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteDefaultInterfaceMethodInvoker.txt
@@ -60,7 +60,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static void n_DoDeclaration (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.DoDeclaration ();
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterface.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterface.txt
@@ -129,7 +129,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static int n_get_Count (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return __this.Count;
 	}
 #pragma warning restore 0169
@@ -145,7 +145,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.Count = value;
 	}
 #pragma warning restore 0169
@@ -178,7 +178,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return JNIEnv.NewString (__this.Key);
 	}
 #pragma warning restore 0169
@@ -194,8 +194,8 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		string value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
 		__this.Key = value;
 	}
 #pragma warning restore 0169
@@ -230,7 +230,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return __this.AbstractCount;
 	}
 #pragma warning restore 0169
@@ -246,7 +246,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.AbstractCount = value;
 	}
 #pragma warning restore 0169
@@ -279,8 +279,8 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		string key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
 		int __ret = __this.GetCountForKey (key);
 		return __ret;
 	}
@@ -294,7 +294,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		IntPtr native_key = JNIEnv.NewString (key);
 		JValue* __args = stackalloc JValue [1];
 		__args [0] = new JValue (native_key);
-		int __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_GetCountForKey_Ljava_lang_String_, __args);
+		var __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_GetCountForKey_Ljava_lang_String_, __args);
 		JNIEnv.DeleteLocalRef (native_key);
 		return __ret;
 	}
@@ -310,7 +310,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return JNIEnv.NewString (__this.Key ());
 	}
 #pragma warning restore 0169
@@ -334,7 +334,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.AbstractMethod ();
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultMethod.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultMethod.txt
@@ -14,7 +14,7 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 
 	private static void n_DoSomething (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.DoSomething ();
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultProperty.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultProperty.txt
@@ -14,7 +14,7 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 
 	private static int n_get_Value (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return __this.Value;
 	}
 #pragma warning restore 0169
@@ -30,7 +30,7 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 
 	private static void n_set_Value_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.Value = value;
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultPropertyGetterOnly.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultPropertyGetterOnly.txt
@@ -14,7 +14,7 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 
 	private static int n_get_Value (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return __this.Value;
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceInvoker.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceInvoker.txt
@@ -60,7 +60,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static int n_get_Count (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return __this.Count;
 	}
 #pragma warning restore 0169
@@ -76,7 +76,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.Count = value;
 	}
 #pragma warning restore 0169
@@ -109,7 +109,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return JNIEnv.NewString (__this.Key);
 	}
 #pragma warning restore 0169
@@ -125,8 +125,8 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		string value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
 		__this.Key = value;
 	}
 #pragma warning restore 0169
@@ -161,7 +161,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return __this.AbstractCount;
 	}
 #pragma warning restore 0169
@@ -177,7 +177,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.AbstractCount = value;
 	}
 #pragma warning restore 0169
@@ -210,8 +210,8 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		string key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
 		int __ret = __this.GetCountForKey (key);
 		return __ret;
 	}
@@ -225,7 +225,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		IntPtr native_key = JNIEnv.NewString (key);
 		JValue* __args = stackalloc JValue [1];
 		__args [0] = new JValue (native_key);
-		int __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_GetCountForKey_Ljava_lang_String_, __args);
+		var __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_GetCountForKey_Ljava_lang_String_, __args);
 		JNIEnv.DeleteLocalRef (native_key);
 		return __ret;
 	}
@@ -241,7 +241,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return JNIEnv.NewString (__this.Key ());
 	}
 #pragma warning restore 0169
@@ -265,7 +265,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.AbstractMethod ();
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodAbstractWithVoidReturn.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodAbstractWithVoidReturn.txt
@@ -9,7 +9,7 @@ static Delegate GetbarHandler ()
 
 static void n_bar (IntPtr jnienv, IntPtr native__this)
 {
-	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	__this.bar ();
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodAsyncifiedWithIntReturn.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodAsyncifiedWithIntReturn.txt
@@ -9,7 +9,7 @@ static Delegate GetbarHandler ()
 
 static int n_bar (IntPtr jnienv, IntPtr native__this)
 {
-	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	return __this.bar ();
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodAsyncifiedWithVoidReturn.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodAsyncifiedWithVoidReturn.txt
@@ -9,7 +9,7 @@ static Delegate GetbarHandler ()
 
 static void n_bar (IntPtr jnienv, IntPtr native__this)
 {
-	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	__this.bar ();
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodProtected.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodProtected.txt
@@ -9,7 +9,7 @@ static Delegate GetbarHandler ()
 
 static void n_bar (IntPtr jnienv, IntPtr native__this)
 {
-	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	__this.bar ();
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodWithIntReturn.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodWithIntReturn.txt
@@ -9,7 +9,7 @@ static Delegate GetbarHandler ()
 
 static int n_bar (IntPtr jnienv, IntPtr native__this)
 {
-	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	return __this.bar ();
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodWithStringReturn.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodWithStringReturn.txt
@@ -9,7 +9,7 @@ static Delegate GetbarHandler ()
 
 static IntPtr n_bar (IntPtr jnienv, IntPtr native__this)
 {
-	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	return JNIEnv.NewString (__this.bar ());
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodWithVoidReturn.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodWithVoidReturn.txt
@@ -9,7 +9,7 @@ static Delegate GetbarHandler ()
 
 static void n_bar (IntPtr jnienv, IntPtr native__this)
 {
-	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	__this.bar ();
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceClass.txt
@@ -98,7 +98,7 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 
 	static int n_GetBar (IntPtr jnienv, IntPtr native__this)
 	{
-		Com.Xamarin.Android.IParent __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return __this.Bar;
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceTypes.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceTypes.txt
@@ -80,7 +80,7 @@ public partial interface IParent : IJavaObject, IJavaPeerable {
 
 		static int n_GetBar (IntPtr jnienv, IntPtr native__this)
 		{
-			Com.Xamarin.Android.IParent.IChild __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent.IChild> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent.IChild> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.Bar;
 		}
 #pragma warning restore 0169
@@ -161,7 +161,7 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 
 	static int n_GetBar (IntPtr jnienv, IntPtr native__this)
 	{
-		Com.Xamarin.Android.IParent __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return __this.Bar;
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteProperty.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteProperty.txt
@@ -9,7 +9,7 @@ static Delegate Getget_MyPropertyHandler ()
 
 static int n_get_MyProperty (IntPtr jnienv, IntPtr native__this)
 {
-	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	return __this.MyProperty;
 }
 #pragma warning restore 0169
@@ -25,7 +25,7 @@ static Delegate Getset_MyProperty_IHandler ()
 
 static void n_set_MyProperty_I (IntPtr jnienv, IntPtr native__this, int value)
 {
-	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	__this.MyProperty = value;
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteUnnestedInterfaceTypes.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteUnnestedInterfaceTypes.txt
@@ -71,7 +71,7 @@ internal partial class IParentChildInvoker : global::Java.Lang.Object, IParentCh
 
 	static int n_GetBar (IntPtr jnienv, IntPtr native__this)
 	{
-		Com.Xamarin.Android.IParentChild __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParentChild> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParentChild> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return __this.Bar;
 	}
 #pragma warning restore 0169
@@ -161,7 +161,7 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 
 	static int n_GetBar (IntPtr jnienv, IntPtr native__this)
 	{
-		Com.Xamarin.Android.IParent __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return __this.Bar;
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteClass.txt
@@ -82,7 +82,7 @@ public partial class MyClass  {
 
 	static int n_get_Count (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return __this.Count;
 	}
 #pragma warning restore 0169
@@ -98,7 +98,7 @@ public partial class MyClass  {
 
 	static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.Count = value;
 	}
 #pragma warning restore 0169
@@ -149,7 +149,7 @@ public partial class MyClass  {
 
 	static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return JNIEnv.NewString (__this.Key);
 	}
 #pragma warning restore 0169
@@ -165,8 +165,8 @@ public partial class MyClass  {
 
 	static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 	{
-		java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		string value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
 		__this.Key = value;
 	}
 #pragma warning restore 0169
@@ -246,7 +246,7 @@ public partial class MyClass  {
 
 	static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return __this.AbstractCount;
 	}
 #pragma warning restore 0169
@@ -262,7 +262,7 @@ public partial class MyClass  {
 
 	static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.AbstractCount = value;
 	}
 #pragma warning restore 0169
@@ -285,8 +285,8 @@ public partial class MyClass  {
 
 	static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
 	{
-		java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		string key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
 		int __ret = __this.GetCountForKey (key);
 		return __ret;
 	}
@@ -326,7 +326,7 @@ public partial class MyClass  {
 
 	static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return JNIEnv.NewString (__this.Key ());
 	}
 #pragma warning restore 0169
@@ -372,7 +372,7 @@ public partial class MyClass  {
 
 	static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.AbstractMethod ();
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteClassMethods.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteClassMethods.txt
@@ -9,8 +9,8 @@ static Delegate GetGetCountForKey_Ljava_lang_String_Handler ()
 
 static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
 {
-	java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-	string key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
 	int __ret = __this.GetCountForKey (key);
 	return __ret;
 }
@@ -50,7 +50,7 @@ static Delegate GetKeyHandler ()
 
 static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
 {
-	java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	return JNIEnv.NewString (__this.Key ());
 }
 #pragma warning restore 0169
@@ -96,7 +96,7 @@ static Delegate GetAbstractMethodHandler ()
 
 static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)
 {
-	java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	__this.AbstractMethod ();
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteClassProperties.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteClassProperties.txt
@@ -9,7 +9,7 @@ static Delegate Getget_CountHandler ()
 
 static int n_get_Count (IntPtr jnienv, IntPtr native__this)
 {
-	java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	return __this.Count;
 }
 #pragma warning restore 0169
@@ -25,7 +25,7 @@ static Delegate Getset_Count_IHandler ()
 
 static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
 {
-	java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	__this.Count = value;
 }
 #pragma warning restore 0169
@@ -76,7 +76,7 @@ static Delegate Getget_KeyHandler ()
 
 static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
 {
-	java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	return JNIEnv.NewString (__this.Key);
 }
 #pragma warning restore 0169
@@ -92,8 +92,8 @@ static Delegate Getset_Key_Ljava_lang_String_Handler ()
 
 static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 {
-	java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-	string value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
 	__this.Key = value;
 }
 #pragma warning restore 0169
@@ -173,7 +173,7 @@ static Delegate Getget_AbstractCountHandler ()
 
 static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
 {
-	java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	return __this.AbstractCount;
 }
 #pragma warning restore 0169
@@ -189,7 +189,7 @@ static Delegate Getset_AbstractCount_IHandler ()
 
 static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
 {
-	java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	__this.AbstractCount = value;
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteInterface.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteInterface.txt
@@ -123,7 +123,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static int n_get_Count (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return __this.Count;
 	}
 #pragma warning restore 0169
@@ -139,7 +139,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.Count = value;
 	}
 #pragma warning restore 0169
@@ -172,7 +172,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return JNIEnv.NewString (__this.Key);
 	}
 #pragma warning restore 0169
@@ -188,8 +188,8 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		string value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
 		__this.Key = value;
 	}
 #pragma warning restore 0169
@@ -224,7 +224,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return __this.AbstractCount;
 	}
 #pragma warning restore 0169
@@ -240,7 +240,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.AbstractCount = value;
 	}
 #pragma warning restore 0169
@@ -273,8 +273,8 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		string key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
 		int __ret = __this.GetCountForKey (key);
 		return __ret;
 	}
@@ -288,7 +288,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		IntPtr native_key = JNIEnv.NewString (key);
 		JValue* __args = stackalloc JValue [1];
 		__args [0] = new JValue (native_key);
-		int __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_GetCountForKey_Ljava_lang_String_, __args);
+		var __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_GetCountForKey_Ljava_lang_String_, __args);
 		JNIEnv.DeleteLocalRef (native_key);
 		return __ret;
 	}
@@ -304,7 +304,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return JNIEnv.NewString (__this.Key ());
 	}
 #pragma warning restore 0169
@@ -328,7 +328,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.AbstractMethod ();
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteInterfaceInvoker.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteInterfaceInvoker.txt
@@ -52,7 +52,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static int n_get_Count (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return __this.Count;
 	}
 #pragma warning restore 0169
@@ -68,7 +68,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.Count = value;
 	}
 #pragma warning restore 0169
@@ -101,7 +101,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return JNIEnv.NewString (__this.Key);
 	}
 #pragma warning restore 0169
@@ -117,8 +117,8 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		string value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
 		__this.Key = value;
 	}
 #pragma warning restore 0169
@@ -153,7 +153,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return __this.AbstractCount;
 	}
 #pragma warning restore 0169
@@ -169,7 +169,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.AbstractCount = value;
 	}
 #pragma warning restore 0169
@@ -202,8 +202,8 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		string key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
 		int __ret = __this.GetCountForKey (key);
 		return __ret;
 	}
@@ -217,7 +217,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		IntPtr native_key = JNIEnv.NewString (key);
 		JValue* __args = stackalloc JValue [1];
 		__args [0] = new JValue (native_key);
-		int __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_GetCountForKey_Ljava_lang_String_, __args);
+		var __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_GetCountForKey_Ljava_lang_String_, __args);
 		JNIEnv.DeleteLocalRef (native_key);
 		return __ret;
 	}
@@ -233,7 +233,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return JNIEnv.NewString (__this.Key ());
 	}
 #pragma warning restore 0169
@@ -257,7 +257,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 
 	static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)
 	{
-		java.code.IMyInterface __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.AbstractMethod ();
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteMethodAbstractWithVoidReturn.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteMethodAbstractWithVoidReturn.txt
@@ -9,7 +9,7 @@ static Delegate GetbarHandler ()
 
 static void n_bar (IntPtr jnienv, IntPtr native__this)
 {
-	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	__this.bar ();
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteMethodAsyncifiedWithIntReturn.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteMethodAsyncifiedWithIntReturn.txt
@@ -9,7 +9,7 @@ static Delegate GetbarHandler ()
 
 static int n_bar (IntPtr jnienv, IntPtr native__this)
 {
-	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	return __this.bar ();
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteMethodAsyncifiedWithVoidReturn.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteMethodAsyncifiedWithVoidReturn.txt
@@ -9,7 +9,7 @@ static Delegate GetbarHandler ()
 
 static void n_bar (IntPtr jnienv, IntPtr native__this)
 {
-	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	__this.bar ();
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteMethodProtected.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteMethodProtected.txt
@@ -9,7 +9,7 @@ static Delegate GetbarHandler ()
 
 static void n_bar (IntPtr jnienv, IntPtr native__this)
 {
-	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	__this.bar ();
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteMethodWithIntReturn.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteMethodWithIntReturn.txt
@@ -9,7 +9,7 @@ static Delegate GetbarHandler ()
 
 static int n_bar (IntPtr jnienv, IntPtr native__this)
 {
-	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	return __this.bar ();
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteMethodWithStringReturn.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteMethodWithStringReturn.txt
@@ -9,7 +9,7 @@ static Delegate GetbarHandler ()
 
 static IntPtr n_bar (IntPtr jnienv, IntPtr native__this)
 {
-	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	return JNIEnv.NewString (__this.bar ());
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteMethodWithVoidReturn.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteMethodWithVoidReturn.txt
@@ -9,7 +9,7 @@ static Delegate GetbarHandler ()
 
 static void n_bar (IntPtr jnienv, IntPtr native__this)
 {
-	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	__this.bar ();
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteProperty.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteProperty.txt
@@ -9,7 +9,7 @@ static Delegate Getget_MyPropertyHandler ()
 
 static int n_get_MyProperty (IntPtr jnienv, IntPtr native__this)
 {
-	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	return __this.MyProperty;
 }
 #pragma warning restore 0169
@@ -25,7 +25,7 @@ static Delegate Getset_MyProperty_IHandler ()
 
 static void n_set_MyProperty_I (IntPtr jnienv, IntPtr native__this, int value)
 {
-	com.mypackage.foo __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+	var __this = global::Java.Lang.Object.GetObject<com.mypackage.foo> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 	__this.MyProperty = value;
 }
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.ji/AccessModifiers/Xamarin.Test.BasePublicClass.cs
+++ b/tests/generator-Tests/expected.ji/AccessModifiers/Xamarin.Test.BasePublicClass.cs
@@ -41,7 +41,7 @@ namespace Xamarin.Test {
 
 		static void n_BaseMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.BasePublicClass __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.BasePublicClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.BasePublicClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.BaseMethod ();
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.ji/AccessModifiers/Xamarin.Test.ExtendPublicClass.cs
+++ b/tests/generator-Tests/expected.ji/AccessModifiers/Xamarin.Test.ExtendPublicClass.cs
@@ -59,7 +59,7 @@ namespace Xamarin.Test {
 
 		static void n_Foo (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.ExtendPublicClass __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.ExtendPublicClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.ExtendPublicClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Foo ();
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.ji/AccessModifiers/Xamarin.Test.PublicClass.cs
+++ b/tests/generator-Tests/expected.ji/AccessModifiers/Xamarin.Test.PublicClass.cs
@@ -81,7 +81,7 @@ namespace Xamarin.Test {
 
 			static void n_Foo (IntPtr jnienv, IntPtr native__this)
 			{
-				global::Xamarin.Test.PublicClass.IProtectedInterface __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.PublicClass.IProtectedInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.PublicClass.IProtectedInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.Foo ();
 			}
 #pragma warning restore 0169
@@ -147,7 +147,7 @@ namespace Xamarin.Test {
 
 		static void n_Foo (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.PublicClass __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.PublicClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.PublicClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Foo ();
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.ji/Adapters/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/Adapters/Java.Interop.__TypeRegistrations.cs
@@ -25,7 +25,7 @@ namespace Java.Interop {
 
 		static Type Lookup (string[] mappings, string javaType)
 		{
-			string managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
+			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
 			if (managedType == null)
 				return null;
 			return Type.GetType (managedType);

--- a/tests/generator-Tests/expected.ji/Adapters/Xamarin.Test.AbsSpinner.cs
+++ b/tests/generator-Tests/expected.ji/Adapters/Xamarin.Test.AbsSpinner.cs
@@ -41,7 +41,7 @@ namespace Xamarin.Test {
 
 		static IntPtr n_GetAdapter (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.AbsSpinner __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.AbsSpinner> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.AbsSpinner> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.ToLocalJniHandle (__this.Adapter);
 		}
 #pragma warning restore 0169
@@ -57,8 +57,8 @@ namespace Xamarin.Test {
 
 		static void n_SetAdapter_Lxamarin_test_SpinnerAdapter_ (IntPtr jnienv, IntPtr native__this, IntPtr native_adapter)
 		{
-			global::Xamarin.Test.AbsSpinner __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.AbsSpinner> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Xamarin.Test.ISpinnerAdapter adapter = (global::Xamarin.Test.ISpinnerAdapter)global::Java.Lang.Object.GetObject<global::Xamarin.Test.ISpinnerAdapter> (native_adapter, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.AbsSpinner> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var adapter = (global::Xamarin.Test.ISpinnerAdapter)global::Java.Lang.Object.GetObject<global::Xamarin.Test.ISpinnerAdapter> (native_adapter, JniHandleOwnership.DoNotTransfer);
 			__this.Adapter = adapter;
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.ji/Adapters/Xamarin.Test.AdapterView.cs
+++ b/tests/generator-Tests/expected.ji/Adapters/Xamarin.Test.AdapterView.cs
@@ -42,7 +42,7 @@ namespace Xamarin.Test {
 
 		static IntPtr n_GetAdapter (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.AdapterView __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.AdapterView> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.AdapterView> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.ToLocalJniHandle (__this.RawAdapter);
 		}
 #pragma warning restore 0169
@@ -58,8 +58,8 @@ namespace Xamarin.Test {
 
 		static void n_SetAdapter_Lxamarin_test_Adapter_ (IntPtr jnienv, IntPtr native__this, IntPtr native_adapter)
 		{
-			global::Xamarin.Test.AdapterView __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.AdapterView> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Java.Lang.Object adapter = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_adapter, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.AdapterView> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var adapter = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_adapter, JniHandleOwnership.DoNotTransfer);
 			__this.RawAdapter = adapter;
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.ji/Adapters/Xamarin.Test.GenericReturnObject.cs
+++ b/tests/generator-Tests/expected.ji/Adapters/Xamarin.Test.GenericReturnObject.cs
@@ -41,7 +41,7 @@ namespace Xamarin.Test {
 
 		static IntPtr n_GenericReturn (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.GenericReturnObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.GenericReturnObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.GenericReturnObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.ToLocalJniHandle (__this.GenericReturn ());
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.ji/Android.Graphics.Color/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/Android.Graphics.Color/Java.Interop.__TypeRegistrations.cs
@@ -25,7 +25,7 @@ namespace Java.Interop {
 
 		static Type Lookup (string[] mappings, string javaType)
 		{
-			string managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
+			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
 			if (managedType == null)
 				return null;
 			return Type.GetType (managedType);

--- a/tests/generator-Tests/expected.ji/Android.Graphics.Color/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/Android.Graphics.Color/Xamarin.Test.SomeObject.cs
@@ -61,7 +61,7 @@ namespace Xamarin.Test {
 
 		static int n_GetSomeColor (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.SomeColor.ToArgb ();
 		}
 #pragma warning restore 0169
@@ -77,8 +77,8 @@ namespace Xamarin.Test {
 
 		static void n_SetSomeColor_I (IntPtr jnienv, IntPtr native__this, int native_newvalue)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Android.Graphics.Color newvalue = new global::Android.Graphics.Color (native_newvalue);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var newvalue = new global::Android.Graphics.Color (native_newvalue);
 			__this.SomeColor = newvalue;
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.ji/Arrays/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/Arrays/Java.Interop.__TypeRegistrations.cs
@@ -25,7 +25,7 @@ namespace Java.Interop {
 
 		static Type Lookup (string[] mappings, string javaType)
 		{
-			string managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
+			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
 			if (managedType == null)
 				return null;
 			return Type.GetType (managedType);

--- a/tests/generator-Tests/expected.ji/CSharpKeywords/Xamarin.Test.CSharpKeywords.cs
+++ b/tests/generator-Tests/expected.ji/CSharpKeywords/Xamarin.Test.CSharpKeywords.cs
@@ -41,7 +41,7 @@ namespace Xamarin.Test {
 
 		static IntPtr n_UsePartial_I (IntPtr jnienv, IntPtr native__this, int partial)
 		{
-			global::Xamarin.Test.CSharpKeywords __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.CSharpKeywords> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.CSharpKeywords> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.NewString (__this.UsePartial (partial));
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.ji/Constructors/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/Constructors/Java.Interop.__TypeRegistrations.cs
@@ -25,7 +25,7 @@ namespace Java.Interop {
 
 		static Type Lookup (string[] mappings, string javaType)
 		{
-			string managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
+			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
 			if (managedType == null)
 				return null;
 			return Type.GetType (managedType);

--- a/tests/generator-Tests/expected.ji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
+++ b/tests/generator-Tests/expected.ji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
@@ -78,10 +78,10 @@ namespace Com.Google.Android.Exoplayer.Drm {
 
 		static void n_OnEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB (IntPtr jnienv, IntPtr native__this, IntPtr native_p0, IntPtr native_p1, int p2, int p3, IntPtr native_p4)
 		{
-			global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener __this = global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm p0 = (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm)global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm> (native_p0, JniHandleOwnership.DoNotTransfer);
-			byte[] p1 = (byte[]) JNIEnv.GetArray (native_p1, JniHandleOwnership.DoNotTransfer, typeof (byte));
-			byte[] p4 = (byte[]) JNIEnv.GetArray (native_p4, JniHandleOwnership.DoNotTransfer, typeof (byte));
+			var __this = global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var p0 = (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm)global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm> (native_p0, JniHandleOwnership.DoNotTransfer);
+			var p1 = (byte[]) JNIEnv.GetArray (native_p1, JniHandleOwnership.DoNotTransfer, typeof (byte));
+			var p4 = (byte[]) JNIEnv.GetArray (native_p4, JniHandleOwnership.DoNotTransfer, typeof (byte));
 			__this.OnEvent (p0, p1, p2, p3, p4);
 			if (p1 != null)
 				JNIEnv.CopyArray (p1, native_p1);
@@ -259,8 +259,8 @@ namespace Com.Google.Android.Exoplayer.Drm {
 
 		static void n_SetOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
 		{
-			global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm __this = global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener p0 = (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener)global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener> (native_p0, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var p0 = (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener)global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener> (native_p0, JniHandleOwnership.DoNotTransfer);
 			__this.SetOnEventListener (p0);
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/Java.Interop.__TypeRegistrations.cs
@@ -25,7 +25,7 @@ namespace Java.Interop {
 
 		static Type Lookup (string[] mappings, string javaType)
 		{
-			string managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
+			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
 			if (managedType == null)
 				return null;
 			return Type.GetType (managedType);

--- a/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.II1.cs
+++ b/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.II1.cs
@@ -77,7 +77,7 @@ namespace Xamarin.Test {
 
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.II1 __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.II1> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.II1> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Close ();
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.II2.cs
+++ b/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.II2.cs
@@ -77,7 +77,7 @@ namespace Xamarin.Test {
 
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.II2 __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.II2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.II2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Close ();
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.SomeObject.cs
@@ -41,7 +41,7 @@ namespace Xamarin.Test {
 
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Close ();
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.SomeObject2.cs
+++ b/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.SomeObject2.cs
@@ -41,7 +41,7 @@ namespace Xamarin.Test {
 
 		static void n_Irrelevant (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.SomeObject2 __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Irrelevant ();
 		}
 #pragma warning restore 0169
@@ -68,7 +68,7 @@ namespace Xamarin.Test {
 
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.SomeObject2 __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Close ();
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.ji/NestedTypes/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/NestedTypes/Java.Interop.__TypeRegistrations.cs
@@ -25,7 +25,7 @@ namespace Java.Interop {
 
 		static Type Lookup (string[] mappings, string javaType)
 		{
-			string managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
+			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
 			if (managedType == null)
 				return null;
 			return Type.GetType (managedType);

--- a/tests/generator-Tests/expected.ji/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
+++ b/tests/generator-Tests/expected.ji/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
@@ -85,7 +85,7 @@ namespace Xamarin.Test {
 
 				static IntPtr n_Build_I (IntPtr jnienv, IntPtr native__this, int p0)
 				{
-					global::Xamarin.Test.NotificationCompatBase.Action.IFactory __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.NotificationCompatBase.Action.IFactory> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+					var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.NotificationCompatBase.Action.IFactory> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 					return JNIEnv.ToLocalJniHandle (__this.Build (p0));
 				}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.ji/NonStaticFields/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/NonStaticFields/Java.Interop.__TypeRegistrations.cs
@@ -25,7 +25,7 @@ namespace Java.Interop {
 
 		static Type Lookup (string[] mappings, string javaType)
 		{
-			string managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
+			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
 			if (managedType == null)
 				return null;
 			return Type.GetType (managedType);

--- a/tests/generator-Tests/expected.ji/NormalMethods/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/NormalMethods/Java.Interop.__TypeRegistrations.cs
@@ -25,7 +25,7 @@ namespace Java.Interop {
 
 		static Type Lookup (string[] mappings, string javaType)
 		{
-			string managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
+			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
 			if (managedType == null)
 				return null;
 			return Type.GetType (managedType);

--- a/tests/generator-Tests/expected.ji/NormalMethods/Xamarin.Test.A.cs
+++ b/tests/generator-Tests/expected.ji/NormalMethods/Xamarin.Test.A.cs
@@ -46,7 +46,7 @@ namespace Xamarin.Test {
 
 			static IntPtr n_SetCustomDimension_I (IntPtr jnienv, IntPtr native__this, int index)
 			{
-				global::Xamarin.Test.A.B __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.A.B> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.A.B> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return JNIEnv.ToLocalJniHandle (__this.SetCustomDimension (index));
 			}
 #pragma warning restore 0169
@@ -99,7 +99,7 @@ namespace Xamarin.Test {
 
 		static int n_GetHandle (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.A __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.A> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.A> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.GetHandle ();
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.ji/NormalMethods/Xamarin.Test.C.cs
+++ b/tests/generator-Tests/expected.ji/NormalMethods/Xamarin.Test.C.cs
@@ -42,7 +42,7 @@ namespace Xamarin.Test {
 
 		static IntPtr n_SetCustomDimension_I (IntPtr jnienv, IntPtr native__this, int index)
 		{
-			global::Xamarin.Test.C __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.C> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.C> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.ToLocalJniHandle (__this.SetCustomDimension (index));
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.ji/NormalMethods/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/NormalMethods/Xamarin.Test.SomeObject.cs
@@ -61,7 +61,7 @@ namespace Xamarin.Test {
 
 		static IntPtr n_GetType (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.NewArray (__this.GetType ());
 		}
 #pragma warning restore 0169
@@ -89,9 +89,9 @@ namespace Xamarin.Test {
 
 		static int n_Handle_Ljava_lang_Object_Ljava_lang_Throwable_ (IntPtr jnienv, IntPtr native__this, IntPtr native_o, IntPtr native_t)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Java.Lang.Object o = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_o, JniHandleOwnership.DoNotTransfer);
-			global::Java.Lang.Throwable t = global::Java.Lang.Object.GetObject<global::Java.Lang.Throwable> (native_t, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var o = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_o, JniHandleOwnership.DoNotTransfer);
+			var t = global::Java.Lang.Object.GetObject<global::Java.Lang.Throwable> (native_t, JniHandleOwnership.DoNotTransfer);
 			int __ret = __this.Handle (o, t);
 			return __ret;
 		}
@@ -123,7 +123,7 @@ namespace Xamarin.Test {
 
 		static int n_IntegerMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.IntegerMethod ();
 		}
 #pragma warning restore 0169
@@ -151,7 +151,7 @@ namespace Xamarin.Test {
 
 		static void n_VoidMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.VoidMethod ();
 		}
 #pragma warning restore 0169
@@ -178,7 +178,7 @@ namespace Xamarin.Test {
 
 		static IntPtr n_StringMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.NewString (__this.StringMethod ());
 		}
 #pragma warning restore 0169
@@ -206,7 +206,7 @@ namespace Xamarin.Test {
 
 		static IntPtr n_ObjectMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.ToLocalJniHandle (__this.ObjectMethod ());
 		}
 #pragma warning restore 0169
@@ -234,9 +234,9 @@ namespace Xamarin.Test {
 
 		static void n_VoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_astring, int anint, IntPtr native_anObject)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			string astring = JNIEnv.GetString (native_astring, JniHandleOwnership.DoNotTransfer);
-			global::Java.Lang.Object anObject = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_anObject, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var astring = JNIEnv.GetString (native_astring, JniHandleOwnership.DoNotTransfer);
+			var anObject = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_anObject, JniHandleOwnership.DoNotTransfer);
 			__this.VoidMethodWithParams (astring, anint, anObject);
 		}
 #pragma warning restore 0169
@@ -271,7 +271,7 @@ namespace Xamarin.Test {
 		[Obsolete]
 		static int n_ObsoleteMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.ObsoleteMethod ();
 		}
 #pragma warning restore 0169
@@ -300,7 +300,7 @@ namespace Xamarin.Test {
 
 		static void n_ArrayListTest_Ljava_util_ArrayList_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			var p0 = global::Android.Runtime.JavaList<global::Java.Lang.Integer>.FromJniHandle (native_p0, JniHandleOwnership.DoNotTransfer);
 			__this.ArrayListTest (p0);
 		}

--- a/tests/generator-Tests/expected.ji/NormalProperties/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/NormalProperties/Java.Interop.__TypeRegistrations.cs
@@ -25,7 +25,7 @@ namespace Java.Interop {
 
 		static Type Lookup (string[] mappings, string javaType)
 		{
-			string managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
+			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
 			if (managedType == null)
 				return null;
 			return Type.GetType (managedType);

--- a/tests/generator-Tests/expected.ji/NormalProperties/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/NormalProperties/Xamarin.Test.SomeObject.cs
@@ -41,7 +41,7 @@ namespace Xamarin.Test {
 
 		static int n_GetSomeInteger (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.SomeInteger;
 		}
 #pragma warning restore 0169
@@ -57,7 +57,7 @@ namespace Xamarin.Test {
 
 		static void n_SetSomeInteger_I (IntPtr jnienv, IntPtr native__this, int newvalue)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.SomeInteger = newvalue;
 		}
 #pragma warning restore 0169
@@ -80,7 +80,7 @@ namespace Xamarin.Test {
 
 		static IntPtr n_GetSomeObjectProperty (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.ToLocalJniHandle (__this.SomeObjectProperty);
 		}
 #pragma warning restore 0169
@@ -96,8 +96,8 @@ namespace Xamarin.Test {
 
 		static void n_SetSomeObjectProperty_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_newvalue)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Java.Lang.Object newvalue = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_newvalue, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var newvalue = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_newvalue, JniHandleOwnership.DoNotTransfer);
 			__this.SomeObjectProperty = newvalue;
 		}
 #pragma warning restore 0169
@@ -120,7 +120,7 @@ namespace Xamarin.Test {
 
 		static IntPtr n_GetSomeString (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.NewString (__this.SomeString);
 		}
 #pragma warning restore 0169
@@ -136,8 +136,8 @@ namespace Xamarin.Test {
 
 		static void n_SetSomeString_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_newvalue)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			string newvalue = JNIEnv.GetString (native_newvalue, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var newvalue = JNIEnv.GetString (native_newvalue, JniHandleOwnership.DoNotTransfer);
 			__this.SomeString = newvalue;
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.ji/ParameterXPath/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/ParameterXPath/Java.Interop.__TypeRegistrations.cs
@@ -25,7 +25,7 @@ namespace Java.Interop {
 
 		static Type Lookup (string[] mappings, string javaType)
 		{
-			string managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
+			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
 			if (managedType == null)
 				return null;
 			return Type.GetType (managedType);

--- a/tests/generator-Tests/expected.ji/ParameterXPath/Xamarin.Test.A.cs
+++ b/tests/generator-Tests/expected.ji/ParameterXPath/Xamarin.Test.A.cs
@@ -42,8 +42,8 @@ namespace Xamarin.Test {
 
 		static void n_SetA_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_adapter)
 		{
-			global::Xamarin.Test.A __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.A> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Java.Lang.Object adapter = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_adapter, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.A> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var adapter = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_adapter, JniHandleOwnership.DoNotTransfer);
 			__this.SetA (adapter);
 		}
 #pragma warning restore 0169
@@ -74,7 +74,7 @@ namespace Xamarin.Test {
 
 		static void n_ListTest_Ljava_util_List_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
 		{
-			global::Xamarin.Test.A __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.A> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.A> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			var p0 = global::Android.Runtime.JavaList<global::Java.Lang.Integer>.FromJniHandle (native_p0, JniHandleOwnership.DoNotTransfer);
 			__this.ListTest (p0);
 		}

--- a/tests/generator-Tests/expected.ji/StaticFields/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/StaticFields/Java.Interop.__TypeRegistrations.cs
@@ -25,7 +25,7 @@ namespace Java.Interop {
 
 		static Type Lookup (string[] mappings, string javaType)
 		{
-			string managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
+			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
 			if (managedType == null)
 				return null;
 			return Type.GetType (managedType);

--- a/tests/generator-Tests/expected.ji/StaticMethods/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/StaticMethods/Java.Interop.__TypeRegistrations.cs
@@ -25,7 +25,7 @@ namespace Java.Interop {
 
 		static Type Lookup (string[] mappings, string javaType)
 		{
-			string managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
+			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
 			if (managedType == null)
 				return null;
 			return Type.GetType (managedType);

--- a/tests/generator-Tests/expected.ji/StaticProperties/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/StaticProperties/Java.Interop.__TypeRegistrations.cs
@@ -25,7 +25,7 @@ namespace Java.Interop {
 
 		static Type Lookup (string[] mappings, string javaType)
 		{
-			string managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
+			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
 			if (managedType == null)
 				return null;
 			return Type.GetType (managedType);

--- a/tests/generator-Tests/expected.ji/Streams/Java.IO.FilterOutputStream.cs
+++ b/tests/generator-Tests/expected.ji/Streams/Java.IO.FilterOutputStream.cs
@@ -63,7 +63,7 @@ namespace Java.IO {
 
 		static void n_Write_I (IntPtr jnienv, IntPtr native__this, int oneByte)
 		{
-			global::Java.IO.FilterOutputStream __this = global::Java.Lang.Object.GetObject<global::Java.IO.FilterOutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.FilterOutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Write (oneByte);
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.ji/Streams/Java.IO.IOException.cs
+++ b/tests/generator-Tests/expected.ji/Streams/Java.IO.IOException.cs
@@ -41,7 +41,7 @@ namespace Java.IO {
 
 		static void n_PrintStackTrace (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Java.IO.IOException __this = global::Java.Lang.Object.GetObject<global::Java.IO.IOException> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.IOException> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.PrintStackTrace ();
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.ji/Streams/Java.IO.InputStream.cs
+++ b/tests/generator-Tests/expected.ji/Streams/Java.IO.InputStream.cs
@@ -59,7 +59,7 @@ namespace Java.IO {
 
 		static int n_Available (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Java.IO.InputStream __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.Available ();
 		}
 #pragma warning restore 0169
@@ -87,7 +87,7 @@ namespace Java.IO {
 
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Java.IO.InputStream __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Close ();
 		}
 #pragma warning restore 0169
@@ -114,7 +114,7 @@ namespace Java.IO {
 
 		static void n_Mark_I (IntPtr jnienv, IntPtr native__this, int readlimit)
 		{
-			global::Java.IO.InputStream __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Mark (readlimit);
 		}
 #pragma warning restore 0169
@@ -143,7 +143,7 @@ namespace Java.IO {
 
 		static bool n_MarkSupported (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Java.IO.InputStream __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.MarkSupported ();
 		}
 #pragma warning restore 0169
@@ -171,7 +171,7 @@ namespace Java.IO {
 
 		static int n_Read (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Java.IO.InputStream __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.Read ();
 		}
 #pragma warning restore 0169
@@ -191,8 +191,8 @@ namespace Java.IO {
 
 		static int n_Read_arrayB (IntPtr jnienv, IntPtr native__this, IntPtr native_buffer)
 		{
-			global::Java.IO.InputStream __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			byte[] buffer = (byte[]) JNIEnv.GetArray (native_buffer, JniHandleOwnership.DoNotTransfer, typeof (byte));
+			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var buffer = (byte[]) JNIEnv.GetArray (native_buffer, JniHandleOwnership.DoNotTransfer, typeof (byte));
 			int __ret = __this.Read (buffer);
 			if (buffer != null)
 				JNIEnv.CopyArray (buffer, native_buffer);
@@ -230,8 +230,8 @@ namespace Java.IO {
 
 		static int n_Read_arrayBII (IntPtr jnienv, IntPtr native__this, IntPtr native_buffer, int byteOffset, int byteCount)
 		{
-			global::Java.IO.InputStream __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			byte[] buffer = (byte[]) JNIEnv.GetArray (native_buffer, JniHandleOwnership.DoNotTransfer, typeof (byte));
+			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var buffer = (byte[]) JNIEnv.GetArray (native_buffer, JniHandleOwnership.DoNotTransfer, typeof (byte));
 			int __ret = __this.Read (buffer, byteOffset, byteCount);
 			if (buffer != null)
 				JNIEnv.CopyArray (buffer, native_buffer);
@@ -271,7 +271,7 @@ namespace Java.IO {
 
 		static void n_Reset (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Java.IO.InputStream __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Reset ();
 		}
 #pragma warning restore 0169
@@ -298,7 +298,7 @@ namespace Java.IO {
 
 		static long n_Skip_J (IntPtr jnienv, IntPtr native__this, long byteCount)
 		{
-			global::Java.IO.InputStream __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.Skip (byteCount);
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.ji/Streams/Java.IO.OutputStream.cs
+++ b/tests/generator-Tests/expected.ji/Streams/Java.IO.OutputStream.cs
@@ -59,7 +59,7 @@ namespace Java.IO {
 
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Java.IO.OutputStream __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Close ();
 		}
 #pragma warning restore 0169
@@ -86,7 +86,7 @@ namespace Java.IO {
 
 		static void n_Flush (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Java.IO.OutputStream __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Flush ();
 		}
 #pragma warning restore 0169
@@ -113,8 +113,8 @@ namespace Java.IO {
 
 		static void n_Write_arrayB (IntPtr jnienv, IntPtr native__this, IntPtr native_buffer)
 		{
-			global::Java.IO.OutputStream __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			byte[] buffer = (byte[]) JNIEnv.GetArray (native_buffer, JniHandleOwnership.DoNotTransfer, typeof (byte));
+			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var buffer = (byte[]) JNIEnv.GetArray (native_buffer, JniHandleOwnership.DoNotTransfer, typeof (byte));
 			__this.Write (buffer);
 			if (buffer != null)
 				JNIEnv.CopyArray (buffer, native_buffer);
@@ -150,8 +150,8 @@ namespace Java.IO {
 
 		static void n_Write_arrayBII (IntPtr jnienv, IntPtr native__this, IntPtr native_buffer, int offset, int count)
 		{
-			global::Java.IO.OutputStream __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			byte[] buffer = (byte[]) JNIEnv.GetArray (native_buffer, JniHandleOwnership.DoNotTransfer, typeof (byte));
+			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var buffer = (byte[]) JNIEnv.GetArray (native_buffer, JniHandleOwnership.DoNotTransfer, typeof (byte));
 			__this.Write (buffer, offset, count);
 			if (buffer != null)
 				JNIEnv.CopyArray (buffer, native_buffer);
@@ -189,7 +189,7 @@ namespace Java.IO {
 
 		static void n_Write_I (IntPtr jnienv, IntPtr native__this, int oneByte)
 		{
-			global::Java.IO.OutputStream __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Write (oneByte);
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.ji/Streams/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/Streams/Java.Interop.__TypeRegistrations.cs
@@ -25,7 +25,7 @@ namespace Java.Interop {
 
 		static Type Lookup (string[] mappings, string javaType)
 		{
-			string managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
+			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
 			if (managedType == null)
 				return null;
 			return Type.GetType (managedType);

--- a/tests/generator-Tests/expected.ji/Streams/Java.Lang.Throwable.cs
+++ b/tests/generator-Tests/expected.ji/Streams/Java.Lang.Throwable.cs
@@ -27,7 +27,7 @@ namespace Java.Lang {
 
 		static IntPtr n_GetMessage (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Java.Lang.Throwable __this = global::Java.Lang.Object.GetObject<global::Java.Lang.Throwable> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Java.Lang.Throwable> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.NewString (__this.Message);
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.ji/TestInterface/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Java.Interop.__TypeRegistrations.cs
@@ -25,7 +25,7 @@ namespace Java.Interop {
 
 		static Type Lookup (string[] mappings, string javaType)
 		{
-			string managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
+			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
 			if (managedType == null)
 				return null;
 			return Type.GetType (managedType);

--- a/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericImplementation.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericImplementation.cs
@@ -59,8 +59,8 @@ namespace Test.ME {
 
 		static void n_SetObject_arrayB (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			global::Test.ME.GenericImplementation __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			byte[] value = (byte[]) JNIEnv.GetArray (native_value, JniHandleOwnership.DoNotTransfer, typeof (byte));
+			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var value = (byte[]) JNIEnv.GetArray (native_value, JniHandleOwnership.DoNotTransfer, typeof (byte));
 			__this.SetObject (value);
 			if (value != null)
 				JNIEnv.CopyArray (value, native_value);

--- a/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericObjectPropertyImplementation.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericObjectPropertyImplementation.cs
@@ -59,7 +59,7 @@ namespace Test.ME {
 
 		static IntPtr n_GetObject (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Test.ME.GenericObjectPropertyImplementation __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericObjectPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericObjectPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.ToLocalJniHandle (__this.Object);
 		}
 #pragma warning restore 0169
@@ -75,8 +75,8 @@ namespace Test.ME {
 
 		static void n_SetObject_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			global::Test.ME.GenericObjectPropertyImplementation __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericObjectPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Java.Lang.Object value = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_value, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericObjectPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var value = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_value, JniHandleOwnership.DoNotTransfer);
 			__this.Object = value;
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericStringImplementation.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericStringImplementation.cs
@@ -59,8 +59,8 @@ namespace Test.ME {
 
 		static void n_SetObject_arrayLjava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			global::Test.ME.GenericStringImplementation __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericStringImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			string[] value = (string[]) JNIEnv.GetArray (native_value, JniHandleOwnership.DoNotTransfer, typeof (string));
+			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericStringImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var value = (string[]) JNIEnv.GetArray (native_value, JniHandleOwnership.DoNotTransfer, typeof (string));
 			__this.SetObject (value);
 			if (value != null)
 				JNIEnv.CopyArray (value, native_value);

--- a/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericStringPropertyImplementation.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericStringPropertyImplementation.cs
@@ -59,7 +59,7 @@ namespace Test.ME {
 
 		static IntPtr n_GetObject (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Test.ME.GenericStringPropertyImplementation __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericStringPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericStringPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.NewString (__this.Object);
 		}
 #pragma warning restore 0169
@@ -75,8 +75,8 @@ namespace Test.ME {
 
 		static void n_SetObject_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			global::Test.ME.GenericStringPropertyImplementation __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericStringPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			string value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericStringPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
 			__this.Object = value;
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.ji/TestInterface/Test.ME.IGenericInterface.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Test.ME.IGenericInterface.cs
@@ -78,8 +78,8 @@ namespace Test.ME {
 
 		static void n_SetObject_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			global::Test.ME.IGenericInterface __this = global::Java.Lang.Object.GetObject<global::Test.ME.IGenericInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Java.Lang.Object value = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_value, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.IGenericInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var value = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_value, JniHandleOwnership.DoNotTransfer);
 			__this.SetObject (value);
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.ji/TestInterface/Test.ME.IGenericPropertyInterface.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Test.ME.IGenericPropertyInterface.cs
@@ -81,7 +81,7 @@ namespace Test.ME {
 
 		static IntPtr n_GetObject (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Test.ME.IGenericPropertyInterface __this = global::Java.Lang.Object.GetObject<global::Test.ME.IGenericPropertyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.IGenericPropertyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.ToLocalJniHandle (__this.Object);
 		}
 #pragma warning restore 0169
@@ -97,8 +97,8 @@ namespace Test.ME {
 
 		static void n_SetObject_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			global::Test.ME.IGenericPropertyInterface __this = global::Java.Lang.Object.GetObject<global::Test.ME.IGenericPropertyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Java.Lang.Object value = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_value, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.IGenericPropertyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var value = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_value, JniHandleOwnership.DoNotTransfer);
 			__this.Object = value;
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.ji/TestInterface/Test.ME.ITestInterface.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Test.ME.ITestInterface.cs
@@ -62,14 +62,14 @@ namespace Test.ME {
 
 		public static void Append (this Test.ME.ITestInterface self, string value)
 		{
-			global::Java.Lang.String jls_value = value == null ? null : new global::Java.Lang.String (value);
+			var jls_value = value == null ? null : new global::Java.Lang.String (value);
 			self.Append (jls_value);
 			jls_value?.Dispose ();
 		}
 
 		public static string Identity (this Test.ME.ITestInterface self, string value)
 		{
-			global::Java.Lang.String jls_value = value == null ? null : new global::Java.Lang.String (value);
+			var jls_value = value == null ? null : new global::Java.Lang.String (value);
 			global::Java.Lang.ICharSequence __result = self.IdentityFormatted (jls_value);
 			var __rsval = __result?.ToString ();
 			jls_value?.Dispose ();
@@ -139,8 +139,8 @@ namespace Test.ME {
 
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_tag)
 		{
-			global::Test.ME.ITestInterface __this = global::Java.Lang.Object.GetObject<global::Test.ME.ITestInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Java.Lang.Object tag = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_tag, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.ITestInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var tag = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_tag, JniHandleOwnership.DoNotTransfer);
 			int __ret = __this.GetSpanFlags (tag);
 			return __ret;
 		}
@@ -153,7 +153,7 @@ namespace Test.ME {
 				id_getSpanFlags_Ljava_lang_Object_ = JNIEnv.GetMethodID (class_ref, "getSpanFlags", "(Ljava/lang/Object;)I");
 			JValue* __args = stackalloc JValue [1];
 			__args [0] = new JValue ((tag == null) ? IntPtr.Zero : ((global::Java.Lang.Object) tag).Handle);
-			int __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getSpanFlags_Ljava_lang_Object_, __args);
+			var __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getSpanFlags_Ljava_lang_Object_, __args);
 			return __ret;
 		}
 
@@ -168,8 +168,8 @@ namespace Test.ME {
 
 		static void n_Append_Ljava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			global::Test.ME.ITestInterface __this = global::Java.Lang.Object.GetObject<global::Test.ME.ITestInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Java.Lang.ICharSequence value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.ITestInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
 			__this.Append (value);
 		}
 #pragma warning restore 0169
@@ -197,8 +197,8 @@ namespace Test.ME {
 
 		static IntPtr n_Identity_Ljava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			global::Test.ME.ITestInterface __this = global::Java.Lang.Object.GetObject<global::Test.ME.ITestInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Java.Lang.ICharSequence value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.ITestInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
 			IntPtr __ret = CharSequence.ToLocalJniHandle (__this.IdentityFormatted (value));
 			return __ret;
 		}
@@ -212,7 +212,7 @@ namespace Test.ME {
 			IntPtr native_value = CharSequence.ToLocalJniHandle (value);
 			JValue* __args = stackalloc JValue [1];
 			__args [0] = new JValue (native_value);
-			global::Java.Lang.ICharSequence __ret = global::Java.Lang.Object.GetObject<Java.Lang.ICharSequence> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_identity_Ljava_lang_CharSequence_, __args), JniHandleOwnership.TransferLocalRef);
+			var __ret = global::Java.Lang.Object.GetObject<Java.Lang.ICharSequence> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_identity_Ljava_lang_CharSequence_, __args), JniHandleOwnership.TransferLocalRef);
 			JNIEnv.DeleteLocalRef (native_value);
 			return __ret;
 		}

--- a/tests/generator-Tests/expected.ji/TestInterface/Test.ME.TestInterfaceImplementation.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Test.ME.TestInterfaceImplementation.cs
@@ -81,8 +81,8 @@ namespace Test.ME {
 
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_tag)
 		{
-			global::Test.ME.TestInterfaceImplementation __this = global::Java.Lang.Object.GetObject<global::Test.ME.TestInterfaceImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Java.Lang.Object tag = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_tag, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.TestInterfaceImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var tag = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_tag, JniHandleOwnership.DoNotTransfer);
 			int __ret = __this.GetSpanFlags (tag);
 			return __ret;
 		}
@@ -103,8 +103,8 @@ namespace Test.ME {
 
 		static void n_Append_Ljava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			global::Test.ME.TestInterfaceImplementation __this = global::Java.Lang.Object.GetObject<global::Test.ME.TestInterfaceImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Java.Lang.ICharSequence value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.TestInterfaceImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
 			__this.Append (value);
 		}
 #pragma warning restore 0169
@@ -115,7 +115,7 @@ namespace Test.ME {
 
 		public void Append (string value)
 		{
-			global::Java.Lang.String jls_value = value == null ? null : new global::Java.Lang.String (value);
+			var jls_value = value == null ? null : new global::Java.Lang.String (value);
 			Append (jls_value);
 			jls_value?.Dispose ();
 		}
@@ -131,8 +131,8 @@ namespace Test.ME {
 
 		static IntPtr n_Identity_Ljava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			global::Test.ME.TestInterfaceImplementation __this = global::Java.Lang.Object.GetObject<global::Test.ME.TestInterfaceImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Java.Lang.ICharSequence value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.TestInterfaceImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
 			IntPtr __ret = CharSequence.ToLocalJniHandle (__this.IdentityFormatted (value));
 			return __ret;
 		}
@@ -144,7 +144,7 @@ namespace Test.ME {
 
 		public string Identity (string value)
 		{
-			global::Java.Lang.String jls_value = value == null ? null : new global::Java.Lang.String (value);
+			var jls_value = value == null ? null : new global::Java.Lang.String (value);
 			global::Java.Lang.ICharSequence __result = IdentityFormatted (jls_value);
 			var __rsval = __result?.ToString ();
 			jls_value?.Dispose ();
@@ -212,6 +212,7 @@ namespace Test.ME {
 				JNIEnv.DeleteLocalRef (native_value);
 			}
 		}
+
 	}
 
 }

--- a/tests/generator-Tests/expected.ji/java.lang.Enum/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/java.lang.Enum/Java.Interop.__TypeRegistrations.cs
@@ -25,7 +25,7 @@ namespace Java.Interop {
 
 		static Type Lookup (string[] mappings, string javaType)
 		{
-			string managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
+			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
 			if (managedType == null)
 				return null;
 			return Type.GetType (managedType);

--- a/tests/generator-Tests/expected.ji/java.lang.Enum/Java.Lang.IComparable.cs
+++ b/tests/generator-Tests/expected.ji/java.lang.Enum/Java.Lang.IComparable.cs
@@ -78,8 +78,8 @@ namespace Java.Lang {
 
 		static int n_CompareTo_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_another)
 		{
-			global::Java.Lang.IComparable __this = global::Java.Lang.Object.GetObject<global::Java.Lang.IComparable> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Java.Lang.Object another = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_another, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Java.Lang.IComparable> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var another = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_another, JniHandleOwnership.DoNotTransfer);
 			int __ret = __this.CompareTo (another);
 			return __ret;
 		}
@@ -93,7 +93,7 @@ namespace Java.Lang {
 			IntPtr native_another = JNIEnv.ToLocalJniHandle (another);
 			JValue* __args = stackalloc JValue [1];
 			__args [0] = new JValue (native_another);
-			int __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_compareTo_Ljava_lang_Object_, __args);
+			var __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_compareTo_Ljava_lang_Object_, __args);
 			JNIEnv.DeleteLocalRef (native_another);
 			return __ret;
 		}

--- a/tests/generator-Tests/expected.ji/java.lang.Object/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/java.lang.Object/Java.Interop.__TypeRegistrations.cs
@@ -25,7 +25,7 @@ namespace Java.Interop {
 
 		static Type Lookup (string[] mappings, string javaType)
 		{
-			string managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
+			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
 			if (managedType == null)
 				return null;
 			return Type.GetType (managedType);

--- a/tests/generator-Tests/expected.ji/java.util.List/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/java.util.List/Java.Interop.__TypeRegistrations.cs
@@ -25,7 +25,7 @@ namespace Java.Interop {
 
 		static Type Lookup (string[] mappings, string javaType)
 		{
-			string managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
+			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
 			if (managedType == null)
 				return null;
 			return Type.GetType (managedType);

--- a/tests/generator-Tests/expected/AccessModifiers/Xamarin.Test.BasePublicClass.cs
+++ b/tests/generator-Tests/expected/AccessModifiers/Xamarin.Test.BasePublicClass.cs
@@ -36,7 +36,7 @@ namespace Xamarin.Test {
 
 		static void n_BaseMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.BasePublicClass __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.BasePublicClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.BasePublicClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.BaseMethod ();
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected/AccessModifiers/Xamarin.Test.ExtendPublicClass.cs
+++ b/tests/generator-Tests/expected/AccessModifiers/Xamarin.Test.ExtendPublicClass.cs
@@ -64,7 +64,7 @@ namespace Xamarin.Test {
 
 		static void n_Foo (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.ExtendPublicClass __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.ExtendPublicClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.ExtendPublicClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Foo ();
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected/AccessModifiers/Xamarin.Test.IExtendedInterface.cs
+++ b/tests/generator-Tests/expected/AccessModifiers/Xamarin.Test.IExtendedInterface.cs
@@ -72,7 +72,7 @@ namespace Xamarin.Test {
 
 		static void n_ExtendedMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.IExtendedInterface __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.IExtendedInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.IExtendedInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.ExtendedMethod ();
 		}
 #pragma warning restore 0169
@@ -96,7 +96,7 @@ namespace Xamarin.Test {
 
 		static void n_BaseMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.IExtendedInterface __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.IExtendedInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.IExtendedInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.BaseMethod ();
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected/AccessModifiers/Xamarin.Test.PublicClass.cs
+++ b/tests/generator-Tests/expected/AccessModifiers/Xamarin.Test.PublicClass.cs
@@ -72,7 +72,7 @@ namespace Xamarin.Test {
 
 			static void n_Foo (IntPtr jnienv, IntPtr native__this)
 			{
-				global::Xamarin.Test.PublicClass.IProtectedInterface __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.PublicClass.IProtectedInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.PublicClass.IProtectedInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.Foo ();
 			}
 #pragma warning restore 0169
@@ -144,7 +144,7 @@ namespace Xamarin.Test {
 
 		static void n_Foo (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.PublicClass __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.PublicClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.PublicClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Foo ();
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected/AccessModifiers/Xamarin.Test.TestClass.cs
+++ b/tests/generator-Tests/expected/AccessModifiers/Xamarin.Test.TestClass.cs
@@ -64,7 +64,7 @@ namespace Xamarin.Test {
 
 		static void n_BaseMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.TestClass __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.TestClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.TestClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.BaseMethod ();
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected/Adapters/Xamarin.Test.AbsSpinner.cs
+++ b/tests/generator-Tests/expected/Adapters/Xamarin.Test.AbsSpinner.cs
@@ -36,7 +36,7 @@ namespace Xamarin.Test {
 
 		static IntPtr n_GetAdapter (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.AbsSpinner __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.AbsSpinner> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.AbsSpinner> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.ToLocalJniHandle (__this.Adapter);
 		}
 #pragma warning restore 0169
@@ -52,8 +52,8 @@ namespace Xamarin.Test {
 
 		static void n_SetAdapter_Lxamarin_test_SpinnerAdapter_ (IntPtr jnienv, IntPtr native__this, IntPtr native_adapter)
 		{
-			global::Xamarin.Test.AbsSpinner __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.AbsSpinner> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Xamarin.Test.ISpinnerAdapter adapter = (global::Xamarin.Test.ISpinnerAdapter)global::Java.Lang.Object.GetObject<global::Xamarin.Test.ISpinnerAdapter> (native_adapter, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.AbsSpinner> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var adapter = (global::Xamarin.Test.ISpinnerAdapter)global::Java.Lang.Object.GetObject<global::Xamarin.Test.ISpinnerAdapter> (native_adapter, JniHandleOwnership.DoNotTransfer);
 			__this.Adapter = adapter;
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected/Adapters/Xamarin.Test.AdapterView.cs
+++ b/tests/generator-Tests/expected/Adapters/Xamarin.Test.AdapterView.cs
@@ -37,7 +37,7 @@ namespace Xamarin.Test {
 
 		static IntPtr n_GetAdapter (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.AdapterView __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.AdapterView> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.AdapterView> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.ToLocalJniHandle (__this.RawAdapter);
 		}
 #pragma warning restore 0169
@@ -53,8 +53,8 @@ namespace Xamarin.Test {
 
 		static void n_SetAdapter_Lxamarin_test_Adapter_ (IntPtr jnienv, IntPtr native__this, IntPtr native_adapter)
 		{
-			global::Xamarin.Test.AdapterView __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.AdapterView> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Java.Lang.Object adapter = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_adapter, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.AdapterView> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var adapter = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_adapter, JniHandleOwnership.DoNotTransfer);
 			__this.RawAdapter = adapter;
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected/Adapters/Xamarin.Test.GenericReturnObject.cs
+++ b/tests/generator-Tests/expected/Adapters/Xamarin.Test.GenericReturnObject.cs
@@ -36,7 +36,7 @@ namespace Xamarin.Test {
 
 		static IntPtr n_GenericReturn (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.GenericReturnObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.GenericReturnObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.GenericReturnObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.ToLocalJniHandle (__this.GenericReturn ());
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected/Android.Graphics.Color/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected/Android.Graphics.Color/Xamarin.Test.SomeObject.cs
@@ -57,7 +57,7 @@ namespace Xamarin.Test {
 
 		static int n_GetSomeColor (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.SomeColor.ToArgb ();
 		}
 #pragma warning restore 0169
@@ -73,8 +73,8 @@ namespace Xamarin.Test {
 
 		static void n_SetSomeColor_I (IntPtr jnienv, IntPtr native__this, int native_newvalue)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Android.Graphics.Color newvalue = new global::Android.Graphics.Color (native_newvalue);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var newvalue = new global::Android.Graphics.Color (native_newvalue);
 			__this.SomeColor = newvalue;
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected/CSharpKeywords/Xamarin.Test.CSharpKeywords.cs
+++ b/tests/generator-Tests/expected/CSharpKeywords/Xamarin.Test.CSharpKeywords.cs
@@ -36,7 +36,7 @@ namespace Xamarin.Test {
 
 		static IntPtr n_UsePartial_I (IntPtr jnienv, IntPtr native__this, int partial)
 		{
-			global::Xamarin.Test.CSharpKeywords __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.CSharpKeywords> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.CSharpKeywords> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.NewString (__this.UsePartial (partial));
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected/EnumerationFixup/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected/EnumerationFixup/Java.Interop.__TypeRegistrations.cs
@@ -25,7 +25,7 @@ namespace Java.Interop {
 
 		static Type Lookup (string[] mappings, string javaType)
 		{
-			string managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
+			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
 			if (managedType == null)
 				return null;
 			return Type.GetType (managedType);

--- a/tests/generator-Tests/expected/EnumerationFixup/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected/EnumerationFixup/Xamarin.Test.SomeObject.cs
@@ -36,7 +36,7 @@ namespace Xamarin.Test {
 
 		static int n_GetSomeObjectProperty (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return (int) __this.SomeObjectProperty;
 		}
 #pragma warning restore 0169
@@ -52,8 +52,8 @@ namespace Xamarin.Test {
 
 		static void n_SetSomeObjectProperty_I (IntPtr jnienv, IntPtr native__this, int native_newvalue)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Xamarin.Test.SomeValues newvalue = (global::Xamarin.Test.SomeValues) native_newvalue;
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var newvalue = (global::Xamarin.Test.SomeValues) native_newvalue;
 			__this.SomeObjectProperty = newvalue;
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected/EnumerationFixup/Xamarin.Test.SomeObject2.cs
+++ b/tests/generator-Tests/expected/EnumerationFixup/Xamarin.Test.SomeObject2.cs
@@ -36,7 +36,7 @@ namespace Xamarin.Test {
 
 		static int n_GetSomeObjectProperty (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.SomeObject2 __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return (int) __this.SomeObjectProperty;
 		}
 #pragma warning restore 0169
@@ -52,8 +52,8 @@ namespace Xamarin.Test {
 
 		static void n_SetSomeObjectProperty_I (IntPtr jnienv, IntPtr native__this, int native_newvalue)
 		{
-			global::Xamarin.Test.SomeObject2 __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Xamarin.Test.SomeValues newvalue = (global::Xamarin.Test.SomeValues) native_newvalue;
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var newvalue = (global::Xamarin.Test.SomeValues) native_newvalue;
 			__this.SomeObjectProperty = newvalue;
 		}
 #pragma warning restore 0169
@@ -104,7 +104,7 @@ namespace Xamarin.Test {
 
 		static IntPtr n_GetSomeObjectPropertyArray (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.SomeObject2 __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.NewArray (__this.GetSomeObjectPropertyArray ());
 		}
 #pragma warning restore 0169
@@ -138,8 +138,8 @@ namespace Xamarin.Test {
 
 		static void n_SetSomeObjectPropertyArray_arrayI (IntPtr jnienv, IntPtr native__this, IntPtr native_newvalue)
 		{
-			global::Xamarin.Test.SomeObject2 __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Xamarin.Test.SomeValues[] newvalue = (global::Xamarin.Test.SomeValues[]) JNIEnv.GetArray (native_newvalue, JniHandleOwnership.DoNotTransfer, typeof (global::Xamarin.Test.SomeValues));
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var newvalue = (global::Xamarin.Test.SomeValues[]) JNIEnv.GetArray (native_newvalue, JniHandleOwnership.DoNotTransfer, typeof (global::Xamarin.Test.SomeValues));
 			__this.SetSomeObjectPropertyArray (newvalue);
 			if (newvalue != null)
 				JNIEnv.CopyArray (newvalue, native_newvalue);

--- a/tests/generator-Tests/expected/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
+++ b/tests/generator-Tests/expected/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
@@ -69,10 +69,10 @@ namespace Com.Google.Android.Exoplayer.Drm {
 
 		static void n_OnEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB (IntPtr jnienv, IntPtr native__this, IntPtr native_p0, IntPtr native_p1, int p2, int p3, IntPtr native_p4)
 		{
-			global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener __this = global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm p0 = (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm)global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm> (native_p0, JniHandleOwnership.DoNotTransfer);
-			byte[] p1 = (byte[]) JNIEnv.GetArray (native_p1, JniHandleOwnership.DoNotTransfer, typeof (byte));
-			byte[] p4 = (byte[]) JNIEnv.GetArray (native_p4, JniHandleOwnership.DoNotTransfer, typeof (byte));
+			var __this = global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var p0 = (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm)global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm> (native_p0, JniHandleOwnership.DoNotTransfer);
+			var p1 = (byte[]) JNIEnv.GetArray (native_p1, JniHandleOwnership.DoNotTransfer, typeof (byte));
+			var p4 = (byte[]) JNIEnv.GetArray (native_p4, JniHandleOwnership.DoNotTransfer, typeof (byte));
 			__this.OnEvent (p0, p1, p2, p3, p4);
 			if (p1 != null)
 				JNIEnv.CopyArray (p1, native_p1);
@@ -242,8 +242,8 @@ namespace Com.Google.Android.Exoplayer.Drm {
 
 		static void n_SetOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
 		{
-			global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm __this = global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener p0 = (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener)global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener> (native_p0, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var p0 = (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener)global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener> (native_p0, JniHandleOwnership.DoNotTransfer);
 			__this.SetOnEventListener (p0);
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected/InterfaceMethodsConflict/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected/InterfaceMethodsConflict/Java.Interop.__TypeRegistrations.cs
@@ -25,7 +25,7 @@ namespace Java.Interop {
 
 		static Type Lookup (string[] mappings, string javaType)
 		{
-			string managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
+			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
 			if (managedType == null)
 				return null;
 			return Type.GetType (managedType);

--- a/tests/generator-Tests/expected/InterfaceMethodsConflict/Xamarin.Test.II1.cs
+++ b/tests/generator-Tests/expected/InterfaceMethodsConflict/Xamarin.Test.II1.cs
@@ -68,7 +68,7 @@ namespace Xamarin.Test {
 
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.II1 __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.II1> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.II1> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Close ();
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected/InterfaceMethodsConflict/Xamarin.Test.II2.cs
+++ b/tests/generator-Tests/expected/InterfaceMethodsConflict/Xamarin.Test.II2.cs
@@ -68,7 +68,7 @@ namespace Xamarin.Test {
 
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.II2 __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.II2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.II2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Close ();
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected/InterfaceMethodsConflict/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected/InterfaceMethodsConflict/Xamarin.Test.SomeObject.cs
@@ -36,7 +36,7 @@ namespace Xamarin.Test {
 
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Close ();
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected/InterfaceMethodsConflict/Xamarin.Test.SomeObject2.cs
+++ b/tests/generator-Tests/expected/InterfaceMethodsConflict/Xamarin.Test.SomeObject2.cs
@@ -36,7 +36,7 @@ namespace Xamarin.Test {
 
 		static void n_Irrelevant (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.SomeObject2 __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Irrelevant ();
 		}
 #pragma warning restore 0169
@@ -69,7 +69,7 @@ namespace Xamarin.Test {
 
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.SomeObject2 __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Close ();
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
+++ b/tests/generator-Tests/expected/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
@@ -76,7 +76,7 @@ namespace Xamarin.Test {
 
 				static IntPtr n_Build_I (IntPtr jnienv, IntPtr native__this, int p0)
 				{
-					global::Xamarin.Test.NotificationCompatBase.Action.IFactory __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.NotificationCompatBase.Action.IFactory> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+					var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.NotificationCompatBase.Action.IFactory> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 					return JNIEnv.ToLocalJniHandle (__this.Build (p0));
 				}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected/NormalMethods/Xamarin.Test.A.cs
+++ b/tests/generator-Tests/expected/NormalMethods/Xamarin.Test.A.cs
@@ -41,7 +41,7 @@ namespace Xamarin.Test {
 
 			static IntPtr n_SetCustomDimension_I (IntPtr jnienv, IntPtr native__this, int index)
 			{
-				global::Xamarin.Test.A.B __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.A.B> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.A.B> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return JNIEnv.ToLocalJniHandle (__this.SetCustomDimension (index));
 			}
 #pragma warning restore 0169
@@ -95,7 +95,7 @@ namespace Xamarin.Test {
 
 		static int n_GetHandle (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.A __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.A> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.A> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.GetHandle ();
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected/NormalMethods/Xamarin.Test.C.cs
+++ b/tests/generator-Tests/expected/NormalMethods/Xamarin.Test.C.cs
@@ -37,7 +37,7 @@ namespace Xamarin.Test {
 
 		static IntPtr n_SetCustomDimension_I (IntPtr jnienv, IntPtr native__this, int index)
 		{
-			global::Xamarin.Test.C __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.C> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.C> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.ToLocalJniHandle (__this.SetCustomDimension (index));
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected/NormalMethods/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected/NormalMethods/Xamarin.Test.SomeObject.cs
@@ -66,7 +66,7 @@ namespace Xamarin.Test {
 
 		static IntPtr n_GetType (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.NewArray (__this.GetType ());
 		}
 #pragma warning restore 0169
@@ -99,9 +99,9 @@ namespace Xamarin.Test {
 
 		static int n_Handle_Ljava_lang_Object_Ljava_lang_Throwable_ (IntPtr jnienv, IntPtr native__this, IntPtr native_o, IntPtr native_t)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Java.Lang.Object o = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_o, JniHandleOwnership.DoNotTransfer);
-			global::Java.Lang.Throwable t = global::Java.Lang.Object.GetObject<global::Java.Lang.Throwable> (native_t, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var o = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_o, JniHandleOwnership.DoNotTransfer);
+			var t = global::Java.Lang.Object.GetObject<global::Java.Lang.Throwable> (native_t, JniHandleOwnership.DoNotTransfer);
 			int __ret = __this.Handle (o, t);
 			return __ret;
 		}
@@ -140,7 +140,7 @@ namespace Xamarin.Test {
 
 		static int n_IntegerMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.IntegerMethod ();
 		}
 #pragma warning restore 0169
@@ -173,7 +173,7 @@ namespace Xamarin.Test {
 
 		static void n_VoidMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.VoidMethod ();
 		}
 #pragma warning restore 0169
@@ -206,7 +206,7 @@ namespace Xamarin.Test {
 
 		static IntPtr n_StringMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.NewString (__this.StringMethod ());
 		}
 #pragma warning restore 0169
@@ -239,7 +239,7 @@ namespace Xamarin.Test {
 
 		static IntPtr n_ObjectMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.ToLocalJniHandle (__this.ObjectMethod ());
 		}
 #pragma warning restore 0169
@@ -272,9 +272,9 @@ namespace Xamarin.Test {
 
 		static void n_VoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_astring, int anint, IntPtr native_anObject)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			string astring = JNIEnv.GetString (native_astring, JniHandleOwnership.DoNotTransfer);
-			global::Java.Lang.Object anObject = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_anObject, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var astring = JNIEnv.GetString (native_astring, JniHandleOwnership.DoNotTransfer);
+			var anObject = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_anObject, JniHandleOwnership.DoNotTransfer);
 			__this.VoidMethodWithParams (astring, anint, anObject);
 		}
 #pragma warning restore 0169
@@ -315,7 +315,7 @@ namespace Xamarin.Test {
 		[Obsolete]
 		static int n_ObsoleteMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.ObsoleteMethod ();
 		}
 #pragma warning restore 0169
@@ -349,7 +349,7 @@ namespace Xamarin.Test {
 
 		static void n_ArrayListTest_Ljava_util_ArrayList_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			var p0 = global::Android.Runtime.JavaList<global::Java.Lang.Integer>.FromJniHandle (native_p0, JniHandleOwnership.DoNotTransfer);
 			__this.ArrayListTest (p0);
 		}

--- a/tests/generator-Tests/expected/NormalProperties/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected/NormalProperties/Xamarin.Test.SomeObject.cs
@@ -36,7 +36,7 @@ namespace Xamarin.Test {
 
 		static int n_GetSomeInteger (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.SomeInteger;
 		}
 #pragma warning restore 0169
@@ -52,7 +52,7 @@ namespace Xamarin.Test {
 
 		static void n_SetSomeInteger_I (IntPtr jnienv, IntPtr native__this, int newvalue)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.SomeInteger = newvalue;
 		}
 #pragma warning restore 0169
@@ -75,7 +75,7 @@ namespace Xamarin.Test {
 
 		static IntPtr n_GetSomeObjectProperty (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.ToLocalJniHandle (__this.SomeObjectProperty);
 		}
 #pragma warning restore 0169
@@ -91,8 +91,8 @@ namespace Xamarin.Test {
 
 		static void n_SetSomeObjectProperty_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_newvalue)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Java.Lang.Object newvalue = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_newvalue, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var newvalue = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_newvalue, JniHandleOwnership.DoNotTransfer);
 			__this.SomeObjectProperty = newvalue;
 		}
 #pragma warning restore 0169
@@ -115,7 +115,7 @@ namespace Xamarin.Test {
 
 		static IntPtr n_GetSomeString (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.NewString (__this.SomeString);
 		}
 #pragma warning restore 0169
@@ -131,8 +131,8 @@ namespace Xamarin.Test {
 
 		static void n_SetSomeString_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_newvalue)
 		{
-			global::Xamarin.Test.SomeObject __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			string newvalue = JNIEnv.GetString (native_newvalue, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var newvalue = JNIEnv.GetString (native_newvalue, JniHandleOwnership.DoNotTransfer);
 			__this.SomeString = newvalue;
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected/ParameterXPath/Xamarin.Test.A.cs
+++ b/tests/generator-Tests/expected/ParameterXPath/Xamarin.Test.A.cs
@@ -37,8 +37,8 @@ namespace Xamarin.Test {
 
 		static void n_SetA_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_adapter)
 		{
-			global::Xamarin.Test.A __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.A> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Java.Lang.Object adapter = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_adapter, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.A> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var adapter = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_adapter, JniHandleOwnership.DoNotTransfer);
 			__this.SetA (adapter);
 		}
 #pragma warning restore 0169
@@ -75,7 +75,7 @@ namespace Xamarin.Test {
 
 		static void n_ListTest_Ljava_util_List_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
 		{
-			global::Xamarin.Test.A __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.A> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.A> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			var p0 = global::Android.Runtime.JavaList<global::Java.Lang.Integer>.FromJniHandle (native_p0, JniHandleOwnership.DoNotTransfer);
 			__this.ListTest (p0);
 		}

--- a/tests/generator-Tests/expected/Streams/Java.IO.FilterOutputStream.cs
+++ b/tests/generator-Tests/expected/Streams/Java.IO.FilterOutputStream.cs
@@ -68,7 +68,7 @@ namespace Java.IO {
 
 		static void n_Write_I (IntPtr jnienv, IntPtr native__this, int oneByte)
 		{
-			global::Java.IO.FilterOutputStream __this = global::Java.Lang.Object.GetObject<global::Java.IO.FilterOutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.FilterOutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Write (oneByte);
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected/Streams/Java.IO.IOException.cs
+++ b/tests/generator-Tests/expected/Streams/Java.IO.IOException.cs
@@ -36,7 +36,7 @@ namespace Java.IO {
 
 		static void n_PrintStackTrace (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Java.IO.IOException __this = global::Java.Lang.Object.GetObject<global::Java.IO.IOException> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.IOException> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.PrintStackTrace ();
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected/Streams/Java.IO.InputStream.cs
+++ b/tests/generator-Tests/expected/Streams/Java.IO.InputStream.cs
@@ -64,7 +64,7 @@ namespace Java.IO {
 
 		static int n_Available (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Java.IO.InputStream __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.Available ();
 		}
 #pragma warning restore 0169
@@ -97,7 +97,7 @@ namespace Java.IO {
 
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Java.IO.InputStream __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Close ();
 		}
 #pragma warning restore 0169
@@ -130,7 +130,7 @@ namespace Java.IO {
 
 		static void n_Mark_I (IntPtr jnienv, IntPtr native__this, int readlimit)
 		{
-			global::Java.IO.InputStream __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Mark (readlimit);
 		}
 #pragma warning restore 0169
@@ -165,7 +165,7 @@ namespace Java.IO {
 
 		static bool n_MarkSupported (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Java.IO.InputStream __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.MarkSupported ();
 		}
 #pragma warning restore 0169
@@ -198,7 +198,7 @@ namespace Java.IO {
 
 		static int n_Read (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Java.IO.InputStream __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.Read ();
 		}
 #pragma warning restore 0169
@@ -218,8 +218,8 @@ namespace Java.IO {
 
 		static int n_Read_arrayB (IntPtr jnienv, IntPtr native__this, IntPtr native_buffer)
 		{
-			global::Java.IO.InputStream __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			byte[] buffer = (byte[]) JNIEnv.GetArray (native_buffer, JniHandleOwnership.DoNotTransfer, typeof (byte));
+			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var buffer = (byte[]) JNIEnv.GetArray (native_buffer, JniHandleOwnership.DoNotTransfer, typeof (byte));
 			int __ret = __this.Read (buffer);
 			if (buffer != null)
 				JNIEnv.CopyArray (buffer, native_buffer);
@@ -264,8 +264,8 @@ namespace Java.IO {
 
 		static int n_Read_arrayBII (IntPtr jnienv, IntPtr native__this, IntPtr native_buffer, int byteOffset, int byteCount)
 		{
-			global::Java.IO.InputStream __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			byte[] buffer = (byte[]) JNIEnv.GetArray (native_buffer, JniHandleOwnership.DoNotTransfer, typeof (byte));
+			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var buffer = (byte[]) JNIEnv.GetArray (native_buffer, JniHandleOwnership.DoNotTransfer, typeof (byte));
 			int __ret = __this.Read (buffer, byteOffset, byteCount);
 			if (buffer != null)
 				JNIEnv.CopyArray (buffer, native_buffer);
@@ -312,7 +312,7 @@ namespace Java.IO {
 
 		static void n_Reset (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Java.IO.InputStream __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Reset ();
 		}
 #pragma warning restore 0169
@@ -345,7 +345,7 @@ namespace Java.IO {
 
 		static long n_Skip_J (IntPtr jnienv, IntPtr native__this, long byteCount)
 		{
-			global::Java.IO.InputStream __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.Skip (byteCount);
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected/Streams/Java.IO.OutputStream.cs
+++ b/tests/generator-Tests/expected/Streams/Java.IO.OutputStream.cs
@@ -64,7 +64,7 @@ namespace Java.IO {
 
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Java.IO.OutputStream __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Close ();
 		}
 #pragma warning restore 0169
@@ -97,7 +97,7 @@ namespace Java.IO {
 
 		static void n_Flush (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Java.IO.OutputStream __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Flush ();
 		}
 #pragma warning restore 0169
@@ -130,8 +130,8 @@ namespace Java.IO {
 
 		static void n_Write_arrayB (IntPtr jnienv, IntPtr native__this, IntPtr native_buffer)
 		{
-			global::Java.IO.OutputStream __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			byte[] buffer = (byte[]) JNIEnv.GetArray (native_buffer, JniHandleOwnership.DoNotTransfer, typeof (byte));
+			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var buffer = (byte[]) JNIEnv.GetArray (native_buffer, JniHandleOwnership.DoNotTransfer, typeof (byte));
 			__this.Write (buffer);
 			if (buffer != null)
 				JNIEnv.CopyArray (buffer, native_buffer);
@@ -173,8 +173,8 @@ namespace Java.IO {
 
 		static void n_Write_arrayBII (IntPtr jnienv, IntPtr native__this, IntPtr native_buffer, int offset, int count)
 		{
-			global::Java.IO.OutputStream __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			byte[] buffer = (byte[]) JNIEnv.GetArray (native_buffer, JniHandleOwnership.DoNotTransfer, typeof (byte));
+			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var buffer = (byte[]) JNIEnv.GetArray (native_buffer, JniHandleOwnership.DoNotTransfer, typeof (byte));
 			__this.Write (buffer, offset, count);
 			if (buffer != null)
 				JNIEnv.CopyArray (buffer, native_buffer);
@@ -218,7 +218,7 @@ namespace Java.IO {
 
 		static void n_Write_I (IntPtr jnienv, IntPtr native__this, int oneByte)
 		{
-			global::Java.IO.OutputStream __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Write (oneByte);
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected/Streams/Java.Lang.Throwable.cs
+++ b/tests/generator-Tests/expected/Streams/Java.Lang.Throwable.cs
@@ -26,7 +26,7 @@ namespace Java.Lang {
 
 		static IntPtr n_GetMessage (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Java.Lang.Throwable __this = global::Java.Lang.Object.GetObject<global::Java.Lang.Throwable> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Java.Lang.Throwable> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.NewString (__this.Message);
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected/TestInterface/ClassWithoutNamespace.cs
+++ b/tests/generator-Tests/expected/TestInterface/ClassWithoutNamespace.cs
@@ -62,7 +62,7 @@ public abstract partial class ClassWithoutNamespace : global::Java.Lang.Object, 
 
 	static void n_Foo (IntPtr jnienv, IntPtr native__this)
 	{
-		ClassWithoutNamespace __this = global::Java.Lang.Object.GetObject<ClassWithoutNamespace> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<ClassWithoutNamespace> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.Foo ();
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected/TestInterface/IInterfaceWithoutNamespace.cs
+++ b/tests/generator-Tests/expected/TestInterface/IInterfaceWithoutNamespace.cs
@@ -66,7 +66,7 @@ internal partial class IInterfaceWithoutNamespaceInvoker : global::Java.Lang.Obj
 
 	static void n_Foo (IntPtr jnienv, IntPtr native__this)
 	{
-		IInterfaceWithoutNamespace __this = global::Java.Lang.Object.GetObject<IInterfaceWithoutNamespace> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var __this = global::Java.Lang.Object.GetObject<IInterfaceWithoutNamespace> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.Foo ();
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected/TestInterface/Test.ME.GenericImplementation.cs
+++ b/tests/generator-Tests/expected/TestInterface/Test.ME.GenericImplementation.cs
@@ -64,8 +64,8 @@ namespace Test.ME {
 
 		static void n_SetObject_arrayB (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			global::Test.ME.GenericImplementation __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			byte[] value = (byte[]) JNIEnv.GetArray (native_value, JniHandleOwnership.DoNotTransfer, typeof (byte));
+			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var value = (byte[]) JNIEnv.GetArray (native_value, JniHandleOwnership.DoNotTransfer, typeof (byte));
 			__this.SetObject (value);
 			if (value != null)
 				JNIEnv.CopyArray (value, native_value);

--- a/tests/generator-Tests/expected/TestInterface/Test.ME.GenericObjectPropertyImplementation.cs
+++ b/tests/generator-Tests/expected/TestInterface/Test.ME.GenericObjectPropertyImplementation.cs
@@ -64,7 +64,7 @@ namespace Test.ME {
 
 		static IntPtr n_GetObject (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Test.ME.GenericObjectPropertyImplementation __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericObjectPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericObjectPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.ToLocalJniHandle (__this.Object);
 		}
 #pragma warning restore 0169
@@ -80,8 +80,8 @@ namespace Test.ME {
 
 		static void n_SetObject_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			global::Test.ME.GenericObjectPropertyImplementation __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericObjectPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Java.Lang.Object value = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_value, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericObjectPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var value = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_value, JniHandleOwnership.DoNotTransfer);
 			__this.Object = value;
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected/TestInterface/Test.ME.GenericStringImplementation.cs
+++ b/tests/generator-Tests/expected/TestInterface/Test.ME.GenericStringImplementation.cs
@@ -64,8 +64,8 @@ namespace Test.ME {
 
 		static void n_SetObject_arrayLjava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			global::Test.ME.GenericStringImplementation __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericStringImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			string[] value = (string[]) JNIEnv.GetArray (native_value, JniHandleOwnership.DoNotTransfer, typeof (string));
+			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericStringImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var value = (string[]) JNIEnv.GetArray (native_value, JniHandleOwnership.DoNotTransfer, typeof (string));
 			__this.SetObject (value);
 			if (value != null)
 				JNIEnv.CopyArray (value, native_value);

--- a/tests/generator-Tests/expected/TestInterface/Test.ME.GenericStringPropertyImplementation.cs
+++ b/tests/generator-Tests/expected/TestInterface/Test.ME.GenericStringPropertyImplementation.cs
@@ -64,7 +64,7 @@ namespace Test.ME {
 
 		static IntPtr n_GetObject (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Test.ME.GenericStringPropertyImplementation __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericStringPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericStringPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.NewString (__this.Object);
 		}
 #pragma warning restore 0169
@@ -80,8 +80,8 @@ namespace Test.ME {
 
 		static void n_SetObject_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			global::Test.ME.GenericStringPropertyImplementation __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericStringPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			string value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericStringPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
 			__this.Object = value;
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected/TestInterface/Test.ME.IGenericInterface.cs
+++ b/tests/generator-Tests/expected/TestInterface/Test.ME.IGenericInterface.cs
@@ -69,8 +69,8 @@ namespace Test.ME {
 
 		static void n_SetObject_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			global::Test.ME.IGenericInterface __this = global::Java.Lang.Object.GetObject<global::Test.ME.IGenericInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Java.Lang.Object value = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_value, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.IGenericInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var value = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_value, JniHandleOwnership.DoNotTransfer);
 			__this.SetObject (value);
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected/TestInterface/Test.ME.IGenericPropertyInterface.cs
+++ b/tests/generator-Tests/expected/TestInterface/Test.ME.IGenericPropertyInterface.cs
@@ -72,7 +72,7 @@ namespace Test.ME {
 
 		static IntPtr n_GetObject (IntPtr jnienv, IntPtr native__this)
 		{
-			global::Test.ME.IGenericPropertyInterface __this = global::Java.Lang.Object.GetObject<global::Test.ME.IGenericPropertyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.IGenericPropertyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.ToLocalJniHandle (__this.Object);
 		}
 #pragma warning restore 0169
@@ -88,8 +88,8 @@ namespace Test.ME {
 
 		static void n_SetObject_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			global::Test.ME.IGenericPropertyInterface __this = global::Java.Lang.Object.GetObject<global::Test.ME.IGenericPropertyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Java.Lang.Object value = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_value, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.IGenericPropertyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var value = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_value, JniHandleOwnership.DoNotTransfer);
 			__this.Object = value;
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected/TestInterface/Test.ME.ITestInterface.cs
+++ b/tests/generator-Tests/expected/TestInterface/Test.ME.ITestInterface.cs
@@ -62,14 +62,14 @@ namespace Test.ME {
 
 		public static void Append (this Test.ME.ITestInterface self, string value)
 		{
-			global::Java.Lang.String jls_value = value == null ? null : new global::Java.Lang.String (value);
+			var jls_value = value == null ? null : new global::Java.Lang.String (value);
 			self.Append (jls_value);
 			jls_value?.Dispose ();
 		}
 
 		public static string Identity (this Test.ME.ITestInterface self, string value)
 		{
-			global::Java.Lang.String jls_value = value == null ? null : new global::Java.Lang.String (value);
+			var jls_value = value == null ? null : new global::Java.Lang.String (value);
 			global::Java.Lang.ICharSequence __result = self.IdentityFormatted (jls_value);
 			var __rsval = __result?.ToString ();
 			jls_value?.Dispose ();
@@ -131,8 +131,8 @@ namespace Test.ME {
 
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_tag)
 		{
-			global::Test.ME.ITestInterface __this = global::Java.Lang.Object.GetObject<global::Test.ME.ITestInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Java.Lang.Object tag = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_tag, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.ITestInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var tag = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_tag, JniHandleOwnership.DoNotTransfer);
 			int __ret = __this.GetSpanFlags (tag);
 			return __ret;
 		}
@@ -145,7 +145,7 @@ namespace Test.ME {
 				id_getSpanFlags_Ljava_lang_Object_ = JNIEnv.GetMethodID (class_ref, "getSpanFlags", "(Ljava/lang/Object;)I");
 			JValue* __args = stackalloc JValue [1];
 			__args [0] = new JValue (tag);
-			int __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getSpanFlags_Ljava_lang_Object_, __args);
+			var __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_getSpanFlags_Ljava_lang_Object_, __args);
 			return __ret;
 		}
 
@@ -160,8 +160,8 @@ namespace Test.ME {
 
 		static void n_Append_Ljava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			global::Test.ME.ITestInterface __this = global::Java.Lang.Object.GetObject<global::Test.ME.ITestInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Java.Lang.ICharSequence value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.ITestInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
 			__this.Append (value);
 		}
 #pragma warning restore 0169
@@ -189,8 +189,8 @@ namespace Test.ME {
 
 		static IntPtr n_Identity_Ljava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			global::Test.ME.ITestInterface __this = global::Java.Lang.Object.GetObject<global::Test.ME.ITestInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Java.Lang.ICharSequence value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.ITestInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
 			IntPtr __ret = CharSequence.ToLocalJniHandle (__this.IdentityFormatted (value));
 			return __ret;
 		}
@@ -204,7 +204,7 @@ namespace Test.ME {
 			IntPtr native_value = CharSequence.ToLocalJniHandle (value);
 			JValue* __args = stackalloc JValue [1];
 			__args [0] = new JValue (native_value);
-			global::Java.Lang.ICharSequence __ret = global::Java.Lang.Object.GetObject<Java.Lang.ICharSequence> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_identity_Ljava_lang_CharSequence_, __args), JniHandleOwnership.TransferLocalRef);
+			var __ret = global::Java.Lang.Object.GetObject<Java.Lang.ICharSequence> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_identity_Ljava_lang_CharSequence_, __args), JniHandleOwnership.TransferLocalRef);
 			JNIEnv.DeleteLocalRef (native_value);
 			return __ret;
 		}

--- a/tests/generator-Tests/expected/TestInterface/Test.ME.TestInterfaceImplementation.cs
+++ b/tests/generator-Tests/expected/TestInterface/Test.ME.TestInterfaceImplementation.cs
@@ -87,8 +87,8 @@ namespace Test.ME {
 
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_tag)
 		{
-			global::Test.ME.TestInterfaceImplementation __this = global::Java.Lang.Object.GetObject<global::Test.ME.TestInterfaceImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Java.Lang.Object tag = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_tag, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.TestInterfaceImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var tag = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_tag, JniHandleOwnership.DoNotTransfer);
 			int __ret = __this.GetSpanFlags (tag);
 			return __ret;
 		}
@@ -109,8 +109,8 @@ namespace Test.ME {
 
 		static void n_Append_Ljava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			global::Test.ME.TestInterfaceImplementation __this = global::Java.Lang.Object.GetObject<global::Test.ME.TestInterfaceImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Java.Lang.ICharSequence value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.TestInterfaceImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
 			__this.Append (value);
 		}
 #pragma warning restore 0169
@@ -121,7 +121,7 @@ namespace Test.ME {
 
 		public void Append (string value)
 		{
-			global::Java.Lang.String jls_value = value == null ? null : new global::Java.Lang.String (value);
+			var jls_value = value == null ? null : new global::Java.Lang.String (value);
 			Append (jls_value);
 			jls_value?.Dispose ();
 		}
@@ -137,8 +137,8 @@ namespace Test.ME {
 
 		static IntPtr n_Identity_Ljava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			global::Test.ME.TestInterfaceImplementation __this = global::Java.Lang.Object.GetObject<global::Test.ME.TestInterfaceImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Java.Lang.ICharSequence value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.TestInterfaceImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
 			IntPtr __ret = CharSequence.ToLocalJniHandle (__this.IdentityFormatted (value));
 			return __ret;
 		}
@@ -150,7 +150,7 @@ namespace Test.ME {
 
 		public string Identity (string value)
 		{
-			global::Java.Lang.String jls_value = value == null ? null : new global::Java.Lang.String (value);
+			var jls_value = value == null ? null : new global::Java.Lang.String (value);
 			global::Java.Lang.ICharSequence __result = IdentityFormatted (jls_value);
 			var __rsval = __result?.ToString ();
 			jls_value?.Dispose ();
@@ -218,6 +218,7 @@ namespace Test.ME {
 				JNIEnv.DeleteLocalRef (native_value);
 			}
 		}
+
 	}
 
 }

--- a/tests/generator-Tests/expected/java.lang.Enum/Java.Lang.IComparable.cs
+++ b/tests/generator-Tests/expected/java.lang.Enum/Java.Lang.IComparable.cs
@@ -69,8 +69,8 @@ namespace Java.Lang {
 
 		static int n_CompareTo_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_another)
 		{
-			global::Java.Lang.IComparable __this = global::Java.Lang.Object.GetObject<global::Java.Lang.IComparable> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			global::Java.Lang.Object another = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_another, JniHandleOwnership.DoNotTransfer);
+			var __this = global::Java.Lang.Object.GetObject<global::Java.Lang.IComparable> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var another = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_another, JniHandleOwnership.DoNotTransfer);
 			int __ret = __this.CompareTo (another);
 			return __ret;
 		}
@@ -84,7 +84,7 @@ namespace Java.Lang {
 			IntPtr native_another = JNIEnv.ToLocalJniHandle (another);
 			JValue* __args = stackalloc JValue [1];
 			__args [0] = new JValue (native_another);
-			int __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_compareTo_Ljava_lang_Object_, __args);
+			var __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_compareTo_Ljava_lang_Object_, __args);
 			JNIEnv.DeleteLocalRef (native_another);
 			return __ret;
 		}

--- a/tests/generator-Tests/expected/java.lang.Object/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected/java.lang.Object/Java.Interop.__TypeRegistrations.cs
@@ -25,7 +25,7 @@ namespace Java.Interop {
 
 		static Type Lookup (string[] mappings, string javaType)
 		{
-			string managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
+			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
 			if (managedType == null)
 				return null;
 			return Type.GetType (managedType);

--- a/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/CodeGenerator.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/CodeGenerator.cs
@@ -1109,7 +1109,7 @@ namespace MonoDroid.Generation
 				writer.WriteLine ($"{indent}[Obsolete]");
 			writer.WriteLine ("{0}{4}static {1} n_{2} (IntPtr jnienv, IntPtr native__this{3})", indent, method.RetVal.NativeType, method.Name + method.IDSignature, method.Parameters.GetCallbackSignature (opt), is_private);
 			writer.WriteLine ("{0}{{", indent);
-			writer.WriteLine ("{0}\t{1} __this = global::Java.Lang.Object.GetObject<{1}> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);", indent, opt.GetOutputName (type.FullName));
+			writer.WriteLine ("{0}\tvar __this = global::Java.Lang.Object.GetObject<{1}> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);", indent, opt.GetOutputName (type.FullName));
 			foreach (string s in method.Parameters.GetCallbackPrep (opt))
 				writer.WriteLine ("{0}\t{1}", indent, s);
 			if (String.IsNullOrEmpty (property_name)) {
@@ -1284,7 +1284,7 @@ namespace MonoDroid.Generation
 			if (method.IsVoid)
 				writer.WriteLine ("{0}{1};", indent, call);
 			else
-				writer.WriteLine ("{0}{1}{2};", indent, method.Parameters.HasCleanup ? opt.GetOutputName (method.RetVal.FullName) + " __ret = " : "return ", method.RetVal.FromNative (opt, call, true));
+				writer.WriteLine ("{0}{1}{2};", indent, method.Parameters.HasCleanup ? "var __ret = " : "return ", method.RetVal.FromNative (opt, call, true));
 
 			foreach (string cleanup in method.Parameters.GetCallCleanup (opt))
 				writer.WriteLine ("{0}{1}", indent, cleanup);
@@ -1300,10 +1300,10 @@ namespace MonoDroid.Generation
 				string pname = p.Name;
 				if (p.Type == "Java.Lang.ICharSequence") {
 					pname = p.GetName ("jls_");
-					writer.WriteLine ("{0}global::Java.Lang.String {1} = {2} == null ? null : new global::Java.Lang.String ({2});", indent, pname, p.Name);
+					writer.WriteLine ("{0}var {1} = {2} == null ? null : new global::Java.Lang.String ({2});", indent, pname, p.Name);
 				} else if (p.Type == "Java.Lang.ICharSequence[]" || p.Type == "params Java.Lang.ICharSequence[]") {
 					pname = p.GetName ("jlca_");
-					writer.WriteLine ("{0}global::Java.Lang.ICharSequence[] {1} = CharSequence.ArrayFromStringArray({2});", indent, pname, p.Name);
+					writer.WriteLine ("{0}var {1} = CharSequence.ArrayFromStringArray({2});", indent, pname, p.Name);
 				}
 				if (call.Length > 0)
 					call.Append (", ");
@@ -1327,7 +1327,7 @@ namespace MonoDroid.Generation
 				if (p.Type == "Java.Lang.ICharSequence")
 					writer.WriteLine ("{0}{1}?.Dispose ();", indent, p.GetName ("jls_"));
 				else if (p.Type == "Java.Lang.ICharSequence[]")
-					writer.WriteLine ("{0}if ({1} != null) foreach (global::Java.Lang.String s in {1}) s?.Dispose ();", indent, p.GetName ("jlca_"));
+					writer.WriteLine ("{0}if ({1} != null) foreach (var s in {1}) s?.Dispose ();", indent, p.GetName ("jlca_"));
 			}
 			if (!method.RetVal.IsVoid) {
 				writer.WriteLine ($"{indent}return __rsval;");
@@ -1741,11 +1741,11 @@ namespace MonoDroid.Generation
 					writer.WriteLine ("{0}\tset {{", indent);
 					writer.WriteLine ("{0}\t\tglobal::Java.Lang.ICharSequence[] jlsa = CharSequence.ArrayFromStringArray (value);", indent);
 					writer.WriteLine ("{0}\t\t{1} = jlsa;", indent, property.AdjustedName);
-					writer.WriteLine ("{0}\t\tforeach (global::Java.Lang.String jls in jlsa) if (jls != null) jls.Dispose ();", indent);
+					writer.WriteLine ("{0}\t\tforeach (var jls in jlsa) if (jls != null) jls.Dispose ();", indent);
 					writer.WriteLine ("{0}\t}}", indent);
 				} else {
 					writer.WriteLine ("{0}\tset {{", indent);
-					writer.WriteLine ("{0}\t\tglobal::Java.Lang.String jls = value == null ? null : new global::Java.Lang.String (value);", indent);
+					writer.WriteLine ("{0}\t\tvar jls = value == null ? null : new global::Java.Lang.String (value);", indent);
 					writer.WriteLine ("{0}\t\t{1} = jls;", indent, property.AdjustedName);
 					writer.WriteLine ("{0}\t\tif (jls != null) jls.Dispose ();", indent);
 					writer.WriteLine ("{0}\t}}", indent);

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ClassGen.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ClassGen.cs
@@ -209,7 +209,7 @@ namespace MonoDroid.Generation
 				sw.WriteLine ();
 				sw.WriteLine ("\t\tstatic Type Lookup (string[] mappings, string javaType)");
 				sw.WriteLine ("\t\t{");
-				sw.WriteLine ("\t\t\tstring managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);");
+				sw.WriteLine ("\t\t\tvar managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);");
 				sw.WriteLine ("\t\t\tif (managedType == null)");
 				sw.WriteLine ("\t\t\t\treturn null;");
 				sw.WriteLine ("\t\t\treturn Type.GetType (managedType);");

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
@@ -710,7 +710,7 @@ namespace MonoDroid.Generation
 
 			return new string []{
 				string.Format ("{0} {1} = {5}global::Java.Lang.Object.GetObject<{4}> ({2}, {3});",
-					       opt.GetOutputName (FullName),
+					       "var",
 					       opt.GetSafeIdentifier (var_name),
 					       opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name)),
 					       owned ? "JniHandleOwnership.TransferLocalRef" : "JniHandleOwnership.DoNotTransfer",

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Parameter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Parameter.cs
@@ -213,7 +213,7 @@ namespace MonoDroid.Generation {
 			else if (NeedsPrep)
 				return sym.PreCallback (opt, Name, false);
 			else
-				return new string[] { opt.GetOutputName (Type) + " " + opt.GetSafeIdentifier (Name) + " = " + FromNative (opt, false) + ";" };
+				return new string[] { "var " + opt.GetSafeIdentifier (Name) + " = " + FromNative (opt, false) + ";" };
 		}
 
 		public string Type {

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/ArraySymbol.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/ArraySymbol.cs
@@ -117,7 +117,7 @@ namespace MonoDroid.Generation {
 
 		public string[] PreCallback (CodeGenerationOptions opt, string var_name, bool owned)
 		{
-			return new string[] { String.Format ("{0}[] {1} = ({0}[]) JNIEnv.GetArray ({2}, JniHandleOwnership.DoNotTransfer, typeof ({3}));", opt.GetOutputName (ElementType), opt.GetSafeIdentifier (var_name), opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name)), opt.GetOutputName (sym.FullName)) };
+			return new string[] { String.Format ("var {1} = ({0}[]) JNIEnv.GetArray ({2}, JniHandleOwnership.DoNotTransfer, typeof ({3}));", opt.GetOutputName (ElementType), opt.GetSafeIdentifier (var_name), opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name)), opt.GetOutputName (sym.FullName)) };
 		}
 
 		public string[] PreCall (CodeGenerationOptions opt, string var_name)

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/CharSequenceSymbol.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/CharSequenceSymbol.cs
@@ -87,7 +87,7 @@ namespace MonoDroid.Generation {
 
 		public string[] PreCallback (CodeGenerationOptions opt, string var_name, bool owned)
 		{
-			return new string[] { String.Format ("global::Java.Lang.ICharSequence {0} = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> ({1}, JniHandleOwnership.DoNotTransfer);", var_name, TypeNameUtilities.GetNativeName (var_name)) };
+			return new string[] { String.Format ("var {0} = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> ({1}, JniHandleOwnership.DoNotTransfer);", var_name, TypeNameUtilities.GetNativeName (var_name)) };
 		}
 
 		public string[] PreCall (CodeGenerationOptions opt, string var_name)

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/GenericTypeParameter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/GenericTypeParameter.cs
@@ -98,7 +98,7 @@ namespace MonoDroid.Generation {
 		public string[] PreCallback (CodeGenerationOptions opt, string var_name, bool owned)
 		{
 			return new string[]{
-				string.Format ("{0} {1} = global::Java.Lang.Object.GetObject<{0}> ({2}, {3});",
+				string.Format ("var {1} = global::Java.Lang.Object.GetObject<{0}> ({2}, {3});",
 						opt.GetOutputName (FullName),
 						var_name,
 						opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name)),

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/StreamSymbol.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/StreamSymbol.cs
@@ -107,7 +107,7 @@ namespace MonoDroid.Generation {
 		public string[] PreCallback (CodeGenerationOptions opt, string var_name, bool owned)
 		{
 			return new string[]{
-				string.Format ("System.IO.Stream {0} = global::Android.Runtime.{1}Invoker.FromJniHandle ({2}, {3});",
+				string.Format ("var {0} = global::Android.Runtime.{1}Invoker.FromJniHandle ({2}, {3});",
 						var_name,
 						base_name,
 						opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name)),

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/StringSymbol.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/StringSymbol.cs
@@ -90,7 +90,7 @@ namespace MonoDroid.Generation {
 
 		public string[] PreCallback (CodeGenerationOptions opt, string var_name, bool owned)
 		{
-			return new string[] { String.Format ("string {0} = JNIEnv.GetString ({1}, JniHandleOwnership.DoNotTransfer);", opt.GetSafeIdentifier (var_name), opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name))) };
+			return new string[] { String.Format ("var {0} = JNIEnv.GetString ({1}, JniHandleOwnership.DoNotTransfer);", opt.GetSafeIdentifier (var_name), opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name))) };
 		}
 
 		public string[] PreCall (CodeGenerationOptions opt, string var_name)

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/XmlPullParserSymbol.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/XmlPullParserSymbol.cs
@@ -87,7 +87,7 @@ namespace MonoDroid.Generation {
 
 		public string[] PreCallback (CodeGenerationOptions opt, string var_name, bool owned)
 		{
-			return new string[] { String.Format ("System.Xml.XmlReader {0} = global::Android.Runtime.XmlPullParserReader.FromJniHandle ({1}, JniHandleOwnership.DoNotTransfer);", opt.GetSafeIdentifier (var_name), opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name))) };
+			return new string[] { String.Format ("var {0} = global::Android.Runtime.XmlPullParserReader.FromJniHandle ({1}, JniHandleOwnership.DoNotTransfer);", opt.GetSafeIdentifier (var_name), opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name))) };
 		}
 
 		public string[] PreCall (CodeGenerationOptions opt, string var_name)

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/XmlResourceParserSymbol.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/XmlResourceParserSymbol.cs
@@ -87,7 +87,7 @@ namespace MonoDroid.Generation {
 
 		public string[] PreCallback (CodeGenerationOptions opt, string var_name, bool owned)
 		{
-			return new string[] { String.Format ("System.Xml.XmlReader {0} = global::Android.Runtime.XmlResourceParserReader.FromJniHandle ({1}, JniHandleOwnership.DoNotTransfer);", opt.GetSafeIdentifier (var_name), opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name))) };
+			return new string[] { String.Format ("var {0} = global::Android.Runtime.XmlResourceParserReader.FromJniHandle ({1}, JniHandleOwnership.DoNotTransfer);", opt.GetSafeIdentifier (var_name), opt.GetSafeIdentifier (TypeNameUtilities.GetNativeName (var_name))) };
 		}
 
 		public string[] PreCall (CodeGenerationOptions opt, string var_name)


### PR DESCRIPTION
Our generated code *may* predate `var`, or at least predate `var` becoming widely accepted.  As such, we generate code like this:
```
java.code.MyClass __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
string key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
```

In an NRT world, each one of these declarations will have to be audited and optionally annotated with the nullable operator `?`. Or..... we can just mark them as `var` and not worry about it.
```
var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
var key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
```

Pulling this change into a separate commit in order to lower the noise in the eventual NRT PR.