### PR TITLE
[generator] Add `--with-javadoc-xml=FILE` support.

### DIFF
--- a/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/IronyExtensions.cs
+++ b/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/IronyExtensions.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Irony.Ast;
+using Irony.Parsing;
+
+namespace Java.Interop.Tools.JavaSource {
+
+	static class IronyExtensions {
+
+		public static void MakePlusRule (this NonTerminal star, Grammar grammar, BnfTerm delimiter)
+		{
+			star.Rule = grammar.MakePlusRule (star, delimiter);
+		}
+
+		public static void MakeStarRule (this NonTerminal star, Grammar grammar, BnfTerm delimiter, BnfTerm of)
+		{
+			star.Rule = grammar.MakeStarRule (star, delimiter, of);
+		}
+
+		public static void MakeStarRule (this NonTerminal star, Grammar grammar, BnfTerm of)
+		{
+			star.Rule = grammar.MakeStarRule (star, of);
+		}
+	}
+}

--- a/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/JavadocInfo.cs
+++ b/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/JavadocInfo.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+using Irony.Ast;
+using Irony.Parsing;
+
+namespace Java.Interop.Tools.JavaSource {
+
+	sealed class JavadocInfo {
+		public  readonly    ICollection<XNode>  Exceptions  = new Collection<XNode> ();
+		public  readonly    ICollection<XNode>  Extra       = new Collection<XNode> ();
+		public  readonly    ICollection<XNode>  Remarks     = new Collection<XNode> ();
+		public  readonly    ICollection<XNode>  Parameters  = new Collection<XNode> ();
+		public  readonly    ICollection<XNode>  Returns     = new Collection<XNode> ();
+
+		public override string ToString ()
+		{
+			return new XElement ("Javadoc",
+					new XElement (nameof (Parameters),  Parameters),
+					new XElement (nameof (Remarks),     Remarks),
+					new XElement (nameof (Returns),     Returns),
+					new XElement (nameof (Exceptions),  Exceptions),
+					new XElement (nameof (Extra),       Extra))
+			.ToString ();
+		}
+	}
+}

--- a/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/SourceJavadocToXmldocGrammar.BlockTagsBnfTerms.cs
+++ b/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/SourceJavadocToXmldocGrammar.BlockTagsBnfTerms.cs
@@ -1,0 +1,239 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+using Irony.Ast;
+using Irony.Parsing;
+
+namespace Java.Interop.Tools.JavaSource {
+
+	public partial class SourceJavadocToXmldocGrammar {
+
+		// https://docs.oracle.com/javase/7/docs/technotes/tools/windows/javadoc.html#javadoctags
+		public class BlockTagsBnfTerms {
+
+			internal BlockTagsBnfTerms ()
+			{
+			}
+
+			internal void CreateRules (SourceJavadocToXmldocGrammar grammar)
+			{
+				AllBlockTerms.Rule = AuthorDeclaration
+					| ApiSinceDeclaration
+					| DeprecatedDeclaration
+					| DeprecatedSinceDeclaration
+					| ExceptionDeclaration
+					| ParamDeclaration
+					| ReturnDeclaration
+					| SeeDeclaration
+					| SerialDataDeclaration
+					| SerialFieldDeclaration
+					| SinceDeclaration
+					| ThrowsDeclaration
+					| UnknownTagDeclaration
+					| VersionDeclaration
+					;
+				BlockValue.Rule = grammar.HtmlTerms.ParsedCharacterData
+					| grammar.HtmlTerms.InlineDeclaration
+					;
+				BlockValues.MakePlusRule (grammar, BlockValue);
+
+				AuthorDeclaration.Rule = "@author" + BlockValues;
+				AuthorDeclaration.AstConfig.NodeCreator = (context, parseNode) => {
+					if (!grammar.ShouldImport (ImportJavadoc.AuthorTag))
+						return;
+					// Ignore; not sure how best to convert to Xmldoc
+					FinishParse (context, parseNode);
+				};
+
+				ApiSinceDeclaration.Rule = "@apiSince" + BlockValues;
+				ApiSinceDeclaration.AstConfig.NodeCreator = (context, parseNode) => {
+					if (!grammar.ShouldImport (ImportJavadoc.SinceTag)) {
+						return;
+					}
+					var p = new XElement ("para", "Added in API level ", AstNodeToXmlContent (parseNode.ChildNodes [1]), ".");
+					FinishParse (context, parseNode).Remarks.Add (p);
+					parseNode.AstNode   = p;
+				};
+
+				DeprecatedDeclaration.Rule = "@deprecated" + BlockValues;
+				DeprecatedDeclaration.AstConfig.NodeCreator = (context, parseNode) => {
+					if (!grammar.ShouldImport (ImportJavadoc.DeprecatedTag)) {
+						return;
+					}
+					var p = new XElement ("para", "This member is deprecated. ", AstNodeToXmlContent (parseNode.ChildNodes [1]));
+					FinishParse (context, parseNode).Remarks.Add (p);
+					parseNode.AstNode   = p;
+				};
+
+				DeprecatedSinceDeclaration.Rule = "@deprecatedSince" + BlockValues;
+				DeprecatedSinceDeclaration.AstConfig.NodeCreator = (context, parseNode) => {
+					if (!grammar.ShouldImport (ImportJavadoc.DeprecatedTag)) {
+						return;
+					}
+					var p = new XElement ("para", "This member was deprecated in API level ", AstNodeToXmlContent (parseNode.ChildNodes [1]), ".");
+					FinishParse (context, parseNode).Remarks.Add (p);
+					parseNode.AstNode   = p;
+				};
+
+				var nonSpaceTerm = new RegexBasedTerminal ("[^ ]", "[^ ]+") {
+					AstConfig = new AstNodeConfig {
+						NodeCreator = (context, parseNode) => parseNode.AstNode = parseNode.Token.Value,
+					},
+				};
+
+				ExceptionDeclaration.Rule = "@exception" + nonSpaceTerm + BlockValues;
+				ExceptionDeclaration.AstConfig.NodeCreator = (context, parseNode) => {
+					if (!grammar.ShouldImport (ImportJavadoc.ExceptionTag)) {
+						return;
+					}
+					// TODO: convert `nonSpaceTerm` into a proper CREF
+					var e = new XElement ("exception",
+							new XAttribute ("cref", string.Join ("", AstNodeToXmlContent (parseNode.ChildNodes [1]))),
+							AstNodeToXmlContent (parseNode.ChildNodes [2]));
+					FinishParse (context, parseNode).Exceptions.Add (e);
+					parseNode.AstNode   = e;
+				};
+
+				ParamDeclaration.Rule = "@param" + nonSpaceTerm + BlockValues;
+				ParamDeclaration.AstConfig.NodeCreator = (context, parseNode) => {
+					if (!grammar.ShouldImport (ImportJavadoc.ParamTag)) {
+						return;
+					}
+					var p = new XElement ("param",
+							new XAttribute ("name", string.Join ("", AstNodeToXmlContent (parseNode.ChildNodes [1]))),
+							AstNodeToXmlContent (parseNode.ChildNodes [2]));
+					FinishParse (context, parseNode).Parameters.Add (p);
+					parseNode.AstNode   = p;
+				};
+
+				ReturnDeclaration.Rule = "@return" + BlockValues;
+				ReturnDeclaration.AstConfig.NodeCreator = (context, parseNode) => {
+					if (!grammar.ShouldImport (ImportJavadoc.ReturnTag)) {
+						return;
+					}
+					var r = new XElement ("returns",
+							AstNodeToXmlContent (parseNode.ChildNodes [1]));
+					FinishParse (context, parseNode).Returns.Add (r);
+					parseNode.AstNode   = r;
+				};
+
+				SeeDeclaration.Rule = "@see" + BlockValues;
+				SeeDeclaration.AstConfig.NodeCreator = (context, parseNode) => {
+					if (!grammar.ShouldImport (ImportJavadoc.SeeTag)) {
+						return;
+					}
+					// TODO: @see supports multiple forms; see: https://docs.oracle.com/javase/7/docs/technotes/tools/windows/javadoc.html#see
+					var e = new XElement ("seealso",
+							new XAttribute ("cref", string.Join ("", AstNodeToXmlContent (parseNode.ChildNodes [1]))));
+					FinishParse (context, parseNode).Extra.Add (e);
+					parseNode.AstNode   = e;
+				};
+
+				SinceDeclaration.Rule = "@since" + BlockValues;
+				SinceDeclaration.AstConfig.NodeCreator = (context, parseNode) => {
+					if (!grammar.ShouldImport (ImportJavadoc.SinceTag)) {
+						return;
+					}
+					var p = new XElement ("para", "Added in ", AstNodeToXmlContent (parseNode.ChildNodes [1]), ".");
+					FinishParse (context, parseNode).Remarks.Add (p);
+					parseNode.AstNode   = p;
+				};
+
+				ThrowsDeclaration.Rule = "@throws" + nonSpaceTerm + BlockValues;
+				ThrowsDeclaration.AstConfig.NodeCreator = (context, parseNode) => {
+					if (!grammar.ShouldImport (ImportJavadoc.ExceptionTag)) {
+						return;
+					}
+					// TODO: convert `nonSpaceTerm` into a proper CREF
+					var e = new XElement ("exception",
+							new XAttribute ("cref", string.Join ("", AstNodeToXmlContent (parseNode.ChildNodes [1]))),
+							AstNodeToXmlContent (parseNode.ChildNodes [2]));
+					FinishParse (context, parseNode).Exceptions.Add (e);
+					parseNode.AstNode   = e;
+				};
+
+				// Ignore serialization informatino
+				SerialDeclaration.Rule = "@serial" + BlockValues;
+				SerialDeclaration.AstConfig.NodeCreator = (context, parseNode) => {
+					if (!grammar.ShouldImport (ImportJavadoc.SerialTag)) {
+						return;
+					}
+					FinishParse (context, parseNode);
+				};
+
+				SerialDataDeclaration.Rule = "@serialData" + BlockValues;
+				SerialDataDeclaration.AstConfig.NodeCreator = (context, parseNode) => {
+					if (!grammar.ShouldImport (ImportJavadoc.SerialTag)) {
+						return;
+					}
+					FinishParse (context, parseNode);
+				};
+
+				SerialFieldDeclaration.Rule = "@serialField" + BlockValues;
+				SerialFieldDeclaration.AstConfig.NodeCreator = (context, parseNode) => {
+					if (!grammar.ShouldImport (ImportJavadoc.SerialTag)) {
+						return;
+					}
+					FinishParse (context, parseNode);
+				};
+
+				var unknownTagTerminal = new RegexBasedTerminal ("@[unknown]", @"@\S+") {
+					Priority    = TerminalPriority.Low,
+				};
+				unknownTagTerminal.AstConfig.NodeCreator = (context, parseNode) =>
+					parseNode.AstNode = parseNode.Token.Value.ToString ();
+
+
+				UnknownTagDeclaration.Rule = unknownTagTerminal + BlockValues;
+				UnknownTagDeclaration.AstConfig.NodeCreator = (context, parseNode) => {
+					if (!grammar.ShouldImport (ImportJavadoc.Remarks)) {
+						return;
+					}
+					Console.WriteLine ($"# Unsupported @block-tag value: {parseNode.ChildNodes [0].AstNode}");
+					FinishParse (context, parseNode);
+				};
+
+				// Ignore Version
+				VersionDeclaration.Rule = "@version" + BlockValues;
+				VersionDeclaration.AstConfig.NodeCreator = (context, parseNode) => {
+					if (!grammar.ShouldImport (ImportJavadoc.VersionTag)) {
+						return;
+					}
+					FinishParse (context, parseNode);
+				};
+			}
+
+			public  readonly    NonTerminal AllBlockTerms              = new NonTerminal (nameof (AllBlockTerms), ConcatChildNodes);
+
+			public  readonly    Terminal    Cdata                      = new CharacterDataTerminal ("#CDATA", preserveLeadingWhitespace: true);
+/*
+			public  readonly    Terminal    Cdata                      = new RegexBasedTerminal (nameof (BlockValue), "[^<]*") {
+				AstConfig   = new AstNodeConfig {
+					NodeCreator = (context, parseNode) => parseNode.AstNode = parseNode.Token.Value.ToString (),
+				},
+			};
+			*/
+
+			public  readonly    NonTerminal BlockValue                 = new NonTerminal (nameof (BlockValue), ConcatChildNodes);
+			public  readonly    NonTerminal BlockValues                = new NonTerminal (nameof (BlockValues), ConcatChildNodes);
+			public  readonly    NonTerminal AuthorDeclaration          = new NonTerminal (nameof (AuthorDeclaration));
+			public  readonly    NonTerminal ApiSinceDeclaration        = new NonTerminal (nameof (ApiSinceDeclaration));
+			public  readonly    NonTerminal DeprecatedDeclaration      = new NonTerminal (nameof (DeprecatedDeclaration));
+			public  readonly    NonTerminal DeprecatedSinceDeclaration = new NonTerminal (nameof (DeprecatedSinceDeclaration));
+			public  readonly    NonTerminal ExceptionDeclaration       = new NonTerminal (nameof (ExceptionDeclaration));
+			public  readonly    NonTerminal ParamDeclaration           = new NonTerminal (nameof (ParamDeclaration));
+			public  readonly    NonTerminal ReturnDeclaration          = new NonTerminal (nameof (ReturnDeclaration));
+			public  readonly    NonTerminal SeeDeclaration             = new NonTerminal (nameof (SeeDeclaration));
+			public  readonly    NonTerminal SerialDeclaration          = new NonTerminal (nameof (SerialDeclaration));
+			public  readonly    NonTerminal SerialDataDeclaration      = new NonTerminal (nameof (SerialDataDeclaration));
+			public  readonly    NonTerminal SerialFieldDeclaration     = new NonTerminal (nameof (SerialFieldDeclaration));
+			public  readonly    NonTerminal SinceDeclaration           = new NonTerminal (nameof (SinceDeclaration));
+			public  readonly    NonTerminal ThrowsDeclaration          = new NonTerminal (nameof (ThrowsDeclaration));
+			public  readonly    NonTerminal UnknownTagDeclaration      = new NonTerminal (nameof (UnknownTagDeclaration));
+			public  readonly    NonTerminal VersionDeclaration         = new NonTerminal (nameof (VersionDeclaration));
+		}
+	}
+}

