### PR TITLE
[build] fix BuildJniEnvironment_g_cs so it builds incrementally

### DIFF
--- a/build-tools/jnienv-gen/Generator.cs
+++ b/build-tools/jnienv-gen/Generator.cs
@@ -33,7 +33,7 @@ namespace Xamarin.Java.Interop
 					string content = w.ToString ();
 					if (jnienv_g_cs == "-")
 						Console.WriteLine (content);
-					else if (!File.Exists (jnienv_g_cs) || !string.Equals (content, File.ReadAllText (jnienv_g_cs)))
+					else
 						File.WriteAllText (jnienv_g_cs, content);
 				}
 				using (TextWriter w = new StringWriter ()) {
@@ -42,7 +42,7 @@ namespace Xamarin.Java.Interop
 					string content = w.ToString ();
 					if (jnienv_g_c == "-" || jnienv_g_cs == "-")
 						Console.WriteLine (content);
-					else if (!File.Exists (jnienv_g_c) || !string.Equals (content, File.ReadAllText (jnienv_g_c)))
+					else
 						File.WriteAllText (jnienv_g_c, content);
 				}
 				return 0;


### PR DESCRIPTION
When building `xamarin-android`, I noticed this always runs when there
are no changes:

    Target Name=BuildJniEnvironment_g_cs Project=Java.Interop.csproj
    Building target "BuildJniEnvironment_g_cs" completely.
    Input file "C:\src\xamarin-android\external\Java.Interop\bin\BuildDebug\jnienv-gen.exe" is newer than output file "Java.Interop/JniEnvironment.g.cs".
    ...
    Exec Task (345ms)

Reviewing the code in `jnienv-gen.exe`, it might not actually update
either of the `Outputs` if there are no changes.

So we can either:

1. Add a `<Touch/>` call in the `BuildJniEnvironment_g_cs` MSBuild
   target.
2. Make `jnienv-gen.exe` always update the files.

I think we should just go with option 2, as it was basically doing:

    if (!File.Exists (jnienv_g_cs) || !string.Equals (content, File.ReadAllText (jnienv_g_cs)))
        File.WriteAllText (jnienv_g_cs, content);

The `string.Equals` call doesn't seem terrible efficient anyway--let's
just remove it and always write.

Now we get this on builds without changes:

    Skipping target "BuildJniEnvironment_g_cs" because all output files are up-to-date with respect to the input files.

Fixing this seems to save the ~350ms per `$(TargetFramework)` in
`Java.Interop.csproj`.