### PR TITLE
[java-interop, Java.Interop] Securely load native libs

### DIFF
--- a/src/Java.Interop/Properties/AssemblyInfo.cs
+++ b/src/Java.Interop/Properties/AssemblyInfo.cs
@@ -1,6 +1,8 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
+[assembly: DefaultDllImportSearchPathsAttribute (DllImportSearchPath.SafeDirectories | DllImportSearchPath.AssemblyDirectory)]
+
 [assembly: AssemblyTitle ("Java.Interop")]
 [assembly: AssemblyDescription ("")]
 [assembly: AssemblyCulture ("")]

--- a/src/Java.Interop/Properties/AssemblyInfo.cs
+++ b/src/Java.Interop/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 [assembly: DefaultDllImportSearchPathsAttribute (DllImportSearchPath.SafeDirectories | DllImportSearchPath.AssemblyDirectory)]
 

--- a/src/Java.Runtime.Environment/Properties/AssemblyInfo.cs
+++ b/src/Java.Runtime.Environment/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.InteropServices;
+
+[assembly: DefaultDllImportSearchPathsAttribute (DllImportSearchPath.SafeDirectories | DllImportSearchPath.AssemblyDirectory)]

--- a/src/java-interop/java-interop-dlfcn.cc
+++ b/src/java-interop/java-interop-dlfcn.cc
@@ -1,0 +1,197 @@
+#include "java-interop.h"
+#include "java-interop-dlfcn.h"
+#include "java-interop-util.h"
+
+#ifdef WINDOWS
+#include <libloaderapi.h>
+#include <winerror.h>
+#include <wtypes.h>
+#include <winbase.h>
+#else
+#include <dlfcn.h>
+#include <string.h>
+#endif
+
+namespace microsoft::java_interop {
+
+static char *
+_get_last_dlerror ()
+{
+#ifdef WINDOWS
+
+	DWORD error = GetLastError ();
+	if (error == ERROR_SUCCESS /* 0 */) {
+		return nullptr;
+	}
+
+	wchar_t *buf = nullptr;
+
+	DWORD size = FormatMessageW (
+			/* dwFlags */       FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+			/* lpSource */      NULL,
+			/* dwMessageId */   error,
+			/* dwLanguageId */  MAKELANGID (LANG_NEUTRAL, SUBLANG_DEFAULT),
+			/* lpBuffer */      (LPWSTR) &buf,
+			/* nSize */         0,
+			/* Arguments */     NULL
+	);
+	if (size == 0)
+		return nullptr;
+
+	char *message = utf16_to_utf8 (buf);
+	LocalFree (buf);
+
+	return message;
+
+#else   // ndef WINDOWS
+
+	return java_interop_strdup (dlerror ());
+
+#endif  // ndef WINDOWS
+}
+
+static void
+_free_error (char **error)
+{
+	if (error == nullptr)
+		return;
+	java_interop_free (*error);
+	*error = nullptr;
+}
+
+static void
+_set_error (char **error, const char *message)
+{
+	if (error == nullptr)
+		return;
+	*error = java_interop_strdup (message);
+}
+
+static void
+_set_error_to_last_error (char **error)
+{
+	if (error == nullptr)
+		return;
+	*error = _get_last_dlerror ();
+}
+
+void*
+java_interop_lib_load (const char *path, [[maybe_unused]] unsigned int flags, char **error)
+{
+	_free_error (error);
+	if (path == nullptr) {
+		_set_error (error, "path=nullptr is not supported");
+		return nullptr;
+	}
+
+	void *handle    = nullptr;
+
+#ifdef WINDOWS
+
+	wchar_t *wpath   = utf8_to_utf16 (path);
+	if (wpath == nullptr) {
+		_set_error (error, "could not convert path to UTF-16");
+		return nullptr;
+	}
+	HMODULE module  = LoadLibraryExW (
+			/* lpLibFileName */ wpath,
+			/* hFile */         nullptr,
+			/* dwFlags */       LOAD_LIBRARY_SEARCH_APPLICATION_DIR | LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_USER_DIRS
+	);
+	java_interop_free (wpath);
+
+	handle = reinterpret_cast<void*>(module);
+
+#else   // ndef WINDOWS
+
+	int mode = 0;
+	if ((flags & JAVA_INTEROP_LIB_LOAD_GLOBALLY) == JAVA_INTEROP_LIB_LOAD_GLOBALLY) {
+		mode = RTLD_GLOBAL;
+	}
+	if ((flags & JAVA_INTEROP_LIB_LOAD_LOCALLY) == JAVA_INTEROP_LIB_LOAD_LOCALLY) {
+		mode = RTLD_LOCAL;
+	}
+
+	if (mode == 0) {
+		mode = RTLD_LOCAL;
+	}
+	mode |= RTLD_NOW;
+
+	handle  = dlopen (path, mode);
+
+#endif  // ndef WINDOWS
+
+	if (handle == nullptr) {
+		_set_error_to_last_error (error);
+	}
+
+	return handle;
+}
+
+void*
+java_interop_lib_symbol (void *library, const char *symbol, char **error)
+{
+	_free_error (error);
+
+	if (library == nullptr) {
+		_set_error (error, "library=nullptr");
+		return nullptr;
+	}
+	if (symbol == nullptr) {
+		_set_error (error, "symbol=nullptr");
+		return nullptr;
+	}
+
+	void *address   = nullptr;
+
+#ifdef WINDOWS
+
+	HMODULE module  = reinterpret_cast<HMODULE>(library);
+	FARPROC a       = GetProcAddress (module, symbol);
+	address	        = reinterpret_cast<void*>(a);
+
+#else   // ndef WINDOWS
+
+	address         = dlsym (library, symbol);
+
+#endif  // ndef WINDOWS
+
+	if (address == nullptr) {
+		_set_error_to_last_error (error);
+	}
+
+	return address;
+}
+
+int
+java_interop_lib_close (void* library, char **error)
+{
+	_free_error (error);
+	if (library == nullptr) {
+		_set_error (error, "library=nullptr");
+		return JAVA_INTEROP_LIB_INVALID_PARAM;
+	}
+
+	int r   = 0;
+
+#ifdef WINDOWS
+	HMODULE h   = reinterpret_cast<HMODULE>(library);
+	BOOL    v   = FreeLibrary (h);
+	if (!v) {
+		r   = JAVA_INTEROP_LIB_CLOSE_FAILED;
+	}
+#else   // ndef WINDOWS
+	r           = dlclose (library);
+	if (r != 0) {
+		r   = JAVA_INTEROP_LIB_CLOSE_FAILED;
+	}
+#endif  // ndef WINDOWS
+
+	if (r != 0) {
+		_set_error_to_last_error (error);
+	}
+
+	return r;
+}
+
+} // namespace microsoft::java_interop