--- a/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/SourceJavadocToXmldocGrammar.HtmlBnfTerms.cs
+++ b/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/SourceJavadocToXmldocGrammar.HtmlBnfTerms.cs
@@ -1,0 +1,326 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+using Irony.Ast;
+using Irony.Parsing;
+
+namespace Java.Interop.Tools.JavaSource {
+
+	using static IronyExtensions;
+
+	public partial class SourceJavadocToXmldocGrammar {
+
+		public class HtmlBnfTerms {
+			internal HtmlBnfTerms ()
+			{
+			}
+
+			internal void CreateRules (SourceJavadocToXmldocGrammar grammar)
+			{
+				AllHtmlTerms.Rule = TopLevelInlineDeclaration
+					| PBlockDeclaration
+					| PreBlockDeclaration
+					;
+
+				var inlineDeclaration = new NonTerminal ("<html inline decl>", ConcatChildNodes) {
+					Rule = ParsedCharacterData
+						| FontStyleDeclaration
+						/*
+						| PhraseDeclaration
+						| SpecialDeclaration
+						| FormCtrlDeclaration
+						*/
+						| grammar.InlineTagsTerms.AllInlineTerms
+						| UnknownHtmlElementStart
+						,
+				};
+				var inlineDeclarations = new NonTerminal ("<html inline decl>*", ConcatChildNodes);
+				inlineDeclarations.MakePlusRule (grammar, inlineDeclaration);
+
+				InlineDeclaration.Rule = inlineDeclaration;
+				InlineDeclarations.MakeStarRule (grammar, InlineDeclaration);
+
+				TopLevelInlineDeclaration.Rule = inlineDeclarations;
+				TopLevelInlineDeclaration.AstConfig.NodeCreator = (context, parseNode) => {
+					var remarks     = FinishParse (context, parseNode).Remarks;
+					var addRemarks  = grammar.ShouldImport (ImportJavadoc.Remarks) ||
+						(grammar.ShouldImport (ImportJavadoc.Summary) && remarks.Count == 0);
+					if (!addRemarks) {
+						parseNode.AstNode   = "";
+						return;
+					}
+					foreach (var p in GetParagraphs (parseNode.ChildNodes)) {
+						remarks.Add (p);
+					}
+					parseNode.AstNode       = "";
+				};
+
+				var fontstyle_tt    = CreateHtmlToCrefElement (grammar, "tt",   "c", InlineDeclarations);
+				var fontstyle_i     = CreateHtmlToCrefElement (grammar, "i",    "i", InlineDeclarations);
+
+				var preText = new PreBlockDeclarationBodyTerminal ();
+				PreBlockDeclaration.Rule = CreateStartElement ("pre", grammar) + preText + CreateEndElement ("pre", grammar);
+				PreBlockDeclaration.AstConfig.NodeCreator = (context, parseNode) => {
+					if (!grammar.ShouldImport (ImportJavadoc.Remarks)) {
+						parseNode.AstNode   = "";
+						return;
+					}
+					var c = new XElement ("code",
+							new XAttribute ("lang", "text/java"),
+							parseNode.ChildNodes [1].Token.Value);
+					FinishParse (context, parseNode).Remarks.Add (c);
+					parseNode.AstNode   = c;
+				};
+
+				FontStyleDeclaration.Rule = fontstyle_tt | fontstyle_i;
+
+				PBlockDeclaration.Rule =
+					CreateStartElement ("p", grammar) + InlineDeclarations + CreateEndElement ("p", grammar, optional:true)
+					;
+				PBlockDeclaration.AstConfig.NodeCreator = (context, parseNode) => {
+					var remarks     = FinishParse (context, parseNode).Remarks;
+					var addRemarks  = grammar.ShouldImport (ImportJavadoc.Remarks) ||
+						(grammar.ShouldImport (ImportJavadoc.Summary) && remarks.Count == 0);
+					if (!addRemarks) {
+						parseNode.AstNode   = "";
+						return;
+					}
+					var p = new XElement ("para",
+							parseNode.ChildNodes
+							.Select (c => AstNodeToXmlContent (c)));
+					FinishParse (context, parseNode).Remarks.Add (p);
+					parseNode.AstNode   = p;
+				};
+			}
+
+			static IEnumerable<XElement> GetParagraphs (ParseTreeNodeList children)
+			{
+				var items = new List<object> ();
+				foreach (var child in children) {
+					var s = child.AstNode as string;
+					if (s == null || (!s.Contains ("\n\n") && !s.Contains ("\r\n\r\n"))) {
+						items.Add (child.AstNode);
+						continue;
+					}
+
+					const string UnixParagraph  = "\n\n";
+					const string DosParagraph   = "\r\n\r\n";
+					for (int i = 0; i < s.Length; ) {
+						int len = 0;
+						int n   = -1;
+
+						if ((n = s.IndexOf (UnixParagraph, i)) >= 0) {
+							len = UnixParagraph.Length;
+						}
+						else if ((n = s.IndexOf (DosParagraph, i)) >= 0) {
+							len = DosParagraph.Length;
+						}
+
+						if (n <= 0) {
+							items.Add (s.Substring (i));
+							break;
+						}
+
+						var c = s.Substring (i, n-i);
+						items.Add (c);
+						i = n + len;
+						yield return new XElement ("para", items.Select (v => ToXmlContent (v)));
+						items.Clear ();
+					}
+				}
+				if (items.Count > 0) {
+					yield return new XElement ("para", items.Select (v => ToXmlContent (v)));
+				}
+			}
+
+			public  readonly    NonTerminal AllHtmlTerms               = new NonTerminal (nameof (AllHtmlTerms), ConcatChildNodes);
+
+			public  readonly    NonTerminal TopLevelInlineDeclaration  = new NonTerminal (nameof (TopLevelInlineDeclaration), ConcatChildNodes);
+
+
+			// https://www.w3.org/TR/html401/struct/global.html#h-7.5.3
+//			public  readonly    Terminal    ParsedCharacterData        = new RegexBasedTerminal (nameof (ParsedCharacterData), "[^<{@}]*") {
+//			public  readonly    Terminal    ParsedCharacterData        = new WikiTextTerminal (nameof (ParsedCharacterData)) {*
+			public  readonly    Terminal    ParsedCharacterData        = new CharacterDataTerminal ("#PCDATA", preserveLeadingWhitespace:true);
+
+			// https://www.w3.org/TR/html4/sgml/dtd.html#inline
+			public  readonly    NonTerminal InlineDeclaration           = new NonTerminal (nameof (InlineDeclaration), ConcatChildNodes);
+			public  readonly    NonTerminal InlineDeclarations          = new NonTerminal (nameof (InlineDeclarations), ConcatChildNodes);
+			// https://www.w3.org/TR/html4/sgml/dtd.html#fontstyle
+			public  readonly    NonTerminal FontStyleDeclaration        = new NonTerminal (nameof (FontStyleDeclaration), ConcatChildNodes);
+			// https://www.w3.org/TR/html4/sgml/dtd.html#phrase
+			public  readonly    NonTerminal PhraseDeclaration           = new NonTerminal (nameof (PhraseDeclaration), ConcatChildNodes);
+			// https://www.w3.org/TR/html4/sgml/dtd.html#special
+			public  readonly    NonTerminal SpecialDeclaration          = new NonTerminal (nameof (SpecialDeclaration), ConcatChildNodes);
+			// https://www.w3.org/TR/html4/sgml/dtd.html#formctrl
+			public  readonly    NonTerminal FormCtrlDeclaration         = new NonTerminal (nameof (FormCtrlDeclaration), ConcatChildNodes);
+			// https://www.w3.org/TR/html4/sgml/dtd.html#block
+			public  readonly    NonTerminal BlockDeclaration            = new NonTerminal (nameof (BlockDeclaration), ConcatChildNodes);
+			public  readonly    NonTerminal PBlockDeclaration           = new NonTerminal (nameof (PBlockDeclaration), ConcatChildNodes);
+			public  readonly    NonTerminal PreBlockDeclaration         = new NonTerminal (nameof (PreBlockDeclaration), ConcatChildNodes);
+
+			public  readonly    Terminal    UnknownHtmlElementStart     = new UnknownHtmlElementStartTerminal (nameof (UnknownHtmlElementStart)) {
+				AstConfig   = new AstNodeConfig {
+					NodeCreator = (context, parseNode) => parseNode.AstNode = parseNode.Token.Value.ToString (),
+				},
+			};
+
+			static NonTerminal CreateHtmlToCrefElement (Grammar grammar, string htmlElement, string crefElement, BnfTerm body, bool optionalEnd = false)
+			{
+				var start       = CreateStartElement (htmlElement, grammar);
+				var end         = CreateEndElement (htmlElement, grammar, optionalEnd);
+				var nonTerminal = new NonTerminal ("<" + htmlElement + ">", ConcatChildNodes) {
+					Rule = start + body + end,
+					AstConfig = {
+						NodeCreator = (context, parseNode) => {
+							var n = new XElement (crefElement,
+									parseNode.ChildNodes.Select (c => c.AstNode ?? ""));
+							parseNode.AstNode = n;
+						},
+					}
+				};
+				return nonTerminal;
+			}
+
+			static NonTerminal CreateStartElement (string startElement, Grammar grammar)
+			{
+				var start   = new NonTerminal ("<" + startElement + ">", nodeCreator: (context, parseNode) => parseNode.AstNode = "") {
+					Rule    = grammar.ToTerm ("<" + startElement + ">") | "<" + startElement.ToUpperInvariant () + ">",
+				};
+				return start;
+			}
+
+			static NonTerminal CreateEndElement (string endElement, Grammar grammar, bool optional = false)
+			{
+				var end	    = new NonTerminal (endElement, nodeCreator: (context, parseNode) => parseNode.AstNode = "") {
+					Rule    = grammar.ToTerm ("</" + endElement + ">") | "</" + endElement.ToUpperInvariant () + ">",
+				};
+				if (optional) {
+					end.Rule |= grammar.Empty;
+				}
+				return end;
+			}
+		}
+	}
+
+	// Based in part on WikiTextTerminal
+	class CharacterDataTerminal : Terminal {
+
+		char[]? _stopChars;
+
+		bool    preserveLeadingWhitespace;
+
+		public CharacterDataTerminal (string name, bool preserveLeadingWhitespace)
+			: base (name)
+		{
+			base.Priority = TerminalPriority.Low;
+
+			this.preserveLeadingWhitespace  = preserveLeadingWhitespace;
+
+			this.AstConfig.NodeCreator = (context, parseNode) =>
+				parseNode.AstNode = parseNode.Token.Value.ToString ();
+		}
+
+		public override void Init (GrammarData grammarData)
+		{
+			base.Init (grammarData);
+			var stopCharSet = new Irony.CharHashSet ();
+			foreach(var term in grammarData.Terminals) {
+				var firsts = term.GetFirsts ();
+				if (firsts == null)
+					continue;
+				foreach (var first in firsts) {
+					if (string.IsNullOrEmpty (first))
+						continue;
+					stopCharSet.Add (first [0]);
+				}
+			}
+			_stopChars = stopCharSet.ToArray();
+		}
+
+		public override Token? TryMatch (ParsingContext context, ISourceStream source)
+		{
+			var stopIndex = source.Text.IndexOfAny (_stopChars, source.Location.Position);
+			if (stopIndex == source.Location.Position)
+				return null;
+			if (stopIndex < 0)
+				stopIndex = source.Text.Length;
+			source.PreviewPosition = stopIndex;
+
+			// preserve leading whitespace, if present.
+			int start = source.Location.Position;
+			if (preserveLeadingWhitespace) {
+				while (start > 0 && char.IsWhiteSpace (source.Text, start-1)) {
+					start--;
+				}
+			}
+			var content = source.Text.Substring (start, stopIndex - start);
+
+			return source.CreateToken (this.OutputTerminal, content);
+		}
+	}
+
+	class PreBlockDeclarationBodyTerminal : Terminal {
+
+		public PreBlockDeclarationBodyTerminal ()
+			: base ("<pre> body")
+		{
+			this.AstConfig.NodeCreator = (context, parseNode) =>
+				parseNode.AstNode = parseNode.Token.Value.ToString ();
+		}
+
+		public override void Init (GrammarData grammarData)
+		{
+			base.Init (grammarData);
+		}
+
+		public override Token? TryMatch (ParsingContext context, ISourceStream source)
+		{
+			int startIndex  = source.Location.Position;
+			var stopIndex   = source.Text.IndexOf ("</pre>", source.Location.Position, StringComparison.OrdinalIgnoreCase);
+			if (stopIndex < 0)
+				stopIndex   = source.Text.Length;
+			source.PreviewPosition = stopIndex;
+
+			var content = source.Text.Substring (startIndex, stopIndex - startIndex);
+
+			return source.CreateToken (this.OutputTerminal, content);
+		}
+	}
+
+	class UnknownHtmlElementStartTerminal : Terminal {
+
+		bool    addingRemarks;
+
+		public UnknownHtmlElementStartTerminal (string name)
+			: base (name)
+		{
+			base.Priority = TerminalPriority.Low-1;
+		}
+
+		public override void Init (GrammarData grammarData)
+		{
+			base.Init (grammarData);
+			var g           = grammarData.Grammar as SourceJavadocToXmldocGrammar;
+			addingRemarks   = g?.ShouldImport (ImportJavadoc.Remarks) ?? false;
+		}
+
+		public override Token? TryMatch (ParsingContext context, ISourceStream source)
+		{
+			if (source.Text [source.Location.Position] != '<')
+				return null;
+			source.PreviewPosition += 1;
+			int start = source.Location.Position;
+			int stop  = start;
+			while (source.Text [stop] != '>' && stop < source.Text.Length)
+				stop++;
+			if (addingRemarks) {
+				Console.Error.WriteLine ($"# Unsupported HTML element: {source.Text.Substring (start, stop - start)}");
+			}
+			return source.CreateToken (this.OutputTerminal, "<");
+		}
+	}
+}

