### PR TITLE
[CI] Set up a .NET Core Windows lane.

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -10,13 +10,13 @@ pr:
 
 # Global variables
 variables:
-  DotNetCoreVersion: 3.1.100
+  DotNetCoreVersion: 3.1.201
   HostedMac: Hosted Mac Internal
   HostedWinVS2019: Hosted Windows 2019 with VS2019
 
 jobs:
 - job: windows_build
-  displayName: Windows Build and Test
+  displayName: Windows - .NET Framework
   pool: $(HostedWinVS2019)
   timeoutInMinutes: 20
   workspace:
@@ -68,8 +68,77 @@ jobs:
       testResultsFiles: TestResult-*.xml
     condition: succeededOrFailed()
 
+- job: windows_dotnet_build
+  displayName: Windows - .NET Core
+  pool: $(HostedWinVS2019)
+  timeoutInMinutes: 20
+  workspace:
+    clean: all
+  steps:
+  - checkout: self
+    submodules: recursive
+
+  - task: UseDotNet@2
+    displayName: Use .NET Core $(DotNetCoreVersion)
+    inputs:
+      version: $(DotNetCoreVersion)
+
+  - task: DotNetCoreCLI@2
+    displayName: Prepare Solution
+    inputs:
+      projects: Java.Interop.sln
+      arguments: '-c $(Build.Configuration) -target:Prepare'
+
+  - task: DotNetCoreCLI@2
+    displayName: Build Solution
+    inputs:
+      projects: Java.Interop.sln
+      arguments: '-c $(Build.Configuration)'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Tests: generator'
+    inputs:
+      command: test
+      arguments: bin\Test$(Build.Configuration)\generator-Tests.dll
+    continueOnError: true
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Tests: JavaCallableWrappers'
+    inputs:
+      command: test
+      arguments: bin\Test$(Build.Configuration)\Java.Interop.Tools.JavaCallableWrappers-Tests.dll
+    continueOnError: true
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Tests: logcat-parse'
+    inputs:
+      command: test
+      arguments: bin\Test$(Build.Configuration)\logcat-parse-Tests.dll
+    continueOnError: true
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Tests: ApiXmlAdjuster'
+    inputs:
+      command: test
+      arguments: bin\Test$(Build.Configuration)\Xamarin.Android.Tools.ApiXmlAdjuster-Tests.dll
+    continueOnError: true
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Tests: Bytecode'
+    inputs:
+      command: test
+      arguments: bin\Test$(Build.Configuration)\Xamarin.Android.Tools.Bytecode-Tests.dll
+    continueOnError: true
+
+  - powershell: |
+      Write-Host "Current job status is: $env:AGENT_JOBSTATUS"
+      if ($env:AGENT_JOBSTATUS -eq "SucceededWithIssues") {
+          Write-Host "##vso[task.complete result=Failed;]DONE"
+      }
+    displayName: Fail job if tests failed
+    
 - job: mac_build
-  displayName: Mac Build and Test
+  displayName: Mac - Mono
   pool: $(HostedMac)
   timeoutInMinutes: 20
   workspace:

--- a/build-tools/scripts/PrepareWindows.targets
+++ b/build-tools/scripts/PrepareWindows.targets
@@ -2,22 +2,11 @@
 <Project DefaultTargets="Prepare" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <_TopDir>$(MSBuildThisFileDirectory)..\..</_TopDir>
-    <_NuGetUri>https://dist.nuget.org/win-x86-commandline/v5.4.0/nuget.exe</_NuGetUri>
-    <_NuGetPath>$(_TopDir)\.nuget</_NuGetPath>
-    <_NuGet>$(_NuGetPath)\NuGet.exe</_NuGet>
   </PropertyGroup>
   <UsingTask AssemblyFile="$(_TopDir)\bin\Build$(Configuration)\Java.Interop.BootstrapTasks.dll" TaskName="Java.Interop.BootstrapTasks.JdkInfo" />
-  <UsingTask AssemblyFile="$(_TopDir)\bin\Build$(Configuration)\Java.Interop.BootstrapTasks.dll" TaskName="Java.Interop.BootstrapTasks.DownloadUri" />
   <Target Name="Prepare">
     <Exec Command="git submodule update --init --recursive" WorkingDirectory="$(_TopDir)" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)..\..\build-tools\Java.Interop.BootstrapTasks\Java.Interop.BootstrapTasks.csproj" />
-    <MakeDir Directories="$(_NuGetPath)" />
-    <DownloadUri
-        SourceUris="$(_NuGetUri)"
-        DestinationFiles="$(_NuGet)"
-    />
-    <Exec Command="$(_NuGet) restore Java.Interop.sln" WorkingDirectory="$(_TopDir)" />
     <JdkInfo
         JdksRoot="$(ProgramFiles)\Java"
         MakeFragmentFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\JdkInfo.mk"


### PR DESCRIPTION
Creates a `Windows - .NET Core` lane for building and testing Java.Interop.  This builds and runs the same projects and tests as the current Windows build.

Also removed some unnecessary `nuget` work in `/t:Prepare` now that we no longer use `packages.config`.

The `Mac - .NET Core` lane requires more investigation and changes before it succeeds, and I need to focus on other priorities right now, so we'll just start with Windows.