--- a/src/java-interop/java-interop-dlfcn.h
+++ b/src/java-interop/java-interop-dlfcn.h
@@ -1,0 +1,28 @@
+#ifndef INC_JAVA_INTEROP_DLFCN_H
+#define INC_JAVA_INTEROP_DLFCN_H
+
+#include "java-interop.h"
+
+namespace microsoft::java_interop {
+
+// Possible flags values for java_interop_lib_load
+constexpr   unsigned int    JAVA_INTEROP_LIB_LOAD_GLOBALLY      = (1 << 0);
+constexpr   unsigned int    JAVA_INTEROP_LIB_LOAD_LOCALLY       = (1 << 1);
+
+
+// Possible error codes from java_interop_lib_close
+constexpr   int JAVA_INTEROP_LIB_FAILED             = -1000;
+constexpr   int JAVA_INTEROP_LIB_CLOSE_FAILED       = JAVA_INTEROP_LIB_FAILED-1;
+constexpr   int JAVA_INTEROP_LIB_INVALID_PARAM      = JAVA_INTEROP_LIB_FAILED-2;
+
+JAVA_INTEROP_BEGIN_DECLS
+
+JAVA_INTEROP_API    void*   java_interop_lib_load (const char *path, unsigned int flags, char **error);
+JAVA_INTEROP_API    void*   java_interop_lib_symbol (void* library, const char *symbol, char **error);
+JAVA_INTEROP_API    int     java_interop_lib_close (void* library, char **error);
+
+JAVA_INTEROP_END_DECLS
+
+}
+
+#endif /* INC_JAVA_INTEROP_DLFCN_H */

--- a/src/java-interop/java-interop-gc-bridge.h
+++ b/src/java-interop/java-interop-gc-bridge.h
@@ -19,41 +19,41 @@ struct JavaInterop_System_RuntimeTypeHandle {
 	void   *value;
 };
 
-MONO_API    JavaInteropGCBridge    *java_interop_gc_bridge_get_current                  (void);
-MONO_API    int                     java_interop_gc_bridge_set_current_once             (JavaInteropGCBridge *bridge);
+JAVA_INTEROP_API    JavaInteropGCBridge    *java_interop_gc_bridge_get_current                  (void);
+JAVA_INTEROP_API    int                     java_interop_gc_bridge_set_current_once             (JavaInteropGCBridge *bridge);
 
-MONO_API    JavaInteropGCBridge    *java_interop_gc_bridge_new                          (JavaVM *jvm);
-MONO_API    int                     java_interop_gc_bridge_free                         (JavaInteropGCBridge *bridge);
+JAVA_INTEROP_API    JavaInteropGCBridge    *java_interop_gc_bridge_new                          (JavaVM *jvm);
+JAVA_INTEROP_API    int                     java_interop_gc_bridge_free                         (JavaInteropGCBridge *bridge);
 
-MONO_API    int                     java_interop_gc_bridge_register_hooks               (JavaInteropGCBridge *bridge, int weak_ref_kind);
-MONO_API    int                     java_interop_gc_bridge_wait_for_bridge_processing   (JavaInteropGCBridge *bridge);
+JAVA_INTEROP_API    int                     java_interop_gc_bridge_register_hooks               (JavaInteropGCBridge *bridge, int weak_ref_kind);
+JAVA_INTEROP_API    int                     java_interop_gc_bridge_wait_for_bridge_processing   (JavaInteropGCBridge *bridge);
 