--- a/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/SourceJavadocToXmldocGrammar.InlineTagsBnfTerms.cs
+++ b/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/SourceJavadocToXmldocGrammar.InlineTagsBnfTerms.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+using Irony.Ast;
+using Irony.Parsing;
+
+namespace Java.Interop.Tools.JavaSource {
+
+	public partial class SourceJavadocToXmldocGrammar {
+
+		// https://docs.oracle.com/javase/7/docs/technotes/tools/windows/javadoc.html#javadoctags
+		public class InlineTagsBnfTerms {
+
+			public InlineTagsBnfTerms ()
+			{
+			}
+
+			internal void CreateRules (SourceJavadocToXmldocGrammar grammar)
+			{
+				AllInlineTerms.Rule = CodeDeclaration
+					| DocRootDeclaration
+					| InheritDocDeclaration
+					| LinkDeclaration
+					| LinkplainDeclaration
+					| LiteralDeclaration
+					| ValueDeclaration
+					;
+
+				CodeDeclaration.Rule = grammar.ToTerm ("{@code") + InlineValue + "}";
+				CodeDeclaration.AstConfig.NodeCreator = (context, parseNode) => {
+					parseNode.AstNode = new XElement ("c", parseNode.ChildNodes [1].AstNode.ToString ().Trim ());
+				};
+
+				DocRootDeclaration.Rule = grammar.ToTerm ("{@docRoot}");
+				DocRootDeclaration.AstConfig.NodeCreator = (context, parseNode) => {
+					parseNode.AstNode = new XText ("[TODO: @docRoot]");
+				};
+
+				InheritDocDeclaration.Rule = grammar.ToTerm ("{@inheritDoc}");
+				InheritDocDeclaration.AstConfig.NodeCreator = (context, parseNode) => {
+					parseNode.AstNode = new XText ("[TODO: @inheritDoc]");
+				};
+
+				LinkDeclaration.Rule = grammar.ToTerm ("{@link") + InlineValue + "}";
+				LinkDeclaration.AstConfig.NodeCreator = (context, parseNode) => {
+					// TODO: *everything*; {@link target label}, but target can contain spaces!
+					// Also need to convert to appropriate CREF value
+					var target = parseNode.ChildNodes [1].AstNode;
+					var x = new XElement ("c");
+					parseNode.AstNode = new XElement ("c", new XElement ("see", new XAttribute ("cref", target)));
+				};
+
+				LinkplainDeclaration.Rule = grammar.ToTerm ("{@linkplain") + InlineValue + "}";
+				LinkplainDeclaration.AstConfig.NodeCreator = (context, parseNode) => {
+					// TODO: *everything*; {@link target label}, but target can contain spaces!
+					// Also need to convert to appropriate CREF value
+					var target = parseNode.ChildNodes [1].AstNode;
+					parseNode.AstNode = new XElement ("see", new XAttribute ("cref", target));
+				};
+
+				LiteralDeclaration.Rule = grammar.ToTerm ("{@literal") + InlineValue + "}";
+				LiteralDeclaration.AstConfig.NodeCreator = (context, parseNode) => {
+					var content = parseNode.ChildNodes [1].AstNode.ToString ();
+					parseNode.AstNode = new XText (content);
+				};
+
+				ValueDeclaration.Rule = grammar.ToTerm ("{@value}")
+					| grammar.ToTerm ("{@value") + InlineValue + "}";
+				ValueDeclaration.AstConfig.NodeCreator = (context, parseNode) => {
+					if (parseNode.ChildNodes.Count > 1) {
+						var field = parseNode.ChildNodes [1].AstNode.ToString ();
+						parseNode.AstNode = new XText ($"[TODO: @value for `{field}`]");
+					}
+					else {
+						parseNode.AstNode = new XText ("[TODO: @value]");
+					}
+				};
+			}
+
+			public  readonly    NonTerminal AllInlineTerms              = new NonTerminal (nameof (AllInlineTerms), ConcatChildNodes);
+
+			public  readonly    Terminal    InlineValue                 = new RegexBasedTerminal (nameof (InlineValue), "[^}]*") {
+				AstConfig = new AstNodeConfig {
+					NodeCreator = (context, parseNode) => parseNode.AstNode = parseNode.Token.Value,
+				},
+			};
+
+			// https://docs.oracle.com/javase/7/docs/technotes/tools/windows/javadoc.html#code
+			public  readonly    NonTerminal CodeDeclaration             = new NonTerminal (nameof (CodeDeclaration));
+
+			// https://docs.oracle.com/javase/7/docs/technotes/tools/windows/javadoc.html#docRoot
+			public  readonly    NonTerminal DocRootDeclaration          = new NonTerminal (nameof (DocRootDeclaration));
+
+			// https://docs.oracle.com/javase/7/docs/technotes/tools/windows/javadoc.html#inheritDoc
+			public  readonly    NonTerminal InheritDocDeclaration       = new NonTerminal (nameof (InheritDocDeclaration));
+
+			// https://docs.oracle.com/javase/7/docs/technotes/tools/windows/javadoc.html#link
+			public  readonly    NonTerminal LinkDeclaration             = new NonTerminal (nameof (LinkDeclaration));
+
+			// https://docs.oracle.com/javase/7/docs/technotes/tools/windows/javadoc.html#linkplain
+			public  readonly    NonTerminal LinkplainDeclaration        = new NonTerminal (nameof (LinkplainDeclaration));
+
+			// https://docs.oracle.com/javase/7/docs/technotes/tools/windows/javadoc.html#literal
+			public  readonly    NonTerminal LiteralDeclaration         = new NonTerminal (nameof (LinkplainDeclaration));
+
+			// https://docs.oracle.com/javase/7/docs/technotes/tools/windows/javadoc.html#value
+			public  readonly    NonTerminal ValueDeclaration           = new NonTerminal (nameof (ValueDeclaration));
+		}
+	}
+}

--- a/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/SourceJavadocToXmldocGrammar.cs
+++ b/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/SourceJavadocToXmldocGrammar.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+using Irony.Ast;
+using Irony.Parsing;
+
+namespace Java.Interop.Tools.JavaSource {
+
+	[Language ("SourceJavadocToXmldoc", "0.1", "Convert Javadoc within Java source code, sans comment delimiter, to CSC /doc XML.")]
+	public partial class SourceJavadocToXmldocGrammar : Grammar {
+
+		public  readonly    BlockTagsBnfTerms   BlockTagsTerms;
+		public  readonly    InlineTagsBnfTerms  InlineTagsTerms;
+		public  readonly    HtmlBnfTerms        HtmlTerms;
+
+		public  readonly    XmldocStyle         XmldocStyle;
+
+		public SourceJavadocToXmldocGrammar (XmldocStyle style)
+		{
+			BlockTagsTerms  = new BlockTagsBnfTerms ();
+			InlineTagsTerms = new InlineTagsBnfTerms ();
+			HtmlTerms       = new HtmlBnfTerms ();
+
+			XmldocStyle     = style;
+
+			BlockTagsTerms.CreateRules (this);
+			InlineTagsTerms.CreateRules (this);
+			HtmlTerms.CreateRules (this);
+
+			var remark  = new NonTerminal ("<html>", ConcatChildNodes) {
+				Rule    = HtmlTerms.AllHtmlTerms,
+			};
+			var remarks = new NonTerminal ("<html>*", ConcatChildNodes);
+			remarks.MakeStarRule (this, remark);
+
+			var block   = new NonTerminal ("@block", ConcatChildNodes) {
+				Rule    = BlockTagsTerms.AllBlockTerms,
+			};
+			var blocks  = new NonTerminal ("@blocks", ConcatChildNodes);
+			blocks.MakeStarRule (this, block);
+
+			var root    = new NonTerminal ("<javadocs>", ConcatChildNodes) {
+				Rule    = remarks + blocks,
+			};
+
+			root.AstConfig.NodeCreator = (context, parseNode) => {
+				FinishParse (context, parseNode);
+			};
+
+			this.Root	= root;
+		}
+
+		internal bool ShouldImport (ImportJavadoc value)
+		{
+			var v = (ImportJavadoc) XmldocStyle;
+			return v.HasFlag (value);
+		}
+
+		internal static void ConcatChildNodes (AstContext context, ParseTreeNode parseNode)
+		{
+			switch (parseNode.ChildNodes.Count) {
+				case 0:
+					parseNode.AstNode = "";
+					break;
+				case 1:
+					parseNode.AstNode = parseNode.ChildNodes [0].AstNode ?? "";
+					break;
+				default: {
+					parseNode.AstNode = parseNode.ChildNodes
+						.Select (c => c.AstNode ?? "")
+						.ToArray ();
+					break;
+				}
+			}
+		}
+
+		internal static IEnumerable<object> AstNodeToXmlContent (ParseTreeNode node)
+		{
+			return ToXmlContent (node.AstNode);
+		}
+
+		// Trim leading & trailing whitespace from `value`, which could be:
+		//   * a string
+		//   * an object[]
+		//   * Anything else (XElement, etc.)
+		internal static IEnumerable<object> ToXmlContent (object? value)
+		{
+			if (value == null)
+				yield break;
+			if (value is string s) {
+				yield return s.Trim ();
+			}
+			else if (value is IEnumerable<object> nested) {
+				object? first    = null;
+				object? last     = null;
+				foreach (var n in nested) {
+					if (first != null) {
+						if (last != null)
+							yield return last;
+						last = n;
+						continue;
+					}
+					first = n;
+					if (first is string s1) {
+						yield return s1.TrimStart ();
+					}
+					else
+						yield return ToXmlContent (first);
+				}
+				if (last != null) {
+					if (last is string l)
+						yield return l.TrimEnd ();
+					else
+						yield return ToXmlContent (last);
+				}
+			}
+			else
+				yield return value;
+		}
+
+		internal static JavadocInfo FinishParse (AstContext context, ParseTreeNode parseNode)
+		{
+			const string key = ".__JavadocInfo";
+			if (!context.Values.TryGetValue (key, out var r)) {
+				context.Values.Add (key, r = new JavadocInfo ());
+			}
+			parseNode.Tag       = r;
+			return (JavadocInfo) r;
+		}
+	}
+}

