### PR TITLE
[JCW] Prevent inherited interfaces from getting generated.

### DIFF
--- a/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGeneratorTests.cs
+++ b/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGeneratorTests.cs
@@ -607,6 +607,16 @@ public class ExampleInstrumentation
 ";
 			Assert.AreEqual (expected, actual);
 		}
+
+		[Test]
+		public void GenerateMultipleInterfaces ()
+		{
+			var actual = Generate (typeof (NonGenericImplementorClass));
+
+			Assert.True (actual.Contains ("mono.android.IGCUserPeer"));
+			Assert.True (actual.Contains ("specificInterface"));
+			Assert.False (actual.Contains ("genericIFace"));
+		}
 	}
 }
 

--- a/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/SupportDeclarations.cs
+++ b/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/SupportDeclarations.cs
@@ -318,4 +318,21 @@ namespace Xamarin.Android.ToolsTests {
 		[Export (Throws = new Type [0])]
 		public ExportsThrowsConstructors (string value) { }
 	}
+
+	[Register ("register.genericIFace")]
+	interface GenericIFace<T> : IJavaObject
+	{
+		void Foo (T value);
+	}
+
+	[Register ("register.specificInterface")]
+	interface SpecificInterface : GenericIFace<string>
+	{
+	}
+
+	[Register ("register.nonGenericImplementorClass")]
+	class NonGenericImplementorClass : Java.Lang.Object, SpecificInterface
+	{
+		public void Foo (string value) => throw new NotImplementedException ();
+	}
 }


### PR DESCRIPTION
Fixes #590 

Given the following hierarchy:
```
[Register ("register.genericIFace")]
interface GenericIFace<T> : IJavaObject
{
	void Foo (T value);
}

[Register ("register.specificInterface")]
interface SpecificInterface : GenericIFace<string>
{
}

[Register ("register.nonGenericImplementorClass")]
class NonGenericImplementorClass : Java.Lang.Object, SpecificInterface
{
	public void Foo (string value) => throw new NotImplementedException ();
}
```

we are generating:
```
public class nonGenericImplementorClass
	extends java.lang.Object
	implements
		mono.android.IGCUserPeer,
		register.specificInterface,
		register.genericIFace
```
which produces a Java error like:
```
genericIFace cannot be inherited with with different arguments: <string> and <>
```

The solution is to only reference the most derived interface like this:
```
public class nonGenericImplementorClass
	extends java.lang.Object
	implements
		mono.android.IGCUserPeer,
		register.specificInterface
```
We achieve this by excluding any interfaces that can be assigned from any other interfaces on the type.