### PR TITLE
[java-interop] Update to SDK style project.

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -6,6 +6,6 @@
 -->
 <configuration>  
   <config>
-    <add key="globalPackagesFolder" value="$\..\packages" />
+    <add key="globalPackagesFolder" value="packages" />
   </config>
 </configuration>

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -161,8 +161,8 @@ jobs:
     
   - script: |
       dotnet tool install --global boots  
-      boots https://download.mono-project.com/archive/6.4.0/macos-10-universal/MonoFramework-MDK-6.4.0.198.macos10.xamarin.universal.pkg
-    displayName: Install Mono 6.4
+      boots --stable Mono
+    displayName: Install Mono-Stable
     
   - script: make prepare CONFIGURATION=$(Build.Configuration)
     displayName: make prepare

--- a/src/java-interop/java-interop.csproj
+++ b/src/java-interop/java-interop.csproj
@@ -1,47 +1,39 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.Build.NoTargets/1.0.110">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ItemType>GenericProject</ItemType>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{BB0AB9F7-0979-41A7-B7A9-877260655F94}</ProjectGuid>
-  </PropertyGroup>
-  <Import Project="..\..\Directory.Build.props" />
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
+    <TargetFramework>net472</TargetFramework>
     <OutputPath>$(ToolOutputFullPath)</OutputPath>
     <JNIEnvGenPath>$(BuildToolOutputFullPath)</JNIEnvGenPath>
     <OutputName>java-interop</OutputName>
-    <CompileTarget>SharedLibrary</CompileTarget>
-    <DefineSymbols>DEBUG JI_DLL_EXPORT MONODEVELOP MONO_DLL_EXPORT</DefineSymbols>
-    <SourceDirectory>.</SourceDirectory>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <OutputPath>$(ToolOutputFullPath)</OutputPath>
-    <OutputName>java-interop</OutputName>
-    <JNIEnvGenPath>$(BuildToolOutputFullPath)</JNIEnvGenPath>
-    <CompileTarget>SharedLibrary</CompileTarget>
-    <OptimizationLevel>3</OptimizationLevel>
     <DefineSymbols>JI_DLL_EXPORT MONODEVELOP MONO_DLL_EXPORT</DefineSymbols>
     <SourceDirectory>.</SourceDirectory>
   </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DefineConstants>DEBUG $(DefineConstants)</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <OptimizationLevel>3</OptimizationLevel>
+  </PropertyGroup>
+
   <ItemGroup>
     <ClInclude Include="java-interop.h" />
     <ClInclude Include="java-interop-gc-bridge.h" />
     <ClInclude Include="java-interop-mono.h" />
   </ItemGroup>
+
   <PropertyGroup>
     <_MonoIncludePath>@(MonoIncludePath->'%(FullPath)')</_MonoIncludePath>
     <_JdkIncludePath>@(JdkIncludePath->'%(FullPath)')</_JdkIncludePath>
   </PropertyGroup>
+
   <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions>$([MSBuild]::Unescape($(DefineSymbols.Replace(' ', ';'))))</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$([MSBuild]::Unescape($(_MonoIncludePath)));$([MSBuild]::Unescape($(_JdkIncludePath)))</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
+
   <ItemGroup>
     <ClCompile Include="jni.c" />
     <ClCompile Include="java-interop.cc" />
@@ -50,20 +42,10 @@
     <ClCompile Include="java-interop-mono.cc" />
     <ClCompile Include="java-interop-gc-bridge-mono.cc" />
   </ItemGroup>
-  <PropertyGroup>
-    <BuildDependsOn>
-      BuildJni_c;
-      BuildMac;
-      BuildUnixLibraries;
-      $(BuildDependsOn)
-    </BuildDependsOn>
-  </PropertyGroup>
+
   <Import Project="java-interop.targets" />
+  
   <ItemGroup>
-    <ProjectReference Include="..\..\build-tools\jnienv-gen\jnienv-gen.csproj">
-      <Project>{6410DA0F-5E14-4FC0-9AEE-F4C542C96C7A}</Project>
-      <Name>jnienv-gen</Name>
-      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
-    </ProjectReference>
-  </ItemGroup>
+    <ProjectReference Include="..\..\build-tools\jnienv-gen\jnienv-gen.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>  
 </Project>