--- a/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/SourceJavadocToXmldocParser.cs
+++ b/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/SourceJavadocToXmldocParser.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using System.Text;
+
+using Irony;
+using Irony.Ast;
+using Irony.Parsing;
+
+namespace Java.Interop.Tools.JavaSource {
+
+	[Flags]
+	internal enum ImportJavadoc {
+		None,
+		Summary             = 1 << 0,
+		Remarks             = 1 << 1,
+		AuthorTag           = 1 << 2,
+		DeprecatedTag       = 1 << 3,
+		ExceptionTag        = 1 << 4,
+		ParamTag            = 1 << 5,
+		ReturnTag           = 1 << 6,
+		SeeTag              = 1 << 7,
+		SerialTag           = 1 << 8,
+		SinceTag            = 1 << 9,
+		VersionTag          = 1 << 10,
+	}
+
+	[Flags]
+	public enum XmldocStyle {
+		None,
+		Full = ImportJavadoc.Summary
+			| ImportJavadoc.Remarks
+			| ImportJavadoc.AuthorTag
+			| ImportJavadoc.DeprecatedTag
+			| ImportJavadoc.ExceptionTag
+			| ImportJavadoc.ParamTag
+			| ImportJavadoc.ReturnTag
+			| ImportJavadoc.SeeTag
+			| ImportJavadoc.SerialTag
+			| ImportJavadoc.SinceTag
+			| ImportJavadoc.VersionTag
+			,
+		IntelliSense = ImportJavadoc.Summary
+			| ImportJavadoc.ExceptionTag
+			| ImportJavadoc.ParamTag
+			| ImportJavadoc.ReturnTag
+			,
+	}
+
+	public class SourceJavadocToXmldocParser : Irony.Parsing.Parser {
+
+		public SourceJavadocToXmldocParser (XmldocStyle style = XmldocStyle.Full)
+			: base (CreateGrammar (style))
+		{
+			XmldocStyle = style;
+		}
+
+		public  XmldocStyle     XmldocStyle                 { get; }
+
+		public  XElement[]?     ExtraRemarks                { get; set; }
+
+		static Grammar CreateGrammar (XmldocStyle style)
+		{
+			return new SourceJavadocToXmldocGrammar (style) {
+				LanguageFlags = LanguageFlags.Default | LanguageFlags.CreateAst,
+			};
+		}
+
+		public IEnumerable<XNode> TryParse (string javadoc, string? fileName = null, Action<ParseTree>? onError = null)
+		{
+			onError   = onError ?? DumpMessages;
+
+			ParseTree parseTree;
+			var r = TryParse (javadoc, fileName, out parseTree);
+			if (parseTree.HasErrors ()) {
+				onError (parseTree);
+			}
+			return r;
+		}
+
+		public IEnumerable<XNode> TryParse (string javadoc, string? fileName, out ParseTree parseTree)
+		{
+			parseTree   = base.Parse (javadoc, fileName);
+			if (parseTree.HasErrors ()) {
+				return Array.Empty<XNode>();
+			}
+			return CreateParseIterator (parseTree);
+		}
+
+		IEnumerable<XNode> CreateParseIterator (ParseTree parseTree)
+		{
+			if (parseTree.Root.Tag is JavadocInfo info) {
+				foreach (var n in info.Parameters)
+					yield return n;
+				var summary = CreateSummaryNode (info);
+				if (summary != null)
+					yield return summary;
+				var style   = (ImportJavadoc) XmldocStyle;
+				if (style.HasFlag (ImportJavadoc.Remarks) &&
+						(info.Remarks.Count > 0 || ExtraRemarks?.Length > 0)) {
+					yield return new XElement ("remarks", info.Remarks, ExtraRemarks);
+				}
+				foreach (var n in info.Returns) {
+					yield return n;
+				}
+				foreach (var n in info.Exceptions) {
+					yield return n;
+				}
+				foreach (var n in info.Extra) {
+					yield return n;
+				}
+				yield break;
+			}
+			var ast = parseTree.Root.AstNode;
+			if (ast is XNode node) {
+				yield return node;
+			}
+			else {
+				yield return new XCData (ast?.ToString ());
+			}
+		}
+
+		static XElement? CreateSummaryNode (JavadocInfo info)
+		{
+			var summaryNode = info.Remarks.FirstOrDefault ();
+			if (summaryNode == null)
+				return null;
+
+			if (summaryNode is XElement p) {
+				var summaryItems    = new List<object> ();
+				for (var n = p.FirstNode; n != null; n = n.NextNode) {
+					if (n is XText text) {
+						var tdot = text.Value.IndexOf ('.');
+						if (tdot < 0) {
+							summaryItems.Add (n);
+							continue;
+						}
+						summaryItems.Add (text.Value.Substring (0, tdot+1));
+						break;
+					}
+					summaryItems.Add (n);
+				}
+				return new XElement ("summary", summaryItems);
+			}
+			var content = summaryNode.ToString ();
+			if (string.IsNullOrWhiteSpace (content))
+				return null;
+
+			var dot = content.IndexOf ('.');
+			if (dot <= 0)
+				return new XElement ("summary", content);
+			return new XElement ("summary", content.Substring (0, dot+1));
+		}
+
+		static void DumpMessages (ParseTree parseTree)
+		{
+			foreach (var m in parseTree.ParserMessages) {
+				Console.Error.WriteLine ($"{m.Level} {m.Location}: {m.Message}");
+			}
+		}
+	}
+}

--- a/src/Java.Interop.Tools.JavaSource/README.md
+++ b/src/Java.Interop.Tools.JavaSource/README.md
@@ -1,0 +1,22 @@
+# Java.Interop.Tools.JavaSource
+
+Utilities for processing Java source code.
+
+## SourceJavadocToXmldocGrammar & SourceJavadocToXmldocParser
+
+`SourceJavadocToXmldocParser` parses Javadoc comments, as found in
+`java-source-utils.jar` output (commit 69e1b80a), and converts it into
+C# /doc XML via the Irony `SourceJavadocToXmldocGrammar` grammar.
+
+Multiple Javadoc+HTML language constructs are not yet supported:
+
+  * Member lookup:
+    `@see #hashCode` is currently translated into
+    `<seealso cref="#hashCode" />`; no translation is performed.
+    This should be turned into
+    `<seealso cref="M:Java.Lang.Object.GetHashCode" />`, but requires
+    additional plumbing so that `SourceJavadocToXmldocGrammar` can "know"
+    about all the possible types & members, and how to map them to C# names.
+
+  * The following HTML elements need to be (better) supported:
+    `ul`, `li`.

--- a/tests/Java.Interop.Tools.JavaSource-Tests/SourceJavadocToXmldocGrammar.BlockTagsBnfTermsTests.cs
+++ b/tests/Java.Interop.Tools.JavaSource-Tests/SourceJavadocToXmldocGrammar.BlockTagsBnfTermsTests.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Linq;
+using System.Xml.Linq;
+
+using NUnit.Framework;
+
+using Java.Interop.Tools.JavaSource;
+
+using Irony;
+using Irony.Parsing;
+
+namespace Java.Interop.Tools.JavaSource.Tests
+{
+	[TestFixture]
+	public class SourceJavadocToXmldocGrammarBlockTagsBnfTermsTests : SourceJavadocToXmldocGrammarFixture {
+
+		[Test]
+		public void ApiSinceDeclaration ()
+		{
+			var p = CreateParser (g => g.BlockTagsTerms.ApiSinceDeclaration);
+
+			var r = p.Parse ("@apiSince 3\n");
+			Assert.IsFalse (r.HasErrors (), "@apiSince: " + DumpMessages (r, p));
+			Assert.AreEqual ("<para>Added in API level 3.</para>", r.Root.AstNode.ToString ());
+		}
+
+		[Test]
+		public void DeprecatedDeclaration ()
+		{
+			var p = CreateParser (g => g.BlockTagsTerms.DeprecatedDeclaration);
+
+			var r = p.Parse ("@deprecated Insert reason here.\n");
+			Assert.IsFalse (r.HasErrors (), "@deprecated: " + DumpMessages (r, p));
+			Assert.AreEqual ("<para>This member is deprecated. Insert reason here.</para>", r.Root.AstNode.ToString ());
+		}
+
+		[Test]
+		public void DeprecatedSinceDeclaration ()
+		{
+			var p = CreateParser (g => g.BlockTagsTerms.DeprecatedSinceDeclaration);
+
+			var r = p.Parse ("@deprecatedSince 3\n");
+			Assert.IsFalse (r.HasErrors (), "@deprecatedSince: " + DumpMessages (r, p));
+			Assert.AreEqual ("<para>This member was deprecated in API level 3.</para>", r.Root.AstNode.ToString ());
+		}
+
+		[Test]
+		public void ExceptionDeclaration ()
+		{
+			var p = CreateParser (g => g.BlockTagsTerms.ExceptionDeclaration);
+
+			var r = p.Parse ("@exception Throwable Just Because.\n");
+			Assert.IsFalse (r.HasErrors (), "@exception: " + DumpMessages (r, p));
+			Assert.AreEqual ("<exception cref=\"Throwable\">Just Because.</exception>", r.Root.AstNode.ToString ());
+		}
+
+		[Test]
+		public void ParamDeclaration ()
+		{
+			var p = CreateParser (g => g.BlockTagsTerms.ParamDeclaration);
+
+			var r = p.Parse ("@param a Insert description here\n");
+			Assert.IsFalse (r.HasErrors (), "@param: " + DumpMessages (r, p));
+			Assert.AreEqual ("<param name=\"a\">Insert description here</param>", r.Root.AstNode.ToString ());
+		}
+
+		[Test]
+		public void ReturnDeclaration ()
+		{
+			var p = CreateParser (g => g.BlockTagsTerms.ReturnDeclaration);
+
+			var r = p.Parse ("@return insert description here");
+			Assert.IsFalse (r.HasErrors (), "single-line @return: " + DumpMessages (r, p));
+			Assert.AreEqual ("<returns>insert description here</returns>", r.Root.AstNode.ToString ());
+
+			r = p.Parse ("@return line 1\n\tline two");
+			Assert.IsFalse (r.HasErrors (), "multi-line @return: " + DumpMessages (r, p));
+			Assert.AreEqual ("<returns>line 1\n\tline two</returns>".Replace ("\n", Environment.NewLine),
+					r.Root.AstNode.ToString ());
+		}
+
+		[Test]
+		public void ReturnDeclaration_WithInlineTags ()
+		{
+			var p = CreateParser (g => g.BlockTagsTerms.ReturnDeclaration);
+
+			var r = p.Parse ("@return {@code text} here.");
+			Assert.IsFalse (r.HasErrors (), DumpMessages (r, p));
+			Assert.AreEqual ("<returns>\n  <c>text</c> here.</returns>".Replace ("\n", Environment.NewLine),
+					r.Root.AstNode.ToString ());
+		}
+
+		[Test]
+		public void SeeDeclaration ()
+		{
+			var p = CreateParser (g => g.BlockTagsTerms.SeeDeclaration);
+
+			var r = p.Parse ("@see \"Insert Book Name Here\"");
+			Assert.IsFalse (r.HasErrors (), "@see: " + DumpMessages (r, p));
+			Assert.AreEqual ("<seealso cref=\"&quot;Insert Book Name Here&quot;\" />", r.Root.AstNode.ToString ());
+		}
+
+		[Test]
+		public void SinceDeclaration ()
+		{
+			var p = CreateParser (g => g.BlockTagsTerms.SinceDeclaration);
+
+			var r = p.Parse ("@since Insert Version Here");
+			Assert.IsFalse (r.HasErrors (), "@since: " + DumpMessages (r, p));
+			Assert.AreEqual ("<para>Added in Insert Version Here.</para>", r.Root.AstNode.ToString ());
+		}
+
+		[Test]
+		public void ThrowsDeclaration ()
+		{
+			var p = CreateParser (g => g.BlockTagsTerms.ThrowsDeclaration);
+
+			var r = p.Parse ("@throws Throwable the {@code Exception} raised by this method");
+			Assert.IsFalse (r.HasErrors (), "@throws: " + DumpMessages (r, p));
+			Assert.AreEqual ("<exception cref=\"Throwable\">the <c>Exception</c> raised by this method</exception>", r.Root.AstNode.ToString ());
+
+			r = p.Parse ("@throws Throwable something <i>or other</i>!");
+			Assert.IsFalse (r.HasErrors (), "@throws: " + DumpMessages (r, p));
+			Assert.AreEqual ("<exception cref=\"Throwable\">something <i>or other</i>!</exception>", r.Root.AstNode.ToString ());
+		}
+
+		[Test]
+		public void UnknownTagDeclaration ()
+		{
+			var p = CreateParser (g => g.BlockTagsTerms.UnknownTagDeclaration);
+
+			var r = p.Parse ("@this-is-not-supported something {@code foo} else.");
+			Assert.IsFalse (r.HasErrors (), "@this-is-not-supported: " + DumpMessages (r, p));
+			Assert.AreEqual (null, r.Root.AstNode);
+		}
+	}
+}

