### PR TITLE
[Java.Interop-MonoAndroid] Remove NullableAttributes.cs to prevent duplicate conflict warnings.

### DIFF
--- a/src/Java.Interop/Java.Interop-MonoAndroid.csproj
+++ b/src/Java.Interop/Java.Interop-MonoAndroid.csproj
@@ -55,6 +55,7 @@
     <Compile Remove="obj\**\*.cs" />
     <Compile Remove="Tests\**\*.cs" />
     <Compile Remove="Java.Interop\JniLocationException.cs" />
+    <Compile Remove="NullableAttributes.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup Condition=" '$(XAInstallPrefix)' == '' ">


### PR DESCRIPTION
When building `Java.Interop-MonoAndroid.csproj` we currently get ~100 warnings of the form:
```
Java.Interop\JavaArray.cs(31,4): warning CS0436: The type 'MaybeNullAttribute' in 
'C:\A\vs2019xam00000Z-1\_work\1\s\external\Java.Interop\src\Java.Interop\NullableAttributes.cs' 
conflicts with the imported type 'MaybeNullAttribute' in 'mscorlib, Version=2.0.5.0, Culture=neutral, 
PublicKeyToken=7cec85d7bea7798e'. Using the type defined in 'C:\A\vs2019xam00000Z-1\_work
\1\s\external\Java.Interop\src\Java.Interop\NullableAttributes.cs'. [C:\A\vs2019xam00000Z-1\_work
\1\s\external\Java.Interop\src\Java.Interop\Java.Interop-MonoAndroid.csproj]
```
Exclude `Java.Interop\src\Java.Interop\NullableAttributes.cs` from our source files to eliminate the warnings.