### PR TITLE
[generator] Use proper syntax for nested classes for default interface method invokers.

### DIFF
--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Method.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Method.cs
@@ -126,7 +126,7 @@ namespace MonoDroid.Generation
 		}
 
 		// Connectors for DIM are defined on the interface, not the implementing type
-		public string GetConnectorNameFull (CodeGenerationOptions opt) => ConnectorName + (opt.SupportDefaultInterfaceMethods && IsInterfaceDefaultMethod ? $":{DeclaringType.FullName}, " + (AssemblyName ?? opt.AssemblyName) : string.Empty);
+		public string GetConnectorNameFull (CodeGenerationOptions opt) => ConnectorName + (opt.SupportDefaultInterfaceMethods && IsInterfaceDefaultMethod ? $":{DeclaringType.AssemblyQualifiedName}, " + (AssemblyName ?? opt.AssemblyName) : string.Empty);
 
 		internal string GetDelegateType (CodeGenerationOptions opt) => opt.GetJniMarshalDelegate (this);
 


### PR DESCRIPTION
Fixes #661 

When we `[Register]` the invoker for a `default` method in a nested interface, we are using `.` to denote a nested interface, when it should be a `/`.

For example, in:
```
[Register ("onActivityPostCreated", "(Landroid/app/Activity;Landroid/os/Bundle;)V", "GetOnActivityPostCreated_Landroid_app_Activity_Landroid_os_Bundle_Handler:Android.App.Application.IActivityLifecycleCallbacks, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null", ApiSince = 29)]
```
`Android.App.Application.IActivityLifecycleCallbacks` should be `Android.App.Application/IActivityLifecycleCallbacks`.

This is causing the nested type to not be found.

Fixed by using `AssemblyQualifiedName` instead of `FullName`, which is explicitly defined to support the correct notation.