### PR TITLE
[logcat-parse.csprj] Update to latest Mono.Terminal nuget with netstandard support.

### DIFF
--- a/tools/logcat-parse/logcat-parse.csproj
+++ b/tools/logcat-parse/logcat-parse.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Mono.Options" Version="5.3.0.1" />
-    <PackageReference Include="Mono.Terminal" Version="4.2.2.0" />
+    <PackageReference Include="Mono.Terminal" Version="5.4.0" />
     <PackageReference Include="Mono.CSharp" Version="4.0.0.143" />
   </ItemGroup>
 


### PR DESCRIPTION
Note the assembly name changed from `Mono.Terminal.dll` to `LineEditor.dll` so we will likely need to update the installers when we bump JI.