### PR TITLE
[generator] Mark protected types nested in sealed classes as private.

### DIFF
--- a/tests/generator-Tests/Unit-Tests/SealedProtectedFixupsTests.cs
+++ b/tests/generator-Tests/Unit-Tests/SealedProtectedFixupsTests.cs
@@ -68,6 +68,21 @@ namespace generatortests
 			Assert.AreEqual ("private", field.Visibility);
 		}
 
+		[Test]
+		public void FixProtectedType ()
+		{
+			var klass = CreateSealedClass ();
+
+			var type = SupportTypeBuilder.CreateClass ("my.example.class.inner", options);
+			type.Visibility = "protected";
+
+			klass.NestedTypes.Add (type);
+
+			SealedProtectedFixups.Fixup (new [] { (GenBase) klass }.ToList ());
+
+			Assert.AreEqual ("private", type.Visibility);
+		}
+
 		private ClassGen CreateSealedClass ()
 		{
 			var klass = SupportTypeBuilder.CreateClass ("my.example.class", options);

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
@@ -867,6 +867,9 @@ namespace MonoDroid.Generation
 		bool ValidateMethod (CodeGenerationOptions opt, Method m, CodeGeneratorContext context) =>
 			m.Validate (opt, TypeParameters, context);
 
-		public string Visibility => string.IsNullOrEmpty (support.Visibility) ? "public" : support.Visibility;
+		public string Visibility {
+			get => string.IsNullOrEmpty (support.Visibility) ? "public" : support.Visibility;
+			set => support.Visibility = value;
+		}
 	}
 }

--- a/tools/generator/Java.Interop.Tools.Generator.Transformation/SealedProtectedFixups.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Transformation/SealedProtectedFixups.cs
@@ -21,6 +21,9 @@ namespace Java.Interop.Tools.Generator.Transformation
 
 				foreach (var p in c.Fields.Where (f => f.Visibility == "protected"))
 					p.Visibility = "private";
+
+				foreach (var p in c.NestedTypes.Where (t => t.Visibility == "protected"))
+					p.Visibility = "private";
 			}
 		}
 	}


### PR DESCRIPTION
In https://github.com/xamarin/java.interop/pull/569 we marked `protected` members in `sealed` classes as `private` to prevent `csc` warnings.  However we did not cover nested types which also cause this warning.
```
sealed class Foo
{
  protected interface Bar
  {
  }

  protected class Bar2
  {
  }
}
```
```
warning CS0628: 'Foo.Bar': new protected member declared in sealed class
warning CS0628: 'Foo.Bar2': new protected member declared in sealed class
```

`Mono.Android.dll` added 28 new protected interfaces in `sealed` classes `CalendarContract` and `ContactContract` which caused new warnings is our builds.
```
obj\Release\monoandroid10\android-30\mcw\Android.Provider.CalendarContract.cs(614,40): warning CS0628: 'CalendarContract.IAttendeesColumns': new protected member declared in sealed class [C:\A\vs2019xam00000Z-1\_work\1\s\src\Mono.Android\Mono.Android.csproj]
```
This PR marks nested types as `private` if the parent class is `sealed`.