### PR TITLE
[param-name-importer] Update to latest SgmlReader NuGet which supports netstandard2.0.

### DIFF
--- a/tools/param-name-importer/param-name-importer.csproj
+++ b/tools/param-name-importer/param-name-importer.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <!-- Not sure why needed, but only System.IO.Compression.FileSystem.dll is
       included by default, and ZipArchive is type forwarded to System.IO.Compression -->
-    <Reference Include="System.IO.Compression" Condition="'$(TargetFramework)' == 'net472'" />
+    <Reference Include="System.IO.Compression" Condition="$(TargetFramework.StartsWith('net4'))" />
   </ItemGroup>
   <ItemGroup>
     <!-- This package erroneously contains /netcoreapp3.1/SgmlReader.exe and /netcoreapp3.1/SgmlReaderDll.dll.

--- a/tools/param-name-importer/param-name-importer.csproj
+++ b/tools/param-name-importer/param-name-importer.csproj
@@ -9,10 +9,16 @@
   <ItemGroup>
     <!-- Not sure why needed, but only System.IO.Compression.FileSystem.dll is
       included by default, and ZipArchive is type forwarded to System.IO.Compression -->
-    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression" Condition="'$(TargetFramework)' == 'net472'" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Xml.SgmlReader" Version="1.8.14" />
+    <!-- This package erroneously contains /netcoreapp3.1/SgmlReader.exe and /netcoreapp3.1/SgmlReaderDll.dll.
+         We are going to use a package reference to download the nuget, and a regular reference to actually
+         reference the correct assembly. -->
+    <PackageReference Include="Microsoft.Xml.SgmlReader" Version="1.8.16" ExcludeAssets="Compile" GeneratePathProperty="true" />
+    <Reference Include="SgmlReader">
+      <HintPath>$(PkgMicrosoft_Xml_SgmlReader)\lib\netstandard2.0\SgmlReaderDll.dll</HintPath>
+    </Reference>
     <PackageReference Include="Mono.Options" Version="5.3.0.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
There is an issue with the new NuGet in that the `lib/netcoreapp3.1` directory contains both `SgmlReader.exe` and `SgmlReaderDll.dll` and the `netcoreapp3.1` version of `param-name-importer` tries to take the `.exe`.  

Worked around this by using the `<PackageReference>` to download the NuGet but not reference any assembly.  Then we add a `<Reference>` to the correct `.dll` and use it.  (We use `netstandard2.0` because both frameworks can use it, `netcoreapp3.1` shouldn't even exist in the package.)

Additionally added a `net4*` `Condition` to the reference to `System.IO.Compression` to fix this warning:

```
Warning MSB3243: No way to resolve conflict between "System.IO.Compression, Version=4.2.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" and "System.IO.Compression". Choosing "System.IO.Compression, Version=4.2.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" arbitrarily.
```

The reference only appears to be needed on `net472`, not `netcoreapp3.1`.