### PR TITLE
[generator] Honor 'api-since' attribute to fill ApiAvailableSince property.

### DIFF
--- a/tests/generator-Tests/Unit-Tests/XmlApiImporterTests.cs
+++ b/tests/generator-Tests/Unit-Tests/XmlApiImporterTests.cs
@@ -20,6 +20,35 @@ namespace generatortests
 		}
 
 		[Test]
+		public void CreateClass_CorrectApiSince ()
+		{
+			var xml = XDocument.Parse ("<package name='com.example.test' jni-name='com/example/test'><class name='myclass' api-since='7' /></package>");
+			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), opt);
+
+			Assert.AreEqual (7, klass.ApiAvailableSince);
+		}
+
+		[Test]
+		public void CreateClass_CorrectApiSinceFromPackage ()
+		{
+			// Make sure we inherit it from <package>.
+			var xml = XDocument.Parse ("<package name='com.example.test' jni-name='com/example/test' api-since='7'><class name='myclass' /></package>");
+			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), opt);
+
+			Assert.AreEqual (7, klass.ApiAvailableSince);
+		}
+
+		[Test]
+		public void CreateClass_CorrectApiSinceOverridePackage ()
+		{
+			// Make sure we inherit it from <package>.
+			var xml = XDocument.Parse ("<package name='com.example.test' jni-name='com/example/test' api-since='7'><class name='myclass' api-since='9' /></package>");
+			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), opt);
+
+			Assert.AreEqual (9, klass.ApiAvailableSince);
+		}
+
+		[Test]
 		public void CreateCtor_EnsureValidName ()
 		{
 			var xml = XDocument.Parse ("<package name=\"com.example.test\" jni-name=\"com/example/test\"><class name=\"test\"><constructor name=\"$3\" /></class></package>");
@@ -29,10 +58,29 @@ namespace generatortests
 		}
 
 		[Test]
+		public void CreateCtor_CorrectApiSince ()
+		{
+			var xml = XDocument.Parse ("<package name='com.example.test' jni-name='com/example/test'><class name='test'><constructor name='ctor' api-since='7' /></class></package>");
+			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), opt);
+
+			Assert.AreEqual (7, klass.Ctors [0].ApiAvailableSince);
+		}
+
+		[Test]
+		public void CreateCtor_CorrectApiSinceFromClass ()
+		{
+			var xml = XDocument.Parse ("<package name='com.example.test' jni-name='com/example/test'><class name='test' api-since='7'><constructor name='ctor' /></class></package>");
+			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), opt);
+
+			Assert.AreEqual (7, klass.Ctors [0].ApiAvailableSince);
+		}
+
+		[Test]
 		public void CreateField_StudlyCaseName ()
 		{
+			var klass = new TestClass ("object", "MyNamespace.MyType");
 			var xml = XDocument.Parse ("<field name=\"_DES_EDE_CBC\" />");
-			var field = XmlApiImporter.CreateField (xml.Root);
+			var field = XmlApiImporter.CreateField (klass, xml.Root);
 
 			Assert.AreEqual ("DesEdeCbc", field.Name);
 		}
@@ -40,8 +88,9 @@ namespace generatortests
 		[Test]
 		public void CreateField_EnsureValidName ()
 		{
+			var klass = new TestClass ("object", "MyNamespace.MyType");
 			var xml = XDocument.Parse ("<field name=\"_3DES_EDE_CBC\" />");
-			var field = XmlApiImporter.CreateField (xml.Root);
+			var field = XmlApiImporter.CreateField (klass, xml.Root);
 
 			Assert.AreEqual ("_3desEdeCbc", field.Name);
 		}
@@ -49,8 +98,9 @@ namespace generatortests
 		[Test]
 		public void CreateField_HandleDollarSign ()
 		{
+			var klass = new TestClass ("object", "MyNamespace.MyType");
 			var xml = XDocument.Parse ("<field name=\"A$3\" />");
-			var field = XmlApiImporter.CreateField (xml.Root);
+			var field = XmlApiImporter.CreateField (klass, xml.Root);
 
 			Assert.AreEqual ("A_3", field.Name);
 		}
@@ -58,10 +108,31 @@ namespace generatortests
 		[Test]
 		public void CreateField_HandleDollarSignNumber ()
 		{
+			var klass = new TestClass ("object", "MyNamespace.MyType");
 			var xml = XDocument.Parse ("<field name=\"$3\" />");
-			var field = XmlApiImporter.CreateField (xml.Root);
+			var field = XmlApiImporter.CreateField (klass, xml.Root);
 
 			Assert.AreEqual ("_3", field.Name);
+		}
+
+		[Test]
+		public void CreateField_CorrectApiVersion ()
+		{
+			var klass = new TestClass ("object", "MyNamespace.MyType");
+			var xml = XDocument.Parse ("<field name='$3' api-since='7' />");
+			var field = XmlApiImporter.CreateField (klass, xml.Root);
+
+			Assert.AreEqual (7, field.ApiAvailableSince);
+		}
+
+		[Test]
+		public void CreateField_CorrectApiVersionFromClass ()
+		{
+			var klass = new TestClass ("object", "MyNamespace.MyType") { ApiAvailableSince = 7 };
+			var xml = XDocument.Parse ("<field name='$3' />");
+			var field = XmlApiImporter.CreateField (klass, xml.Root);
+
+			Assert.AreEqual (7, field.ApiAvailableSince);
 		}
 
 		[Test]