--- a/tests/Java.Interop.Tools.JavaSource-Tests/SourceJavadocToXmldocGrammar.HtmlBnfTermsTests.cs
+++ b/tests/Java.Interop.Tools.JavaSource-Tests/SourceJavadocToXmldocGrammar.HtmlBnfTermsTests.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using System.Text;
+
+using NUnit.Framework;
+
+using Java.Interop.Tools.JavaSource;
+
+using Irony;
+using Irony.Parsing;
+
+namespace Java.Interop.Tools.JavaSource.Tests
+{
+	[TestFixture]
+	public class SourceJavadocToXmldocGrammarHtmlBnfTermsTests : SourceJavadocToXmldocGrammarFixture {
+
+		[Test]
+		public void PBlockDeclaration ()
+		{
+			var p = CreateParser (g => g.HtmlTerms.PBlockDeclaration);
+
+			var r = p.Parse ("<p>paragraph text\nand more!");
+			Assert.IsFalse (r.HasErrors (), DumpMessages (r, p));
+			Assert.AreEqual ("<para>paragraph text\nand more!</para>".Replace ("\n", Environment.NewLine),
+					r.Root.AstNode.ToString ());
+
+			r = p.Parse ("<p>r= {@code Object} and following {@literal A<B>C}   text</p>");
+			Assert.IsFalse (r.HasErrors (), DumpMessages (r, p));
+			Assert.AreEqual ("<para>r= <c>Object</c> and following A&lt;B&gt;C   text</para>", r.Root.AstNode.ToString ());
+
+			r = p.Parse("<p>r= <em>unknown</em> text");
+			Assert.IsFalse (r.HasErrors (), DumpMessages (r, p));
+			Assert.AreEqual ("<para>r= &lt;em&gt;unknown&lt;/em&gt; text</para>", r.Root.AstNode.ToString ());
+		}
+
+		[Test]
+		public void PreBlockDeclaration ()
+		{
+			var p = CreateParser (g => g.HtmlTerms.PreBlockDeclaration);
+
+			var r = p.Parse ("<pre>this @contains <arbitrary/> text.</pre>");
+			Assert.IsFalse (r.HasErrors (), DumpMessages (r, p));
+			Assert.AreEqual ("<code lang=\"text/java\">this @contains &lt;arbitrary/&gt; text.</code>",
+					r.Root.AstNode.ToString ());
+
+		}
+	}
+}

--- a/tests/Java.Interop.Tools.JavaSource-Tests/SourceJavadocToXmldocGrammar.InlineTagsBnfTermsTests.cs
+++ b/tests/Java.Interop.Tools.JavaSource-Tests/SourceJavadocToXmldocGrammar.InlineTagsBnfTermsTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Linq;
+using System.Xml.Linq;
+
+using NUnit.Framework;
+
+using Java.Interop.Tools.JavaSource;
+
+using Irony;
+using Irony.Parsing;
+
+namespace Java.Interop.Tools.JavaSource.Tests
+{
+	[TestFixture]
+	public class SourceJavadocToXmldocGrammarInlineTagsBnfTermsTests : SourceJavadocToXmldocGrammarFixture {
+
+		[Test]
+		public void CodeDeclaration ()
+		{
+			var p = CreateParser (g => g.InlineTagsTerms.CodeDeclaration);
+
+			var r = p.Parse ("{@code Object}");
+			Assert.IsFalse (r.HasErrors (), DumpMessages (r, p));
+			Assert.AreEqual ("<c>Object</c>", r.Root.AstNode.ToString ());
+		}
+
+		[Test]
+		public void DocRootDeclaration ()
+		{
+			var p = CreateParser (g => g.InlineTagsTerms.DocRootDeclaration);
+
+			var r = p.Parse ("{@docRoot}");
+			Assert.IsFalse (r.HasErrors (), DumpMessages (r, p));
+			Assert.AreEqual ("[TODO: @docRoot]", r.Root.AstNode.ToString ());
+		}
+
+		[Test]
+		public void InheritDocDeclaration ()
+		{
+			var p = CreateParser (g => g.InlineTagsTerms.InheritDocDeclaration);
+
+			var r = p.Parse ("{@inheritDoc}");
+			Assert.IsFalse (r.HasErrors (), DumpMessages (r, p));
+			Assert.AreEqual ("[TODO: @inheritDoc]", r.Root.AstNode.ToString ());
+		}
+
+		[Test]
+		public void LinkDeclaration ()
+		{
+			var p = CreateParser (g => g.InlineTagsTerms.LinkDeclaration);
+
+			var r = p.Parse ("{@link #ctor}");
+			Assert.IsFalse (r.HasErrors (), DumpMessages (r, p));
+			var c = (XElement) r.Root.AstNode;
+			Assert.AreEqual ("<c><see cref=\"#ctor\" /></c>", c.ToString (SaveOptions.DisableFormatting));
+		}
+
+		[Test]
+		public void LinkplainDeclaration ()
+		{
+			var p = CreateParser (g => g.InlineTagsTerms.LinkplainDeclaration);
+
+			var r = p.Parse ("{@linkplain #ctor}");
+			Assert.IsFalse (r.HasErrors (), DumpMessages (r, p));
+			Assert.AreEqual ("<see cref=\"#ctor\" />", r.Root.AstNode.ToString ());
+		}
+
+		[Test]
+		public void LiteralDeclaration ()
+		{
+			var p = CreateParser (g => g.InlineTagsTerms.LiteralDeclaration);
+
+			var r = p.Parse ("{@literal A<B>C}");
+			Assert.IsFalse (r.HasErrors (), DumpMessages (r, p));
+			Assert.AreEqual ("A&lt;B&gt;C", r.Root.AstNode.ToString ());
+		}
+
+		[Test]
+		public void ValueDeclaration ()
+		{
+			var p = CreateParser (g => g.InlineTagsTerms.ValueDeclaration);
+
+			var r = p.Parse ("{@value}");
+			Assert.IsFalse (r.HasErrors (), DumpMessages (r, p));
+			Assert.AreEqual ("[TODO: @value]", r.Root.AstNode.ToString ());
+
+			r = p.Parse ("{@value #field}");
+			Assert.IsFalse (r.HasErrors (), DumpMessages (r, p));
+			Assert.AreEqual ("[TODO: @value for `#field`]", r.Root.AstNode.ToString ());
+		}
+	}
+}

--- a/tests/Java.Interop.Tools.JavaSource-Tests/SourceJavadocToXmldocGrammarFixture.cs
+++ b/tests/Java.Interop.Tools.JavaSource-Tests/SourceJavadocToXmldocGrammarFixture.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using System.Text;
+
+using NUnit.Framework;
+
+using Java.Interop.Tools.JavaSource;
+
+using Irony;
+using Irony.Parsing;
+
+namespace Java.Interop.Tools.JavaSource.Tests
+{
+	[TestFixture]
+	public class SourceJavadocToXmldocGrammarFixture {
+
+		public static Parser CreateParser (Func<SourceJavadocToXmldocGrammar, NonTerminal> root)
+		{
+			var g = new SourceJavadocToXmldocGrammar (XmldocStyle.Full) {
+				LanguageFlags = LanguageFlags.Default | LanguageFlags.CreateAst,
+			};
+			g.Root = root (g);
+			return new Parser (g) {
+				Context = {
+					TracingEnabled = true,
+				}
+			};
+		}
+
+		public static string DumpMessages (ParseTree tree, Parser parser)
+		{
+			var lines   = GetLines (tree.SourceText);
+			var message = new StringBuilder ();
+			message.AppendLine ("ParserMessages:");
+			foreach (var m in tree.ParserMessages) {
+				message.AppendLine ($"  {m.Level} {m.Location}: {m.Message}");
+				message.AppendLine (lines [m.Location.Line]);
+				message.Append ("  ");
+				message.Append (new string (' ', m.Location.Column));
+				message.Append ("^");
+				message.AppendLine ();
+			}
+			message.AppendLine ("ParserTrace:");
+			foreach (var t in parser.Context.ParserTrace) {
+				message.AppendLine ($"  input=`{t.Input}`; error? {t.IsError}; message={t.Message}");
+			}
+			return message.ToString ();
+		}
+
+		static List<string> GetLines (string text)
+		{
+			var lines = new List<string>();
+			var reader = new StringReader (text);
+			string line;
+			while ((line = reader.ReadLine()) != null) {
+				lines.Add (line);
+			}
+			return lines;
+		}
+	}
+}

--- a/tools/generator/CodeGenerator.cs
+++ b/tools/generator/CodeGenerator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml;
+using System.Xml.Linq;
 using Mono.Cecil;
 using MonoDroid.Generation;
 using Xamarin.AndroidTools.AnnotationSupport;
@@ -179,6 +180,7 @@ namespace Xamarin.Android.Binder
 			SealedProtectedFixups.Fixup (gens);
 
 			GenerateAnnotationAttributes (gens, annotations_zips);
+			JavadocFixups.Fixup (gens, options);
 
 			//SymbolTable.Dump ();
 

--- a/tools/generator/CodeGeneratorOptions.cs
+++ b/tools/generator/CodeGeneratorOptions.cs
@@ -2,6 +2,9 @@ using System;
 using System.Collections.ObjectModel;
 using Mono.Cecil;
 using Mono.Options;
+
+using Java.Interop.Tools.JavaSource;
+
 using MonoDroid.Generation;
 
 namespace Xamarin.Android.Binder
@@ -15,6 +18,7 @@ namespace Xamarin.Android.Binder
 			FixupFiles          = new Collection<string> ();
 			LibraryPaths        = new Collection<string> ();
 			AnnotationsZipFiles = new Collection<string> ();
+			JavadocXmlFiles     = new Collection<string> ();
 		}
 
 		public string               ApiLevel {get; set;}
@@ -24,6 +28,7 @@ namespace Xamarin.Android.Binder
 		public Collection<string>   AssemblyReferences {get; private set;}
 		public Collection<string>   FixupFiles {get; private set;}
 		public Collection<string>   LibraryPaths {get; private set;}
+		public Collection<string>   JavadocXmlFiles {get; private set;}
 		public bool                 GlobalTypeNames {get; set;}
 		public bool                 OnlyBindPublicTypes {get; set;}
 		public string               ApiDescriptionFile {get; set;}
@@ -46,6 +51,8 @@ namespace Xamarin.Android.Binder
 		public bool		    SupportDefaultInterfaceMethods { get; set; }
 		public bool		    SupportNestedInterfaceTypes { get; set; }
 		public bool		    SupportNullableReferenceTypes { get; set; }
+
+		public XmldocStyle		    XmldocStyle { get; set; } = XmldocStyle.IntelliSense;
 
 		public static CodeGeneratorOptions Parse (string[] args)
 		{
@@ -125,6 +132,18 @@ namespace Xamarin.Android.Binder
 					"Show this message and exit.",
 					v => show_help = v != null },
 				"",
+				"Javadoc to C# Documentation Comments Support:",
+				{ "doc-comment-verbosity=",
+					"{STYLE} of C# documentation comments to emit.\n" +
+					"Defaults to `full`.  {STYLE} may be:\n" +
+					"  * `intellisense`: emit <summary>, <param>,\n" +
+					"    <returns>, <exception>.\n" +
+					"  * `full`: plus <remarks>, <seealso>, ...",
+					v => opts.XmldocStyle = ParseXmldocStyle (v) },
+				{ "with-javadoc-xml=",
+					"{PATH} to `api.xml` containing Javadoc docs in\n`<javadoc/>` elements",
+					v => opts.JavadocXmlFiles.Add (v) },
+				"",
 				"C# Enumeration Support:",
 				{ "enumdir=",
 					"{DIRECTORY} to write enumeration declarations.",
@@ -189,5 +208,11 @@ namespace Xamarin.Android.Binder
 			}
 			throw new NotSupportedException ($"Don't know how to convert '{value}' to a CodeGenerationTarget value!");
 		}
+
+		static XmldocStyle ParseXmldocStyle (string style) => style?.ToLowerInvariant () switch {
+			"intellisense" => XmldocStyle.IntelliSense,
+			"full" => XmldocStyle.Full,
+			_ => XmldocStyle.Full,
+		};
 	}
 }

--- a/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
@@ -113,6 +113,7 @@ namespace MonoDroid.Generation
 				IsFinal = elem.XGetAttribute ("final") == "true",
 				IsStatic = elem.XGetAttribute ("static") == "true",
 				JavaName = elem.XGetAttribute ("name"),
+				JniSignature = elem.XGetAttribute ("jni-signature"),
 				NotNull = elem.XGetAttribute ("not-null") == "true",
 				SetterParameter = CreateParameter (elem, options),
 				TypeName = elem.XGetAttribute ("type"),

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Field.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Field.cs
@@ -24,6 +24,9 @@ namespace MonoDroid.Generation
 		public string TypeName { get; set; }
 		public string Value { get; set; }
 		public string Visibility { get; set; }
