### PR TITLE
[Java.Interop.Tools.Cecil] Change DirectoryAssemblyResolver Warning to Diagnostic Output

### DIFF
--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/DirectoryAssemblyResolver.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/DirectoryAssemblyResolver.cs
@@ -163,9 +163,9 @@ namespace Java.Interop.Tools.Cecil {
 				return AssemblyDefinition.ReadAssembly (file, reader_parameters);
 			} catch (Exception ex) {
 				logger (
-						TraceLevel.Warning,
+						TraceLevel.Verbose,
 						$"Failed to read '{file}' with debugging symbols. Retrying to load it without it. Error details are logged below.");
-				logger (TraceLevel.Warning, $"{ex.ToString ()}");
+				logger (TraceLevel.Verbose, $"{ex.ToString ()}");
 				reader_parameters.ReadSymbols = false;
 				return AssemblyDefinition.ReadAssembly (file, reader_parameters);
 			}


### PR DESCRIPTION
Context https://github.com/xamarin/xamarin-android/issues/2120

When building an app and using an Obfuscator you wne up with allot
of warnings like.

	warning : Failed to read 'obj\Release\90\android\assets\DotfuscatorForms.Android.dll' with debugging symbols. Retrying to load it without it. Error details are logged below.
	warning : Mono.Cecil.Cil.SymbolsNotMatchingException: Symbols were found but are not matching the assembly

These are probably the result of the Obfuscation process since the
assembly changed. However the warning was NOT useful or more
importantly... actionable by the user. It is just noise. It might
be useful for the developers writing the Java.Interop tooling itself.

So rather than a warning , lets change it to be `Verbose`. This will
allow it up show up in full diagnostic output, but NOT in a normal
build. Also it won't be a warning so users will not feel the need
to fix it.