### PR TITLE
[jnimarshalmethod-gen] support methods with 14+ arguments

### DIFF
--- a/tests/Java.Interop.Export-Tests/java/com/xamarin/interop/export/ExportType.java
+++ b/tests/Java.Interop.Export-Tests/java/com/xamarin/interop/export/ExportType.java
@@ -64,7 +64,6 @@ public class ExportType
 		staticActionInt (1);
 		staticActionFloat (2.0f);
 
-		/*
 		boolean r = staticFuncThisMethodTakesLotsOfParameters (
 				false,
 				(byte) 0xb,
@@ -85,7 +84,6 @@ public class ExportType
 		);
 		if (r != true)
 			throw new Error ("staticFuncThisMethodTakesLotsOfParameters should return true!");
-		 */
 	}
 
 	public native void action ();

--- a/tools/jnimarshalmethod-gen/App.cs
+++ b/tools/jnimarshalmethod-gen/App.cs
@@ -397,13 +397,6 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 							continue;
 					}
 
-#if !_ALL_THE_ARGUMENTS
-					if (method.GetParameters ().Length > 14) {
-						Warning ($"Methods taking more than 14 parameters is not supported.");
-						continue;
-					}
-#endif	// !_ALL_THE_ARGUMENTS
-
 					if (dt == null)
 						dt = GetTypeBuilder (dm, type);
 

--- a/tools/jnimarshalmethod-gen/Xamarin.Android.Tools.JniMarshalMethodGenerator.csproj
+++ b/tools/jnimarshalmethod-gen/Xamarin.Android.Tools.JniMarshalMethodGenerator.csproj
@@ -17,10 +17,6 @@
     <DefineConstants>_DUMP_REGISTER_NATIVE_MEMBERS;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(_AllTheArguments)' == 'True' ">
-    <DefineConstants>_ALL_THE_ARGUMENTS;$(DefineConstants)</DefineConstants>
-  </PropertyGroup>
-    
   <ItemGroup>
     <PackageReference Include="Mono.Options" Version="5.3.0.1" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />


### PR DESCRIPTION
Commits 70fc4c07 and 857b9a94 introduced support for handling methods with 14 and more 
arguments. `jnimarshalmethod-gen` still needed update for handling these correctly and it is 
implemented here.

The IL improvements code was updated to know how to handle new custom delegates code from 
`System.Linq.Expression`.

The `_ALL_THE_ARGUMENTS` define was removed as it is no longer needed.

The test was updated to use the new `staticFuncThisMethodTakesLotsOfParameters` method.

Example generated code:

```
[JniAddNativeMethodRegistration]
public static void __RegisterNativeMembers (JniNativeMethodRegistrationArguments args)
{
	args.AddRegistrations (new JniNativeMethodRegistration[11] {
		new JniNativeMethodRegistration ("funcIJavaObject", "()Ljava/lang/Object;", new Func<IntPtr, IntPtr, IntPtr> (FuncIJavaObject)),
		new JniNativeMethodRegistration ("funcInt64", "()J", new Func<IntPtr, IntPtr, long> (FuncInt64)),
		new JniNativeMethodRegistration ("action", "()V", new Action<IntPtr, IntPtr> (InstanceAction)),
		new JniNativeMethodRegistration ("actionIJavaObject", "(Ljava/lang/Object;)V", new Action<IntPtr, IntPtr, IntPtr> (InstanceActionIJavaObject)),
		new JniNativeMethodRegistration ("staticAction", "()V", new Action<IntPtr, IntPtr> (StaticAction)),
		new JniNativeMethodRegistration ("staticActionFloat", "(F)V", new Action<IntPtr, IntPtr, float> (StaticActionFloat)),
		new JniNativeMethodRegistration ("staticActionIJavaObject", "(Ljava/lang/Object;)V", new Action<IntPtr, IntPtr, IntPtr> (StaticActionIJavaObject)),
		new JniNativeMethodRegistration ("staticActionInt", "(I)V", new Action<IntPtr, IntPtr, int> (StaticActionInt)),
		new JniNativeMethodRegistration ("staticActionInt32String", "(ILjava/lang/String;)V", new Action<IntPtr, IntPtr, int, IntPtr> (StaticActionInt32String)),
		new JniNativeMethodRegistration ("staticFuncMyLegacyColorMyColor_MyColor", "(II)I", new Func<IntPtr, IntPtr, int, int, int> (StaticFuncMyLegacyColorMyColor_MyColor)),
		new JniNativeMethodRegistration ("staticFuncThisMethodTakesLotsOfParameters", "(ZBCSIJFDLjava/lang/Object;Ljava/lang/String;Ljava/util/ArrayList;Ljava/lang/String;Ljava/lang/Object;DFJ)Z", new _JniMarshal_PPZBCSIJFDLLLLLDFJ_Z (StaticFuncThisMethodTakesLotsOfParameters))
	});
}
```