### PR TITLE
[generator-Tests] Run directly with Roslyn as DotNetCompilerPlatform doesn't work on .NET Core.

### DIFF
--- a/tests/generator-Tests/generator-Tests.csproj
+++ b/tests/generator-Tests/generator-Tests.csproj
@@ -13,11 +13,11 @@
   <Import Project="..\..\build-tools\scripts\cecil.projitems" />
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.5.0" />
     <PackageReference Include="nunit" Version="3.11.0" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" Version="2.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
`generator-Tests` contains a few hacks to get things building on Roslyn back when it was written.  It does this with a package from ASP.Net called [Microsoft.CodeDom.Providers.DotNetCompilerPlatform](https://www.nuget.org/packages/Microsoft.CodeDom.Providers.DotNetCompilerPlatform).

This package uses the MSBuild `CodeTaskFactory` which is not available on .NET Core.  Although it has recently been [fixed](https://github.com/aspnet/RoslynCodeDomProvider/issues/51), there hasn't been a new NuGet package in 1.5 years, so it is unknown when we can expect one.

Luckily we're not afraid to get our hands dirty!  We can reference the `Microsoft.CodeAnalysis.CSharp` package directly and accomplish the same thing for roughly the same amount of effort.

This new version will now build on .NET Core.