@@ -71,6 +142,35 @@ namespace generatortests
 			var iface = XmlApiImporter.CreateInterface (xml.Root, xml.Root.Element ("interface"), opt);
 
 			Assert.AreEqual ("I_3", iface.Name);
+		}
+
+		[Test]
+		public void CreateInterface_CorrectApiSince ()
+		{
+			var xml = XDocument.Parse ("<package name='com.example.test' jni-name='com/example/test'><interface name='myclass' api-since='7' /></package>");
+			var iface = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("interface"), opt);
+
+			Assert.AreEqual (7, iface.ApiAvailableSince);
+		}
+
+		[Test]
+		public void CreateInterface_CorrectApiSinceFromPackage ()
+		{
+			// Make sure we inherit it from <package>.
+			var xml = XDocument.Parse ("<package name='com.example.test' jni-name='com/example/test' api-since='7'><interface name='myclass' /></package>");
+			var iface = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("interface"), opt);
+
+			Assert.AreEqual (7, iface.ApiAvailableSince);
+		}
+
+		[Test]
+		public void CreateInterface_CorrectApiSinceOverridePackage ()
+		{
+			// Make sure we inherit it from <package>.
+			var xml = XDocument.Parse ("<package name='com.example.test' jni-name='com/example/test' api-since='7'><interface name='myclass' api-since='9' /></package>");
+			var iface = XmlApiImporter.CreateInterface (xml.Root, xml.Root.Element ("interface"), opt);
+
+			Assert.AreEqual (9, iface.ApiAvailableSince);
 		}
 
 		[Test]
@@ -89,6 +189,24 @@ namespace generatortests
 			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), opt);
 
 			Assert.AreEqual ("_3", klass.Methods [0].Name);
+		}
+
+		[Test]
+		public void CreateMethod_CorrectApiSince ()
+		{
+			var xml = XDocument.Parse ("<package name='com.example.test' jni-name='com/example/test'><class name='test'><method name='-3' api-since='7' /></class></package>");
+			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), opt);
+
+			Assert.AreEqual (7, klass.Methods [0].ApiAvailableSince);
+		}
+
+		[Test]
+		public void CreateMethod_CorrectApiSinceFromClass ()
+		{
+			var xml = XDocument.Parse ("<package name='com.example.test' jni-name='com/example/test'><class name='test' api-since='7'><method name='-3' /></class></package>");
+			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), opt);
+
+			Assert.AreEqual (7, klass.Methods [0].ApiAvailableSince);
 		}
 
 		[Test]

--- a/tests/generator-Tests/Unit-Tests/XmlTests.cs
+++ b/tests/generator-Tests/Unit-Tests/XmlTests.cs
@@ -171,7 +171,7 @@ namespace generatortests
 		{
 			var element = package.Element ("class");
 			var @class = XmlApiImporter.CreateClass (package, element, options);
-			var field = XmlApiImporter.CreateField (element.Element ("field"));
+			var field = XmlApiImporter.CreateField (@class, element.Element ("field"));
 			Assert.IsTrue (field.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "field.Validate failed!");
 
 			Assert.AreEqual ("Value", field.Name);


### PR DESCRIPTION
Today, `generator` provides the ability to assign versions to each bound member that is exposed in its `Register` attribute `ApiSince` field, a la:
```
[Register ("android/view/inspector/IntFlagMapping", DoNotGenerateAcw=true, ApiSince=29)]
```

This is populated via the internal `apiversions=` option, which reads in a Google provided file containing the api version each member for appeared in.  Unfortunately we have found that Google's support of this file isn't guaranteed.  Sometimes it is missing, other times it changes randomly, causing `ApiCompat` breakage.

This PR provides an alternate way to set this `ApiSince` field in the `api.xml`.  The attribute `api-since` in now honored on `package`, `class/interface`, `method`, and `field` elements:
```
<field name='VERSION_CODE' api-since='7' />
```

This allows it to be set via  `metadata` or any external tooling that modifies `api.xml`.

Note that members will inherit version from parent types and parent package definitions, but can also override them as necessary.  For example a package added in api 7 containing a class added in api 9:
```
<package name='com.example.test' jni-name='com/example/test' api-since='7'>
  <class name='MyClassFrom7' />
  <class name='MyClassFrom9' api-since='9' />
</package>
```

Like previously, this feature is probably only useful for `Mono.Android.dll` purposes, but it is a little more accessible now. 