### PR TITLE
[generator] Reduce BG8402 warning to verbose message.

### DIFF
--- a/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/CodeGenerator.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/CodeGenerator.cs
@@ -396,7 +396,8 @@ namespace MonoDroid.Generation
 					continue;
 				}
 				if (seen != null && seen.Contains (f.Name)) {
-					Report.Warning (0, Report.WarningDuplicateField, "Skipping {0}.{1}, due to a duplicate field. (Field) (Java type: {2})", gen.FullName, f.Name, gen.JavaName);
+					// This is not an actionable message, so it is not written as a warning.
+					Report.Verbose (0, $"BG{Report.WarningDuplicateField:X04}: Skipping {gen.FullName}.{f.Name}, due to a duplicate field. (Field) (Java type: {gen.JavaName})");
 					continue;
 				}
 				if (f.Validate (opt, gen.TypeParameters, Context)) {


### PR DESCRIPTION
The warning `BG8402: Skipping Android.Provider.ContactsContract.IContactsColumns.PhotoFileId, due to a duplicate field. (Field) (Java type: android.provider.ContactsContract.ContactsColumns)` is caused by our `InterfaceConsts` binding sugar.

Given:
```
interface IFoo 
{
  static const int MyValue = 1;
}

interface IFoo2
{
  static const int MyValue = 1;
}

class Bar : IFoo, IFoo2
{ ... }
```

we will attempt to add the inherited interface constants to a class `Bar.InterfaceConsts` for the user, however this would produce a duplicate field:

```
class Bar
{
  class InterfaceConsts
  {
    // From IFoo
    static const int MyValue = 1;

    // From IFoo2
    static const int MyValue = 1;
  }
}
```

We detect this case and prevent it by only generating the first constant we come to, and adding the warning for the rest.  The warning isn't really actionable as the only way to fix it is to remove the constant from `IFoo2`, however it is likely that the constant is still desired on the `interface`.

Instead, change the warning to a message so that a user reading detailed logs can see why the constant field was not generated, but it doesn't show as a warning implying the user should try to fix it.

(This is a pretty common pattern in `android.jar`, with `DataColumns`.)