### PR TITLE
[Java.Interop.Export] Remove Action/Func use.

### DIFF
--- a/src/Java.Interop.Export/Java.Interop.Export.csproj
+++ b/src/Java.Interop.Export/Java.Interop.Export.csproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>8.0</LangVersion>
     <ProjectGuid>{B501D075-6183-4E1D-92C9-F7B5002475B1}</ProjectGuid>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>

--- a/tests/Java.Interop.Export-Tests/Java.Interop/ExportTest.cs
+++ b/tests/Java.Interop.Export-Tests/Java.Interop/ExportTest.cs
@@ -6,6 +6,28 @@ using System.Collections.Generic;
 using Java.Interop;
 using Java.Interop.Expressions;
 
+// For use by `jnimarshalmethod-gen.exe` & `make run-test-jnimarshal`
+delegate bool _JniMarshal_PPZBCSIJFDLLLLLDFJ_Z (
+		IntPtr              jnienv,
+		IntPtr              klass,
+		bool                a,
+		sbyte               b,
+		char                c,
+		short               d,
+		int                 e,
+		long                f,
+		float               g,
+		double              h,
+		IntPtr              i,  // java.lang.Object
+		IntPtr              j,  // java.lang.String
+		IntPtr              k,  // java.util.ArrayList<String>
+		IntPtr              l,  // java.lang.String
+		IntPtr              m,  // java.lang.Object
+		double              n,
+		float               o,
+		long                p
+);
+
 namespace Java.InteropTests
 {
 	[JniTypeSignature ("com/xamarin/interop/export/ExportType")]
@@ -82,6 +104,60 @@ namespace Java.InteropTests
 		[JavaCallable ("staticActionFloat", Signature="(F)V")]
 		public static void StaticActionFloat (float f)
 		{
+		}
+
+		[JavaCallable ("staticFuncThisMethodTakesLotsOfParameters", Signature="(ZBCSIJFDLjava/lang/Object;Ljava/lang/String;Ljava/util/ArrayList;Ljava/lang/String;Ljava/lang/Object;DFJ)Z")]
+		public static bool StaticFuncThisMethodTakesLotsOfParameters (
+				bool                a,
+				sbyte               b,
+				char                c,
+				short               d,
+				int                 e,
+				long                f,
+				float               g,
+				double              h,
+				IntPtr              i,  // java.lang.Object
+				IntPtr              j,  // java.lang.String
+				IntPtr              k,  // java.util.ArrayList<String>
+				IntPtr              l,  // java.lang.String
+				IntPtr              m,  // java.lang.Object
+				double              n,
+				float               o,
+				long                p)
+		{
+			if (a != false)
+				return false;
+			if (b != (byte) 0xb)
+				return false;
+			if (c != 'c')
+				return false;
+			if (d != (short) 0xd)
+				return false;
+			if (e != 0xe)
+				return false;
+			if (f != 0xf)
+				return false;
+			if (g != 1.0f)
+				return false;
+			if (h != 2.0)
+				return false;
+			if (i == IntPtr.Zero)
+				return false;
+			if (j == IntPtr.Zero)
+				return false;
+			if (k == IntPtr.Zero)
+				return false;
+			if (l == IntPtr.Zero)
+				return false;
+			if (m == IntPtr.Zero)
+				return false;
+			if (n != 3.0)
+				return false;
+			if (o != 4.0f)
+				return false;
+			if (p != 0x70)
+				return false;
+			return true;
 		}
 	}
 

--- a/tests/Java.Interop.Export-Tests/Java.Interop/MarshalMemberBuilderTest.cs
+++ b/tests/Java.Interop.Export-Tests/Java.Interop/MarshalMemberBuilderTest.cs
@@ -22,7 +22,7 @@ namespace Java.InteropTests
 				var methods = CreateBuilder ()
 					.GetExportedMemberRegistrations (typeof (ExportTest))
 					.ToList ();
-				Assert.AreEqual (10, methods.Count);
+				Assert.AreEqual (11, methods.Count);
 
 				Assert.AreEqual ("action",  methods [0].Name);
 				Assert.AreEqual ("()V",     methods [0].Signature);

--- a/tests/Java.Interop.Export-Tests/java/com/xamarin/interop/export/ExportType.java
+++ b/tests/Java.Interop.Export-Tests/java/com/xamarin/interop/export/ExportType.java
@@ -30,21 +30,62 @@ public class ExportType
 	public static native void staticActionInt32String (int i, String s);
 	public static native int  staticFuncMyLegacyColorMyColor_MyColor (int color1, int color2);
 