+		public string JniSignature { get; set; }
+
+		public JavadocInfo JavadocInfo { get; set; }
 
 		public int LineNumber { get; set; } = -1;
 		public int LinePosition { get; set; } = -1;

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
@@ -39,6 +39,8 @@ namespace MonoDroid.Generation
 
 		public string ReturnCast => string.Empty;
 
+		public JavadocInfo JavadocInfo { get; set; }
+
 		// This means Ctors/Methods/Properties/Fields has not been populated yet.
 		// If this type is retrieved from the SymbolTable, it will call PopulateAction
 		// to fill in members before returning it to the user.

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Javadoc.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Javadoc.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Xml.Linq;
+
+using Irony.Parsing;
+
+using Java.Interop.Tools.JavaSource;
+
+namespace MonoDroid.Generation
+{
+	public static class Javadoc {
+
+		public static void AddJavadocs (ICollection<string> comments, string javadoc)
+		{
+			if (string.IsNullOrWhiteSpace (javadoc))
+				return;
+
+			javadoc         = javadoc.Trim ();
+
+			ParseTree tree  = null;
+
+			try {
+				var parser  = new SourceJavadocToXmldocParser ();
+				var nodes   = parser.TryParse (javadoc, fileName: null, out tree);
+				foreach (var node in (nodes ?? new XNode [0])) {
+					AddNode (comments, node);
+				}
+			}
+			catch (Exception e) {
+				Console.Error.WriteLine ($"## Exception translating remarks: {e.ToString ()}");
+			}
+
+			if (tree != null && tree.HasErrors ()) {
+				Console.Error.WriteLine ($"## Unable to translate remarks:");
+				Console.Error.WriteLine ("```");
+				Console.Error.WriteLine (javadoc);
+				Console.Error.WriteLine ("```");
+				PrintMessages (tree, Console.Error);
+				Console.Error.WriteLine ();
+			}
+		}
+
+		static void AddNode (ICollection<string> comments, XNode node)
+		{
+			if (node == null)
+				return;
+			var contents = node.ToString ();
+
+			var lines = new StringReader (contents);
+			string line;
+			while ((line = lines.ReadLine ()) != null) {
+				comments.Add ($"/// {line}");
+			}
+		}
+
+		static void PrintMessages (ParseTree tree, TextWriter writer)
+		{
+			var lines   = GetLines (tree.SourceText);
+			foreach (var m in tree.ParserMessages) {
+				writer.WriteLine ($"{m.Level} {m.Location}: {m.Message}");
+				writer.WriteLine (lines [m.Location.Line]);
+				writer.Write (new string (' ', m.Location.Column));
+				writer.WriteLine ("^");
+			}
+		}
+
+		static List<string> GetLines (string text)
+		{
+			var lines = new List<string>();
+			var reader = new StringReader (text);
+			string line;
+			while ((line = reader.ReadLine()) != null) {
+				lines.Add (line);
+			}
+			return lines;
+		}
+	}
+}

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/JavadocInfo.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/JavadocInfo.cs
@@ -1,0 +1,344 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+
+using Irony.Parsing;
+
+using Java.Interop.Tools.JavaSource;
+
+namespace MonoDroid.Generation
+{
+	enum ApiLinkStyle {
+		None,
+		DeveloperAndroidComReference_2020Nov,
+	}
+
+	public sealed class JavadocInfo {
+
+		public  string          Javadoc             { get; set; }
+
+		public  XElement[]      ExtraRemarks        { get; set; }
+
+		public  XmldocStyle     XmldocStyle         { get; set; }
+
+		string  MemberDescription;
+
+		public static JavadocInfo CreateInfo (XElement element, XmldocStyle style)
+		{
+			if (element == null) {
+				return null;
+			}
+
+			string javadoc                  = element.Element ("javadoc")?.Value;
+
+			var desc                        = GetMemberDescription (element);
+			string declaringJniType         = desc.DeclaringJniType;
+			string declaringMemberName      = desc.DeclaringMemberName;
+			var declaringMemberJniSignature = desc.DeclaringMemberJniSignature;
+
+			XElement[]  extra               = GetExtra (element, style, declaringJniType, declaringMemberName, declaringMemberJniSignature);
+
+			if (string.IsNullOrEmpty (javadoc) && extra == null)
+				return null;
+
+			var info = new JavadocInfo () {
+				ExtraRemarks        = extra,
+				Javadoc             = javadoc,
+				MemberDescription   = declaringMemberName == null
+					? declaringJniType
+					: $"{declaringJniType}.{declaringMemberName}.{declaringMemberJniSignature}",
+				XmldocStyle         = style,
+			};
+			return info;
+		}
+
+		static (string DeclaringJniType, string DeclaringMemberName, string DeclaringMemberJniSignature) GetMemberDescription (XElement element)
+		{
+			bool isType     = element.Name.LocalName == "class" ||
+				element.Name.LocalName == "interface";
+
+			string declaringJniType             = isType
+				? (string) element.Attribute ("jni-signature")
+				: (string) element.Parent.Attribute ("jni-signature");
+			if (declaringJniType.StartsWith ("L", StringComparison.Ordinal) &&
+					declaringJniType.EndsWith (";", StringComparison.Ordinal)) {
+				declaringJniType = declaringJniType.Substring (1, declaringJniType.Length-2);
+			}
+
+			string declaringMemberName          = isType
+				? null
+				: (string) element.Attribute ("name") ?? declaringJniType.Substring (declaringJniType.LastIndexOf ('/')+1);
+			string declaringMemberJniSignature  = isType
+				? null
+				: (string) element.Attribute ("jni-signature");
+
+			return (declaringJniType, declaringMemberName, declaringMemberJniSignature);
+		}
+
+		static XElement[] GetExtra (XElement element, XmldocStyle style, string declaringJniType, string declaringMemberName, string declaringMemberJniSignature)
+		{
+			if (!style.HasFlag (XmldocStyle.Full))
+				return null;
+
+			XElement javadocMetadata    = null;
+			while (element != null) {
+				javadocMetadata = element.Element ("javadoc-metadata");
+				if (javadocMetadata != null) {
+					break;
+				}
+				element         = element.Parent;
+			}
+
+			List<XElement>  extra   = null;
+			if (javadocMetadata != null) {
+				var link            = javadocMetadata.Element ("link");
+				var urlPrefix       = (string) link.Attribute ("prefix");
+				var linkStyle       = (string) link.Attribute ("style");
+				var kind            = ParseApiLinkStyle (linkStyle);
+
+				XElement docLink	= null;
+				if (!string.IsNullOrEmpty (urlPrefix)) {
+					docLink         = CreateDocLinkUrl (kind, urlPrefix, declaringJniType, declaringMemberName, declaringMemberJniSignature);
+				}
+				extra           = new List<XElement> ();
+				extra.Add (docLink);
+				extra.AddRange (javadocMetadata.Element ("copyright").Elements ());
+			}
+			return extra?.ToArray ();
+		}
+
+		static ApiLinkStyle ParseApiLinkStyle (string style)
+		{
+			switch (style) {
+				case "developer.android.com/reference@2020-Nov":
+					return ApiLinkStyle.DeveloperAndroidComReference_2020Nov;
+				default:
+					return ApiLinkStyle.None;
+			}
+		}
+
+
+		public void AddJavadocs (ICollection<string> comments)
+		{
+			var nodes = ParseJavadoc ();
+			AddComments (comments, nodes);
+		}
+
+		public IEnumerable<XNode> ParseJavadoc ()
+		{
+			if (string.IsNullOrWhiteSpace (Javadoc))
+				return Enumerable.Empty<XNode> ();
+
+			Javadoc         = Javadoc.Trim ();
+
+			ParseTree           tree    = null;
+			IEnumerable<XNode>  nodes   = null;
+
+			try {
+				var parser  = new SourceJavadocToXmldocParser (XmldocStyle) {
+					ExtraRemarks    = ExtraRemarks,
+				};
+				nodes       = parser.TryParse (Javadoc, fileName: null, out tree);
+			}
+			catch (Exception e) {
+				Console.Error.WriteLine ($"## Exception translating remarks: {e.ToString ()}");
+			}
+
+			if (tree != null && tree.HasErrors ()) {
+				Console.Error.WriteLine ($"## Unable to translate remarks for {MemberDescription}:");
+				Console.Error.WriteLine ("```");
+				Console.Error.WriteLine (Javadoc);
+				Console.Error.WriteLine ("```");
+				PrintMessages (tree, Console.Error);
+				Console.Error.WriteLine ();
+			}
+
+			return nodes;
+		}
+
+		public static void AddComments (ICollection<string> comments, IEnumerable<XNode> nodes)
+		{
+			if (nodes == null)
+				return;
+
+			foreach (var node in nodes) {
+				AddNode (comments, node);
+			}
+		}
+
+		static void AddNode (ICollection<string> comments, XNode node)
+		{
+			if (node == null)
+				return;
+			var contents = node.ToString ();
+
+			var lines = new StringReader (contents);
+			string line;
+			while ((line = lines.ReadLine ()) != null) {
+				comments.Add ($"/// {line}");
+			}
+		}
+
+		static void PrintMessages (ParseTree tree, TextWriter writer)
+		{
+			var lines   = GetLines (tree.SourceText);
+			foreach (var m in tree.ParserMessages) {
+				writer.WriteLine ($"{m.Level} {m.Location}: {m.Message}");
+				writer.WriteLine (lines [m.Location.Line]);
+				writer.Write (new string (' ', m.Location.Column));
+				writer.WriteLine ("^");
+			}
+		}
+
+		static List<string> GetLines (string text)
+		{
+			var lines = new List<string>();
+			var reader = new StringReader (text);
+			string line;
+			while ((line = reader.ReadLine()) != null) {
+				lines.Add (line);
+			}
+			return lines;
+		}
+
+		static Dictionary<ApiLinkStyle, Func<string, string, string, string, XElement>> UrlCreators = new Dictionary<ApiLinkStyle, Func<string, string, string, string, XElement>> {
+			[ApiLinkStyle.DeveloperAndroidComReference_2020Nov] = CreateAndroidDocLinkUri,
+		};
+
+		static XElement CreateDocLinkUrl (ApiLinkStyle style, string prefix, string declaringJniType, string declaringMemberName, string declaringMemberJniSignature)
+		{
+			;
+			if (style == ApiLinkStyle.None || prefix == null || declaringJniType == null)
+				return null;
+			if (UrlCreators.TryGetValue (style, out var creator)) {
+				return creator (prefix, declaringJniType, declaringMemberName, declaringMemberJniSignature);
+			}
+			return null;
+		}
+
+		static XElement CreateAndroidDocLinkUri (string prefix, string declaringJniType, string declaringMemberName, string declaringMemberJniSignature)
+		{
+			// URL is:
+			//  * {prefix}
+			//  * declaring type in JNI format
+			//  * when `declaringJniMemberName` != null, `#{declaringJniMemberName}`
+			//  * for methods & constructors, a `(`, the arguments in *Java* syntax -- separated by `, ` -- and `)`
+			//
+			// Example: https://developer.android.com/reference/android/app/Application#registerOnProvideAssistDataListener(android.app.Application.OnProvideAssistDataListener)
+
+			var java    = new StringBuilder (declaringJniType)
+				.Replace ("/", ".")
+				.Replace ("$", ".");
+			var url     = new StringBuilder (prefix);
+			if (!prefix.EndsWith ("/")) {
+				url.Append ("/");
+			}
+			url.Append (declaringJniType);
+
+			if (declaringMemberName != null) {
+				java.Append (".").Append (declaringMemberName);
+				url.Append ("#").Append (declaringMemberName);
+				if (declaringMemberJniSignature?.StartsWith ("(", StringComparison.Ordinal) ?? false) {
+					java.Append ("(");
+					url.Append ("(");
+					AppendJavaParameterTypes (java, declaringMemberJniSignature);
+					AppendJavaParameterTypes (url, declaringMemberJniSignature);
+					java.Append (")");
+					url.Append (")");
+				}
+			}
+			var format  = new XElement ("format",
+					new XAttribute ("type", "text/html"),
+					new XElement ("a",
+						new XAttribute ("href", new Uri (url.ToString ()).AbsoluteUri),
+						"Java documentation for ",
+						new XElement ("tt", java.ToString ()),
+						"."));
+			return new XElement ("para", format);
+		}
+
+		static StringBuilder AppendJavaParameterTypes (StringBuilder builder, string declaringMemberJniSignature)
+		{
+			if (string.IsNullOrEmpty (declaringMemberJniSignature) || declaringMemberJniSignature [0] != '(')
+				return builder;
+
+			int startLen = builder.Length;
+
+			for (int i = 1; i < declaringMemberJniSignature.Length; ++i) {
+				if (declaringMemberJniSignature [i] == ')')
+					break;
+				AppendComma ();
+				AppendJavaParameterType (builder, declaringMemberJniSignature, ref i);
+			}
+
+			return builder;
+
+			void AppendComma ()
+			{
+				if (startLen == builder.Length)
+					return;
+				builder.Append (", ");
+			}
+		}
+
+		static void AppendJavaParameterType (StringBuilder builder, string declaringMemberJniSignature, ref int i)
+		{
+			switch (declaringMemberJniSignature [i]) {
+				case '[': {
+					++i;
+					AppendJavaParameterType (builder, declaringMemberJniSignature, ref i);
+					builder.Append ("[]");
+					break;
+				}
+				case 'B': {
+					builder.Append ("byte");
+					break;
+				}
+				case 'C': {
+					builder.Append ("char");
+					break;
+				}
+				case 'D': {
+					builder.Append ("double");
+					break;
+				}
+				case 'F': {
+					builder.Append ("float");
+					break;
+				}
+				case 'I': {
+					builder.Append ("int");
+					break;
+				}
+				case 'J': {
+					builder.Append ("long");
+					break;
+				}
+				case 'L': {
+					int end = declaringMemberJniSignature.IndexOf (';', i);
+					if (end < 0)
+						throw new InvalidOperationException ($"INTERNAL ERROR: Invalid JNI signature '{declaringMemberJniSignature}': no ';' to end 'L' at index {i}!");
+					var type    = declaringMemberJniSignature.Substring (i+1, end - i - 1)
+						.Replace ('/', '.')
+						.Replace ('$', '.');
+					builder.Append (type);
+					i           = end;
+					break;
+				}
+				case 'S': {
+					builder.Append ("short");
+					break;
+				}
+				case 'Z': {
+					builder.Append ("boolean");
+					break;
+				}
+				default:
+					throw new NotSupportedException ($"INTERNAL ERROR: Don't know what to do with '{declaringMemberJniSignature [i]}' in '{declaringMemberJniSignature}'!");
+			}
+		}
+	}
+}

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/MethodBase.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/MethodBase.cs
@@ -28,6 +28,8 @@ namespace MonoDroid.Generation
 		public int LinePosition { get; set; } = -1;
 		public string SourceFile { get; set; }
 
