### PR TITLE
[Java.Interop, java-interop] java_interop_jvm_load error handling

### DIFF
--- a/src/java-interop/java-interop-jvm.h
+++ b/src/java-interop/java-interop-jvm.h
@@ -14,6 +14,7 @@ JAVA_INTEROP_BEGIN_DECLS
 #define JAVA_INTEROP_JVM_FAILED_SYMBOL_MISSING  (JAVA_INTEROP_JVM_FAILED-4)
 
 MONO_API    int java_interop_jvm_load (const char *path);
+MONO_API    int java_interop_jvm_load_with_error_message (const char *path, char **error);
 MONO_API    int java_interop_jvm_create (JavaVM **p_vm, void **p_env, void *vm_args);
 MONO_API    int java_interop_jvm_list (JavaVM **vmBuf, int bufLen, int *nVMs);
 


### PR DESCRIPTION
Two problems were found via manual review of `java_interop_jvm_load()`:

 1. If `path` is loaded but required symbols cannot be found, the
    loaded library is never closed, which could be a resource leak.

 2. If `path` *can't* be loaded, there's no easy way to determine
    *why* it couldn't be loaded, because **dlerror**(3) isn't called.

Fix (1) by closing the loaded library before freeing `jvm`.

Fix (2) by renaming `java_interop_jvm_load()` to
`java_interop_jvm_load_with_error_message()`, which takes an
"optional" `char**` parameter which will hold the `dlerror()` output
if the library cannot be loaded:

	const char *path = …;
	char *error;
	int status = java_interop_jvm_load_with_error_message (path, &error);
	if (status != 0) {
	  fprintf (stderr, "Could not load `%s`: %s", path, error);
	  java_interop_free (error);
	}

The value of `error` must be freed with `java_interop_free()`.