### PR TITLE
[Java.Interop] Fix C# warnings.

### DIFF
--- a/src/Java.Interop/Java.Interop/JavaArray.cs
+++ b/src/Java.Interop/Java.Interop/JavaArray.cs
@@ -258,31 +258,31 @@ namespace Java.Interop
 			throw new NotSupportedException ();
 		}
 
-		bool IList.Contains (object value)
+		bool IList.Contains (object? value)
 		{
 			if (value is T)
 				return Contains ((T) value);
 			return false;
 		}
 
-		int IList.IndexOf (object value)
+		int IList.IndexOf (object? value)
 		{
 			if (value is T)
 				return IndexOf ((T) value);
 			return -1;
 		}
 
-		int IList.Add (object value)
+		int IList.Add (object? value)
 		{
 			throw new NotSupportedException ();
 		}
 
-		void IList.Insert (int index, object value)
+		void IList.Insert (int index, object? value)
 		{
 			throw new NotSupportedException ();
 		}
 
-		void IList.Remove (object value)
+		void IList.Remove (object? value)
 		{
 			throw new NotSupportedException ();
 		}

--- a/src/Java.Interop/Java.Interop/JavaException.cs
+++ b/src/Java.Interop/Java.Interop/JavaException.cs
@@ -162,7 +162,7 @@ namespace Java.Interop
 			}
 		}
 