+		public JavadocInfo JavadocInfo { get; set; }
+
 		public string [] AutoDetectEnumifiedOverrideParameters (AncestorDescendantCache cache)
 		{
 			if (Parameters.All (p => p.Type != "int"))

--- a/tools/generator/Java.Interop.Tools.Generator.Transformation/JavadocFixups.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Transformation/JavadocFixups.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+using Java.Interop.Tools.JavaSource;
+
+using MonoDroid.Generation;
+using MonoDroid.Utils;
+
+using Xamarin.Android.Binder;
+
+namespace Java.Interop.Tools.Generator.Transformation
+{
+	public static class JavadocFixups
+	{
+		public static void Fixup (List<GenBase> gens, CodeGeneratorOptions options)
+		{
+			if (options.JavadocXmlFiles == null || options.JavadocXmlFiles.Count == 0)
+				return;
+
+			var typeJavadocs = new Dictionary<string, XElement> ();
+
+			foreach (var path in options.JavadocXmlFiles) {
+				XDocument doc = null;
+				try {
+					doc = XDocument.Load (path);
+				}
+				catch (Exception e) {
+					Report.LogCodedWarning (0, Report.WarningInvalidXmlFile, e, path, e.Message);
+					continue;
+				}
+
+				var types = doc.Elements ("api")
+					.Elements ("package")
+					.Elements ();
+				foreach (var typeXml in types) {
+					var typeJniSig  = (string) typeXml.Attribute ("jni-signature");
+					if (string.IsNullOrEmpty (typeJniSig))
+						continue;
+					if (!typeJavadocs.TryGetValue (typeJniSig, out _))
+						typeJavadocs.Add (typeJniSig, typeXml);
+				}
+			}
+
+			foreach (var type in gens) {
+				AddJavadoc (type, typeJavadocs, options.XmldocStyle);
+			}
+		}
+
+		static void AddJavadoc (GenBase type, Dictionary<string, XElement> typeJavadocs, XmldocStyle style)
+		{
+			if (!typeJavadocs.TryGetValue (type.JniName, out XElement typeJavadoc))
+				return;
+			if (typeJavadoc == null)
+				return;
+
+			if (type.JavadocInfo == null) {
+				type.JavadocInfo    = JavadocInfo.CreateInfo (typeJavadoc, style);
+			}
+
+			foreach (var method in type.Methods) {
+				if (method.JavadocInfo != null)
+					continue;
+				var methodJavadoc   = GetMemberJavadoc (typeJavadoc, "method", method.JavaName, method.JniSignature);
+				method.JavadocInfo  = JavadocInfo.CreateInfo (methodJavadoc?.Parent, style);
+			}
+
+			foreach (var property in type.Properties) {
+				if (property.Getter != null && property.Getter.JavadocInfo == null) {
+					var getterJavadoc           = GetMemberJavadoc (typeJavadoc, "method", property.Getter.JavaName, property.Getter.JniSignature);
+					property.Getter.JavadocInfo = JavadocInfo.CreateInfo (getterJavadoc?.Parent, style);
+				}
+				if (property.Setter != null && property.Setter.JavadocInfo == null) {
+					var setterJavadoc           = GetMemberJavadoc (typeJavadoc, "method", property.Setter.JavaName, property.Setter.JniSignature);
+					property.Setter.JavadocInfo = JavadocInfo.CreateInfo (setterJavadoc?.Parent, style);
+				}
+			}
+
+			foreach (var field in type.Fields) {
+				if (field.JavadocInfo != null)
+					continue;
+				var fieldJavadoc    = GetMemberJavadoc (typeJavadoc, "field", field.JavaName, field.JniSignature);
+				field.JavadocInfo   = JavadocInfo.CreateInfo (fieldJavadoc?.Parent, style);
+			}
+
+			if (type is ClassGen @class) {
+				foreach (var ctor in @class.Ctors) {
+					if (ctor.JavadocInfo != null)
+						continue;
+					var ctorJavadoc     = GetMemberJavadoc (typeJavadoc, "constructor", null, ctor.JniSignature);
+					ctor.JavadocInfo    = JavadocInfo.CreateInfo (ctorJavadoc?.Parent, style);
+				}
+			}
+		}
+
+		static XElement GetMemberJavadoc (XElement typeJavadoc, string elementName, string name, string jniSignature)
+		{
+			return typeJavadoc
+				.Elements (elementName)
+				.Where (e => jniSignature == (string) e.Attribute ("jni-signature") &&
+						name == null ? true : name == (string) e.Attribute ("name"))
+				.Elements ("javadoc")
+				.FirstOrDefault ();
+		}
+	}
+}

--- a/tools/generator/SourceWriters/BoundClass.cs
+++ b/tools/generator/SourceWriters/BoundClass.cs
@@ -39,6 +39,7 @@ namespace generator.SourceWriters
 
 			AddImplementedInterfaces (klass);
 
+			klass.JavadocInfo?.AddJavadocs (Comments);
 			Comments.Add ($"// Metadata.xml XPath class reference: path=\"{klass.MetadataXPathReference}\"");
 
 			if (klass.IsDeprecated)

--- a/tools/generator/SourceWriters/BoundConstructor.cs
+++ b/tools/generator/SourceWriters/BoundConstructor.cs
@@ -24,6 +24,7 @@ namespace generator.SourceWriters
 
 			Name = klass.Name;
 
+			constructor.JavadocInfo?.AddJavadocs (Comments);
 			Comments.Add (string.Format ("// Metadata.xml XPath constructor reference: path=\"{0}/constructor[@name='{1}'{2}]\"", klass.MetadataXPathReference, klass.JavaSimpleName, constructor.Parameters.GetMethodXPathPredicate ()));
 
 			Attributes.Add (new RegisterAttr (".ctor", constructor.JniSignature, string.Empty, additionalProperties: constructor.AdditionalAttributeString ()));

--- a/tools/generator/SourceWriters/BoundField.cs
+++ b/tools/generator/SourceWriters/BoundField.cs
@@ -19,6 +19,7 @@ namespace generator.SourceWriters
 			Name = field.Name;
 			Type = new TypeReferenceWriter (opt.GetOutputName (field.Symbol.FullName));
 
+			field.JavadocInfo?.AddJavadocs (Comments);
 			Comments.Add ($"// Metadata.xml XPath field reference: path=\"{type.MetadataXPathReference}/field[@name='{field.JavaName}']\"");
 
 			Attributes.Add (new RegisterAttr (field.JavaName, additionalProperties: field.AdditionalAttributeString ()));

--- a/tools/generator/SourceWriters/BoundFieldAsProperty.cs
+++ b/tools/generator/SourceWriters/BoundFieldAsProperty.cs
@@ -25,6 +25,7 @@ namespace generator.SourceWriters
 			var fieldType = field.Symbol.IsArray ? "IList<" + field.Symbol.ElementType + ">" + opt.NullableOperator : opt.GetTypeReferenceName (field);
 			PropertyType = new TypeReferenceWriter (fieldType);
 
+			field.JavadocInfo?.AddJavadocs (Comments);
 			Comments.Add ($"// Metadata.xml XPath field reference: path=\"{type.MetadataXPathReference}/field[@name='{field.JavaName}']\"");
 
 			if (field.IsEnumified)

--- a/tools/generator/SourceWriters/BoundInterface.cs
+++ b/tools/generator/SourceWriters/BoundInterface.cs
@@ -37,6 +37,7 @@ namespace generator.SourceWriters
 
 			SetVisibility (iface.Visibility);
 
+			iface.JavadocInfo?.AddJavadocs (Comments);
 			Comments.Add ($"// Metadata.xml XPath interface reference: path=\"{iface.MetadataXPathReference}\"");
 
 			if (iface.IsDeprecated)

--- a/tools/generator/SourceWriters/BoundInterfaceMethodDeclaration.cs
+++ b/tools/generator/SourceWriters/BoundInterfaceMethodDeclaration.cs
@@ -33,6 +33,8 @@ namespace generator.SourceWriters
 
 			Attributes.Add (new RegisterAttr (method.JavaName, method.JniSignature, method.ConnectorName + ":" + method.GetAdapterName (opt, adapter), additionalProperties: method.AdditionalAttributeString ()));
 
+			method.JavadocInfo?.AddJavadocs (Comments);
+
 			SourceWriterExtensions.AddMethodCustomAttributes (Attributes, method);
 			this.AddMethodParameters (method.Parameters, opt);
 		}

--- a/tools/generator/SourceWriters/BoundMethod.cs
+++ b/tools/generator/SourceWriters/BoundMethod.cs
@@ -59,6 +59,8 @@ namespace generator.SourceWriters
 
 			ReturnType = new TypeReferenceWriter (opt.GetTypeReferenceName (method.RetVal));
 
+			method.JavadocInfo?.AddJavadocs (Comments);
+
 			if (method.DeclaringType.IsGeneratable)
 				Comments.Add ($"// Metadata.xml XPath method reference: path=\"{method.GetMetadataXPathReference (method.DeclaringType)}\"");
 

--- a/tools/generator/SourceWriters/BoundMethodAbstractDeclaration.cs
+++ b/tools/generator/SourceWriters/BoundMethodAbstractDeclaration.cs
@@ -41,6 +41,8 @@ namespace generator.SourceWriters
 
 			method_callback = new MethodCallback (impl, method, opt, null, method.IsReturnCharSequence);
 
+			method.JavadocInfo?.AddJavadocs (Comments);
+
 			if (method.DeclaringType.IsGeneratable)
 				Comments.Add ($"// Metadata.xml XPath method reference: path=\"{method.GetMetadataXPathReference (method.DeclaringType)}\"");
 

--- a/tools/generator/SourceWriters/BoundMethodStringOverload.cs
+++ b/tools/generator/SourceWriters/BoundMethodStringOverload.cs
@@ -27,6 +27,8 @@ namespace generator.SourceWriters
 			if (method.Deprecated != null)
 				Attributes.Add (new ObsoleteAttr (method.Deprecated.Replace ("\"", "\"\"").Trim ()));
 
+			method.JavadocInfo?.AddJavadocs (Comments);
+
 			this.AddMethodParametersStringOverloads (method.Parameters, opt);
 		}
 

--- a/tools/generator/generator.csproj
+++ b/tools/generator/generator.csproj
@@ -30,6 +30,7 @@
   <Import Project="..\..\build-tools\scripts\cecil.projitems" />
 
   <ItemGroup>
+    <PackageReference Include="Irony" Version="1.1.0" />
     <PackageReference Include="Mono.Options" Version="5.3.0.1" />
     <!-- Since we are sharing an OutputDirectory, and HtmlAgilityPack is also referenced by a different netstandard2.0 libary,
           we can explicitly reference the netstandard2.0 version here. This will also ensure symbol files are copied to the output directory. -->