-MONO_API    int                     java_interop_gc_bridge_add_current_app_domain       (JavaInteropGCBridge *bridge);
-MONO_API    int                     java_interop_gc_bridge_remove_current_app_domain    (JavaInteropGCBridge *bridge);
+JAVA_INTEROP_API    int                     java_interop_gc_bridge_add_current_app_domain       (JavaInteropGCBridge *bridge);
+JAVA_INTEROP_API    int                     java_interop_gc_bridge_remove_current_app_domain    (JavaInteropGCBridge *bridge);
 
-MONO_API    int                     java_interop_gc_bridge_set_bridge_processing_field  (JavaInteropGCBridge *bridge,   struct JavaInterop_System_RuntimeTypeHandle type_handle,    char *field_name);
-MONO_API    int                     java_interop_gc_bridge_register_bridgeable_type     (JavaInteropGCBridge *bridge,   struct JavaInterop_System_RuntimeTypeHandle type_handle);
-MONO_API    int                     java_interop_gc_bridge_enable                       (JavaInteropGCBridge *bridge,   int enable);
+JAVA_INTEROP_API    int                     java_interop_gc_bridge_set_bridge_processing_field  (JavaInteropGCBridge *bridge,   struct JavaInterop_System_RuntimeTypeHandle type_handle,    char *field_name);
+JAVA_INTEROP_API    int                     java_interop_gc_bridge_register_bridgeable_type     (JavaInteropGCBridge *bridge,   struct JavaInterop_System_RuntimeTypeHandle type_handle);
+JAVA_INTEROP_API    int                     java_interop_gc_bridge_enable                       (JavaInteropGCBridge *bridge,   int enable);
 
-MONO_API    int                     java_interop_gc_bridge_get_gref_count           (JavaInteropGCBridge *bridge);
-MONO_API    int                     java_interop_gc_bridge_get_weak_gref_count      (JavaInteropGCBridge *bridge);
+JAVA_INTEROP_API    int                     java_interop_gc_bridge_get_gref_count           (JavaInteropGCBridge *bridge);
+JAVA_INTEROP_API    int                     java_interop_gc_bridge_get_weak_gref_count      (JavaInteropGCBridge *bridge);
 
-MONO_API    int                     java_interop_gc_bridge_lref_set_log_file        (JavaInteropGCBridge *bridge,   const char *gref_log_file);
-MONO_API    FILE*                   java_interop_gc_bridge_lref_get_log_file        (JavaInteropGCBridge *bridge);
-MONO_API    int                     java_interop_gc_bridge_lref_set_log_level       (JavaInteropGCBridge *bridge,   int level);
-MONO_API    void                    java_interop_gc_bridge_lref_log_message         (JavaInteropGCBridge *bridge,   int level, const char *message);
-MONO_API    void                    java_interop_gc_bridge_lref_log_new             (JavaInteropGCBridge *bridge,   int lref_count,     jobject curHandle,  char curType,   jobject newHandle,  char newType,   const char *thread_name,   int64_t thread_id,  const char *from);
-MONO_API    void                    java_interop_gc_bridge_lref_log_delete          (JavaInteropGCBridge *bridge,   int lref_count,     jobject handle,     char type,                                          const char *thread_name,   int64_t thread_id,  const char *from);
+JAVA_INTEROP_API    int                     java_interop_gc_bridge_lref_set_log_file        (JavaInteropGCBridge *bridge,   const char *gref_log_file);
+JAVA_INTEROP_API    FILE*                   java_interop_gc_bridge_lref_get_log_file        (JavaInteropGCBridge *bridge);
+JAVA_INTEROP_API    int                     java_interop_gc_bridge_lref_set_log_level       (JavaInteropGCBridge *bridge,   int level);
+JAVA_INTEROP_API    void                    java_interop_gc_bridge_lref_log_message         (JavaInteropGCBridge *bridge,   int level, const char *message);
+JAVA_INTEROP_API    void                    java_interop_gc_bridge_lref_log_new             (JavaInteropGCBridge *bridge,   int lref_count,     jobject curHandle,  char curType,   jobject newHandle,  char newType,   const char *thread_name,   int64_t thread_id,  const char *from);
+JAVA_INTEROP_API    void                    java_interop_gc_bridge_lref_log_delete          (JavaInteropGCBridge *bridge,   int lref_count,     jobject handle,     char type,                                          const char *thread_name,   int64_t thread_id,  const char *from);
 
