### PR TITLE
[tools] Add response file support

### DIFF
--- a/tools/class-parse/Program.cs
+++ b/tools/class-parse/Program.cs
@@ -24,7 +24,7 @@ namespace Xamarin.Android.Tools {
 			string platform = null;
 			var  docsPaths  = new List<string> ();
 			var p = new OptionSet () {
-				"usage: class-dump [-dump] FILES",
+				"usage: class-dump [-dump] FILES [@RESPONSE-FILES]",
 				"",
 				"View the metadata contents of a Java .class or .jar file.",
 				"",
@@ -56,6 +56,7 @@ namespace Xamarin.Android.Tools {
 				{ "h|?|help",
 				  "Show this message and exit.",
 				  v => help = v != null },
+				new ResponseFileSource (),
 			};
 			var files = p.Parse (args);
 			if (help) {

--- a/tools/generator/CodeGeneratorOptions.cs
+++ b/tools/generator/CodeGeneratorOptions.cs
@@ -54,7 +54,7 @@ namespace Xamarin.Android.Binder
 			bool show_help = false;
 
 			var parser = new OptionSet {
-				"Usage: generator.exe OPTIONS+ API_DESCRIPTION",
+				"Usage: generator.exe OPTIONS+ API_DESCRIPTION [@RESPONSE-FILES]",
 				"",
 				"Generates C# source files to bind Java code described by API_DESCRIPTION.",
 				"",
@@ -147,6 +147,7 @@ namespace Xamarin.Android.Binder
 				{ "annotations=",
 					"For internal use.",
 					v => opts.AnnotationsZipFiles.Add (v) },
+				new ResponseFileSource (),
 			};
 
 			var apis = parser.Parse (args);

--- a/tools/jcw-gen/App.cs
+++ b/tools/jcw-gen/App.cs
@@ -23,7 +23,7 @@ namespace Java.Interop.Tools
 			int     verbosity   = 0;
 
 			var options = new OptionSet {
-				"Usage: jcw-gen.exe OPTIONS* ASSEMBLY+",
+				"Usage: jcw-gen.exe OPTIONS* ASSEMBLY+ [@RESPONSE-FILES]",
 				"",
 				"Generates Java Callable Wrappers from specified assemblies.",
 				"",
@@ -42,6 +42,7 @@ namespace Java.Interop.Tools
 				{ "h|help|?",
 				  "Show this message and exit",
 				  v => help = v != null },
+				new ResponseFileSource (),
 			};
 			var cache = new TypeDefinitionCache ();
 			var scanner = new JavaTypeScanner (Diagnostic.CreateConsoleLogger (), cache);

--- a/tools/jnimarshalmethod-gen/App.cs
+++ b/tools/jnimarshalmethod-gen/App.cs
@@ -75,7 +75,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 		{
 			var help = false;
 			var options = new OptionSet {
-				$"Usage: {Name}.exe OPTIONS* ASSEMBLY+",
+				$"Usage: {Name}.exe OPTIONS* ASSEMBLY+ [@RESPONSE-FILES]",
 				"",
 				"Generates helper marshaling methods for specified assemblies.",
 				"",

--- a/tools/logcat-parse/Program.cs
+++ b/tools/logcat-parse/Program.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Android.Tools.LogcatParse {
 			var options = new OptionSet () {
 				"logcat-parse: Parse `adb logcat` output to analyze GREF information.",
 				"",
-				"usage: logcat-parse [-p PID] FILE",
+				"usage: logcat-parse [-p PID] FILE [@RESPONSE-FILES]",
 				{ "p|pid=",
 				  "The {PID} to filter GREF output.",
 				  v => pid = int.Parse (v, CultureInfo.InvariantCulture)
@@ -22,6 +22,7 @@ namespace Xamarin.Android.Tools.LogcatParse {
 				{ "h|?|help",
 				  "Show this message and exit.",
 				  v => help = v != null },
+				new ResponseFileSource (),
 			};
 			var files = options.Parse (args);
 			if (help) {

--- a/tools/param-name-importer/Program.cs
+++ b/tools/param-name-importer/Program.cs
@@ -32,6 +32,7 @@ namespace Xamarin.Android.ApiTools
 				{"output-xml=", v => ret.OutputXmlFile = v },
 				{"verbose", v => ret.DiagnosticWriter = Console.Error },
 				{"framework-only", v => ret.FrameworkOnly = true },
+				new ResponseFileSource (),
 			};
 			options.Parse (args);
 			return ret;


### PR DESCRIPTION
Fixes #664.
Context: https://github.com/mono/mono/commit/08fb9274e6b378b5edd333efcc1d6dfb04f912eb

Some utilities support *lots* of command-line options, which in turn
presents the *possibility* of having command-line lengths which are
"too long" for a given operating system, which on [Windows is 8KB][0].

[Response files][1] are a widely-supported "alternative"/"workaround":
instead of placing command-line options on the command-line, place
them into a *file*, which can contain command-line options.

A response file is a command-line option that starts with `@`,
followed by a filename:

	$ echo " --help" > args.txt
	$ mono bin/Debug/generator.exe @args.txt
	# `generator.exe --help` output is printed

[0]: https://support.microsoft.com/en-us/help/830473/command-prompt-cmd-exe-command-line-string-limitation
[1]: https://docs.microsoft.com/en-us/windows/win32/midl/response-files