### PR TITLE
[Actions] Use GitHub actions to automatically generate release notes

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -39,6 +39,8 @@ jobs:
     - name: Commit release note changes
       working-directory: ${{ github.workspace }}/wiki
       run: |
+        git config user.email "you@example.com"
+        git config user.name "Release Notes Bot"
         git add -A
         git commit -m "Update release notes" || echo "No changes to commit"
         git push origin master || echo "No changes to commit"

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -37,7 +37,8 @@ jobs:
         --token ${{ github.token }}
          
     - name: Commit release note changes
+      working-directory: ${{ github.workspace }}/wiki
       run: |
-        git add ${{ github.workspace }}/wiki/*
+        git add -A
         git commit -m "Update release notes" || echo "No changes to commit"
         git push origin master || echo "No changes to commit"

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -3,6 +3,8 @@ name: .NET Core
 on:
   push:
     branches: [ master ]
+  pull_request:
+    branches: [ master ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -36,7 +36,7 @@ jobs:
         --repository-name Java.Interop 
         --token ${{ github.token }}
          
-    - name: Commit release note changes
+    - name: Commit release notes changes
       working-directory: ${{ github.workspace }}/wiki
       run: |
         git config user.email "you@example.com"

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,41 @@
+name: .NET Core
+
+on:
+  push:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out wiki repo
+      uses: actions/checkout@v2
+      with: 
+        repository: xamarin/java.interop.wiki
+        path: wiki
+        
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.x
+        
+    - name: Install Noted
+      run: dotnet tool install -g noted
+      
+    - name: Run Noted
+      run: >
+        noted
+        --repository-owner xamarin 
+        --repository java.interop 
+        --output-directory ${{ github.workspace }}/wiki
+        --repository-name Java.Interop 
+        --token ${{ github.token }}
+         
+    - name: Commit release note changes
+      run: |
+        git add ${{ github.workspace }}/wiki/*
+        git commit -m "Update release notes" || echo "No changes to commit"
+        git push origin master || echo "No changes to commit"

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,10 +1,11 @@
-name: .NET Core
+# This action runs every day and updates the draft release notes on the wiki
+# from comments put on PR's tagged with the `release-notes` label.
+name: Update Release Notes
 
+# Runs every day at 06:00 UTC
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+  schedule:
+    - cron: 0 6 * * *
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Creates a GitHub action that automatically generates draft release notes from merged PR's that contain the label `release-notes`.

These release notes are placed on the wiki, along with instructions on how to include a PR and how to format the release note message.

https://github.com/xamarin/java.interop/wiki/Release-Notes

This action runs every morning at 06:00 UTC.  Once this workflow is committed to `master`, it should also be available to be run manually via the Actions tab: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/.

PR scanning and release notes generation code is external to this repository, available here: https://github.com/jpobst/noted.