-MONO_API    int                     java_interop_gc_bridge_gref_set_log_file        (JavaInteropGCBridge *bridge,   const char *gref_log_file);
-MONO_API    FILE*                   java_interop_gc_bridge_gref_get_log_file        (JavaInteropGCBridge *bridge);
-MONO_API    int                     java_interop_gc_bridge_gref_set_log_level       (JavaInteropGCBridge *bridge,   int level);
-MONO_API    void                    java_interop_gc_bridge_gref_log_message         (JavaInteropGCBridge *bridge,   int level, const char *message);
-MONO_API    int                     java_interop_gc_bridge_gref_log_new             (JavaInteropGCBridge *bridge,   jobject curHandle,  char curType,   jobject newHandle,  char newType,   const char *thread_name,    int64_t thread_id,  const char *from);
-MONO_API    int                     java_interop_gc_bridge_gref_log_delete          (JavaInteropGCBridge *bridge,   jobject handle,     char type,                                          const char *thread_name,    int64_t thread_id,  const char *from);
+JAVA_INTEROP_API    int                     java_interop_gc_bridge_gref_set_log_file        (JavaInteropGCBridge *bridge,   const char *gref_log_file);
+JAVA_INTEROP_API    FILE*                   java_interop_gc_bridge_gref_get_log_file        (JavaInteropGCBridge *bridge);
+JAVA_INTEROP_API    int                     java_interop_gc_bridge_gref_set_log_level       (JavaInteropGCBridge *bridge,   int level);
+JAVA_INTEROP_API    void                    java_interop_gc_bridge_gref_log_message         (JavaInteropGCBridge *bridge,   int level, const char *message);
+JAVA_INTEROP_API    int                     java_interop_gc_bridge_gref_log_new             (JavaInteropGCBridge *bridge,   jobject curHandle,  char curType,   jobject newHandle,  char newType,   const char *thread_name,    int64_t thread_id,  const char *from);
+JAVA_INTEROP_API    int                     java_interop_gc_bridge_gref_log_delete          (JavaInteropGCBridge *bridge,   jobject handle,     char type,                                          const char *thread_name,    int64_t thread_id,  const char *from);
 
-MONO_API    int                     java_interop_gc_bridge_weak_gref_log_new        (JavaInteropGCBridge *bridge,   jobject curHandle,  char curType,   jobject newHandle,  char newType,   const char *thread_name,    int64_t thread_id,  const char *from);
-MONO_API    int                     java_interop_gc_bridge_weak_gref_log_delete     (JavaInteropGCBridge *bridge,   jobject handle,     char type,                                          const char *thread_name,    int64_t thread_id,  const char *from);
+JAVA_INTEROP_API    int                     java_interop_gc_bridge_weak_gref_log_new        (JavaInteropGCBridge *bridge,   jobject curHandle,  char curType,   jobject newHandle,  char newType,   const char *thread_name,    int64_t thread_id,  const char *from);
+JAVA_INTEROP_API    int                     java_interop_gc_bridge_weak_gref_log_delete     (JavaInteropGCBridge *bridge,   jobject handle,     char type,                                          const char *thread_name,    int64_t thread_id,  const char *from);
 
 JAVA_INTEROP_END_DECLS
 

--- a/src/java-interop/java-interop-jvm.cc
+++ b/src/java-interop/java-interop-jvm.cc
@@ -1,10 +1,11 @@
 #include <stdlib.h>
-#include <dlfcn.h>
 
 #include "java-interop-jvm.h"
+#include "java-interop-dlfcn.h"
 #include "java-interop-logger.h"
 #include "java-interop-util.h"
 
+using namespace microsoft::java_interop;
 
 typedef int (JNICALL *java_interop_JNI_CreateJavaVM_fptr) (JavaVM **p_vm, void **p_env, void *vm_args);
 typedef int (JNICALL *java_interop_JNI_GetCreatedJavaVMs_fptr) (JavaVM **vmBuf, int bufLen, int *nVMs);
@@ -33,11 +34,14 @@ java_interop_jvm_load_with_error_message (const char *path, char **error_message
 		return JAVA_INTEROP_JVM_FAILED_OOM;
 	}
 
