### PR TITLE
[generator] Don't invalidate interface if we invalidate a static method on it.

### DIFF
--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
@@ -677,11 +677,11 @@ namespace MonoDroid.Generation
 			}
 			Fields = valid_fields;
 
-			// If we can't validate a default interface method it's ok to ignore it and still bind the interface
-			var method_cnt = Methods.Where (m => !m.IsInterfaceDefaultMethod).Count ();
+			// If we can't validate a static or default interface method it's ok to ignore it and still bind the interface
+			var method_cnt = Methods.Where (m => !m.IsInterfaceDefaultMethod && !m.IsStatic).Count ();
 
 			Methods = Methods.Where (m => ValidateMethod (opt, m, context)).ToList ();
-			MethodValidationFailed = method_cnt != Methods.Where (m => !m.IsInterfaceDefaultMethod).Count ();
+			MethodValidationFailed = method_cnt != Methods.Where (m => !m.IsInterfaceDefaultMethod && !m.IsStatic).Count ();
 
 			foreach (Method m in Methods) {
 				if (m.IsVirtual)


### PR DESCRIPTION
Fixes #588 

If we cannot bind a method on an interface we mark the interface as unbindable and omit the interface from the generated code (and anything that depends on it).  This is because an interface with a missing method cannot be implemented in C#.

However if the method is `static` we can remove the method but still keep the interface, as the user is not required to implement the static method.  This PR makes this change to keep the interface.

Note we already properly handled DIM, this adds support for `static` methods as well.