-		public override bool Equals (object obj)
+		public override bool Equals (object? obj)
 		{
 			JniPeerMembers.AssertSelf (this);
 

--- a/src/Java.Interop/Java.Interop/JavaObject.cs
+++ b/src/Java.Interop/Java.Interop/JavaObject.cs
@@ -110,7 +110,7 @@ namespace Java.Interop
 		{
 		}
 
-		public override bool Equals (object obj)
+		public override bool Equals (object? obj)
 		{
 			JniPeerMembers.AssertSelf (this);
 

--- a/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.cs
+++ b/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 
 using Java.Interop.Expressions;
 using System.Linq.Expressions;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Java.Interop {
 
@@ -246,7 +247,7 @@ namespace Java.Interop {
 						(ref JniObjectReference h, JniObjectReferenceOptions o) => new JavaBooleanArray (ref h, o));
 			}
 
-			public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState (IList<Boolean> value, ParameterAttributes synchronize)
+			public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState ([MaybeNull] IList<Boolean> value, ParameterAttributes synchronize)
 			{
 				return JavaArray<Boolean>.CreateArgumentState (value, synchronize, (list, copy) => {
 					var a = copy
@@ -257,7 +258,7 @@ namespace Java.Interop {
 				});
 			}
 
-			public override void DestroyGenericArgumentState (IList<Boolean> value, ref JniValueMarshalerState state, ParameterAttributes synchronize)
+			public override void DestroyGenericArgumentState ([AllowNull] IList<Boolean> value, ref JniValueMarshalerState state, ParameterAttributes synchronize)
 			{
 				JavaArray<Boolean>.DestroyArgumentState<JavaBooleanArray> (value, ref state, synchronize);
 			}
@@ -422,7 +423,7 @@ namespace Java.Interop {
 						(ref JniObjectReference h, JniObjectReferenceOptions o) => new JavaSByteArray (ref h, o));
 			}
 
-			public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState (IList<SByte> value, ParameterAttributes synchronize)
+			public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState ([MaybeNull] IList<SByte> value, ParameterAttributes synchronize)
 			{
 				return JavaArray<SByte>.CreateArgumentState (value, synchronize, (list, copy) => {
 					var a = copy
@@ -433,7 +434,7 @@ namespace Java.Interop {
 				});
 			}
 
-			public override void DestroyGenericArgumentState (IList<SByte> value, ref JniValueMarshalerState state, ParameterAttributes synchronize)
+			public override void DestroyGenericArgumentState ([AllowNull] IList<SByte> value, ref JniValueMarshalerState state, ParameterAttributes synchronize)
 			{
 				JavaArray<SByte>.DestroyArgumentState<JavaSByteArray> (value, ref state, synchronize);
 			}
@@ -598,7 +599,7 @@ namespace Java.Interop {
 						(ref JniObjectReference h, JniObjectReferenceOptions o) => new JavaCharArray (ref h, o));
 			}
 
-			public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState (IList<Char> value, ParameterAttributes synchronize)
+			public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState ([MaybeNull] IList<Char> value, ParameterAttributes synchronize)
 			{
 				return JavaArray<Char>.CreateArgumentState (value, synchronize, (list, copy) => {
 					var a = copy
@@ -609,7 +610,7 @@ namespace Java.Interop {
 				});
 			}
 
-			public override void DestroyGenericArgumentState (IList<Char> value, ref JniValueMarshalerState state, ParameterAttributes synchronize)
+			public override void DestroyGenericArgumentState ([AllowNull] IList<Char> value, ref JniValueMarshalerState state, ParameterAttributes synchronize)
 			{
 				JavaArray<Char>.DestroyArgumentState<JavaCharArray> (value, ref state, synchronize);
 			}
@@ -774,7 +775,7 @@ namespace Java.Interop {
 						(ref JniObjectReference h, JniObjectReferenceOptions o) => new JavaInt16Array (ref h, o));
 			}
 
-			public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState (IList<Int16> value, ParameterAttributes synchronize)
+			public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState ([MaybeNull] IList<Int16> value, ParameterAttributes synchronize)
 			{
 				return JavaArray<Int16>.CreateArgumentState (value, synchronize, (list, copy) => {
 					var a = copy
@@ -785,7 +786,7 @@ namespace Java.Interop {
 				});
 			}
 
-			public override void DestroyGenericArgumentState (IList<Int16> value, ref JniValueMarshalerState state, ParameterAttributes synchronize)
+			public override void DestroyGenericArgumentState ([AllowNull] IList<Int16> value, ref JniValueMarshalerState state, ParameterAttributes synchronize)
 			{
 				JavaArray<Int16>.DestroyArgumentState<JavaInt16Array> (value, ref state, synchronize);
 			}
@@ -950,7 +951,7 @@ namespace Java.Interop {
 						(ref JniObjectReference h, JniObjectReferenceOptions o) => new JavaInt32Array (ref h, o));
 			}
 
-			public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState (IList<Int32> value, ParameterAttributes synchronize)
+			public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState ([MaybeNull] IList<Int32> value, ParameterAttributes synchronize)
 			{
 				return JavaArray<Int32>.CreateArgumentState (value, synchronize, (list, copy) => {
 					var a = copy
@@ -961,7 +962,7 @@ namespace Java.Interop {
 				});
 			}
 
-			public override void DestroyGenericArgumentState (IList<Int32> value, ref JniValueMarshalerState state, ParameterAttributes synchronize)
+			public override void DestroyGenericArgumentState ([AllowNull] IList<Int32> value, ref JniValueMarshalerState state, ParameterAttributes synchronize)
 			{
 				JavaArray<Int32>.DestroyArgumentState<JavaInt32Array> (value, ref state, synchronize);
 			}
@@ -1126,7 +1127,7 @@ namespace Java.Interop {
 						(ref JniObjectReference h, JniObjectReferenceOptions o) => new JavaInt64Array (ref h, o));
 			}
 
-			public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState (IList<Int64> value, ParameterAttributes synchronize)
+			public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState ([MaybeNull] IList<Int64> value, ParameterAttributes synchronize)
 			{
 				return JavaArray<Int64>.CreateArgumentState (value, synchronize, (list, copy) => {
 					var a = copy
@@ -1137,7 +1138,7 @@ namespace Java.Interop {
 				});
 			}
 
-			public override void DestroyGenericArgumentState (IList<Int64> value, ref JniValueMarshalerState state, ParameterAttributes synchronize)
+			public override void DestroyGenericArgumentState ([AllowNull] IList<Int64> value, ref JniValueMarshalerState state, ParameterAttributes synchronize)
 			{
 				JavaArray<Int64>.DestroyArgumentState<JavaInt64Array> (value, ref state, synchronize);
 			}
@@ -1302,7 +1303,7 @@ namespace Java.Interop {
 						(ref JniObjectReference h, JniObjectReferenceOptions o) => new JavaSingleArray (ref h, o));
 			}
 
-			public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState (IList<Single> value, ParameterAttributes synchronize)
+			public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState ([MaybeNull] IList<Single> value, ParameterAttributes synchronize)
 			{
 				return JavaArray<Single>.CreateArgumentState (value, synchronize, (list, copy) => {
 					var a = copy
@@ -1313,7 +1314,7 @@ namespace Java.Interop {
 				});
 			}
 
-			public override void DestroyGenericArgumentState (IList<Single> value, ref JniValueMarshalerState state, ParameterAttributes synchronize)
+			public override void DestroyGenericArgumentState ([AllowNull] IList<Single> value, ref JniValueMarshalerState state, ParameterAttributes synchronize)
 			{
 				JavaArray<Single>.DestroyArgumentState<JavaSingleArray> (value, ref state, synchronize);
 			}
@@ -1478,7 +1479,7 @@ namespace Java.Interop {
 						(ref JniObjectReference h, JniObjectReferenceOptions o) => new JavaDoubleArray (ref h, o));
 			}
 
-			public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState (IList<Double> value, ParameterAttributes synchronize)
+			public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState ([MaybeNull] IList<Double> value, ParameterAttributes synchronize)
 			{
 				return JavaArray<Double>.CreateArgumentState (value, synchronize, (list, copy) => {
 					var a = copy
@@ -1489,7 +1490,7 @@ namespace Java.Interop {
 				});
 			}
 
-			public override void DestroyGenericArgumentState (IList<Double> value, ref JniValueMarshalerState state, ParameterAttributes synchronize)
+			public override void DestroyGenericArgumentState ([AllowNull] IList<Double> value, ref JniValueMarshalerState state, ParameterAttributes synchronize)
 			{
 				JavaArray<Double>.DestroyArgumentState<JavaDoubleArray> (value, ref state, synchronize);
 			}

--- a/src/Java.Interop/Java.Interop/JavaProxyObject.cs
+++ b/src/Java.Interop/Java.Interop/JavaProxyObject.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System;
 using System.Diagnostics.CodeAnalysis;
@@ -51,7 +51,7 @@ namespace Java.Interop {
 
 		public bool Equals (JavaProxyObject? other) => object.Equals (Value, other?.Value);
 
-		public override string ToString ()
+		public override string? ToString ()
 		{
 			return Value.ToString ();
 		}
@@ -63,8 +63,7 @@ namespace Java.Interop {
 				return null;
 
 			lock (CachedValues) {
-				JavaProxyObject proxy;
-				if (CachedValues.TryGetValue (value, out proxy))
+				if (CachedValues.TryGetValue (value, out var proxy))
 					return proxy;
 				proxy = new JavaProxyObject (value);
 				CachedValues.Add (value, proxy);

--- a/src/Java.Interop/Java.Interop/JniBuiltinMarshalers.cs
+++ b/src/Java.Interop/Java.Interop/JniBuiltinMarshalers.cs
@@ -8,6 +8,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 
 using Java.Interop.Expressions;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Java.Interop {
 
@@ -233,12 +234,12 @@ namespace Java.Interop {
 			return JniBoolean.GetValueFromJni (ref reference, options, targetType);
 		}
 
-		public override JniValueMarshalerState CreateGenericArgumentState (Boolean value, ParameterAttributes synchronize = ParameterAttributes.In)
+		public override JniValueMarshalerState CreateGenericArgumentState ([MaybeNull] Boolean value, ParameterAttributes synchronize = ParameterAttributes.In)
 		{
 			return new JniValueMarshalerState (new JniArgumentValue (value));
 		}
 
-		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState (Boolean value, ParameterAttributes synchronize)
+		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState ([MaybeNull] Boolean value, ParameterAttributes synchronize)
 		{
 			var r = JniBoolean.CreateLocalRef (value);
 			return new JniValueMarshalerState (r);
@@ -286,7 +287,7 @@ namespace Java.Interop {
 			return JniBoolean.GetValueFromJni (ref reference, options, targetType: null);
 		}
 
-		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState (Boolean? value, ParameterAttributes synchronize)
+		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState ([MaybeNull] Boolean? value, ParameterAttributes synchronize)
 		{
 		    if (!value.HasValue)
 		        return new JniValueMarshalerState ();
@@ -360,12 +361,12 @@ namespace Java.Interop {
 			return JniByte.GetValueFromJni (ref reference, options, targetType);
 		}
 
-		public override JniValueMarshalerState CreateGenericArgumentState (SByte value, ParameterAttributes synchronize = ParameterAttributes.In)
+		public override JniValueMarshalerState CreateGenericArgumentState ([MaybeNull] SByte value, ParameterAttributes synchronize = ParameterAttributes.In)
 		{
 			return new JniValueMarshalerState (new JniArgumentValue (value));
 		}
 
-		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState (SByte value, ParameterAttributes synchronize)
+		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState ([MaybeNull] SByte value, ParameterAttributes synchronize)
 		{
 			var r = JniByte.CreateLocalRef (value);
 			return new JniValueMarshalerState (r);
@@ -413,7 +414,7 @@ namespace Java.Interop {
 			return JniByte.GetValueFromJni (ref reference, options, targetType: null);
 		}
 
-		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState (SByte? value, ParameterAttributes synchronize)
+		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState ([MaybeNull] SByte? value, ParameterAttributes synchronize)
 		{
 		    if (!value.HasValue)
 		        return new JniValueMarshalerState ();
@@ -487,12 +488,12 @@ namespace Java.Interop {
 			return JniCharacter.GetValueFromJni (ref reference, options, targetType);
 		}
 
-		public override JniValueMarshalerState CreateGenericArgumentState (Char value, ParameterAttributes synchronize = ParameterAttributes.In)
+		public override JniValueMarshalerState CreateGenericArgumentState ([MaybeNull] Char value, ParameterAttributes synchronize = ParameterAttributes.In)
 		{
 			return new JniValueMarshalerState (new JniArgumentValue (value));
 		}
 
-		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState (Char value, ParameterAttributes synchronize)
+		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState ([MaybeNull] Char value, ParameterAttributes synchronize)
 		{
 			var r = JniCharacter.CreateLocalRef (value);
 			return new JniValueMarshalerState (r);
@@ -540,7 +541,7 @@ namespace Java.Interop {
 			return JniCharacter.GetValueFromJni (ref reference, options, targetType: null);
 		}
 
-		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState (Char? value, ParameterAttributes synchronize)
+		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState ([MaybeNull] Char? value, ParameterAttributes synchronize)
 		{
 		    if (!value.HasValue)
 		        return new JniValueMarshalerState ();
@@ -614,12 +615,12 @@ namespace Java.Interop {
 			return JniShort.GetValueFromJni (ref reference, options, targetType);
 		}
 
-		public override JniValueMarshalerState CreateGenericArgumentState (Int16 value, ParameterAttributes synchronize = ParameterAttributes.In)
+		public override JniValueMarshalerState CreateGenericArgumentState ([MaybeNull] Int16 value, ParameterAttributes synchronize = ParameterAttributes.In)
 		{
 			return new JniValueMarshalerState (new JniArgumentValue (value));
 		}
 
-		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState (Int16 value, ParameterAttributes synchronize)
+		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState ([MaybeNull] Int16 value, ParameterAttributes synchronize)
 		{
 			var r = JniShort.CreateLocalRef (value);
 			return new JniValueMarshalerState (r);
@@ -667,7 +668,7 @@ namespace Java.Interop {
 			return JniShort.GetValueFromJni (ref reference, options, targetType: null);
 		}
 
-		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState (Int16? value, ParameterAttributes synchronize)
+		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState ([MaybeNull] Int16? value, ParameterAttributes synchronize)
 		{
 		    if (!value.HasValue)
 		        return new JniValueMarshalerState ();
@@ -741,12 +742,12 @@ namespace Java.Interop {
 			return JniInteger.GetValueFromJni (ref reference, options, targetType);
 		}
 
-		public override JniValueMarshalerState CreateGenericArgumentState (Int32 value, ParameterAttributes synchronize = ParameterAttributes.In)
+		public override JniValueMarshalerState CreateGenericArgumentState ([MaybeNull] Int32 value, ParameterAttributes synchronize = ParameterAttributes.In)
 		{
 			return new JniValueMarshalerState (new JniArgumentValue (value));
 		}
 
-		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState (Int32 value, ParameterAttributes synchronize)
+		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState ([MaybeNull] Int32 value, ParameterAttributes synchronize)
 		{
 			var r = JniInteger.CreateLocalRef (value);
 			return new JniValueMarshalerState (r);
@@ -794,7 +795,7 @@ namespace Java.Interop {
 			return JniInteger.GetValueFromJni (ref reference, options, targetType: null);
 		}
 
-		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState (Int32? value, ParameterAttributes synchronize)
+		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState ([MaybeNull] Int32? value, ParameterAttributes synchronize)
 		{
 		    if (!value.HasValue)
 		        return new JniValueMarshalerState ();
@@ -868,12 +869,12 @@ namespace Java.Interop {
 			return JniLong.GetValueFromJni (ref reference, options, targetType);
 		}
 
-		public override JniValueMarshalerState CreateGenericArgumentState (Int64 value, ParameterAttributes synchronize = ParameterAttributes.In)
+		public override JniValueMarshalerState CreateGenericArgumentState ([MaybeNull] Int64 value, ParameterAttributes synchronize = ParameterAttributes.In)
 		{
 			return new JniValueMarshalerState (new JniArgumentValue (value));
 		}
 
-		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState (Int64 value, ParameterAttributes synchronize)
+		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState ([MaybeNull] Int64 value, ParameterAttributes synchronize)
 		{
 			var r = JniLong.CreateLocalRef (value);
 			return new JniValueMarshalerState (r);
@@ -921,7 +922,7 @@ namespace Java.Interop {
 			return JniLong.GetValueFromJni (ref reference, options, targetType: null);
 		}
 
-		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState (Int64? value, ParameterAttributes synchronize)
+		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState ([MaybeNull] Int64? value, ParameterAttributes synchronize)
 		{
 		    if (!value.HasValue)
 		        return new JniValueMarshalerState ();
@@ -995,12 +996,12 @@ namespace Java.Interop {
 			return JniFloat.GetValueFromJni (ref reference, options, targetType);
 		}
 
-		public override JniValueMarshalerState CreateGenericArgumentState (Single value, ParameterAttributes synchronize = ParameterAttributes.In)
+		public override JniValueMarshalerState CreateGenericArgumentState ([MaybeNull] Single value, ParameterAttributes synchronize = ParameterAttributes.In)
 		{
 			return new JniValueMarshalerState (new JniArgumentValue (value));
 		}
 
-		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState (Single value, ParameterAttributes synchronize)
+		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState ([MaybeNull] Single value, ParameterAttributes synchronize)
 		{
 			var r = JniFloat.CreateLocalRef (value);
 			return new JniValueMarshalerState (r);
@@ -1048,7 +1049,7 @@ namespace Java.Interop {
 			return JniFloat.GetValueFromJni (ref reference, options, targetType: null);
 		}
 
-		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState (Single? value, ParameterAttributes synchronize)
+		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState ([MaybeNull] Single? value, ParameterAttributes synchronize)
 		{
 		    if (!value.HasValue)
 		        return new JniValueMarshalerState ();
@@ -1122,12 +1123,12 @@ namespace Java.Interop {
 			return JniDouble.GetValueFromJni (ref reference, options, targetType);
 		}
 
-		public override JniValueMarshalerState CreateGenericArgumentState (Double value, ParameterAttributes synchronize = ParameterAttributes.In)
+		public override JniValueMarshalerState CreateGenericArgumentState ([MaybeNull] Double value, ParameterAttributes synchronize = ParameterAttributes.In)
 		{
 			return new JniValueMarshalerState (new JniArgumentValue (value));
 		}
 
-		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState (Double value, ParameterAttributes synchronize)
+		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState ([MaybeNull] Double value, ParameterAttributes synchronize)
 		{
 			var r = JniDouble.CreateLocalRef (value);
 			return new JniValueMarshalerState (r);
@@ -1175,7 +1176,7 @@ namespace Java.Interop {
 			return JniDouble.GetValueFromJni (ref reference, options, targetType: null);
 		}
 
-		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState (Double? value, ParameterAttributes synchronize)
+		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState ([MaybeNull] Double? value, ParameterAttributes synchronize)
 		{
 		    if (!value.HasValue)
 		        return new JniValueMarshalerState ();

--- a/src/Java.Interop/Java.Interop/JniEnvironment.cs
+++ b/src/Java.Interop/Java.Interop/JniEnvironment.cs
@@ -17,7 +17,7 @@ namespace Java.Interop {
 		internal    static  JniEnvironmentInfo      CurrentInfo {
 			[MethodImpl (MethodImplOptions.AggressiveInlining)]
 			get {
-				var e = Info.Value;
+				var e = Info.Value!;
 				if (!e.IsValid)
 					throw new NotSupportedException ("JNI Environment Information has been invalidated on this thread.");
 				return e;
@@ -243,7 +243,7 @@ namespace Java.Interop {
 
 		internal unsafe JniObjectReference ToJavaName (string jniTypeName)
 		{
-			int index = jniTypeName.IndexOf ('/');
+			int index = jniTypeName.IndexOf ("/", StringComparison.Ordinal);
 
 			if (index == -1)
 				return JniEnvironment.Strings.NewString (jniTypeName);

--- a/src/Java.Interop/Java.Interop/JniObjectReference.cs
+++ b/src/Java.Interop/Java.Interop/JniObjectReference.cs
@@ -106,7 +106,7 @@ namespace Java.Interop
 			return Handle.GetHashCode ();
 		}
 
-		public override bool Equals (object obj)
+		public override bool Equals (object? obj)
 		{
 			var o = obj as JniObjectReference?;
 			if (o.HasValue)

--- a/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceFields.cs
+++ b/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceFields.cs
@@ -25,8 +25,7 @@ namespace Java.Interop
 		public JniFieldInfo GetFieldInfo (string encodedMember)
 		{
 			lock (InstanceFields) {
-				JniFieldInfo f;
-				if (!InstanceFields.TryGetValue (encodedMember, out f)) {
+				if (!InstanceFields.TryGetValue (encodedMember, out var f)) {
 					string field, signature;
 					JniPeerMembers.GetNameAndSignature (encodedMember, out field, out signature);
 					f = Members.JniPeerType.GetInstanceField (field, signature);

--- a/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods.cs
+++ b/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods.cs
@@ -59,8 +59,7 @@ namespace Java.Interop
 			if (signature == null)
 				throw new ArgumentNullException (nameof (signature));
 			lock (InstanceMethods) {
-				JniMethodInfo m;
-				if (!InstanceMethods.TryGetValue (signature, out m)) {
+				if (!InstanceMethods.TryGetValue (signature, out var m)) {
 					m = JniPeerType.GetConstructor (signature);
 					InstanceMethods.Add (signature, m);
 				}
@@ -73,21 +72,19 @@ namespace Java.Interop
 			if (declaringType == DeclaringType)
 				return this;
 
-			JniInstanceMethods methods;
 			lock (SubclassConstructors) {
-				if (!SubclassConstructors.TryGetValue (declaringType, out methods)) {
+				if (!SubclassConstructors.TryGetValue (declaringType, out var methods)) {
 					methods = new JniInstanceMethods (declaringType);
 					SubclassConstructors.Add (declaringType, methods);
 				}
+				return methods;
 			}
-			return methods;
 		}
 
 		public JniMethodInfo GetMethodInfo (string encodedMember)
 		{
 			lock (InstanceMethods) {
-				JniMethodInfo m;
-				if (!InstanceMethods.TryGetValue (encodedMember, out m)) {
+				if (!InstanceMethods.TryGetValue (encodedMember, out var m)) {
 					string method, signature;
 					JniPeerMembers.GetNameAndSignature (encodedMember, out method, out signature);
 					m = JniPeerType.GetInstanceMethod (method, signature);

--- a/src/Java.Interop/Java.Interop/JniPeerMembers.JniStaticFields.cs
+++ b/src/Java.Interop/Java.Interop/JniPeerMembers.JniStaticFields.cs
@@ -20,8 +20,7 @@ namespace Java.Interop
 		public JniFieldInfo GetFieldInfo (string encodedMember)
 		{
 			lock (StaticFields) {
-				JniFieldInfo f;
-				if (!StaticFields.TryGetValue (encodedMember, out f)) {
+				if (!StaticFields.TryGetValue (encodedMember, out var f)) {
 					string field, signature;
 					JniPeerMembers.GetNameAndSignature (encodedMember, out field, out signature);
 					f = Members.JniPeerType.GetStaticField (field, signature);

--- a/src/Java.Interop/Java.Interop/JniPeerMembers.JniStaticMethods.cs
+++ b/src/Java.Interop/Java.Interop/JniPeerMembers.JniStaticMethods.cs
@@ -25,8 +25,7 @@ namespace Java.Interop
 		public JniMethodInfo GetMethodInfo (string encodedMember)
 		{
 			lock (StaticMethods) {
-				JniMethodInfo m;
-				if (!StaticMethods.TryGetValue (encodedMember, out m)) {
+				if (!StaticMethods.TryGetValue (encodedMember, out var m)) {
 					string method, signature;
 					JniPeerMembers.GetNameAndSignature (encodedMember, out method, out signature);
 					m = Members.JniPeerType.GetStaticMethod (method, signature);

--- a/src/Java.Interop/Java.Interop/JniPeerMembers.cs
+++ b/src/Java.Interop/Java.Interop/JniPeerMembers.cs
@@ -172,7 +172,7 @@ namespace Java.Interop {
 		{
 			if (encodedMember == null)
 				throw new ArgumentNullException (nameof (encodedMember));
-			int n = encodedMember.IndexOf ('.');
+			int n = encodedMember.IndexOf (".", StringComparison.Ordinal);
 			if (n < 0)
 				throw new ArgumentException (
 						"Invalid encoding; 'encodedMember' should be encoded as \"<NAME>.<SIGNATURE>\".",

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniMarshalMemberBuilder.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniMarshalMemberBuilder.cs
@@ -48,8 +48,8 @@ namespace Java.Interop {
 			var t   = jie.GetType ("Java.Interop.MarshalMemberBuilder");
 			if (t == null)
 				throw new InvalidOperationException ("Could not find Java.Interop.MarshalMemberBuilder from Java.Interop.Export.dll!");
-			var b   = (JniMarshalMemberBuilder?) Activator.CreateInstance (t);
-			marshalMemberBuilder    = SetRuntime (b!);
+			var b   = (JniMarshalMemberBuilder) Activator.CreateInstance (t)!;
+			marshalMemberBuilder    = SetRuntime (b);
 		}
 
 		public abstract class JniMarshalMemberBuilder : IDisposable, ISetRuntime
@@ -87,7 +87,7 @@ namespace Java.Interop {
 			{
 				if (value == null)
 					throw new ArgumentNullException (nameof (value));
-				return CreateMarshalToManagedExpression (value.GetMethodInfo ()!).Compile ();
+				return CreateMarshalToManagedExpression (value.GetMethodInfo ()).Compile ();
 			}
 
 			public  abstract    LambdaExpression                            CreateMarshalToManagedExpression (MethodInfo method);

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniMarshalMemberBuilder.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniMarshalMemberBuilder.cs
@@ -48,8 +48,8 @@ namespace Java.Interop {
 			var t   = jie.GetType ("Java.Interop.MarshalMemberBuilder");
 			if (t == null)
 				throw new InvalidOperationException ("Could not find Java.Interop.MarshalMemberBuilder from Java.Interop.Export.dll!");
-			var b   = (JniMarshalMemberBuilder) Activator.CreateInstance (t);
-			marshalMemberBuilder    = SetRuntime (b);
+			var b   = (JniMarshalMemberBuilder?) Activator.CreateInstance (t);
+			marshalMemberBuilder    = SetRuntime (b!);
 		}
 
 		public abstract class JniMarshalMemberBuilder : IDisposable, ISetRuntime
@@ -87,7 +87,7 @@ namespace Java.Interop {
 			{
 				if (value == null)
 					throw new ArgumentNullException (nameof (value));
-				return CreateMarshalToManagedExpression (value.GetMethodInfo ()).Compile ();
+				return CreateMarshalToManagedExpression (value.GetMethodInfo ()!).Compile ();
 			}
 
 			public  abstract    LambdaExpression                            CreateMarshalToManagedExpression (MethodInfo method);
@@ -155,7 +155,7 @@ namespace Java.Interop {
 					attr = null;
 				}
 				if (attr != null) {
-					return (JniValueMarshaler) Activator.CreateInstance (attr.MarshalerType);
+					return (JniValueMarshaler) Activator.CreateInstance (attr.MarshalerType)!;
 				}
 				return Runtime.ValueManager.GetValueMarshaler (parameter.ParameterType);
 			}

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
@@ -145,7 +145,7 @@ namespace Java.Interop {
 					if (type.IsArray && type.GetArrayRank () > 1)
 						throw new ArgumentException ("Multidimensional array '" + originalType.FullName + "' is not supported.", nameof (type));
 					rank++;
-					type = type.GetElementType ();
+					type = type.GetElementType ()!;
 				}
 
 				if (type.IsEnum)
@@ -232,7 +232,7 @@ namespace Java.Interop {
 
 				if (jniSimpleReference == null)
 					throw new ArgumentNullException (nameof (jniSimpleReference));
-				if (jniSimpleReference != null && jniSimpleReference.Contains ("."))
+				if (jniSimpleReference != null && jniSimpleReference.IndexOf (".", StringComparison.Ordinal) >= 0)
 					throw new ArgumentException ("JNI type names do not contain '.', they use '/'. Are you sure you're using a JNI type name?", nameof (jniSimpleReference));
 				if (jniSimpleReference != null && jniSimpleReference.StartsWith ("[", StringComparison.Ordinal))
 					throw new ArgumentException ("Only simplified type references are supported.", nameof (jniSimpleReference));
@@ -245,7 +245,7 @@ namespace Java.Interop {
 
 			IEnumerable<Type> CreateGetTypesForSimpleReferenceEnumerator (string jniSimpleReference)
 			{
-				if (JniBuiltinSimpleReferenceToType.Value.TryGetValue (jniSimpleReference, out Type ret)) {
+				if (JniBuiltinSimpleReferenceToType.Value.TryGetValue (jniSimpleReference, out var ret)) {
 					yield return ret;
 				}
 				yield break;

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -496,8 +496,7 @@ namespace Java.Interop
 				if (r != null)
 					return r;
 				lock (Marshalers) {
-					JniValueMarshaler d;
-					if (!Marshalers.TryGetValue (typeof (T), out d))
+					if (!Marshalers.TryGetValue (typeof (T), out var d))
 						Marshalers.Add (typeof (T), d = new DelegatingValueMarshaler<T> (m));
 					return (JniValueMarshaler<T>) d;
 				}
@@ -515,7 +514,7 @@ namespace Java.Interop
 
 				var marshalerAttr   = type.GetCustomAttribute<JniValueMarshalerAttribute> ();
 				if (marshalerAttr != null)
-					return (JniValueMarshaler) Activator.CreateInstance (marshalerAttr.MarshalerType);
+					return (JniValueMarshaler) Activator.CreateInstance (marshalerAttr.MarshalerType)!;
 
 				if (typeof (IJavaPeerable) == type)
 					return JavaPeerableValueMarshaler.Instance;
@@ -561,7 +560,7 @@ namespace Java.Interop
 					}
 				}
 				if (ifaceAttribute != null)
-					return (JniValueMarshaler) Activator.CreateInstance (ifaceAttribute.MarshalerType);
+					return (JniValueMarshaler) Activator.CreateInstance (ifaceAttribute.MarshalerType)!;
 
 				return GetValueMarshalerCore (type);
 			}

--- a/src/Java.Interop/Java.Interop/JniRuntime.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.cs
@@ -290,7 +290,11 @@ namespace Java.Interop
 		public virtual void FailFast (string? message)
 		{
 			var m = typeof (Environment).GetMethod ("FailFast");
-			m?.Invoke (null, new object?[]{ message });
+
+			if (m is null)
+				Environment.Exit (1);
+
+			m!.Invoke (null, new object?[]{ message });
 		}
 
 		public override string ToString ()

--- a/src/Java.Interop/Java.Interop/JniRuntime.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.cs
@@ -101,9 +101,8 @@ namespace Java.Interop
 
 		public static JniRuntime? GetRegisteredRuntime (IntPtr invocationPointer)
 		{
-			JniRuntime vm;
 			lock (Runtimes) {
-				return Runtimes.TryGetValue (invocationPointer, out vm)
+				return Runtimes.TryGetValue (invocationPointer, out var vm)
 					? vm
 					: null;
 			}
@@ -270,7 +269,7 @@ namespace Java.Interop
 		static unsafe JavaVMInterface CreateInvoker (IntPtr handle)
 		{
 			IntPtr p = Marshal.ReadIntPtr (handle);
-			return (JavaVMInterface) Marshal.PtrToStructure (p, typeof (JavaVMInterface));
+			return (JavaVMInterface) Marshal.PtrToStructure (p, typeof (JavaVMInterface))!;
 		}
 
 		~JniRuntime ()
@@ -291,7 +290,7 @@ namespace Java.Interop
 		public virtual void FailFast (string? message)
 		{
 			var m = typeof (Environment).GetMethod ("FailFast");
-			m.Invoke (null, new object?[]{ message });
+			m?.Invoke (null, new object?[]{ message });
 		}
 
 		public override string ToString ()
@@ -411,15 +410,13 @@ namespace Java.Interop
 
 		internal void UnTrack (IntPtr key)
 		{
-			IDisposable _;
-			TrackedInstances.TryRemove (key, out _);
+			TrackedInstances.TryRemove (key, out var _);
 		}
 
 		void ClearTrackedReferences ()
 		{
 			foreach (var k in TrackedInstances.Keys.ToList ()) {
-				IDisposable d;
-				if (TrackedInstances.TryRemove (k, out d))
+				if (TrackedInstances.TryRemove (k, out var d))
 					d.Dispose ();
 			}
 			TrackedInstances.Clear ();

--- a/src/Java.Interop/Java.Interop/JniTypeSignature.cs
+++ b/src/Java.Interop/Java.Interop/JniTypeSignature.cs
@@ -43,7 +43,7 @@ namespace Java.Interop
 		public JniTypeSignature (string? simpleReference, int arrayRank = 0, bool keyword = false)
 		{
 			if (simpleReference != null) {
-				if (simpleReference.Contains ("."))
+				if (simpleReference.IndexOf (".", StringComparison.Ordinal) >= 0)
 					throw new ArgumentException ("JNI type names do not contain '.', they use '/'. Are you sure you're using a JNI type name?", nameof (simpleReference));
 				if (simpleReference.StartsWith ("[", StringComparison.Ordinal))
 					throw new ArgumentException ("To specify an array, use the ArrayRank property.", nameof (simpleReference));
@@ -172,10 +172,14 @@ namespace Java.Interop
 
 		public override int GetHashCode ()
 		{
+#if NETCOREAPP
+			return QualifiedReference.GetHashCode (StringComparison.Ordinal);
+#else
 			return QualifiedReference.GetHashCode ();
+#endif
 		}
 
-		public override bool Equals (object obj)
+		public override bool Equals (object? obj)
 		{
 			var v = obj as JniTypeSignature?;
 			if (v.HasValue)

--- a/src/Java.Interop/Java.Interop/JniTypeSignatureAttribute.cs
+++ b/src/Java.Interop/Java.Interop/JniTypeSignatureAttribute.cs
@@ -13,7 +13,7 @@ namespace Java.Interop
 		{
 			if (simpleReference == null)
 				throw new ArgumentNullException (nameof (simpleReference));
-			if (simpleReference.Contains ("."))
+			if (simpleReference.IndexOf (".", StringComparison.Ordinal) >= 0)
 				throw new ArgumentException ("JNI type names do not contain '.', they use '/'. Are you sure you're using a JNI type name?", nameof (simpleReference));
 			if (simpleReference.StartsWith ("[", StringComparison.Ordinal))
 				throw new ArgumentException ("Arrays cannot be present in simple type references.", nameof (simpleReference));

--- a/src/Java.Interop/Java.Interop/JniValueMarshaler.cs
+++ b/src/Java.Interop/Java.Interop/JniValueMarshaler.cs
@@ -110,7 +110,7 @@ namespace Java.Interop {
 			return string.Format ("JniValueMarshalerState({0}, ReferenceValue={1}, PeerableValue=0x{2}, Extra={3})",
 					JniArgumentValue.ToString (),
 					ReferenceValue.ToString (),
-					RuntimeHelpers.GetHashCode (PeerableValue).ToString ("x"),
+					RuntimeHelpers.GetHashCode (PeerableValue!).ToString ("x"),
 					Extra);
 		}
 	}

--- a/src/Java.Interop/Java.Interop/ManagedPeer.cs
+++ b/src/Java.Interop/Java.Interop/ManagedPeer.cs
@@ -84,7 +84,7 @@ namespace Java.Interop {
 					return;
 				}
 
-				var type    = Type.GetType (JniEnvironment.Strings.ToString (n_assemblyQualifiedName), throwOnError: true);
+				var type    = Type.GetType (JniEnvironment.Strings.ToString (n_assemblyQualifiedName)!, throwOnError: true)!;
 				if (type.IsGenericTypeDefinition) {
 					throw new NotSupportedException (
 							"Constructing instances of generic types from Java is not supported, as the type parameters cannot be determined.",
@@ -157,7 +157,7 @@ namespace Java.Interop {
 			var typeNames   = signature!.Split (':');
 			var ptypes      = new Type [typeNames.Length];
 			for (int i = 0; i < typeNames.Length; i++)
-				ptypes [i] = Type.GetType (typeNames [i], throwOnError:true);
+				ptypes [i] = Type.GetType (typeNames [i], throwOnError:true)!;
 			return ptypes;
 		}
 
@@ -196,7 +196,7 @@ namespace Java.Interop {
 				var assemblyQualifiedName   = JniEnvironment.Strings.ToString (new JniObjectReference (n_assemblyQualifiedName));
 				var methods                 = JniEnvironment.Strings.ToString (new JniObjectReference (n_methods));
 
-				var type    = Type.GetType (assemblyQualifiedName, throwOnError: true);
+				var type    = Type.GetType (assemblyQualifiedName!, throwOnError: true)!;
 
 				JniEnvironment.Runtime.TypeManager.RegisterNativeMembers (nativeClass, type, methods);
 			}

--- a/tools/jnimarshalmethod-gen/App.cs
+++ b/tools/jnimarshalmethod-gen/App.cs
@@ -174,7 +174,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 			foreach (var r in references) {
 				try {
 					Assembly.LoadFile (Path.GetFullPath (r));
-				} catch (Exception e) {
+				} catch (Exception) {
 					Error ($"Unable to preload reference '{r}'.");
 					Environment.Exit (1);
 				}


### PR DESCRIPTION
- Fixes 43 NRT warnings.
- Fixes 1 `CS0168` warning: (`The variable 'e' is declared but never used`)
- Fixes 6 `CA1307` warnings introduced by targeting `netcoreapp3.1`. (`The behavior of 'string.IndexOf(char)' could vary based on the current user's locale settings.`)