+	public static native boolean staticFuncThisMethodTakesLotsOfParameters (
+			boolean             a,
+			byte                b,
+			char                c,
+			short               d,
+			int                 e,
+			long                f,
+			float               g,
+			double              h,
+			Object              i,
+			String              j,
+			ArrayList<String>   k,
+			String              l,
+			Object              m,
+			double              n,
+			float               o,
+			long                p);
+
 	public void testMethods () {
-	    action ();
+		action ();
 
-	    actionIJavaObject (this);
+		actionIJavaObject (this);
 
-	    long j = funcInt64 ();
-	    if (j != 42)
-	        throw new Error ("funcInt64() should return 42!");
+		long j = funcInt64 ();
+		if (j != 42)
+			throw new Error ("funcInt64() should return 42!");
 
-	    Object o = funcIJavaObject ();
-	    if (o != this)
-	        throw new Error ("funcIJavaObject() should return `this`!");
+		Object o = funcIJavaObject ();
+		if (o != this)
+			throw new Error ("funcIJavaObject() should return `this`!");
 
-	    staticActionInt (1);
-	    staticActionFloat (2.0f);
+		staticActionInt (1);
+		staticActionFloat (2.0f);
+
+		/*
+		boolean r = staticFuncThisMethodTakesLotsOfParameters (
+				false,
+				(byte) 0xb,
+				'c',
+				(short) 0xd,
+				0xe,
+				0xf,
+				1.0f,
+				2.0,
+				new Object (),
+				"j",
+				new ArrayList<String>(),
+				"l",
+				new Object (),
+				3.0,
+				4.0f,
+				0x70
+		);
+		if (r != true)
+			throw new Error ("staticFuncThisMethodTakesLotsOfParameters should return true!");
+		 */
 	}
 
 	public native void action ();

--- a/tools/jnimarshalmethod-gen/Xamarin.Android.Tools.JniMarshalMethodGenerator.csproj
+++ b/tools/jnimarshalmethod-gen/Xamarin.Android.Tools.JniMarshalMethodGenerator.csproj
@@ -12,9 +12,21 @@
   <PropertyGroup>
     <OutputPath>$(UtilityOutputFullPath)</OutputPath>
   </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(_DumpRegisterNativeMembers)' == 'True' ">
+    <DefineConstants>_DUMP_REGISTER_NATIVE_MEMBERS;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(_AllTheArguments)' == 'True' ">
+    <DefineConstants>_ALL_THE_ARGUMENTS;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
     
   <ItemGroup>
     <PackageReference Include="Mono.Options" Version="5.3.0.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(_DumpRegisterNativeMembers)' == 'True' ">
+    <PackageReference Include="Mono.Linq.Expressions" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/4631
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3685184&view=logs&j=b1314ebb-4483-559c-0367-730fc62c4440&t=5022c07e-db44-5ce4-1a38-092215b61c50
Context: 70fc4c0771ca7f7ea346f221eca83fb109732a5d

Commit 70fc4c07 broke use of `jnimarshalmethod-gen.exe` within
xamarin-android and `Mono.Android.dll`, as it allows methods taking
more than 14 parameters to be bound, which results in
`jnimarshalmethod-gen.exe` trying to use an `Action<…>` or
`Func<…>` that takes more than 16 parameters, which isn't allowed:

	EXEC : error : jnimarshalmethod-gen: Unable to process assembly '…/xamarin-android/bin/Release/lib/xamarin.android/xbuild-frameworks/MonoAndroid/v10.0/Mono.Android.dll'
	  An incorrect number of type arguments were specified for the declaration of an Action type.
	  Parameter name: typeArgs
	  System.ArgumentException: An incorrect number of type arguments were specified for the declaration of an Action type.
	  Parameter name: typeArgs
	    at System.Linq.Expressions.Expression.GetActionType (System.Type[] typeArgs)
	    at Java.Interop.MarshalMemberBuilder.CreateMarshalToManagedExpression (System.Reflection.MethodInfo method, Java.Interop.JavaCallableAttribute callable, System.Type type)
	    at Java.Interop.MarshalMemberBuilder.CreateMarshalToManagedExpression (System.Reflection.MethodInfo method)
	    at Xamarin.Android.Tools.JniMarshalMethodGenerator.App.CreateMarshalMethodAssembly (System.String path)
	    at Xamarin.Android.Tools.JniMarshalMethodGenerator.App.ProcessAssemblies (System.Collections.Generic.List`1[T] assemblies)

Looks like we don't actually *need* to lookup a delegate type, as
there's an `Expression.Lambda()` overload which only requires the
lambda body and parameters.  Use that instead.

Remove use of `Expression.GetActionType()` and
`Expression.GetFuncType()`, as these will fail when dealing with
methods that contain more than 14 parameters: