### PR TITLE
[logcat-parse] Support the Android 10 `logcat` format

### DIFF
--- a/tests/logcat-parse-Tests/Resources/logcat-get_class_ref.txt
+++ b/tests/logcat-parse-Tests/Resources/logcat-get_class_ref.txt
@@ -1,9 +1,9 @@
 ﻿# If get_class_ref() is in the callstack, this is a "burned" GREF which references
 # a jclass for the specified type; it can never be collected.
-I/monodroid-gref(11718): +g+ grefc 1 gwrefc 0 obj-handle 0x7830001d/L -> new-handle 0x10046a/G from thread '(null)'(1)
-I/monodroid-gref(11718):    at Android.Runtime.JNIEnv.NewGlobalRef(IntPtr jobject)
-I/monodroid-gref(11718):    at Android.Runtime.JNIEnv.FindClass(System.String classname)
-I/monodroid-gref(11718):    at Android.Runtime.JNIEnv.FindClass(System.String className, IntPtr ByRef cachedJniClassHandle)
-I/monodroid-gref(11718):    at Android.Widget.Button.get_class_ref()
-I/monodroid-gref(11718):    at Android.Widget.Button.get_ThresholdClass()
-I/monodroid-gref(11718):    at Android.Views.View.SetLayerType(LayerType layerType, Android.Graphics.Paint paint)
+06-15 14:29:12.360 11718 11718 I monodroid-gref: +g+ grefc 1 gwrefc 0 obj-handle 0x7830001d/L -> new-handle 0x10046a/G from thread '(null)'(1)
+06-15 14:29:12.360 11718 11718 I monodroid-gref:    at Android.Runtime.JNIEnv.NewGlobalRef(IntPtr jobject)
+06-15 14:29:12.360 11718 11718 I monodroid-gref:    at Android.Runtime.JNIEnv.FindClass(System.String classname)
+06-15 14:29:12.360 11718 11718 I monodroid-gref:    at Android.Runtime.JNIEnv.FindClass(System.String className, IntPtr ByRef cachedJniClassHandle)
+06-15 14:29:12.360 11718 11718 I monodroid-gref:    at Android.Widget.Button.get_class_ref()
+06-15 14:29:12.360 11718 11718 I monodroid-gref:    at Android.Widget.Button.get_ThresholdClass()
+06-15 14:29:12.360 11718 11718 I monodroid-gref:    at Android.Views.View.SetLayerType(LayerType layerType, Android.Graphics.Paint paint)

--- a/tools/logcat-parse/Grefs.cs
+++ b/tools/logcat-parse/Grefs.cs
@@ -9,7 +9,14 @@ namespace Xamarin.Android.Tools.LogcatParse {
 
 	public class Grefs {
 
-		const string Prefix               = @"^(\[monodroid-gref\] |(\d\d-\d\d \d\d:\d\d:[^:]+: )?I/monodroid-gref\(\s*(?<pid>{0})\): )?";
+		const string FilePrefix           = @"\[monodroid-gref\] ";
+		const string AndroidPrefix        = @"(\d\d-\d\d \d\d:\d\d:[^:]+: )?I/monodroid-gref\(\s*(?<pid>{0})\): ";
+		const string Android10Prefix      = @"(\d\d-\d\d \d\d:\d\d:[^ ]+ (?<pid>{0}) \d+ )?I monodroid-gref: ";
+
+		const string Prefix               = "^(" + FilePrefix +
+		                                    "|" + AndroidPrefix +
+		                                    "|" + Android10Prefix +
+		                                    ")?";
 		const string ThreadAndStack       = @"(thread (?<thread>'[^']+'\([^)]+\)))?(?<stack>.*)$";
 		const string AddGrefFormat        = Prefix + @"\+g\+ grefc (?<gcount>\d+) gwrefc (?<wgcount>\d+) obj-handle (?<handle>0x[0-9A-Fa-f]+)/(?<handle_type>.) -> new-handle (?<ghandle>0x[0-9A-Fa-f]+)/(?<ghandle_type>.) from " + ThreadAndStack;
 		const string AddWgrefFormat       = Prefix + @"\+w\+ grefc (?<gcount>\d+) gwrefc (?<wgcount>\d+) obj-handle (?<handle>0x[0-9A-Fa-f]+)/(?<handle_type>.) -> new-handle (?<whandle>0x[0-9A-Fa-f]+)/(?<whandle_type>.) from " + ThreadAndStack;


### PR DESCRIPTION
Android 10 has changed it's `adb logcat` output to be more
"space delimited", e.g. instead of the previous `I/monodroid-gref(PID)`
seen previously, the ordering has changed and spaces delimit values:

	06-15 14:29:08.206 31409 31409 I monodroid-gref: +g+ grefc 20 gwrefc 0 obj-handle 0x89/I -> new-handle 0x3bc6/G from thread '(null)'(1)

Update `Grefs.Prefix` so that it supports this new output format.