@@ -48,6 +49,7 @@
     <ProjectReference Include="..\..\src\Java.Interop.Tools.Diagnostics\Java.Interop.Tools.Diagnostics.csproj" />
     <ProjectReference Include="..\..\src\Java.Interop.Tools.Cecil\Java.Interop.Tools.Cecil.csproj" />
     <ProjectReference Include="..\..\src\Java.Interop.Tools.JavaCallableWrappers\Java.Interop.Tools.JavaCallableWrappers.csproj" />
+    <ProjectReference Include="..\..\src\Java.Interop.Tools.JavaSource\Java.Interop.Tools.JavaSource.csproj" />
     <ProjectReference Include="..\..\src\Xamarin.SourceWriter\Xamarin.SourceWriter.csproj" />
   </ItemGroup>
 

--- a/tools/java-source-utils/src/main/java/com/microsoft/android/App.java
+++ b/tools/java-source-utils/src/main/java/com/microsoft/android/App.java
@@ -40,7 +40,7 @@ public class App {
 			if ((options.outputParamsTxt = Parameter.normalize(options.outputParamsTxt, "")).length() > 0) {
 				generateParamsTxt(options.outputParamsTxt, packages);
 			}
-			generateXml(options.outputJavadocXml, packages);
+			generateXml(options, packages);
 			options.close();
 		}
 		catch (Throwable t) {
@@ -66,8 +66,9 @@ public class App {
 		}
 	}
 
-	static void generateXml(String filename, JniPackagesInfo packages) throws Throwable {
-		try (final   JavadocXmlGenerator       javadocXmlGen   = new JavadocXmlGenerator(filename)) {
+	static void generateXml(JavaSourceUtilsOptions options, JniPackagesInfo packages) throws Throwable {
+		try (final   JavadocXmlGenerator       javadocXmlGen   = new JavadocXmlGenerator(options.outputJavadocXml)) {
+			javadocXmlGen.writeCopyrightInfo(options.docCopyrightFile, options.docUrlPrefix, options.docUrlStyle);
 			javadocXmlGen.writePackages(packages);
 		}
 	}

--- a/tools/java-source-utils/src/main/java/com/microsoft/android/JavaSourceUtilsOptions.java
+++ b/tools/java-source-utils/src/main/java/com/microsoft/android/JavaSourceUtilsOptions.java
@@ -40,10 +40,45 @@ import com.github.javaparser.symbolsolver.resolution.typesolvers.*;
 
 
 public class JavaSourceUtilsOptions implements AutoCloseable {
-	public static final String HELP_STRING = "[-v] [<-a|--aar> AAR]* [<-j|--jar> JAR]* [<-s|--source> DIRS]*\n" +
+	public static final String HELP_STRING =
+		"[-v] [<-a|--aar> AAR]* [<-j|--jar> JAR]* [<-s|--source> DIRS]*\n" +
 		"\t[--bootclasspath CLASSPATH]\n" +
 		"\t[<-P|--output-params> OUT.params.txt] [<-D|--output-javadoc> OUT.xml]\n" +
-		"\t[@RESPONSE-FILE]* FILES";
+		"\t[--doc-copyright FILE] [--doc-url-prefix URL] [--doc-url-style STYLE]\n" +
+		"\t[@RESPONSE-FILE]* FILES\n" +
+		"\n" +
+		"Options:\n" +
+		"      @RESPONSE-FILE         Additional options to parse, one option per line.\n" +
+		"      FILES                  .java files to parse.\n" +
+		"  -v                         Verbose output; show diagnostic information.\n" +
+		"  -h, -?, --help             Show this message and exit.\n" +
+		"\n" +
+		"Java type resolution options:\n" +
+		"      --bootclasspath CLASSPATH\n" +
+		"                             '" + File.pathSeparator + "'-separated list of .jar files to use\n" +
+		"                               for type resolution.\n" +
+		"  -a, --aar FILE             .aar file to use for type resolution.\n" +
+		"  -j, --jar FILE             .jar file to use for type resolution.\n" +
+		"  -s, --source DIR           Directory containing .java files for type\n" +
+		"                               resolution purposes.  DOES NOT parse all files.\n" +
+		"\n" +
+		"Documentation copyright file options:\n" +
+		"  Results in an additional '/api/javadoc-metadata' element when using\n" +
+		"  --output-javadoc.\n" +
+		"      --doc-copyright FILE   Copyright information for Javadoc.  Should be in\n" +
+		"                               mdoc(5) XML, to be held within <remarks/>.\n" +
+		"                               Stored in //javadoc-metadata/copyright.\n" +
+		"      --doc-url-prefix URL   Base URL for links to documentation.\n" +
+		"                               Stored in //javadoc-metadata/link/@prefix.\n" +
+		"      --doc-url-style STYLE  STYLE of URLs to generate for member links.\n" +
+		"                               Stored in //javadoc-metadata/link/@style.\n" +
+		"                               Supported styles include:\n" +
+		"                               - developer.android.com/reference@2020-Nov\n" +
+		"\n" +
+		"Output file options:\n" +
+		"  -P, --output-params FILE   Write method parameter names to FILE.\n" +
+		"  -D, --output-javadoc FILE  Write Javadoc within XML container to FILE.\n" +
+		"";
 
 	public  static  boolean             verboseOutput;
 
@@ -55,6 +90,10 @@ public class JavaSourceUtilsOptions implements AutoCloseable {
 	public  boolean haveBootClassPath;
 	public  String  outputParamsTxt;
 	public  String  outputJavadocXml;
+
+	public  File    docCopyrightFile;
+	public  String  docUrlPrefix;
+	public  String  docUrlStyle;
 
 	private final   Collection<File>    sourceDirectoryFiles  = new ArrayList<File>();
 	private         File                extractedTempDir;
@@ -147,6 +186,24 @@ public class JavaSourceUtilsOptions implements AutoCloseable {
 					aarFiles.add(file);
 					break;
 				}
+				case "--doc-copyright": {
+					final   File    file    = getNextOptionFile(args, arg);
+					if (file == null) {
+						break;
+					}
+					docCopyrightFile = file;
+					break;
+				}
+				case "--doc-url-prefix": {
+					final   String  prefix  = getNextOptionValue(args, arg);
+					docUrlPrefix            = prefix;
+					break;
+				}
+				case "--doc-url-style": {
+					final   String  style   = getNextOptionValue(args, arg);
+					docUrlStyle             = style;
+					break;
+				}
 				case "-j":
 				case "--jar": {
 					final   File    file    = getNextOptionFile(args, arg);
@@ -180,6 +237,7 @@ public class JavaSourceUtilsOptions implements AutoCloseable {
 					break;
 				}
 				case "-h":
+				case "-?":
 				case "--help": {
 					return null;
 				}

--- a/tools/java-source-utils/src/test/java/com/microsoft/android/JavadocXmlGeneratorTest.java
+++ b/tools/java-source-utils/src/test/java/com/microsoft/android/JavadocXmlGeneratorTest.java
@@ -18,7 +18,7 @@ import com.microsoft.android.ast.*;
 
 public final class JavadocXmlGeneratorTest {
 	@Test(expected = FileNotFoundException.class)
-	public void init_invalidFileThrows() throws FileNotFoundException, UnsupportedEncodingException {
+	public void init_invalidFileThrows() throws FileNotFoundException, ParserConfigurationException, TransformerException, UnsupportedEncodingException {
 		try (JavadocXmlGenerator g = new JavadocXmlGenerator("/this/file/does/not/exist")) {
 		}
 	}
@@ -38,6 +38,7 @@ public final class JavadocXmlGeneratorTest {
 
 		JniPackagesInfo packages = new JniPackagesInfo();
 		generator.writePackages(packages);
+		generator.close();
 
 		final   String  expected =
 			"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
@@ -96,6 +97,7 @@ public final class JavadocXmlGeneratorTest {
 			"</api>\n";
 
 		generator.writePackages(packages);
+		generator.close();
 		assertEquals("global package + example packages", expected, bytes.toString());
 	}
 
@@ -126,6 +128,7 @@ public final class JavadocXmlGeneratorTest {
 		final   String                  expected        = JniPackagesInfoTest.getResourceContents(resourceXml);
 
 		generator.writePackages(packagesInfo);
+		generator.close();
 		// try (FileOutputStream o = new FileOutputStream(resourceXml + "-jonp.xml")) {
 		// 	bytes.writeTo(o);
 		// }


### PR DESCRIPTION
Fixes: https://github.com/xamarin/java.interop/issues/642

Context: https://github.com/xamarin/xamarin-android/issues/4789
Context: https://github.com/xamarin/xamarin-android/issues/5200

Commit 69e1b80a added `tools/java-source-utils`, which along with
b588ef50, can parse Java source code and extract Javadoc comments
from Android API-30 sources into an XML file:
into an XML file:

        # API-30 `sources` package contains both `Object.java` and `Object.annotated.java`;
        # Skip the `.annotated.java` files
        $ find $HOME/android-toolchain/sdk/platforms/android-30/src/{android,java,javax,org} -iname \*.java \
                | grep -v '\.annotated\.' > sources.txt
        $ java -jar java-source-utils.jar -v \
                --source "$HOME/android-toolchain/sdk/platforms/android-30/src" \
                --output-javadoc android-javadoc.xml \
                @sources.txt

What can we *do* with the generated `android-javadoc.xml`?

`android-javadoc.xml` contains parameter names, and thus can be used
with `class-parse --docspath`; see commit 806082f2.

What we *really* want to do is make the Javadoc information *useful*
to consumers of the binding assembly.  This means that we want a
C# XML Documentation file for the binding assembly.

The most straightforward way to get a C# XML Documentation File is to
emit [C# XML Documentation Comments][0] into the binding source code!

Add a new `generator --with-javadoc-xml=FILE` option.  When specified,
`FILE` will be treated as an XML file containing the output from
`java-source-utils.jar --output-javadoc` (69e1b80a), and all
`<javadoc/>` elements within the XML file will be associated with C#
types and members to emit, based on the `//@jni-signature` and
`//@name` attributes, as appropriate.

When the bindings are written to disk, the Javadoc comments will be
translated to C# XML Documentation comments, in a "best effort" basis.
(THIS WILL BE INCOMPLETE.)

To perform the Javadoc-to-C# XML Documentation comments conversion,
add a new Irony-based grammar to `Java.Interop.Tools.JavaSource.dll`,
in the new `Java.Interop.Tools.JavaSource.SourceJavadocToXmldocParser`
type, which parses the Javadoc content and translates to XML.

In addition to transforming the Javadoc comments into C# XML
documentation comments, we *also* want to provide "upstream
information" in the form of:

 1. A URL to the corresponding online Javadoc HTML documentation.
 2. A copyright notice disclaimer.

Allow provision of this information by updating
`java-source-utils.jar` to support the new options:

        --doc-copyright FILE   Copyright information for Javadoc.  Should be in
                                 mdoc(5) XML, to be held within <remarks/>.
                                 Stored in //javadoc-metadata/copyright.
        --doc-url-prefix URL   Base URL for links to documentation.
                                 Stored in //javadoc-metadata/link/@prefix.
        --doc-url-style STYLE  STYLE of URLs to generate for member links.
                                 Stored in //javadoc-metadata/link/@style.
                                 Supported styles include:
                                 - developer.android.com/reference@2020-Nov

The new `/api/javadoc-metadata/link@prefix` and
`/api/javadoc-metadata/link@style` XML attributes, stored within
`java-source-utils.jar --output-javadoc` XML output, allow
construction of a URL to the Java member.

For example, given:

        java -jar java-source-utils.jar \
                --doc-url-prefix https://developer.android.com/reference \
                --doc-url-style developer.android.com/reference@2020-Nov

Then `generator` can emit the C# documentation comment for
`java.lang.Object.equals(Object)`:

        /// <format type="text/html">
        ///   <a href="https://developer.android.com/reference/java/lang/Object#equals(java.lang.Object)">Java documentation for <tt>java.lang.Object.equals(java.lang.Object)</tt>.</a>
        /// </format>

The copyright notice disclaimer is supported by
`java-source-utils.jar --doc-copyright FILE`; the contents of `FILE`
are inserted into the `/api/javadoc-metadata/copyright` element, and
will be copied into the output of every C# XML documentation block.

Example output is at:

  * <https://gist.github.com/jonpryor/004f01f4cd5ff32299ff590ba7a2fe0e>

Unfortunately, converting Javadoc to C# XML Documentation Comments is
not a "zero cost" operation.  Add a new
`generator --doc-comment-verbosity=STYLE` option to control how
"complete" the generated documentation comments are:

        --doc-comment-verbosity=STYLE
                               STYLE of C# documentation comments to emit.
                                 Defaults to `full`.  STYLE may be:
                                   * `intellisense`: emit <summary>, <param>,
                                     <returns>, <exception>.
                                   * `full`: plus <remarks>, <altmember>, ...

Using `--doc-comment-verbosity=full` will *most* impact build times.

TODO:

  * `SourceJavadocToXmldocParser` doesn't support many constructs.

[0]: https://docs.microsoft.com/en-us/dotnet/csharp/codedoc