-	jvm->dl_handle = dlopen (path, RTLD_LAZY);
+	char *error    = nullptr;
+	jvm->dl_handle = java_interop_lib_load (path, JAVA_INTEROP_LIB_LOAD_LOCALLY, &error);
 	if (!jvm->dl_handle) {
 		if (error_message) {
-			*error_message = java_interop_strdup (dlerror ());
+			*error_message = error;
+			error          = nullptr;
 		}
+		java_interop_free (error);
 		free (jvm);
 		jvm = NULL;
 		return JAVA_INTEROP_JVM_FAILED_NOT_LOADED;
@@ -46,10 +50,13 @@ java_interop_jvm_load_with_error_message (const char *path, char **error_message
 	int symbols_missing = 0;
 
 #define LOAD_SYMBOL_CAST(symbol, Type) do { \
-		jvm->symbol = reinterpret_cast<Type>(dlsym (jvm->dl_handle, #symbol)); \
+		error = nullptr; \
+		jvm->symbol = reinterpret_cast<Type>(java_interop_lib_symbol (jvm->dl_handle, #symbol, &error)); \
 		if (!jvm->symbol) { \
-			log_error (LOG_DEFAULT, "Failed to load JVM symbol: %s", #symbol); \
+			log_error (LOG_DEFAULT, "Failed to load JVM symbol: %s: %s", #symbol, error); \
 			symbols_missing = 1; \
+			java_interop_free (error); \
+			error = nullptr; \
 		} \
 	} while (0)
 #define LOAD_SYMBOL(symbol) LOAD_SYMBOL_CAST(symbol, java_interop_ ## symbol ## _fptr)
@@ -61,7 +68,7 @@ java_interop_jvm_load_with_error_message (const char *path, char **error_message
 #undef LOAD_SYMBOL
 
 	if (symbols_missing) {
-		dlclose (jvm->dl_handle);
+		java_interop_lib_close (jvm->dl_handle, nullptr);
 		free (jvm);
 		jvm = NULL;
 		return JAVA_INTEROP_JVM_FAILED_SYMBOL_MISSING;

--- a/src/java-interop/java-interop-jvm.h
+++ b/src/java-interop/java-interop-jvm.h
@@ -13,10 +13,10 @@ JAVA_INTEROP_BEGIN_DECLS
 #define JAVA_INTEROP_JVM_FAILED_OOM             (JAVA_INTEROP_JVM_FAILED-3)
 #define JAVA_INTEROP_JVM_FAILED_SYMBOL_MISSING  (JAVA_INTEROP_JVM_FAILED-4)
 
-MONO_API    int java_interop_jvm_load (const char *path);
-MONO_API    int java_interop_jvm_load_with_error_message (const char *path, char **error);
-MONO_API    int java_interop_jvm_create (JavaVM **p_vm, void **p_env, void *vm_args);
-MONO_API    int java_interop_jvm_list (JavaVM **vmBuf, int bufLen, int *nVMs);
+JAVA_INTEROP_API    int java_interop_jvm_load (const char *path);
+JAVA_INTEROP_API    int java_interop_jvm_load_with_error_message (const char *path, char **error);
+JAVA_INTEROP_API    int java_interop_jvm_create (JavaVM **p_vm, void **p_env, void *vm_args);
+JAVA_INTEROP_API    int java_interop_jvm_list (JavaVM **vmBuf, int bufLen, int *nVMs);
 
 JAVA_INTEROP_END_DECLS
 

--- a/src/java-interop/java-interop-mono.h
+++ b/src/java-interop/java-interop-mono.h
@@ -3,43 +3,13 @@
 
 #include "java-interop.h"
 
-#if defined (XAMARIN_ANDROID_DYLIB_MONO)
-
-	#include "dylib-mono.h"
-	#include "monodroid-glue.h"
-
-	#define mono_class_from_mono_type               (monodroid_get_dylib ()->class_from_mono_type)
-	#define mono_class_from_name                    (monodroid_get_dylib ()->class_from_name)
-	#define mono_class_get_field_from_name          (monodroid_get_dylib ()->class_get_field_from_name)
-	#define mono_class_get_name                     (monodroid_get_dylib ()->class_get_name)
-	#define mono_class_get_namespace                (monodroid_get_dylib ()->class_get_namespace)
-	#define mono_class_is_subclass_of               (monodroid_get_dylib ()->class_is_subclass_of)
-	#define mono_class_vtable                       (monodroid_get_dylib ()->class_vtable)
-	#define mono_domain_get                         (monodroid_get_dylib ()->domain_get)
-	#define mono_field_get_value                    (monodroid_get_dylib ()->field_get_value)
-	#define mono_field_set_value                    (monodroid_get_dylib ()->field_set_value)
-	#define mono_field_static_set_value             (monodroid_get_dylib ()->field_static_set_value)
-	#define mono_object_get_class                   (monodroid_get_dylib ()->object_get_class)
-	#define mono_thread_attach                      (monodroid_get_dylib ()->thread_attach)
-	#define mono_thread_current                     (monodroid_get_dylib ()->thread_current)
-	#define mono_gc_register_bridge_callbacks       (monodroid_get_dylib ()->gc_register_bridge_callbacks)
-	#define mono_gc_wait_for_bridge_processing      (monodroid_get_dylib ()->gc_wait_for_bridge_processing)
-
-#else   /* !defined (XAMARIN_ANDROID_DYLIB_MONO) */
-
-	#undef MONO_API_EXPORT
-	#undef MONO_API_IMPORT
-	#undef MONO_API
-
-	#include <mono/metadata/assembly.h>
-	#include <mono/metadata/class.h>
-	#include <mono/metadata/object.h>
-	#include <mono/metadata/sgen-bridge.h>
-	#include <mono/metadata/threads.h>
-	#include <mono/utils/mono-counters.h>
-	#include <mono/utils/mono-dl-fallback.h>
-
-#endif  /* !defined (XAMARIN_ANDROID_DYLIB_MONO) */
+#include <mono/metadata/assembly.h>
+#include <mono/metadata/class.h>
+#include <mono/metadata/object.h>
+#include <mono/metadata/sgen-bridge.h>
+#include <mono/metadata/threads.h>
+#include <mono/utils/mono-counters.h>
+#include <mono/utils/mono-dl-fallback.h>
 
 JAVA_INTEROP_BEGIN_DECLS
 

--- a/src/java-interop/java-interop-util.h
+++ b/src/java-interop/java-interop-util.h
@@ -1,6 +1,8 @@
 #ifndef __JAVA_INTEROP_UTIL_H__
 #define __JAVA_INTEROP_UTIL_H__
 
+#include <cstdlib>
+
 #ifdef WINDOWS
 /* Those two conversion functions are only properly implemented on Windows
  * because that's the only place where they should be useful.
@@ -44,7 +46,7 @@ _assert_valid_pointer (void *p, size_t size)
 		}
 
 		log_fatal (LOG_DEFAULT, "Out of memory!");
-		exit (FATAL_EXIT_OUT_OF_MEMORY);
+		std::exit (FATAL_EXIT_OUT_OF_MEMORY);
 	}
 
 	return p;

--- a/src/java-interop/java-interop.csproj
+++ b/src/java-interop/java-interop.csproj
@@ -4,7 +4,7 @@
     <OutputPath>$(ToolOutputFullPath)</OutputPath>
     <JNIEnvGenPath>$(BuildToolOutputFullPath)</JNIEnvGenPath>
     <OutputName>java-interop</OutputName>
-    <DefineSymbols>JI_DLL_EXPORT MONODEVELOP MONO_DLL_EXPORT</DefineSymbols>
+    <DefineSymbols>JI_DLL_EXPORT MONODEVELOP JAVA_INTEROP_DLL_EXPORT</DefineSymbols>
     <SourceDirectory>.</SourceDirectory>
   </PropertyGroup>
 
@@ -18,8 +18,12 @@
 
   <ItemGroup>
     <ClInclude Include="java-interop.h" />
+    <ClInclude Include="java-interop-dlfcn.h" />
     <ClInclude Include="java-interop-gc-bridge.h" />
+    <ClInclude Include="java-interop-jvm.h" />
+    <ClInclude Include="java-interop-logger.h" />
     <ClInclude Include="java-interop-mono.h" />
+    <ClInclude Include="java-interop-util.h" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -37,6 +41,7 @@
   <ItemGroup>
     <ClCompile Include="jni.c" />
     <ClCompile Include="java-interop.cc" />
+    <ClCompile Include="java-interop-dlfcn.cc" />
     <ClCompile Include="java-interop-jvm.cc" />
     <ClCompile Include="java-interop-logger.cc" />
     <ClCompile Include="java-interop-mono.cc" />

--- a/src/java-interop/java-interop.h
+++ b/src/java-interop/java-interop.h
@@ -5,26 +5,26 @@
 
 #if defined(_MSC_VER)
 
-	#define MONO_API_EXPORT __declspec(dllexport)
-	#define MONO_API_IMPORT __declspec(dllimport)
+	#define JAVA_INTEROP_API_EXPORT __declspec(dllexport)
+	#define JAVA_INTEROP_API_IMPORT __declspec(dllimport)
 
 #else   /* defined(_MSC_VER */
 
 	#ifdef __GNUC__
-		#define MONO_API_EXPORT __attribute__ ((visibility ("default")))
+		#define JAVA_INTEROP_API_EXPORT __attribute__ ((visibility ("default")))
 	#else
-		#define MONO_API_EXPORT
+		#define JAVA_INTEROP_API_EXPORT
 	#endif
-	#define MONO_API_IMPORT
+	#define JAVA_INTEROP_API_IMPORT
 
 #endif  /* !defined(_MSC_VER) */
 
-#if defined(MONO_DLL_EXPORT)
-	#define MONO_API MONO_API_EXPORT
-#elif defined(MONO_DLL_IMPORT)
-	#define MONO_API MONO_API_IMPORT
-#else   /* !defined(MONO_DLL_IMPORT) && !defined(MONO_API_IMPORT) */
-	#define MONO_API
+#if defined(MONO_DLL_EXPORT) || defined(JAVA_INTEROP_DLL_EXPORT)
+	#define JAVA_INTEROP_API JAVA_INTEROP_API_EXPORT
+#elif defined(MONO_DLL_IMPORT) || defined(JAVA_INTEROP_DLL_IMPORT)
+	#define JAVA_INTEROP_API JAVA_INTEROP_API_IMPORT
+#else   /* !defined(MONO_DLL_IMPORT) && !defined(MONO_DLL_EXPORT) */
+	#define JAVA_INTEROP_API
 #endif  /* MONO_DLL_EXPORT... */
 
 #ifdef __cplusplus
@@ -37,8 +37,8 @@
 
 JAVA_INTEROP_BEGIN_DECLS
 
-MONO_API    char   *java_interop_strdup (const char* value);
-MONO_API    void    java_interop_free   (void *p);
+JAVA_INTEROP_API    char   *java_interop_strdup (const char* value);
+JAVA_INTEROP_API    void    java_interop_free   (void *p);
 
 JAVA_INTEROP_END_DECLS
 

--- a/src/java-interop/java-interop.targets
+++ b/src/java-interop/java-interop.targets
@@ -9,43 +9,60 @@
 
   <PropertyGroup>
     <_MacLib>$(OutputPath)/lib$(OutputName).dylib</_MacLib>
+    <_UnixLib>$(OutputPath)/lib$(OutputName).so</_UnixLib>
   </PropertyGroup>
 
-  <Target Name="_CompileObjectFiles"
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>$([MSBuild]::Unescape($(DefineSymbols.Replace(' ', ';'))))</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$([MSBuild]::Unescape($(_MonoIncludePath)));$([MSBuild]::Unescape($(_JdkIncludePath)))</AdditionalIncludeDirectories>
+      <Obj Condition=" '$(OS)' != 'Windows_NT' ">obj/$(Configuration)/%(Filename).o</Obj>
+    </ClCompile>
+  </ItemDefinitionGroup>
+
+  <Target Name="_CompileUnixObjectFiles"
       Condition=" '$(OS)' != 'Windows_NT' "
       DependsOnTargets="BuildJni_c"
-      Inputs="@(ClCompile)"
-      Outputs="obj\$(Configuration)\%(Filename).o">
+      Inputs="@(ClCompile);@(ClInclude)"
+      Outputs="%(ClCompile.Obj)">
     <MakeDir Directories="obj\$(Configuration)" />
     <ItemGroup>
+      <_Cl Include="@(ClCompile)">
+        <Compiler Condition=" '%(Extension)' == '.c' ">gcc -std=c99 -fPIC</Compiler>
+        <Compiler Condition=" '%(Extension)' == '.cc' ">g++ -std=c++17 -fPIC</Compiler>
+      </_Cl>
       <_Defines Include="%(ClCompile.PreprocessorDefinitions)" />
       <_Includes Include="%(ClCompile.AdditionalIncludeDirectories)" />
     </ItemGroup>
     <PropertyGroup>
       <_Arch Condition=" Exists ('/Library/Frameworks/') ">-m64</_Arch>
-      <_Cc Condition=" '%(ClCompile.Extension)' == '.c' ">gcc -std=c99 -fPIC</_Cc>
-      <_Cc Condition=" '%(ClCompile.Extension)' == '.cc' ">g++ -std=c++11 -fPIC</_Cc>
       <_Def>@(_Defines->'-D%(Identity)', ' ')</_Def>
       <_Inc>@(_Includes->'-I "%(Identity)"', ' ')</_Inc>
     </PropertyGroup>
     <Exec
-        Command="$(_Cc) -c -g $(_Arch) -o &quot;obj/$(Configuration)/%(ClCompile.Filename).o&quot; $(_Def) $(_Inc) &quot;%(Identity)&quot;"
+        Command="%(_Cl.Compiler) -c -g $(_Arch) -o &quot;%(_Cl.Obj)&quot; $(_Def) $(_Inc) &quot;%(_Cl.Identity)&quot;"
     />
   </Target>
 
   <Target Name="BuildMac"
       AfterTargets="Build"
       Condition=" '$(OS)' != 'Windows_NT' And Exists ('/Library/Frameworks/')"
-      DependsOnTargets="_CompileObjectFiles"
-      Inputs="@(ClCompile)"
+      DependsOnTargets="_CompileUnixObjectFiles"
+      Inputs="@(ClCompile->'%(Obj)')"
       Outputs="$(_MacLib)">
+    <ItemGroup>
+      <_Objs Include="%(ClCompile.Obj)" />
+    </ItemGroup>
     <PropertyGroup>
       <_LinkFlags>-fvisibility=hidden -Wl,-undefined -Wl,suppress -Wl,-flat_namespace</_LinkFlags>
       <_Libs>$(MonoLibs)</_Libs>
-      <_Files>@(ClCompile->'obj\$(Configuration)\%(Filename).o', ' ')</_Files>
+      <_Files>@(_Objs->'%(Identity)', ' ')</_Files>
     </PropertyGroup>
     <!-- Use 'IgnoreStandardErrorWarningFormat' to ignore 'ld: warning: text-based stub file X and and library file Y are out of sync' warnings. -->
-    <Exec Command="gcc -g -shared -m64 -std=c99 -fPIC -o &quot;$(_MacLib)&quot; $(_LinkFlags) $(_Libs) $(_Files)" IgnoreStandardErrorWarningFormat="true" />
+    <Exec
+        Command="gcc -g -shared -m64 -std=c99 -fPIC -o &quot;$(_MacLib)&quot; $(_LinkFlags) $(_Libs) $(_Files)"
+        IgnoreStandardErrorWarningFormat="true"
+    />
     <!-- Mono 4.4.0 (mono-4.4.0-branch/a3fabf1) has an incorrect shared library name. Fix it -->
     <Exec Command="install_name_tool -change /private/tmp/source-mono-4.4.0/bockbuild-mono-4.4.0-branch/profiles/mono-mac-xamarin/package-root/lib/libmonosgen-2.0.1.dylib /Library/Frameworks/Mono.framework/Libraries/libmonosgen-2.0.1.dylib &quot;$(_MacLib)&quot;" />
   </Target>
@@ -53,28 +70,25 @@
   <Target Name="BuildUnixLibraries"
       AfterTargets="Build"
       Condition=" '$(OS)' != 'Windows_NT' And !Exists ('/Library/Frameworks/')"
-      DependsOnTargets="_CompileObjectFiles"
-      Inputs="@(ClCompile)"
-      Outputs="$(OutputPath)\lib$(OutputName).so">
-    <PropertyGroup>
-      <_FixedDefines>$(DefineSymbols.Split(' '))</_FixedDefines>
-    </PropertyGroup>
+      DependsOnTargets="_CompileUnixObjectFiles"
+      Inputs="@(ClCompile->'%(Obj)')"
+      Outputs="$(_UnixLib)">
     <ItemGroup>
-      <_Defines Include="$(_FixedDefines)" />
+      <_Objs Include="%(ClCompile.Obj)" />
     </ItemGroup>
     <PropertyGroup>
       <_LinkFlags>-fvisibility=hidden -Wl,-undefined -Wl,suppress -Wl,-flat_namespace -fPIC</_LinkFlags>
       <_Libs>$(MonoLibs)</_Libs>
-      <_Files>@(ClCompile->'obj\$(Configuration)\%(Filename).o', ' ')</_Files>
+      <_Files>@(_Objs->'%(Identity)', ' ')</_Files>
     </PropertyGroup>
-    <Exec Command="g++ -g -shared -o &quot;$(OutputPath)/lib$(OutputName).so&quot; $(_LinkFlags) $(_Libs) $(_Files)" />
+    <Exec Command="g++ -g -shared -o &quot;$(_UnixLib)&quot; $(_LinkFlags) $(_Libs) $(_Files)" />
   </Target>
 
   <Target Name="Clean">
     <RemoveDir Directories="obj" />
     <Delete Files="jni.c" />
     <Delete
-        Files="$(OutputPath)\lib$(OutputName).dylib"
+        Files="$(_MacLib);$(_UnixLib)"
         Condition=" '$(OS)' != 'Windows_NT' "
     />
   </Target>


### PR DESCRIPTION
Fixes: https://github.com/xamarin/java.interop/issues/676

Context: https://liquid.microsoft.com/Web/Object/Read/ms.security/Requirements/Microsoft.Security.SystemsADM.10039#guide

The current security guidance is that the
[`System.Runtime.InteropServices.DefaultDllImportSearchPathsAttribute`][0]
attribute should be placed either on the assembly or on `[DllImport]`
methods to control and constrain where [`LoadLibraryEx()`][1] will look
for native libraries, in particular to *prevent* looking for native
libraries within e.g. the current working directory or `%PATH%` or any
other "attacker-controlled" location.

Update `Java.Interop.dll` and `Java.Runtime.Environment.dll` so that
the [`DllImportSearchPath`][2] values `AssemblyDirectory` and
`SafeDirectories` are used:

  * `AssemblyDirectory`: "include the directory that contains the
    assembly itself, and search that directory first."

  * `SafeDirectories`: "Include the application directory, the
    `%WinDir%\System32` directory, and user directories in the DLL
    search path.

Additionally, update `src/java-interop` so that instead of requiring
the use of [**dlopen**(3)][3] on Windows, the following functions are
added to support loading native libraries and resolving symbols
from those native libraries:

	void*   java_interop_lib_load (const char *path, unsigned int flags, char **error);
	void*   java_interop_lib_symbol (void* library, const char *symbol, char **error);
	int     java_interop_lib_close (void* library, char **error);

(Previously, xamarin-android used the [dlfcn-win32/dlfcn-win32][4]
library to implement **dlopen**(3), but
dlfcn-win32/dlfcn-win32@ef7e412d calls `LoadLibraryEx()` with
`LOAD_WITH_ALTERED_SEARCH_PATH`, which doesn't fulfill our internal
requirements.)

On Windows, `java_interop_lib_load()` will use
[`LoadLibraryEx()`][5] to load libraries from a constrained set of
directories:

  * `LOAD_LIBRARY_SEARCH_APPLICATION_DIR`: "the application's
    installation directory is searched for the DLL and its dependencies"

  * `LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR`: "the directory that contains
    the DLL is temporarily added to the beginning of the list of
    directories that are searched for the DLL's dependencies."

  * `LOAD_LIBRARY_SEARCH_USER_DIRS`: "directories added using the
    `AddDllDirectory()` or the `SetDllDirectory()` function are searched
    for the DLL and its dependencies"

In order to simplify the introduction of
`java_interop_lib_load()`, start *requiring* the presence of the
symbols `mono_thread_get_managed_id` and `mono_thread_get_name_utf8`.
These symbols have been present within Mono for ages at this point,
and requiring means we don't need to support `dlopen(NULL)` semantics.

Update the `@(ClInclude)` item group and `BuildMac` and related targets
so that we properly rebuild things when e.g. `java-interop-dlfcn.h`
changes, as would "normally" be expected.

Finally, the continued use of `MONO_API` and other macros causes
"weird" compiler issues when integrating with xamarin-android.
Replace `MONO_API`/etc. use with `JAVA_INTEROP_API`/etc. instead.

[0]: https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.defaultdllimportsearchpathsattribute?view=netcore-3.1
[1]: https://docs.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexa?redirectedfrom=MSDN
[2]: https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.dllimportsearchpath?view=netcore-3.1
[3]: https://linux.die.net/man/3/dlopen
[4]: https://github.com/dlfcn-win32/dlfcn-win32
[5]: https://docs.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexa