### PR TITLE
[crc64] Change the hash prefix back to `crc64`

### DIFF
--- a/src/Java.Interop.Tools.TypeNameMappings/Java.Interop.Tools.TypeNameMappings/JavaNativeTypeManager.cs
+++ b/src/Java.Interop.Tools.TypeNameMappings/Java.Interop.Tools.TypeNameMappings/JavaNativeTypeManager.cs
@@ -41,7 +41,7 @@ namespace Java.Interop.Tools.TypeNameMappings
 	public
 #endif
 	static class JavaNativeTypeManager {
-		const string CRC_PREFIX = "c64r2";
+		const string CRC_PREFIX = "crc64";
 
 		public static PackageNamingPolicy PackageNamingPolicy { get; set; } = PackageNamingPolicy.LowercaseCrc64;
 

--- a/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGeneratorTests.cs
+++ b/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGeneratorTests.cs
@@ -124,7 +124,7 @@ public class Name
 		)
 		{
 			var actual      = Generate (typeof (IndirectApplication), applicationJavaClass);
-			var expected    = @"package c64r2197ae30a36756915;
+			var expected    = @"package crc64197ae30a36756915;
 
 
 public class IndirectApplication
@@ -175,7 +175,7 @@ public class IndirectApplication
 		public void GenerateExportedMembers ()
 		{
 			var actual = Generate (typeof (ExportsMembers));
-			var expected = @"package c64r2197ae30a36756915;
+			var expected = @"package crc64197ae30a36756915;
 
 
 public class ExportsMembers
@@ -187,7 +187,7 @@ public class ExportsMembers
 	public static final String __md_methods;
 	static {
 		__md_methods = 
-			""n_GetInstance:()Lc64r2197ae30a36756915/ExportsMembers;:__export__\n"" +
+			""n_GetInstance:()Lcrc64197ae30a36756915/ExportsMembers;:__export__\n"" +
 			""n_GetValue:()Ljava/lang/String;:__export__\n"" +
 			""n_methodNamesNotMangled:()V:__export__\n"" +
 			""n_CompletelyDifferentName:(Ljava/lang/String;I)Ljava/lang/String;:__export__\n"" +
@@ -198,17 +198,17 @@ public class ExportsMembers
 	}
 
 
-	public static c64r2197ae30a36756915.ExportsMembers STATIC_INSTANCE = GetInstance ();
+	public static crc64197ae30a36756915.ExportsMembers STATIC_INSTANCE = GetInstance ();
 
 
 	public java.lang.String VALUE = GetValue ();
 
-	public static c64r2197ae30a36756915.ExportsMembers GetInstance ()
+	public static crc64197ae30a36756915.ExportsMembers GetInstance ()
 	{
 		return n_GetInstance ();
 	}
 
-	private static native c64r2197ae30a36756915.ExportsMembers n_GetInstance ();
+	private static native crc64197ae30a36756915.ExportsMembers n_GetInstance ();
 
 	public java.lang.String GetValue ()
 	{
@@ -271,7 +271,7 @@ public class ExportsMembers
 		public void GenerateInnerClass ()
 		{
 			var actual = Generate (typeof (ExampleOuterClass));
-			var expected = @"package c64r2197ae30a36756915;
+			var expected = @"package crc64197ae30a36756915;
 
 
 public class ExampleOuterClass

--- a/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/JavaNativeTypeManagerTests.cs
+++ b/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/JavaNativeTypeManagerTests.cs
@@ -29,7 +29,7 @@ namespace Java.Interop.Tools.JavaCallableWrappersTests
 		public void Crc64 ()
 		{
 			JavaNativeTypeManager.PackageNamingPolicy = PackageNamingPolicy.LowercaseCrc64;
-			Assert.AreEqual ("c64r2b74743e9328eed0a", JavaNativeTypeManager.GetPackageName (typeof (string)));
+			Assert.AreEqual ("crc64b74743e9328eed0a", JavaNativeTypeManager.GetPackageName (typeof (string)));
 		}
 
 		[Test]

--- a/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/TypeNameMapGeneratorTests.cs
+++ b/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/TypeNameMapGeneratorTests.cs
@@ -59,12 +59,12 @@ namespace Xamarin.Android.ToolsTests
 				"value-offset=" + offset + "\u0000" +
 				GetJ2MEntryLine (typeof (ActivityName),                             "activity/Name",                                                                                offset, length) +
 				GetJ2MEntryLine (typeof (ApplicationName),                          "application/Name",                                                                             offset, length) +
-				GetJ2MEntryLine (typeof (DefaultName),                              "c64r2197ae30a36756915/DefaultName",                                                            offset, length) +
-				GetJ2MEntryLine (typeof (DefaultName.A),                            "c64r2197ae30a36756915/DefaultName_A",                                                          offset, length) +
-				GetJ2MEntryLine (typeof (DefaultName.A.B),                          "c64r2197ae30a36756915/DefaultName_A_B",                                                        offset, length) +
-				GetJ2MEntryLine (typeof (DefaultName.C.D),                          "c64r2197ae30a36756915/DefaultName_C_D",                                                        offset, length) +
-				GetJ2MEntryLine (typeof (ExampleOuterClass),                        "c64r2197ae30a36756915/ExampleOuterClass",                                                      offset, length) +
-				GetJ2MEntryLine (typeof (ExampleOuterClass.ExampleInnerClass),      "c64r2197ae30a36756915/ExampleOuterClass$ExampleOuterClass_ExampleInnerClass",                  offset, length) +
+				GetJ2MEntryLine (typeof (DefaultName),                              "crc64197ae30a36756915/DefaultName",                                                            offset, length) +
+				GetJ2MEntryLine (typeof (DefaultName.A),                            "crc64197ae30a36756915/DefaultName_A",                                                          offset, length) +
+				GetJ2MEntryLine (typeof (DefaultName.A.B),                          "crc64197ae30a36756915/DefaultName_A_B",                                                        offset, length) +
+				GetJ2MEntryLine (typeof (DefaultName.C.D),                          "crc64197ae30a36756915/DefaultName_C_D",                                                        offset, length) +
+				GetJ2MEntryLine (typeof (ExampleOuterClass),                        "crc64197ae30a36756915/ExampleOuterClass",                                                      offset, length) +
+				GetJ2MEntryLine (typeof (ExampleOuterClass.ExampleInnerClass),      "crc64197ae30a36756915/ExampleOuterClass$ExampleOuterClass_ExampleInnerClass",                  offset, length) +
 				GetJ2MEntryLine (typeof (InstrumentationName),                      "instrumentation/Name",                                                                         offset, length) +
 				GetJ2MEntryLine (typeof (AbstractClass),                            "my/AbstractClass",                                                                             offset, length) +
 				GetJ2MEntryLine (typeof (ExampleActivity),                          "my/ExampleActivity",                                                                           offset, length) +
@@ -139,14 +139,14 @@ namespace Xamarin.Android.ToolsTests
 				GetM2JEntryLine (typeof (AbstractClassInvoker),                     "my/AbstractClass",                                                                             offset, length) +
 				GetM2JEntryLine (typeof (ActivityName),                             "activity/Name",                                                                                offset, length) +
 				GetM2JEntryLine (typeof (ApplicationName),                          "application/Name",                                                                             offset, length) +
-				GetM2JEntryLine (typeof (DefaultName.A.B),                          "c64r2197ae30a36756915/DefaultName_A_B",                                                        offset, length) +
-				GetM2JEntryLine (typeof (DefaultName.A),                            "c64r2197ae30a36756915/DefaultName_A",                                                          offset, length) +
-				GetM2JEntryLine (typeof (DefaultName.C.D),                          "c64r2197ae30a36756915/DefaultName_C_D",                                                        offset, length) +
-				GetM2JEntryLine (typeof (DefaultName),                              "c64r2197ae30a36756915/DefaultName",                                                            offset, length) +
+				GetM2JEntryLine (typeof (DefaultName.A.B),                          "crc64197ae30a36756915/DefaultName_A_B",                                                        offset, length) +
+				GetM2JEntryLine (typeof (DefaultName.A),                            "crc64197ae30a36756915/DefaultName_A",                                                          offset, length) +
+				GetM2JEntryLine (typeof (DefaultName.C.D),                          "crc64197ae30a36756915/DefaultName_C_D",                                                        offset, length) +
+				GetM2JEntryLine (typeof (DefaultName),                              "crc64197ae30a36756915/DefaultName",                                                            offset, length) +
 				GetM2JEntryLine (typeof (ExampleActivity),                          "my/ExampleActivity",                                                                           offset, length) +
 				GetM2JEntryLine (typeof (ExampleInstrumentation),                   "my/ExampleInstrumentation",                                                                    offset, length) +
-				GetM2JEntryLine (typeof (ExampleOuterClass.ExampleInnerClass),      "c64r2197ae30a36756915/ExampleOuterClass$ExampleOuterClass_ExampleInnerClass",                  offset, length) +
-				GetM2JEntryLine (typeof (ExampleOuterClass),                        "c64r2197ae30a36756915/ExampleOuterClass",                                                      offset, length) +
+				GetM2JEntryLine (typeof (ExampleOuterClass.ExampleInnerClass),      "crc64197ae30a36756915/ExampleOuterClass$ExampleOuterClass_ExampleInnerClass",                  offset, length) +
+				GetM2JEntryLine (typeof (ExampleOuterClass),                        "crc64197ae30a36756915/ExampleOuterClass",                                                      offset, length) +
 				GetM2JEntryLine (typeof (InstrumentationName),                      "instrumentation/Name",                                                                         offset, length) +
 				GetM2JEntryLine (typeof (NonStaticOuterClass.NonStaticInnerClass),  "register/NonStaticOuterClass$NonStaticInnerClass",                                             offset, length) +
 				GetM2JEntryLine (typeof (NonStaticOuterClass),                      "register/NonStaticOuterClass",                                                                 offset, length) +


### PR DESCRIPTION
Context: 9b88ce79f231136a41eca197e0fb154baa6a6a44
Context: 7fe3a11ac3a1c8a3cb47ec86d0daccdc79dfb61d

7fe3a11a fixed the new CRC64 calculation algorithm so that it properly
processes all the data, which had the (expected) effect of generating
the same checksums for the same data as those generated before 9b88ce79

However, 7fe3a11a missed changing the new `c64r2` hash prefix back to
`crc64`, thus this commit to make the change.

The change will remove any backward incompatibility with code that may
rely on the old hash format, including Xamarin.Android tests.