--- a/src/java-interop/java-interop.targets
+++ b/src/java-interop/java-interop.targets
@@ -1,20 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project>
   <PropertyGroup>
     <Runtime Condition="'$(OS)' != 'Windows_NT'">mono</Runtime>
   </PropertyGroup>
-  <Target Name="Build" DependsOnTargets="$(BuildDependsOn)" />
   <Target Name="BuildJni_c"
       Inputs="$(JNIEnvGenPath)\jnienv-gen.exe"
       Outputs="jni.c">
     <MakeDir Directories="$(OutputPath)" />
     <Exec Command="$(Runtime) &quot;$(JNIEnvGenPath)\jnienv-gen.exe&quot; jni.g.cs jni.c" />
   </Target>
+
   <PropertyGroup>
     <_MacLib>$(OutputPath)\lib$(OutputName).dylib</_MacLib>
   </PropertyGroup>
+
   <Target Name="_CompileObjectFiles"
       Condition=" '$(OS)' != 'Windows_NT' "
+      DependsOnTargets="BuildJni_c"
       Inputs="@(ClCompile)"
       Outputs="obj\$(Configuration)\%(Filename).o">
     <MakeDir Directories="obj\$(Configuration)" />
@@ -33,7 +35,9 @@
         Command="$(_Cc) -c -g $(_Arch) -o &quot;obj\$(Configuration)\%(ClCompile.Filename).o&quot; $(_Def) $(_Inc) &quot;%(Identity)&quot;"
     />
   </Target>
+
   <Target Name="BuildMac"
+      AfterTargets="Build"
       Condition=" '$(OS)' != 'Windows_NT' And Exists ('/Library/Frameworks/')"
       DependsOnTargets="_CompileObjectFiles"
       Inputs="@(ClCompile)"
@@ -47,7 +51,9 @@
     <!-- Mono 4.4.0 (mono-4.4.0-branch/a3fabf1) has an incorrect shared library name. Fix it -->
     <Exec Command="install_name_tool -change /private/tmp/source-mono-4.4.0/bockbuild-mono-4.4.0-branch/profiles/mono-mac-xamarin/package-root/lib/libmonosgen-2.0.1.dylib /Library/Frameworks/Mono.framework/Libraries/libmonosgen-2.0.1.dylib &quot;$(_MacLib)&quot;" />
   </Target>
+
   <Target Name="BuildUnixLibraries"
+      AfterTargets="Build"
       Condition=" '$(OS)' != 'Windows_NT' And !Exists ('/Library/Frameworks/')"
       DependsOnTargets="_CompileObjectFiles"
       Inputs="@(ClCompile)"
@@ -65,6 +71,7 @@
     </PropertyGroup>
     <Exec Command="g++ -g -shared -o &quot;$(OutputPath)\lib$(OutputName).so&quot; $(_LinkFlags) $(_Libs) $(_Files)" />
   </Target>
+
   <Target Name="Clean">
     <RemoveDir Directories="obj" />
     <Delete Files="jni.c" />
@@ -72,7 +79,5 @@
         Files="$(OutputPath)\lib$(OutputName).dylib"
         Condition=" '$(OS)' != 'Windows_NT' "
     />
-  </Target>
-  <Target Name="Restore">
   </Target>
 </Project>


### PR DESCRIPTION
Updates `java-interop.csproj` to SDK style.  This is a bit tricky because this is not a C# assembly, it is just hijacking a `.csproj` and overriding some targets to build a C lib.

It felt cleaner to go with a more "supported" version of doing this, so the project is built on [Microsoft.Build.NoTargets](https://github.com/microsoft/MSBuildSdks/tree/master/src/NoTargets) which is designed to run arbitrary commands without building an assembly.

Also switches to stable Mono.  Not sure if this is necessary but the more modern the `MSBuild` support when working with SDK style projects the better.

The automatic downloading of the `NoTargets` package didn't work with our `globalPackagesFolder` set to `$\..\packages`, so that was changed to `packages`, which is what XA uses and it works.

Ran a XA build against this change to ensure the resulting library still works: https://github.com/xamarin/xamarin-android/pull/4759.