### PR TITLE
[generator] Clean up generated whitespace.

### DIFF
--- a/src/Xamarin.SourceWriter/CodeWriter.cs
+++ b/src/Xamarin.SourceWriter/CodeWriter.cs
@@ -33,22 +33,31 @@ namespace Xamarin.SourceWriter
 
 		public void WriteLine ()
 		{
-			WriteIndent ();
 			stream.WriteLine ();
 			need_indent = true;
 		}
 
 		public void WriteLine (string value)
 		{
-			WriteIndent ();
+			if (value?.Length > 0)
+				WriteIndent ();
+
 			stream.WriteLine (value);
 			need_indent = true;
 		}
 
 		public void WriteLine (string format, params object[] args)
 		{
-			WriteIndent ();
+			if (format?.Length > 0)
+				WriteIndent ();
+
 			stream.WriteLine (format, args);
+			need_indent = true;
+		}
+
+		public void WriteLineNoIndent (string value)
+		{
+			stream.WriteLine (value);
 			need_indent = true;
 		}
 

--- a/src/Xamarin.SourceWriter/Models/CommentWriter.cs
+++ b/src/Xamarin.SourceWriter/Models/CommentWriter.cs
@@ -16,7 +16,10 @@ namespace Xamarin.SourceWriter
 
 		public virtual void Write (CodeWriter writer)
 		{
-			writer.WriteLine (Value);
+			if (Value.StartsWith ("#pragma"))
+				writer.WriteLineNoIndent (Value);
+			else
+				writer.WriteLine (Value);
 		}
 	}
 }

--- a/src/Xamarin.SourceWriter/Models/PropertyWriter.cs
+++ b/src/Xamarin.SourceWriter/Models/PropertyWriter.cs
@@ -156,18 +156,43 @@ namespace Xamarin.SourceWriter
 
 		protected virtual void WriteAutomaticPropertyBody (CodeWriter writer)
 		{
-			writer.Write ("{ ");
+			var need_unindent = false;
+
+			writer.Write ("{");
 
 			if (HasGet) {
+				if (GetterComments.Count > 0 || GetterAttributes.Count > 0) {
+					writer.WriteLine ();
+					writer.Indent ();
+					need_unindent = true;
+				}
+
 				WriteGetterComments (writer);
 				WriteGetterAttributes (writer);
 				writer.Write ("get; ");
+
+				if (need_unindent) {
+					writer.WriteLine ();
+					writer.Unindent ();
+					need_unindent = false;
+				}
 			}
 
 			if (HasSet) {
+				if (SetterComments.Count > 0 || SetterAttributes.Count > 0) {
+					writer.WriteLine ();
+					writer.Indent ();
+					need_unindent = true;
+				}
+
 				WriteSetterComments (writer);
 				WriteSetterAttributes (writer);
 				writer.Write ("set; ");
+
+				if (need_unindent) {
+					writer.WriteLine ();
+					writer.Unindent ();
+				}
 			}
 
 			writer.WriteLine ("}");

--- a/src/Xamarin.SourceWriter/Models/TypeWriter.cs
+++ b/src/Xamarin.SourceWriter/Models/TypeWriter.cs
@@ -158,13 +158,9 @@ namespace Xamarin.SourceWriter
 
 			WriteConstructors (writer);
 
-			writer.WriteLine ();
 			WriteEvents (writer);
-			writer.WriteLine ();
 			WriteDelegates (writer);
-			writer.WriteLine ();
 			WriteProperties (writer);
-			writer.WriteLine ();
 			WriteMethods (writer);
 		}
 

--- a/tests/Xamarin.SourceWriter-Tests/ClassWriterTests.cs
+++ b/tests/Xamarin.SourceWriter-Tests/ClassWriterTests.cs
@@ -34,13 +34,13 @@ namespace Xamarin.SourceWriter.Tests
 			var expected =
 @"public partial class MyClass : System.Object {
 	public bool my_field;
-	
+
 	// Test comment
-	
+
 	public void MyMethod (bool test)
 	{
 	}
-	
+
 }
 ";
 

--- a/tests/Xamarin.SourceWriter-Tests/InterfaceWriterTests.cs
+++ b/tests/Xamarin.SourceWriter-Tests/InterfaceWriterTests.cs
@@ -31,7 +31,7 @@ namespace Xamarin.SourceWriter.Tests
 			var expected =
 @"public partial interface IMyInterface : IDisposable {
 	void MyMethod (bool test);
-	
+
 }
 ";
 

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/ObsoleteInterfaceAlternativeClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/ObsoleteInterfaceAlternativeClass.txt
@@ -1,7 +1,6 @@
 [Register ("com/xamarin/android/Parent", DoNotGenerateAcw=true)]
 [global::System.Obsolete ("Use the 'Com.Xamarin.Android.IParent' type. This class will be removed in a future release.")]
 public abstract class Parent : Java.Lang.Object {
-
 	internal Parent ()
 	{
 	}
@@ -28,6 +27,7 @@ public abstract class Parent : Java.Lang.Object {
 			return JNIEnv.GetString (__v.Handle, JniHandleOwnership.TransferLocalRef);
 		}
 	}
+
 	// Metadata.xml XPath method reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent']/method[@name='comparing' and count(parameter)=0]"
 	[Obsolete (@"Use 'Com.Xamarin.Android.IParent.Comparing'. This class will be removed in a future release.")]
 	[Register ("comparing", "()I", "")]
@@ -54,8 +54,8 @@ public abstract class Parent : Java.Lang.Object {
 		}
 	}
 
-
 	static readonly JniPeerMembers _members = new JniPeerMembers ("com/xamarin/android/Parent", typeof (Parent));
+
 }
 
 // Metadata.xml XPath interface reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent']"
@@ -101,7 +101,6 @@ public partial interface IParent : IJavaObject, IJavaPeerable {
 
 [global::Android.Runtime.Register ("com/xamarin/android/Parent", DoNotGenerateAcw=true)]
 internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
-
 	static readonly JniPeerMembers _members = new JniPeerMembers ("com/xamarin/android/Parent", typeof (IParentInvoker));
 
 	static IntPtr java_class_ref {
@@ -130,8 +129,7 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 	static IntPtr Validate (IntPtr handle)
 	{
 		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
-			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
-						JNIEnv.GetClassNameFromInstance (handle), "com.xamarin.android.Parent"));
+			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "com.xamarin.android.Parent"));
 		return handle;
 	}
 
@@ -151,4 +149,3 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 	}
 
 }
-

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteClass.txt
@@ -1,20 +1,19 @@
 // Metadata.xml XPath class reference: path="/api/package[@name='java.code']/class[@name='MyClass']"
 [global::Android.Runtime.Register ("java/code/MyClass", DoNotGenerateAcw=true)]
-public partial class MyClass  {
-
+public partial class MyClass {
 	static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/MyClass", typeof (MyClass));
+
 	internal static IntPtr class_ref {
-		get {
-			return _members.JniPeerType.PeerReference.Handle;
-		}
+		get { return _members.JniPeerType.PeerReference.Handle; }
 	}
 
-	protected MyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+	protected MyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+	{
+	}
 
 	// Metadata.xml XPath constructor reference: path="/api/package[@name='java.code']/class[@name='MyClass']/constructor[@name='MyClass' and count(parameter)=0]"
 	[Register (".ctor", "()V", "")]
-	 unsafe MyClass ()
-		: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+	unsafe MyClass () : base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 	{
 		const string __id = "()V";
 
@@ -31,8 +30,7 @@ public partial class MyClass  {
 
 	// Metadata.xml XPath constructor reference: path="/api/package[@name='java.code']/class[@name='MyClass']/constructor[@name='MyClass' and count(parameter)=1 and parameter[1][@type='java.lang.String']]"
 	[Register (".ctor", "(Ljava/lang/String;)V", "")]
-	 unsafe MyClass (string p0)
-		: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+	unsafe MyClass (string p0) : base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 	{
 		const string __id = "(Ljava/lang/String;)V";
 
@@ -224,9 +222,12 @@ public partial class MyClass  {
 
 	public abstract int AbstractCount {
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='get_AbstractCount' and count(parameter)=0]"
-		[Register ("get_AbstractCount", "()I", "Getget_AbstractCountHandler")] get;
+		[Register ("get_AbstractCount", "()I", "Getget_AbstractCountHandler")]
+		get; 
+
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='set_AbstractCount' and count(parameter)=1 and parameter[1][@type='int']]"
-		[Register ("set_AbstractCount", "(I)V", "Getset_AbstractCount_IHandler")] set;
+		[Register ("set_AbstractCount", "(I)V", "Getset_AbstractCount_IHandler")]
+		set; 
 	}
 
 	static Delegate cb_GetCountForKey_Ljava_lang_String_;

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteDefaultInterfaceMethodInvoker.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteDefaultInterfaceMethodInvoker.txt
@@ -2,37 +2,40 @@
 [Register ("java/code/IMyInterface", "", "java.code.IMyInterfaceInvoker")]
 public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 	private static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
-	
+
 	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='DoDeclaration' and count(parameter)=0]"
 	[Register ("DoDeclaration", "()V", "GetDoDeclarationHandler:java.code.IMyInterfaceInvoker, MyAssembly")]
 	void DoDeclaration ();
-	
+
 	private static Delegate cb_DoDefault;
-	#pragma warning disable 0169
+#pragma warning disable 0169
 	private static Delegate GetDoDefaultHandler ()
 	{
 		if (cb_DoDefault == null)
 			cb_DoDefault = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_V) n_DoDefault);
 		return cb_DoDefault;
 	}
+
 	private static void n_DoDefault (IntPtr jnienv, IntPtr native__this)
 	{
 		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.DoDefault ();
 	}
-	#pragma warning restore 0169
+#pragma warning restore 0169
+
 	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='DoDefault' and count(parameter)=0]"
 	[Register ("DoDefault", "()V", "GetDoDefaultHandler:java.code.IMyInterface, MyAssembly")]
 	virtual unsafe void DoDefault ()
 	{
 		const string __id = "DoDefault.()V";
 		try {
-		_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, null);
+			_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, null);
 		} finally {
 		}
 	}
-	
+
 }
+
 [global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
 	static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
@@ -63,8 +66,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static IntPtr Validate (IntPtr handle)
 	{
 		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
-			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
-						JNIEnv.GetClassNameFromInstance (handle), "java.code.IMyInterface"));
+			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "java.code.IMyInterface"));
 		return handle;
 	}
 
@@ -108,4 +110,3 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	}
 
 }
-

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterface.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterface.txt
@@ -1,9 +1,9 @@
 [Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 public abstract class MyInterface : Java.Lang.Object {
-
 	internal MyInterface ()
 	{
 	}
+
 	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='StaticMethod' and count(parameter)=0]"
 	[Register ("StaticMethod", "()V", "")]
 	public static unsafe void StaticMethod ()
@@ -15,42 +15,50 @@ public abstract class MyInterface : Java.Lang.Object {
 		}
 	}
 
-
 	static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (MyInterface));
+
 }
 
 [Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 [global::System.Obsolete ("Use the 'MyInterface' type. This type will be removed in a future release.", error: true)]
 public abstract class MyInterfaceConsts : MyInterface {
-
 	private MyInterfaceConsts ()
 	{
 	}
+
 }
 
 // Metadata.xml XPath interface reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']"
 [Register ("java/code/IMyInterface", "", "java.code.IMyInterfaceInvoker")]
 public partial interface IMyInterface : IJavaObject, IJavaPeerable {
-
 	int Count {
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='get_Count' and count(parameter)=0]"
-		[Register ("get_Count", "()I", "Getget_CountHandler:java.code.IMyInterfaceInvoker, ")] get;
+		[Register ("get_Count", "()I", "Getget_CountHandler:java.code.IMyInterfaceInvoker, ")]
+		get; 
+
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='set_Count' and count(parameter)=1 and parameter[1][@type='int']]"
-		[Register ("set_Count", "(I)V", "Getset_Count_IHandler:java.code.IMyInterfaceInvoker, ")] set;
+		[Register ("set_Count", "(I)V", "Getset_Count_IHandler:java.code.IMyInterfaceInvoker, ")]
+		set; 
 	}
 
 	string Key {
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='get_Key' and count(parameter)=0]"
-		[Register ("get_Key", "()Ljava/lang/String;", "Getget_KeyHandler:java.code.IMyInterfaceInvoker, ")] get;
+		[Register ("get_Key", "()Ljava/lang/String;", "Getget_KeyHandler:java.code.IMyInterfaceInvoker, ")]
+		get; 
+
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='set_Key' and count(parameter)=1 and parameter[1][@type='java.lang.String']]"
-		[Register ("set_Key", "(Ljava/lang/String;)V", "Getset_Key_Ljava_lang_String_Handler:java.code.IMyInterfaceInvoker, ")] set;
+		[Register ("set_Key", "(Ljava/lang/String;)V", "Getset_Key_Ljava_lang_String_Handler:java.code.IMyInterfaceInvoker, ")]
+		set; 
 	}
 
 	int AbstractCount {
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='get_AbstractCount' and count(parameter)=0]"
-		[Register ("get_AbstractCount", "()I", "Getget_AbstractCountHandler:java.code.IMyInterfaceInvoker, ")] get;
+		[Register ("get_AbstractCount", "()I", "Getget_AbstractCountHandler:java.code.IMyInterfaceInvoker, ")]
+		get; 
+
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='set_AbstractCount' and count(parameter)=1 and parameter[1][@type='int']]"
-		[Register ("set_AbstractCount", "(I)V", "Getset_AbstractCount_IHandler:java.code.IMyInterfaceInvoker, ")] set;
+		[Register ("set_AbstractCount", "(I)V", "Getset_AbstractCount_IHandler:java.code.IMyInterfaceInvoker, ")]
+		set; 
 	}
 
 	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='GetCountForKey' and count(parameter)=1 and parameter[1][@type='java.lang.String']]"
@@ -69,7 +77,6 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 
 [global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
-
 	static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
 
 	static IntPtr java_class_ref {
@@ -98,8 +105,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static IntPtr Validate (IntPtr handle)
 	{
 		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
-			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
-						JNIEnv.GetClassNameFromInstance (handle), "java.code.IMyInterface"));
+			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "java.code.IMyInterface"));
 		return handle;
 	}
 
@@ -348,4 +354,3 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	}
 
 }
-

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterfaceDefaultMethod.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterfaceDefaultMethod.txt
@@ -2,67 +2,70 @@
 [Register ("java/code/IMyInterface", "", "java.code.IMyInterfaceInvoker")]
 public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 	private static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
-	
+
 	private static Delegate cb_DoSomething;
-	#pragma warning disable 0169
+#pragma warning disable 0169
 	private static Delegate GetDoSomethingHandler ()
 	{
 		if (cb_DoSomething == null)
 			cb_DoSomething = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_V) n_DoSomething);
 		return cb_DoSomething;
 	}
+
 	private static void n_DoSomething (IntPtr jnienv, IntPtr native__this)
 	{
 		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.DoSomething ();
 	}
-	#pragma warning restore 0169
+#pragma warning restore 0169
+
 	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='DoSomething' and count(parameter)=0]"
 	[Register ("DoSomething", "()V", "GetDoSomethingHandler:java.code.IMyInterface, MyAssembly")]
 	virtual unsafe void DoSomething ()
 	{
 		const string __id = "DoSomething.()V";
 		try {
-		_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, null);
+			_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, null);
 		} finally {
 		}
 	}
-	
+
 }
+
 [global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
 	static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
-	
+
 	static IntPtr java_class_ref {
 		get { return _members.JniPeerType.PeerReference.Handle; }
 	}
-	
+
 	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 		get { return _members; }
 	}
-	
+
 	protected override IntPtr ThresholdClass {
 		get { return class_ref; }
 	}
-	
+
 	protected override global::System.Type ThresholdType {
 		get { return _members.ManagedPeerType; }
 	}
-	
+
 	IntPtr class_ref;
-	
+
 	public static IMyInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
 	{
 		return global::Java.Lang.Object.GetObject<IMyInterface> (handle, transfer);
 	}
-	
+
 	static IntPtr Validate (IntPtr handle)
 	{
 		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
 			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "java.code.IMyInterface"));
 		return handle;
 	}
-	
+
 	protected override void Dispose (bool disposing)
 	{
 		if (this.class_ref != IntPtr.Zero)
@@ -70,12 +73,12 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		this.class_ref = IntPtr.Zero;
 		base.Dispose (disposing);
 	}
-	
+
 	public IMyInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
 	{
 		IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
 		this.class_ref = JNIEnv.NewGlobalRef (local_ref);
 		JNIEnv.DeleteLocalRef (local_ref);
 	}
-	
+
 }

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterfaceDefaultProperty.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterfaceDefaultProperty.txt
@@ -2,43 +2,47 @@
 [Register ("java/code/IMyInterface", "", "java.code.IMyInterfaceInvoker")]
 public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 	private static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
-	
+
 	private static Delegate cb_get_Value;
-	#pragma warning disable 0169
+#pragma warning disable 0169
 	private static Delegate Getget_ValueHandler ()
 	{
 		if (cb_get_Value == null)
 			cb_get_Value = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_I) n_get_Value);
 		return cb_get_Value;
 	}
+
 	private static int n_get_Value (IntPtr jnienv, IntPtr native__this)
 	{
 		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return __this.Value;
 	}
-	#pragma warning restore 0169
+#pragma warning restore 0169
+
 	private static Delegate cb_set_Value_I;
-	#pragma warning disable 0169
+#pragma warning disable 0169
 	private static Delegate Getset_Value_IHandler ()
 	{
 		if (cb_set_Value_I == null)
 			cb_set_Value_I = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPI_V) n_set_Value_I);
 		return cb_set_Value_I;
 	}
+
 	private static void n_set_Value_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
 		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.Value = value;
 	}
-	#pragma warning restore 0169
+#pragma warning restore 0169
+
 	virtual unsafe int Value {
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='get_Value' and count(parameter)=0]"
 		[Register ("get_Value", "()I", "Getget_ValueHandler:java.code.IMyInterface, MyAssembly")]
 		get {
 			const string __id = "get_Value.()I";
 			try {
-			var __rm = _members.InstanceMethods.InvokeVirtualInt32Method (__id, this, null);
-			return __rm;
+				var __rm = _members.InstanceMethods.InvokeVirtualInt32Method (__id, this, null);
+				return __rm;
 			} finally {
 			}
 		}
@@ -47,49 +51,50 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 		set {
 			const string __id = "set_Value.(I)V";
 			try {
-			JniArgumentValue* __args = stackalloc JniArgumentValue [1];
-			__args [0] = new JniArgumentValue (value);
-			_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, __args);
+				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+				__args [0] = new JniArgumentValue (value);
+				_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, __args);
 			} finally {
 			}
 		}
 	}
-	
+
 }
+
 [global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
 	static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
-	
+
 	static IntPtr java_class_ref {
 		get { return _members.JniPeerType.PeerReference.Handle; }
 	}
-	
+
 	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 		get { return _members; }
 	}
-	
+
 	protected override IntPtr ThresholdClass {
 		get { return class_ref; }
 	}
-	
+
 	protected override global::System.Type ThresholdType {
 		get { return _members.ManagedPeerType; }
 	}
-	
+
 	IntPtr class_ref;
-	
+
 	public static IMyInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
 	{
 		return global::Java.Lang.Object.GetObject<IMyInterface> (handle, transfer);
 	}
-	
+
 	static IntPtr Validate (IntPtr handle)
 	{
 		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
 			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "java.code.IMyInterface"));
 		return handle;
 	}
-	
+
 	protected override void Dispose (bool disposing)
 	{
 		if (this.class_ref != IntPtr.Zero)
@@ -97,12 +102,12 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		this.class_ref = IntPtr.Zero;
 		base.Dispose (disposing);
 	}
-	
+
 	public IMyInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
 	{
 		IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
 		this.class_ref = JNIEnv.NewGlobalRef (local_ref);
 		JNIEnv.DeleteLocalRef (local_ref);
 	}
-	
+
 }

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterfaceDefaultPropertyGetterOnly.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterfaceDefaultPropertyGetterOnly.txt
@@ -2,69 +2,72 @@
 [Register ("java/code/IMyInterface", "", "java.code.IMyInterfaceInvoker")]
 public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 	private static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
-	
+
 	private static Delegate cb_get_Value;
-	#pragma warning disable 0169
+#pragma warning disable 0169
 	private static Delegate Getget_ValueHandler ()
 	{
 		if (cb_get_Value == null)
 			cb_get_Value = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_I) n_get_Value);
 		return cb_get_Value;
 	}
+
 	private static int n_get_Value (IntPtr jnienv, IntPtr native__this)
 	{
 		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return __this.Value;
 	}
-	#pragma warning restore 0169
+#pragma warning restore 0169
+
 	virtual unsafe int Value {
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='get_Value' and count(parameter)=0]"
 		[Register ("get_Value", "()I", "Getget_ValueHandler:java.code.IMyInterface, MyAssembly")]
 		get {
 			const string __id = "get_Value.()I";
 			try {
-			var __rm = _members.InstanceMethods.InvokeVirtualInt32Method (__id, this, null);
-			return __rm;
+				var __rm = _members.InstanceMethods.InvokeVirtualInt32Method (__id, this, null);
+				return __rm;
 			} finally {
 			}
 		}
 	}
-	
+
 }
+
 [global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
 	static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
-	
+
 	static IntPtr java_class_ref {
 		get { return _members.JniPeerType.PeerReference.Handle; }
 	}
-	
+
 	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 		get { return _members; }
 	}
-	
+
 	protected override IntPtr ThresholdClass {
 		get { return class_ref; }
 	}
-	
+
 	protected override global::System.Type ThresholdType {
 		get { return _members.ManagedPeerType; }
 	}
-	
+
 	IntPtr class_ref;
-	
+
 	public static IMyInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
 	{
 		return global::Java.Lang.Object.GetObject<IMyInterface> (handle, transfer);
 	}
-	
+
 	static IntPtr Validate (IntPtr handle)
 	{
 		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
 			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "java.code.IMyInterface"));
 		return handle;
 	}
-	
+
 	protected override void Dispose (bool disposing)
 	{
 		if (this.class_ref != IntPtr.Zero)
@@ -72,12 +75,12 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		this.class_ref = IntPtr.Zero;
 		base.Dispose (disposing);
 	}
-	
+
 	public IMyInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
 	{
 		IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
 		this.class_ref = JNIEnv.NewGlobalRef (local_ref);
 		JNIEnv.DeleteLocalRef (local_ref);
 	}
-	
+
 }

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterfaceRedeclaredDefaultMethod.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteInterfaceRedeclaredDefaultMethod.txt
@@ -4,42 +4,43 @@ public partial interface IMyInterface2 : java.code.IMyInterface {
 	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='DoSomething' and count(parameter)=0]"
 	[Register ("DoSomething", "()V", "GetDoSomethingHandler:java.code.IMyInterface2Invoker, MyAssembly")]
 	void DoSomething ();
-	
+
 }
+
 [global::Android.Runtime.Register ("java/code/IMyInterface2", DoNotGenerateAcw=true)]
 internal partial class IMyInterface2Invoker : global::Java.Lang.Object, IMyInterface2 {
 	static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface2", typeof (IMyInterface2Invoker));
-	
+
 	static IntPtr java_class_ref {
 		get { return _members.JniPeerType.PeerReference.Handle; }
 	}
-	
+
 	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 		get { return _members; }
 	}
-	
+
 	protected override IntPtr ThresholdClass {
 		get { return class_ref; }
 	}
-	
+
 	protected override global::System.Type ThresholdType {
 		get { return _members.ManagedPeerType; }
 	}
-	
+
 	IntPtr class_ref;
-	
+
 	public static IMyInterface2 GetObject (IntPtr handle, JniHandleOwnership transfer)
 	{
 		return global::Java.Lang.Object.GetObject<IMyInterface2> (handle, transfer);
 	}
-	
+
 	static IntPtr Validate (IntPtr handle)
 	{
 		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
 			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "java.code.IMyInterface2"));
 		return handle;
 	}
-	
+
 	protected override void Dispose (bool disposing)
 	{
 		if (this.class_ref != IntPtr.Zero)
@@ -47,28 +48,30 @@ internal partial class IMyInterface2Invoker : global::Java.Lang.Object, IMyInter
 		this.class_ref = IntPtr.Zero;
 		base.Dispose (disposing);
 	}
-	
+
 	public IMyInterface2Invoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
 	{
 		IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
 		this.class_ref = JNIEnv.NewGlobalRef (local_ref);
 		JNIEnv.DeleteLocalRef (local_ref);
 	}
-	
+
 	static Delegate cb_DoSomething;
-	#pragma warning disable 0169
+#pragma warning disable 0169
 	static Delegate GetDoSomethingHandler ()
 	{
 		if (cb_DoSomething == null)
 			cb_DoSomething = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_V) n_DoSomething);
 		return cb_DoSomething;
 	}
+
 	static void n_DoSomething (IntPtr jnienv, IntPtr native__this)
 	{
 		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.DoSomething ();
 	}
-	#pragma warning restore 0169
+#pragma warning restore 0169
+
 	IntPtr id_DoSomething;
 	public unsafe void DoSomething ()
 	{
@@ -76,5 +79,5 @@ internal partial class IMyInterface2Invoker : global::Java.Lang.Object, IMyInter
 			id_DoSomething = JNIEnv.GetMethodID (class_ref, "DoSomething", "()V");
 		JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_DoSomething);
 	}
-	
+
 }

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteKotlinUnsignedArrayTypeMethodsClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteKotlinUnsignedArrayTypeMethodsClass.txt
@@ -1,15 +1,15 @@
 // Metadata.xml XPath class reference: path="/api/package[@name='java.code']/class[@name='MyClass']"
 [global::Android.Runtime.Register ("java/code/MyClass", DoNotGenerateAcw=true)]
-public partial class MyClass  {
-
+public partial class MyClass {
 	static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/MyClass", typeof (MyClass));
+
 	internal static IntPtr class_ref {
-		get {
-			return _members.JniPeerType.PeerReference.Handle;
-		}
+		get { return _members.JniPeerType.PeerReference.Handle; }
 	}
 
-	protected MyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+	protected MyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+	{
+	}
 
 	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='Echo' and count(parameter)=1 and parameter[1][@type='uint[]']]"
 	[Register ("Echo", "([I)[I", "")]

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteKotlinUnsignedArrayTypePropertiesClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteKotlinUnsignedArrayTypePropertiesClass.txt
@@ -1,15 +1,15 @@
 // Metadata.xml XPath class reference: path="/api/package[@name='java.code']/class[@name='MyClass']"
 [global::Android.Runtime.Register ("java/code/MyClass", DoNotGenerateAcw=true)]
-public partial class MyClass  {
-
+public partial class MyClass {
 	static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/MyClass", typeof (MyClass));
+
 	internal static IntPtr class_ref {
-		get {
-			return _members.JniPeerType.PeerReference.Handle;
-		}
+		get { return _members.JniPeerType.PeerReference.Handle; }
 	}
 
-	protected MyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+	protected MyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+	{
+	}
 
 	public unsafe uint[] UIntProp {
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='get_UIntProp' and count(parameter)=0]"

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteKotlinUnsignedTypeMethodsClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteKotlinUnsignedTypeMethodsClass.txt
@@ -1,15 +1,15 @@
 // Metadata.xml XPath class reference: path="/api/package[@name='java.code']/class[@name='MyClass']"
 [global::Android.Runtime.Register ("java/code/MyClass", DoNotGenerateAcw=true)]
-public partial class MyClass  {
-
+public partial class MyClass {
 	static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/MyClass", typeof (MyClass));
+
 	internal static IntPtr class_ref {
-		get {
-			return _members.JniPeerType.PeerReference.Handle;
-		}
+		get { return _members.JniPeerType.PeerReference.Handle; }
 	}
 
-	protected MyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+	protected MyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+	{
+	}
 
 	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='Echo' and count(parameter)=1 and parameter[1][@type='uint']]"
 	[Register ("Echo", "(I)I", "")]

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteKotlinUnsignedTypePropertiesClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteKotlinUnsignedTypePropertiesClass.txt
@@ -1,15 +1,15 @@
 // Metadata.xml XPath class reference: path="/api/package[@name='java.code']/class[@name='MyClass']"
 [global::Android.Runtime.Register ("java/code/MyClass", DoNotGenerateAcw=true)]
-public partial class MyClass  {
-
+public partial class MyClass {
 	static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/MyClass", typeof (MyClass));
+
 	internal static IntPtr class_ref {
-		get {
-			return _members.JniPeerType.PeerReference.Handle;
-		}
+		get { return _members.JniPeerType.PeerReference.Handle; }
 	}
 
-	protected MyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+	protected MyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+	{
+	}
 
 	public unsafe uint UIntProp {
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='get_UIntProp' and count(parameter)=0]"

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteNestedInterfaceClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteNestedInterfaceClass.txt
@@ -1,21 +1,19 @@
 // Metadata.xml XPath interface reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent']"
 [Register ("com/xamarin/android/Parent", "", "Com.Xamarin.Android.IParentInvoker")]
 public partial interface IParent : IJavaObject, IJavaPeerable {
-
 	int Bar {
 		// Metadata.xml XPath method reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent']/method[@name='getBar' and count(parameter)=0]"
-		[Register ("getBar", "()I", "GetGetBarHandler:Com.Xamarin.Android.IParentInvoker, MyAssembly")] get;
+		[Register ("getBar", "()I", "GetGetBarHandler:Com.Xamarin.Android.IParentInvoker, MyAssembly")]
+		get; 
 	}
 
 	// Metadata.xml XPath class reference: path="/api/package[@name='com.xamarin.android']/class[@name='Parent.Child']"
 	[global::Android.Runtime.Register ("com/xamarin/android/Parent$Child", DoNotGenerateAcw=true)]
 	public partial class Child : Java.Lang.Object {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("com/xamarin/android/Parent$Child", typeof (Child));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -30,7 +28,9 @@ public partial interface IParent : IJavaObject, IJavaPeerable {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected Child (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected Child (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 	}
 
@@ -38,7 +38,6 @@ public partial interface IParent : IJavaObject, IJavaPeerable {
 
 [global::Android.Runtime.Register ("com/xamarin/android/Parent", DoNotGenerateAcw=true)]
 internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
-
 	static readonly JniPeerMembers _members = new JniPeerMembers ("com/xamarin/android/Parent", typeof (IParentInvoker));
 
 	static IntPtr java_class_ref {
@@ -67,8 +66,7 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 	static IntPtr Validate (IntPtr handle)
 	{
 		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
-			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
-						JNIEnv.GetClassNameFromInstance (handle), "com.xamarin.android.Parent"));
+			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "com.xamarin.android.Parent"));
 		return handle;
 	}
 
@@ -113,4 +111,3 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 	}
 
 }
-

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteNestedInterfaceTypes.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteNestedInterfaceTypes.txt
@@ -1,26 +1,25 @@
 // Metadata.xml XPath interface reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent']"
 [Register ("com/xamarin/android/Parent", "", "Com.Xamarin.Android.IParentInvoker")]
 public partial interface IParent : IJavaObject, IJavaPeerable {
-
 	int Bar {
 		// Metadata.xml XPath method reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent']/method[@name='getBar' and count(parameter)=0]"
-		[Register ("getBar", "()I", "GetGetBarHandler:Com.Xamarin.Android.IParentInvoker, MyAssembly")] get;
+		[Register ("getBar", "()I", "GetGetBarHandler:Com.Xamarin.Android.IParentInvoker, MyAssembly")]
+		get; 
 	}
 
 	// Metadata.xml XPath interface reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent.Child']"
 	[Register ("com/xamarin/android/Parent$Child", "", "Com.Xamarin.Android.IParent/IChildInvoker")]
 	public partial interface IChild : IJavaObject, IJavaPeerable {
-
 		int Bar {
 			// Metadata.xml XPath method reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent.Child']/method[@name='getBar' and count(parameter)=0]"
-			[Register ("getBar", "()I", "GetGetBarHandler:Com.Xamarin.Android.IParent/IChildInvoker, MyAssembly")] get;
+			[Register ("getBar", "()I", "GetGetBarHandler:Com.Xamarin.Android.IParent/IChildInvoker, MyAssembly")]
+			get; 
 		}
 
 	}
 
 	[global::Android.Runtime.Register ("com/xamarin/android/Parent$Child", DoNotGenerateAcw=true)]
 	internal partial class IChildInvoker : global::Java.Lang.Object, IChild {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("com/xamarin/android/Parent$Child", typeof (IChildInvoker));
 
 		static IntPtr java_class_ref {
@@ -49,8 +48,7 @@ public partial interface IParent : IJavaObject, IJavaPeerable {
 		static IntPtr Validate (IntPtr handle)
 		{
 			if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
-				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
-							JNIEnv.GetClassNameFromInstance (handle), "com.xamarin.android.Parent.Child"));
+				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "com.xamarin.android.Parent.Child"));
 			return handle;
 		}
 
@@ -96,12 +94,10 @@ public partial interface IParent : IJavaObject, IJavaPeerable {
 
 	}
 
-
 }
 
 [global::Android.Runtime.Register ("com/xamarin/android/Parent", DoNotGenerateAcw=true)]
 internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
-
 	static readonly JniPeerMembers _members = new JniPeerMembers ("com/xamarin/android/Parent", typeof (IParentInvoker));
 
 	static IntPtr java_class_ref {
@@ -130,8 +126,7 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 	static IntPtr Validate (IntPtr handle)
 	{
 		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
-			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
-						JNIEnv.GetClassNameFromInstance (handle), "com.xamarin.android.Parent"));
+			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "com.xamarin.android.Parent"));
 		return handle;
 	}
 
@@ -176,4 +171,3 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 	}
 
 }
-

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteStaticInterfaceMethod.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteStaticInterfaceMethod.txt
@@ -1,9 +1,9 @@
 [Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 public abstract class MyInterface : Java.Lang.Object {
-
 	internal MyInterface ()
 	{
 	}
+
 	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='DoSomething' and count(parameter)=0]"
 	[Register ("DoSomething", "()V", "")]
 	public static unsafe void DoSomething ()
@@ -15,17 +15,17 @@ public abstract class MyInterface : Java.Lang.Object {
 		}
 	}
 
-
 	static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (MyInterface));
+
 }
 
 [Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 [global::System.Obsolete ("Use the 'MyInterface' type. This type will be removed in a future release.", error: true)]
 public abstract class MyInterfaceConsts : MyInterface {
-
 	private MyInterfaceConsts ()
 	{
 	}
+
 }
 
 // Metadata.xml XPath interface reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']"
@@ -48,7 +48,6 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 
 [global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
-
 	static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
 
 	static IntPtr java_class_ref {
@@ -77,8 +76,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static IntPtr Validate (IntPtr handle)
 	{
 		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
-			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
-						JNIEnv.GetClassNameFromInstance (handle), "java.code.IMyInterface"));
+			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "java.code.IMyInterface"));
 		return handle;
 	}
 
@@ -98,4 +96,3 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	}
 
 }
-

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteStaticInterfaceProperty.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteStaticInterfaceProperty.txt
@@ -2,15 +2,15 @@
 [Register ("java/code/IMyInterface", "", "java.code.IMyInterfaceInvoker")]
 public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 	private static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
-	
+
 	static unsafe int Value {
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='get_Value' and count(parameter)=0]"
 		[Register ("get_Value", "()I", "")]
 		get {
 			const string __id = "get_Value.()I";
 			try {
-			var __rm = _members.StaticMethods.InvokeInt32Method (__id, null);
-			return __rm;
+				var __rm = _members.StaticMethods.InvokeInt32Method (__id, null);
+				return __rm;
 			} finally {
 			}
 		}
@@ -19,49 +19,50 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 		set {
 			const string __id = "set_Value.(I)V";
 			try {
-			JniArgumentValue* __args = stackalloc JniArgumentValue [1];
-			__args [0] = new JniArgumentValue (value);
-			_members.StaticMethods.InvokeVoidMethod (__id, __args);
+				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+				__args [0] = new JniArgumentValue (value);
+				_members.StaticMethods.InvokeVoidMethod (__id, __args);
 			} finally {
 			}
 		}
 	}
-	
+
 }
+
 [global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
 	static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
-	
+
 	static IntPtr java_class_ref {
 		get { return _members.JniPeerType.PeerReference.Handle; }
 	}
-	
+
 	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 		get { return _members; }
 	}
-	
+
 	protected override IntPtr ThresholdClass {
 		get { return class_ref; }
 	}
-	
+
 	protected override global::System.Type ThresholdType {
 		get { return _members.ManagedPeerType; }
 	}
-	
+
 	IntPtr class_ref;
-	
+
 	public static IMyInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
 	{
 		return global::Java.Lang.Object.GetObject<IMyInterface> (handle, transfer);
 	}
-	
+
 	static IntPtr Validate (IntPtr handle)
 	{
 		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
 			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "java.code.IMyInterface"));
 		return handle;
 	}
-	
+
 	protected override void Dispose (bool disposing)
 	{
 		if (this.class_ref != IntPtr.Zero)
@@ -69,12 +70,12 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		this.class_ref = IntPtr.Zero;
 		base.Dispose (disposing);
 	}
-	
+
 	public IMyInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
 	{
 		IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
 		this.class_ref = JNIEnv.NewGlobalRef (local_ref);
 		JNIEnv.DeleteLocalRef (local_ref);
 	}
-	
+
 }

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteUnnestedInterfaceTypes.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteUnnestedInterfaceTypes.txt
@@ -1,17 +1,16 @@
 // Metadata.xml XPath interface reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent.Child']"
 [Register ("com/xamarin/android/Parent$Child", "", "Com.Xamarin.Android.IParentChildInvoker")]
 public partial interface IParentChild : IJavaObject, IJavaPeerable {
-
 	int Bar {
 		// Metadata.xml XPath method reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent.Child']/method[@name='getBar' and count(parameter)=0]"
-		[Register ("getBar", "()I", "GetGetBarHandler:Com.Xamarin.Android.IParentChildInvoker, MyAssembly")] get;
+		[Register ("getBar", "()I", "GetGetBarHandler:Com.Xamarin.Android.IParentChildInvoker, MyAssembly")]
+		get; 
 	}
 
 }
 
 [global::Android.Runtime.Register ("com/xamarin/android/Parent$Child", DoNotGenerateAcw=true)]
 internal partial class IParentChildInvoker : global::Java.Lang.Object, IParentChild {
-
 	static readonly JniPeerMembers _members = new JniPeerMembers ("com/xamarin/android/Parent$Child", typeof (IParentChildInvoker));
 
 	static IntPtr java_class_ref {
@@ -40,8 +39,7 @@ internal partial class IParentChildInvoker : global::Java.Lang.Object, IParentCh
 	static IntPtr Validate (IntPtr handle)
 	{
 		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
-			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
-						JNIEnv.GetClassNameFromInstance (handle), "com.xamarin.android.Parent.Child"));
+			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "com.xamarin.android.Parent.Child"));
 		return handle;
 	}
 
@@ -87,21 +85,19 @@ internal partial class IParentChildInvoker : global::Java.Lang.Object, IParentCh
 
 }
 
-
 // Metadata.xml XPath interface reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent']"
 [Register ("com/xamarin/android/Parent", "", "Com.Xamarin.Android.IParentInvoker")]
 public partial interface IParent : IJavaObject, IJavaPeerable {
-
 	int Bar {
 		// Metadata.xml XPath method reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent']/method[@name='getBar' and count(parameter)=0]"
-		[Register ("getBar", "()I", "GetGetBarHandler:Com.Xamarin.Android.IParentInvoker, MyAssembly")] get;
+		[Register ("getBar", "()I", "GetGetBarHandler:Com.Xamarin.Android.IParentInvoker, MyAssembly")]
+		get; 
 	}
 
 }
 
 [global::Android.Runtime.Register ("com/xamarin/android/Parent", DoNotGenerateAcw=true)]
 internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
-
 	static readonly JniPeerMembers _members = new JniPeerMembers ("com/xamarin/android/Parent", typeof (IParentInvoker));
 
 	static IntPtr java_class_ref {
@@ -130,8 +126,7 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 	static IntPtr Validate (IntPtr handle)
 	{
 		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
-			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
-						JNIEnv.GetClassNameFromInstance (handle), "com.xamarin.android.Parent"));
+			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "com.xamarin.android.Parent"));
 		return handle;
 	}
 
@@ -176,4 +171,3 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 	}
 
 }
-

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteClass.txt
@@ -1,20 +1,19 @@
 // Metadata.xml XPath class reference: path="/api/package[@name='java.code']/class[@name='MyClass']"
 [global::Android.Runtime.Register ("java/code/MyClass", DoNotGenerateAcw=true)]
-public partial class MyClass  {
-
+public partial class MyClass {
 	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/MyClass", typeof (MyClass));
+
 	internal static IntPtr class_ref {
-		get {
-			return _members.JniPeerType.PeerReference.Handle;
-		}
+		get { return _members.JniPeerType.PeerReference.Handle; }
 	}
 
-	protected MyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+	protected MyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+	{
+	}
 
 	// Metadata.xml XPath constructor reference: path="/api/package[@name='java.code']/class[@name='MyClass']/constructor[@name='MyClass' and count(parameter)=0]"
 	[Register (".ctor", "()V", "")]
-	 unsafe MyClass ()
-		: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+	unsafe MyClass () : base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 	{
 		const string __id = "()V";
 
@@ -31,8 +30,7 @@ public partial class MyClass  {
 
 	// Metadata.xml XPath constructor reference: path="/api/package[@name='java.code']/class[@name='MyClass']/constructor[@name='MyClass' and count(parameter)=1 and parameter[1][@type='java.lang.String']]"
 	[Register (".ctor", "(Ljava/lang/String;)V", "")]
-	 unsafe MyClass (string? p0)
-		: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+	unsafe MyClass (string? p0) : base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 	{
 		const string __id = "(Ljava/lang/String;)V";
 
@@ -224,9 +222,12 @@ public partial class MyClass  {
 
 	public abstract int AbstractCount {
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='get_AbstractCount' and count(parameter)=0]"
-		[Register ("get_AbstractCount", "()I", "Getget_AbstractCountHandler")] get;
+		[Register ("get_AbstractCount", "()I", "Getget_AbstractCountHandler")]
+		get; 
+
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='set_AbstractCount' and count(parameter)=1 and parameter[1][@type='int']]"
-		[Register ("set_AbstractCount", "(I)V", "Getset_AbstractCount_IHandler")] set;
+		[Register ("set_AbstractCount", "(I)V", "Getset_AbstractCount_IHandler")]
+		set; 
 	}
 
 	static Delegate? cb_GetCountForKey_Ljava_lang_String_;

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteInterface.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteInterface.txt
@@ -1,9 +1,9 @@
 [Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 public abstract class MyInterface : Java.Lang.Object {
-
 	internal MyInterface ()
 	{
 	}
+
 	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='StaticMethod' and count(parameter)=0]"
 	[Register ("StaticMethod", "()V", "")]
 	public static unsafe void StaticMethod ()
@@ -15,42 +15,50 @@ public abstract class MyInterface : Java.Lang.Object {
 		}
 	}
 
-
 	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (MyInterface));
+
 }
 
 [Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 [global::System.Obsolete ("Use the 'MyInterface' type. This type will be removed in a future release.", error: true)]
 public abstract class MyInterfaceConsts : MyInterface {
-
 	private MyInterfaceConsts ()
 	{
 	}
+
 }
 
 // Metadata.xml XPath interface reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']"
 [Register ("java/code/IMyInterface", "", "java.code.IMyInterfaceInvoker")]
 public partial interface IMyInterface : IJavaObject, IJavaPeerable {
-
 	int Count {
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='get_Count' and count(parameter)=0]"
-		[Register ("get_Count", "()I", "Getget_CountHandler:java.code.IMyInterfaceInvoker, ")] get;
+		[Register ("get_Count", "()I", "Getget_CountHandler:java.code.IMyInterfaceInvoker, ")]
+		get; 
+
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='set_Count' and count(parameter)=1 and parameter[1][@type='int']]"
-		[Register ("set_Count", "(I)V", "Getset_Count_IHandler:java.code.IMyInterfaceInvoker, ")] set;
+		[Register ("set_Count", "(I)V", "Getset_Count_IHandler:java.code.IMyInterfaceInvoker, ")]
+		set; 
 	}
 
 	string? Key {
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='get_Key' and count(parameter)=0]"
-		[Register ("get_Key", "()Ljava/lang/String;", "Getget_KeyHandler:java.code.IMyInterfaceInvoker, ")] get;
+		[Register ("get_Key", "()Ljava/lang/String;", "Getget_KeyHandler:java.code.IMyInterfaceInvoker, ")]
+		get; 
+
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='set_Key' and count(parameter)=1 and parameter[1][@type='java.lang.String']]"
-		[Register ("set_Key", "(Ljava/lang/String;)V", "Getset_Key_Ljava_lang_String_Handler:java.code.IMyInterfaceInvoker, ")] set;
+		[Register ("set_Key", "(Ljava/lang/String;)V", "Getset_Key_Ljava_lang_String_Handler:java.code.IMyInterfaceInvoker, ")]
+		set; 
 	}
 
 	int AbstractCount {
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='get_AbstractCount' and count(parameter)=0]"
-		[Register ("get_AbstractCount", "()I", "Getget_AbstractCountHandler:java.code.IMyInterfaceInvoker, ")] get;
+		[Register ("get_AbstractCount", "()I", "Getget_AbstractCountHandler:java.code.IMyInterfaceInvoker, ")]
+		get; 
+
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='set_AbstractCount' and count(parameter)=1 and parameter[1][@type='int']]"
-		[Register ("set_AbstractCount", "(I)V", "Getset_AbstractCount_IHandler:java.code.IMyInterfaceInvoker, ")] set;
+		[Register ("set_AbstractCount", "(I)V", "Getset_AbstractCount_IHandler:java.code.IMyInterfaceInvoker, ")]
+		set; 
 	}
 
 	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='GetCountForKey' and count(parameter)=1 and parameter[1][@type='java.lang.String']]"
@@ -69,7 +77,6 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 
 [global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
-
 	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
 
 	static IntPtr java_class_ref {
@@ -98,8 +105,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static IntPtr Validate (IntPtr handle)
 	{
 		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
-			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
-						JNIEnv.GetClassNameFromInstance (handle), "java.code.IMyInterface"));
+			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "java.code.IMyInterface"));
 		return handle;
 	}
 
@@ -348,4 +354,3 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	}
 
 }
-

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/ObsoleteInterfaceAlternativeClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/ObsoleteInterfaceAlternativeClass.txt
@@ -1,7 +1,6 @@
 [Register ("com/xamarin/android/Parent", DoNotGenerateAcw=true)]
 [global::System.Obsolete ("Use the 'Com.Xamarin.Android.IParent' type. This class will be removed in a future release.")]
 public abstract class Parent : Java.Lang.Object {
-
 	internal Parent ()
 	{
 	}
@@ -28,6 +27,7 @@ public abstract class Parent : Java.Lang.Object {
 			return JNIEnv.GetString (__v.Handle, JniHandleOwnership.TransferLocalRef);
 		}
 	}
+
 	// Metadata.xml XPath method reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent']/method[@name='comparing' and count(parameter)=0]"
 	[Obsolete (@"Use 'Com.Xamarin.Android.IParent.Comparing'. This class will be removed in a future release.")]
 	[Register ("comparing", "()I", "")]
@@ -54,8 +54,8 @@ public abstract class Parent : Java.Lang.Object {
 		}
 	}
 
-
 	static readonly JniPeerMembers _members = new XAPeerMembers ("com/xamarin/android/Parent", typeof (Parent));
+
 }
 
 // Metadata.xml XPath interface reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent']"
@@ -101,7 +101,6 @@ public partial interface IParent : IJavaObject, IJavaPeerable {
 
 [global::Android.Runtime.Register ("com/xamarin/android/Parent", DoNotGenerateAcw=true)]
 internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
-
 	static readonly JniPeerMembers _members = new XAPeerMembers ("com/xamarin/android/Parent", typeof (IParentInvoker));
 
 	static IntPtr java_class_ref {
@@ -130,8 +129,7 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 	static IntPtr Validate (IntPtr handle)
 	{
 		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
-			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
-						JNIEnv.GetClassNameFromInstance (handle), "com.xamarin.android.Parent"));
+			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "com.xamarin.android.Parent"));
 		return handle;
 	}
 
@@ -151,4 +149,3 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 	}
 
 }
-

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClass.txt
@@ -1,20 +1,19 @@
 // Metadata.xml XPath class reference: path="/api/package[@name='java.code']/class[@name='MyClass']"
 [global::Android.Runtime.Register ("java/code/MyClass", DoNotGenerateAcw=true)]
-public partial class MyClass  {
-
+public partial class MyClass {
 	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/MyClass", typeof (MyClass));
+
 	internal static IntPtr class_ref {
-		get {
-			return _members.JniPeerType.PeerReference.Handle;
-		}
+		get { return _members.JniPeerType.PeerReference.Handle; }
 	}
 
-	protected MyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+	protected MyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+	{
+	}
 
 	// Metadata.xml XPath constructor reference: path="/api/package[@name='java.code']/class[@name='MyClass']/constructor[@name='MyClass' and count(parameter)=0]"
 	[Register (".ctor", "()V", "")]
-	 unsafe MyClass ()
-		: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+	unsafe MyClass () : base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 	{
 		const string __id = "()V";
 
@@ -31,8 +30,7 @@ public partial class MyClass  {
 
 	// Metadata.xml XPath constructor reference: path="/api/package[@name='java.code']/class[@name='MyClass']/constructor[@name='MyClass' and count(parameter)=1 and parameter[1][@type='java.lang.String']]"
 	[Register (".ctor", "(Ljava/lang/String;)V", "")]
-	 unsafe MyClass (string p0)
-		: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+	unsafe MyClass (string p0) : base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 	{
 		const string __id = "(Ljava/lang/String;)V";
 
@@ -224,9 +222,12 @@ public partial class MyClass  {
 
 	public abstract int AbstractCount {
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='get_AbstractCount' and count(parameter)=0]"
-		[Register ("get_AbstractCount", "()I", "Getget_AbstractCountHandler")] get;
+		[Register ("get_AbstractCount", "()I", "Getget_AbstractCountHandler")]
+		get; 
+
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/class[@name='MyClass']/method[@name='set_AbstractCount' and count(parameter)=1 and parameter[1][@type='int']]"
-		[Register ("set_AbstractCount", "(I)V", "Getset_AbstractCount_IHandler")] set;
+		[Register ("set_AbstractCount", "(I)V", "Getset_AbstractCount_IHandler")]
+		set; 
 	}
 
 	static Delegate cb_GetCountForKey_Ljava_lang_String_;

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteDefaultInterfaceMethodInvoker.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteDefaultInterfaceMethodInvoker.txt
@@ -2,71 +2,74 @@
 [Register ("java/code/IMyInterface", "", "java.code.IMyInterfaceInvoker")]
 public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 	private static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
-	
+
 	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='DoDeclaration' and count(parameter)=0]"
 	[Register ("DoDeclaration", "()V", "GetDoDeclarationHandler:java.code.IMyInterfaceInvoker, MyAssembly")]
 	void DoDeclaration ();
-	
+
 	private static Delegate cb_DoDefault;
-	#pragma warning disable 0169
+#pragma warning disable 0169
 	private static Delegate GetDoDefaultHandler ()
 	{
 		if (cb_DoDefault == null)
 			cb_DoDefault = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_V) n_DoDefault);
 		return cb_DoDefault;
 	}
+
 	private static void n_DoDefault (IntPtr jnienv, IntPtr native__this)
 	{
 		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.DoDefault ();
 	}
-	#pragma warning restore 0169
+#pragma warning restore 0169
+
 	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='DoDefault' and count(parameter)=0]"
 	[Register ("DoDefault", "()V", "GetDoDefaultHandler:java.code.IMyInterface, MyAssembly")]
 	virtual unsafe void DoDefault ()
 	{
 		const string __id = "DoDefault.()V";
 		try {
-		_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, null);
+			_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, null);
 		} finally {
 		}
 	}
-	
+
 }
+
 [global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
 	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
-	
+
 	static IntPtr java_class_ref {
 		get { return _members.JniPeerType.PeerReference.Handle; }
 	}
-	
+
 	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 		get { return _members; }
 	}
-	
+
 	protected override IntPtr ThresholdClass {
 		get { return class_ref; }
 	}
-	
+
 	protected override global::System.Type ThresholdType {
 		get { return _members.ManagedPeerType; }
 	}
-	
+
 	IntPtr class_ref;
-	
+
 	public static IMyInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
 	{
 		return global::Java.Lang.Object.GetObject<IMyInterface> (handle, transfer);
 	}
-	
+
 	static IntPtr Validate (IntPtr handle)
 	{
 		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
 			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "java.code.IMyInterface"));
 		return handle;
 	}
-	
+
 	protected override void Dispose (bool disposing)
 	{
 		if (this.class_ref != IntPtr.Zero)
@@ -74,28 +77,30 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		this.class_ref = IntPtr.Zero;
 		base.Dispose (disposing);
 	}
-	
+
 	public IMyInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
 	{
 		IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
 		this.class_ref = JNIEnv.NewGlobalRef (local_ref);
 		JNIEnv.DeleteLocalRef (local_ref);
 	}
-	
+
 	static Delegate cb_DoDeclaration;
-	#pragma warning disable 0169
+#pragma warning disable 0169
 	static Delegate GetDoDeclarationHandler ()
 	{
 		if (cb_DoDeclaration == null)
 			cb_DoDeclaration = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_V) n_DoDeclaration);
 		return cb_DoDeclaration;
 	}
+
 	static void n_DoDeclaration (IntPtr jnienv, IntPtr native__this)
 	{
 		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.DoDeclaration ();
 	}
-	#pragma warning restore 0169
+#pragma warning restore 0169
+
 	IntPtr id_DoDeclaration;
 	public unsafe void DoDeclaration ()
 	{
@@ -103,5 +108,5 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 			id_DoDeclaration = JNIEnv.GetMethodID (class_ref, "DoDeclaration", "()V");
 		JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_DoDeclaration);
 	}
-	
+
 }

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterface.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterface.txt
@@ -1,9 +1,9 @@
 [Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 public abstract class MyInterface : Java.Lang.Object {
-
 	internal MyInterface ()
 	{
 	}
+
 	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='StaticMethod' and count(parameter)=0]"
 	[Register ("StaticMethod", "()V", "")]
 	public static unsafe void StaticMethod ()
@@ -15,42 +15,50 @@ public abstract class MyInterface : Java.Lang.Object {
 		}
 	}
 
-
 	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (MyInterface));
+
 }
 
 [Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 [global::System.Obsolete ("Use the 'MyInterface' type. This type will be removed in a future release.", error: true)]
 public abstract class MyInterfaceConsts : MyInterface {
-
 	private MyInterfaceConsts ()
 	{
 	}
+
 }
 
 // Metadata.xml XPath interface reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']"
 [Register ("java/code/IMyInterface", "", "java.code.IMyInterfaceInvoker")]
 public partial interface IMyInterface : IJavaObject, IJavaPeerable {
-
 	int Count {
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='get_Count' and count(parameter)=0]"
-		[Register ("get_Count", "()I", "Getget_CountHandler:java.code.IMyInterfaceInvoker, ")] get;
+		[Register ("get_Count", "()I", "Getget_CountHandler:java.code.IMyInterfaceInvoker, ")]
+		get; 
+
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='set_Count' and count(parameter)=1 and parameter[1][@type='int']]"
-		[Register ("set_Count", "(I)V", "Getset_Count_IHandler:java.code.IMyInterfaceInvoker, ")] set;
+		[Register ("set_Count", "(I)V", "Getset_Count_IHandler:java.code.IMyInterfaceInvoker, ")]
+		set; 
 	}
 
 	string Key {
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='get_Key' and count(parameter)=0]"
-		[Register ("get_Key", "()Ljava/lang/String;", "Getget_KeyHandler:java.code.IMyInterfaceInvoker, ")] get;
+		[Register ("get_Key", "()Ljava/lang/String;", "Getget_KeyHandler:java.code.IMyInterfaceInvoker, ")]
+		get; 
+
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='set_Key' and count(parameter)=1 and parameter[1][@type='java.lang.String']]"
-		[Register ("set_Key", "(Ljava/lang/String;)V", "Getset_Key_Ljava_lang_String_Handler:java.code.IMyInterfaceInvoker, ")] set;
+		[Register ("set_Key", "(Ljava/lang/String;)V", "Getset_Key_Ljava_lang_String_Handler:java.code.IMyInterfaceInvoker, ")]
+		set; 
 	}
 
 	int AbstractCount {
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='get_AbstractCount' and count(parameter)=0]"
-		[Register ("get_AbstractCount", "()I", "Getget_AbstractCountHandler:java.code.IMyInterfaceInvoker, ")] get;
+		[Register ("get_AbstractCount", "()I", "Getget_AbstractCountHandler:java.code.IMyInterfaceInvoker, ")]
+		get; 
+
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='set_AbstractCount' and count(parameter)=1 and parameter[1][@type='int']]"
-		[Register ("set_AbstractCount", "(I)V", "Getset_AbstractCount_IHandler:java.code.IMyInterfaceInvoker, ")] set;
+		[Register ("set_AbstractCount", "(I)V", "Getset_AbstractCount_IHandler:java.code.IMyInterfaceInvoker, ")]
+		set; 
 	}
 
 	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='GetCountForKey' and count(parameter)=1 and parameter[1][@type='java.lang.String']]"
@@ -69,7 +77,6 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 
 [global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
-
 	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
 
 	static IntPtr java_class_ref {
@@ -98,8 +105,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static IntPtr Validate (IntPtr handle)
 	{
 		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
-			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
-						JNIEnv.GetClassNameFromInstance (handle), "java.code.IMyInterface"));
+			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "java.code.IMyInterface"));
 		return handle;
 	}
 
@@ -348,4 +354,3 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	}
 
 }
-

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultMethod.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultMethod.txt
@@ -2,67 +2,70 @@
 [Register ("java/code/IMyInterface", "", "java.code.IMyInterfaceInvoker")]
 public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 	private static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
-	
+
 	private static Delegate cb_DoSomething;
-	#pragma warning disable 0169
+#pragma warning disable 0169
 	private static Delegate GetDoSomethingHandler ()
 	{
 		if (cb_DoSomething == null)
 			cb_DoSomething = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_V) n_DoSomething);
 		return cb_DoSomething;
 	}
+
 	private static void n_DoSomething (IntPtr jnienv, IntPtr native__this)
 	{
 		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.DoSomething ();
 	}
-	#pragma warning restore 0169
+#pragma warning restore 0169
+
 	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='DoSomething' and count(parameter)=0]"
 	[Register ("DoSomething", "()V", "GetDoSomethingHandler:java.code.IMyInterface, MyAssembly")]
 	virtual unsafe void DoSomething ()
 	{
 		const string __id = "DoSomething.()V";
 		try {
-		_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, null);
+			_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, null);
 		} finally {
 		}
 	}
-	
+
 }
+
 [global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
 	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
-	
+
 	static IntPtr java_class_ref {
 		get { return _members.JniPeerType.PeerReference.Handle; }
 	}
-	
+
 	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 		get { return _members; }
 	}
-	
+
 	protected override IntPtr ThresholdClass {
 		get { return class_ref; }
 	}
-	
+
 	protected override global::System.Type ThresholdType {
 		get { return _members.ManagedPeerType; }
 	}
-	
+
 	IntPtr class_ref;
-	
+
 	public static IMyInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
 	{
 		return global::Java.Lang.Object.GetObject<IMyInterface> (handle, transfer);
 	}
-	
+
 	static IntPtr Validate (IntPtr handle)
 	{
 		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
 			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "java.code.IMyInterface"));
 		return handle;
 	}
-	
+
 	protected override void Dispose (bool disposing)
 	{
 		if (this.class_ref != IntPtr.Zero)
@@ -70,12 +73,12 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		this.class_ref = IntPtr.Zero;
 		base.Dispose (disposing);
 	}
-	
+
 	public IMyInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
 	{
 		IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
 		this.class_ref = JNIEnv.NewGlobalRef (local_ref);
 		JNIEnv.DeleteLocalRef (local_ref);
 	}
-	
+
 }

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultProperty.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultProperty.txt
@@ -2,43 +2,47 @@
 [Register ("java/code/IMyInterface", "", "java.code.IMyInterfaceInvoker")]
 public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 	private static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
-	
+
 	private static Delegate cb_get_Value;
-	#pragma warning disable 0169
+#pragma warning disable 0169
 	private static Delegate Getget_ValueHandler ()
 	{
 		if (cb_get_Value == null)
 			cb_get_Value = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_I) n_get_Value);
 		return cb_get_Value;
 	}
+
 	private static int n_get_Value (IntPtr jnienv, IntPtr native__this)
 	{
 		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return __this.Value;
 	}
-	#pragma warning restore 0169
+#pragma warning restore 0169
+
 	private static Delegate cb_set_Value_I;
-	#pragma warning disable 0169
+#pragma warning disable 0169
 	private static Delegate Getset_Value_IHandler ()
 	{
 		if (cb_set_Value_I == null)
 			cb_set_Value_I = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPI_V) n_set_Value_I);
 		return cb_set_Value_I;
 	}
+
 	private static void n_set_Value_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
 		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.Value = value;
 	}
-	#pragma warning restore 0169
+#pragma warning restore 0169
+
 	virtual unsafe int Value {
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='get_Value' and count(parameter)=0]"
 		[Register ("get_Value", "()I", "Getget_ValueHandler:java.code.IMyInterface, MyAssembly")]
 		get {
 			const string __id = "get_Value.()I";
 			try {
-			var __rm = _members.InstanceMethods.InvokeVirtualInt32Method (__id, this, null);
-			return __rm;
+				var __rm = _members.InstanceMethods.InvokeVirtualInt32Method (__id, this, null);
+				return __rm;
 			} finally {
 			}
 		}
@@ -47,49 +51,50 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 		set {
 			const string __id = "set_Value.(I)V";
 			try {
-			JniArgumentValue* __args = stackalloc JniArgumentValue [1];
-			__args [0] = new JniArgumentValue (value);
-			_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, __args);
+				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+				__args [0] = new JniArgumentValue (value);
+				_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, __args);
 			} finally {
 			}
 		}
 	}
-	
+
 }
+
 [global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
 	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
-	
+
 	static IntPtr java_class_ref {
 		get { return _members.JniPeerType.PeerReference.Handle; }
 	}
-	
+
 	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 		get { return _members; }
 	}
-	
+
 	protected override IntPtr ThresholdClass {
 		get { return class_ref; }
 	}
-	
+
 	protected override global::System.Type ThresholdType {
 		get { return _members.ManagedPeerType; }
 	}
-	
+
 	IntPtr class_ref;
-	
+
 	public static IMyInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
 	{
 		return global::Java.Lang.Object.GetObject<IMyInterface> (handle, transfer);
 	}
-	
+
 	static IntPtr Validate (IntPtr handle)
 	{
 		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
 			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "java.code.IMyInterface"));
 		return handle;
 	}
-	
+
 	protected override void Dispose (bool disposing)
 	{
 		if (this.class_ref != IntPtr.Zero)
@@ -97,12 +102,12 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		this.class_ref = IntPtr.Zero;
 		base.Dispose (disposing);
 	}
-	
+
 	public IMyInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
 	{
 		IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
 		this.class_ref = JNIEnv.NewGlobalRef (local_ref);
 		JNIEnv.DeleteLocalRef (local_ref);
 	}
-	
+
 }

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultPropertyGetterOnly.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultPropertyGetterOnly.txt
@@ -2,69 +2,72 @@
 [Register ("java/code/IMyInterface", "", "java.code.IMyInterfaceInvoker")]
 public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 	private static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
-	
+
 	private static Delegate cb_get_Value;
-	#pragma warning disable 0169
+#pragma warning disable 0169
 	private static Delegate Getget_ValueHandler ()
 	{
 		if (cb_get_Value == null)
 			cb_get_Value = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_I) n_get_Value);
 		return cb_get_Value;
 	}
+
 	private static int n_get_Value (IntPtr jnienv, IntPtr native__this)
 	{
 		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		return __this.Value;
 	}
-	#pragma warning restore 0169
+#pragma warning restore 0169
+
 	virtual unsafe int Value {
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='get_Value' and count(parameter)=0]"
 		[Register ("get_Value", "()I", "Getget_ValueHandler:java.code.IMyInterface, MyAssembly")]
 		get {
 			const string __id = "get_Value.()I";
 			try {
-			var __rm = _members.InstanceMethods.InvokeVirtualInt32Method (__id, this, null);
-			return __rm;
+				var __rm = _members.InstanceMethods.InvokeVirtualInt32Method (__id, this, null);
+				return __rm;
 			} finally {
 			}
 		}
 	}
-	
+
 }
+
 [global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
 	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
-	
+
 	static IntPtr java_class_ref {
 		get { return _members.JniPeerType.PeerReference.Handle; }
 	}
-	
+
 	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 		get { return _members; }
 	}
-	
+
 	protected override IntPtr ThresholdClass {
 		get { return class_ref; }
 	}
-	
+
 	protected override global::System.Type ThresholdType {
 		get { return _members.ManagedPeerType; }
 	}
-	
+
 	IntPtr class_ref;
-	
+
 	public static IMyInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
 	{
 		return global::Java.Lang.Object.GetObject<IMyInterface> (handle, transfer);
 	}
-	
+
 	static IntPtr Validate (IntPtr handle)
 	{
 		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
 			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "java.code.IMyInterface"));
 		return handle;
 	}
-	
+
 	protected override void Dispose (bool disposing)
 	{
 		if (this.class_ref != IntPtr.Zero)
@@ -72,12 +75,12 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		this.class_ref = IntPtr.Zero;
 		base.Dispose (disposing);
 	}
-	
+
 	public IMyInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
 	{
 		IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
 		this.class_ref = JNIEnv.NewGlobalRef (local_ref);
 		JNIEnv.DeleteLocalRef (local_ref);
 	}
-	
+
 }

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceRedeclaredDefaultMethod.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceRedeclaredDefaultMethod.txt
@@ -4,42 +4,43 @@ public partial interface IMyInterface2 : java.code.IMyInterface {
 	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='DoSomething' and count(parameter)=0]"
 	[Register ("DoSomething", "()V", "GetDoSomethingHandler:java.code.IMyInterface2Invoker, MyAssembly")]
 	void DoSomething ();
-	
+
 }
+
 [global::Android.Runtime.Register ("java/code/IMyInterface2", DoNotGenerateAcw=true)]
 internal partial class IMyInterface2Invoker : global::Java.Lang.Object, IMyInterface2 {
 	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface2", typeof (IMyInterface2Invoker));
-	
+
 	static IntPtr java_class_ref {
 		get { return _members.JniPeerType.PeerReference.Handle; }
 	}
-	
+
 	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 		get { return _members; }
 	}
-	
+
 	protected override IntPtr ThresholdClass {
 		get { return class_ref; }
 	}
-	
+
 	protected override global::System.Type ThresholdType {
 		get { return _members.ManagedPeerType; }
 	}
-	
+
 	IntPtr class_ref;
-	
+
 	public static IMyInterface2 GetObject (IntPtr handle, JniHandleOwnership transfer)
 	{
 		return global::Java.Lang.Object.GetObject<IMyInterface2> (handle, transfer);
 	}
-	
+
 	static IntPtr Validate (IntPtr handle)
 	{
 		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
 			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "java.code.IMyInterface2"));
 		return handle;
 	}
-	
+
 	protected override void Dispose (bool disposing)
 	{
 		if (this.class_ref != IntPtr.Zero)
@@ -47,28 +48,30 @@ internal partial class IMyInterface2Invoker : global::Java.Lang.Object, IMyInter
 		this.class_ref = IntPtr.Zero;
 		base.Dispose (disposing);
 	}
-	
+
 	public IMyInterface2Invoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
 	{
 		IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
 		this.class_ref = JNIEnv.NewGlobalRef (local_ref);
 		JNIEnv.DeleteLocalRef (local_ref);
 	}
-	
+
 	static Delegate cb_DoSomething;
-	#pragma warning disable 0169
+#pragma warning disable 0169
 	static Delegate GetDoSomethingHandler ()
 	{
 		if (cb_DoSomething == null)
 			cb_DoSomething = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_V) n_DoSomething);
 		return cb_DoSomething;
 	}
+
 	static void n_DoSomething (IntPtr jnienv, IntPtr native__this)
 	{
 		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.DoSomething ();
 	}
-	#pragma warning restore 0169
+#pragma warning restore 0169
+
 	IntPtr id_DoSomething;
 	public unsafe void DoSomething ()
 	{
@@ -76,5 +79,5 @@ internal partial class IMyInterface2Invoker : global::Java.Lang.Object, IMyInter
 			id_DoSomething = JNIEnv.GetMethodID (class_ref, "DoSomething", "()V");
 		JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_DoSomething);
 	}
-	
+
 }

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceClass.txt
@@ -1,21 +1,19 @@
 // Metadata.xml XPath interface reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent']"
 [Register ("com/xamarin/android/Parent", "", "Com.Xamarin.Android.IParentInvoker")]
 public partial interface IParent : IJavaObject, IJavaPeerable {
-
 	int Bar {
 		// Metadata.xml XPath method reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent']/method[@name='getBar' and count(parameter)=0]"
-		[Register ("getBar", "()I", "GetGetBarHandler:Com.Xamarin.Android.IParentInvoker, MyAssembly")] get;
+		[Register ("getBar", "()I", "GetGetBarHandler:Com.Xamarin.Android.IParentInvoker, MyAssembly")]
+		get; 
 	}
 
 	// Metadata.xml XPath class reference: path="/api/package[@name='com.xamarin.android']/class[@name='Parent.Child']"
 	[global::Android.Runtime.Register ("com/xamarin/android/Parent$Child", DoNotGenerateAcw=true)]
 	public partial class Child : Java.Lang.Object {
-
 		static readonly JniPeerMembers _members = new XAPeerMembers ("com/xamarin/android/Parent$Child", typeof (Child));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -30,7 +28,9 @@ public partial interface IParent : IJavaObject, IJavaPeerable {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected Child (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected Child (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 	}
 
@@ -38,7 +38,6 @@ public partial interface IParent : IJavaObject, IJavaPeerable {
 
 [global::Android.Runtime.Register ("com/xamarin/android/Parent", DoNotGenerateAcw=true)]
 internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
-
 	static readonly JniPeerMembers _members = new XAPeerMembers ("com/xamarin/android/Parent", typeof (IParentInvoker));
 
 	static IntPtr java_class_ref {
@@ -67,8 +66,7 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 	static IntPtr Validate (IntPtr handle)
 	{
 		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
-			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
-						JNIEnv.GetClassNameFromInstance (handle), "com.xamarin.android.Parent"));
+			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "com.xamarin.android.Parent"));
 		return handle;
 	}
 
@@ -113,4 +111,3 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 	}
 
 }
-

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceTypes.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceTypes.txt
@@ -1,26 +1,25 @@
 // Metadata.xml XPath interface reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent']"
 [Register ("com/xamarin/android/Parent", "", "Com.Xamarin.Android.IParentInvoker")]
 public partial interface IParent : IJavaObject, IJavaPeerable {
-
 	int Bar {
 		// Metadata.xml XPath method reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent']/method[@name='getBar' and count(parameter)=0]"
-		[Register ("getBar", "()I", "GetGetBarHandler:Com.Xamarin.Android.IParentInvoker, MyAssembly")] get;
+		[Register ("getBar", "()I", "GetGetBarHandler:Com.Xamarin.Android.IParentInvoker, MyAssembly")]
+		get; 
 	}
 
 	// Metadata.xml XPath interface reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent.Child']"
 	[Register ("com/xamarin/android/Parent$Child", "", "Com.Xamarin.Android.IParent/IChildInvoker")]
 	public partial interface IChild : IJavaObject, IJavaPeerable {
-
 		int Bar {
 			// Metadata.xml XPath method reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent.Child']/method[@name='getBar' and count(parameter)=0]"
-			[Register ("getBar", "()I", "GetGetBarHandler:Com.Xamarin.Android.IParent/IChildInvoker, MyAssembly")] get;
+			[Register ("getBar", "()I", "GetGetBarHandler:Com.Xamarin.Android.IParent/IChildInvoker, MyAssembly")]
+			get; 
 		}
 
 	}
 
 	[global::Android.Runtime.Register ("com/xamarin/android/Parent$Child", DoNotGenerateAcw=true)]
 	internal partial class IChildInvoker : global::Java.Lang.Object, IChild {
-
 		static readonly JniPeerMembers _members = new XAPeerMembers ("com/xamarin/android/Parent$Child", typeof (IChildInvoker));
 
 		static IntPtr java_class_ref {
@@ -49,8 +48,7 @@ public partial interface IParent : IJavaObject, IJavaPeerable {
 		static IntPtr Validate (IntPtr handle)
 		{
 			if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
-				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
-							JNIEnv.GetClassNameFromInstance (handle), "com.xamarin.android.Parent.Child"));
+				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "com.xamarin.android.Parent.Child"));
 			return handle;
 		}
 
@@ -96,12 +94,10 @@ public partial interface IParent : IJavaObject, IJavaPeerable {
 
 	}
 
-
 }
 
 [global::Android.Runtime.Register ("com/xamarin/android/Parent", DoNotGenerateAcw=true)]
 internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
-
 	static readonly JniPeerMembers _members = new XAPeerMembers ("com/xamarin/android/Parent", typeof (IParentInvoker));
 
 	static IntPtr java_class_ref {
@@ -130,8 +126,7 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 	static IntPtr Validate (IntPtr handle)
 	{
 		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
-			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
-						JNIEnv.GetClassNameFromInstance (handle), "com.xamarin.android.Parent"));
+			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "com.xamarin.android.Parent"));
 		return handle;
 	}
 
@@ -176,4 +171,3 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 	}
 
 }
-

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteStaticInterfaceMethod.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteStaticInterfaceMethod.txt
@@ -1,9 +1,9 @@
 [Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 public abstract class MyInterface : Java.Lang.Object {
-
 	internal MyInterface ()
 	{
 	}
+
 	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='DoSomething' and count(parameter)=0]"
 	[Register ("DoSomething", "()V", "")]
 	public static unsafe void DoSomething ()
@@ -15,17 +15,17 @@ public abstract class MyInterface : Java.Lang.Object {
 		}
 	}
 
-
 	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (MyInterface));
+
 }
 
 [Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 [global::System.Obsolete ("Use the 'MyInterface' type. This type will be removed in a future release.", error: true)]
 public abstract class MyInterfaceConsts : MyInterface {
-
 	private MyInterfaceConsts ()
 	{
 	}
+
 }
 
 // Metadata.xml XPath interface reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']"
@@ -48,7 +48,6 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 
 [global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
-
 	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
 
 	static IntPtr java_class_ref {
@@ -77,8 +76,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static IntPtr Validate (IntPtr handle)
 	{
 		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
-			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
-						JNIEnv.GetClassNameFromInstance (handle), "java.code.IMyInterface"));
+			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "java.code.IMyInterface"));
 		return handle;
 	}
 
@@ -98,4 +96,3 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	}
 
 }
-

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteStaticInterfaceProperty.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteStaticInterfaceProperty.txt
@@ -2,15 +2,15 @@
 [Register ("java/code/IMyInterface", "", "java.code.IMyInterfaceInvoker")]
 public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 	private static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
-	
+
 	static unsafe int Value {
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='get_Value' and count(parameter)=0]"
 		[Register ("get_Value", "()I", "")]
 		get {
 			const string __id = "get_Value.()I";
 			try {
-			var __rm = _members.StaticMethods.InvokeInt32Method (__id, null);
-			return __rm;
+				var __rm = _members.StaticMethods.InvokeInt32Method (__id, null);
+				return __rm;
 			} finally {
 			}
 		}
@@ -19,49 +19,50 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 		set {
 			const string __id = "set_Value.(I)V";
 			try {
-			JniArgumentValue* __args = stackalloc JniArgumentValue [1];
-			__args [0] = new JniArgumentValue (value);
-			_members.StaticMethods.InvokeVoidMethod (__id, __args);
+				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+				__args [0] = new JniArgumentValue (value);
+				_members.StaticMethods.InvokeVoidMethod (__id, __args);
 			} finally {
 			}
 		}
 	}
-	
+
 }
+
 [global::Android.Runtime.Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
 internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterface {
 	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterfaceInvoker));
-	
+
 	static IntPtr java_class_ref {
 		get { return _members.JniPeerType.PeerReference.Handle; }
 	}
-	
+
 	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 		get { return _members; }
 	}
-	
+
 	protected override IntPtr ThresholdClass {
 		get { return class_ref; }
 	}
-	
+
 	protected override global::System.Type ThresholdType {
 		get { return _members.ManagedPeerType; }
 	}
-	
+
 	IntPtr class_ref;
-	
+
 	public static IMyInterface GetObject (IntPtr handle, JniHandleOwnership transfer)
 	{
 		return global::Java.Lang.Object.GetObject<IMyInterface> (handle, transfer);
 	}
-	
+
 	static IntPtr Validate (IntPtr handle)
 	{
 		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
 			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "java.code.IMyInterface"));
 		return handle;
 	}
-	
+
 	protected override void Dispose (bool disposing)
 	{
 		if (this.class_ref != IntPtr.Zero)
@@ -69,12 +70,12 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		this.class_ref = IntPtr.Zero;
 		base.Dispose (disposing);
 	}
-	
+
 	public IMyInterfaceInvoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
 	{
 		IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
 		this.class_ref = JNIEnv.NewGlobalRef (local_ref);
 		JNIEnv.DeleteLocalRef (local_ref);
 	}
-	
+
 }

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteUnnestedInterfaceTypes.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteUnnestedInterfaceTypes.txt
@@ -1,17 +1,16 @@
 // Metadata.xml XPath interface reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent.Child']"
 [Register ("com/xamarin/android/Parent$Child", "", "Com.Xamarin.Android.IParentChildInvoker")]
 public partial interface IParentChild : IJavaObject, IJavaPeerable {
-
 	int Bar {
 		// Metadata.xml XPath method reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent.Child']/method[@name='getBar' and count(parameter)=0]"
-		[Register ("getBar", "()I", "GetGetBarHandler:Com.Xamarin.Android.IParentChildInvoker, MyAssembly")] get;
+		[Register ("getBar", "()I", "GetGetBarHandler:Com.Xamarin.Android.IParentChildInvoker, MyAssembly")]
+		get; 
 	}
 
 }
 
 [global::Android.Runtime.Register ("com/xamarin/android/Parent$Child", DoNotGenerateAcw=true)]
 internal partial class IParentChildInvoker : global::Java.Lang.Object, IParentChild {
-
 	static readonly JniPeerMembers _members = new XAPeerMembers ("com/xamarin/android/Parent$Child", typeof (IParentChildInvoker));
 
 	static IntPtr java_class_ref {
@@ -40,8 +39,7 @@ internal partial class IParentChildInvoker : global::Java.Lang.Object, IParentCh
 	static IntPtr Validate (IntPtr handle)
 	{
 		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
-			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
-						JNIEnv.GetClassNameFromInstance (handle), "com.xamarin.android.Parent.Child"));
+			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "com.xamarin.android.Parent.Child"));
 		return handle;
 	}
 
@@ -87,21 +85,19 @@ internal partial class IParentChildInvoker : global::Java.Lang.Object, IParentCh
 
 }
 
-
 // Metadata.xml XPath interface reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent']"
 [Register ("com/xamarin/android/Parent", "", "Com.Xamarin.Android.IParentInvoker")]
 public partial interface IParent : IJavaObject, IJavaPeerable {
-
 	int Bar {
 		// Metadata.xml XPath method reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent']/method[@name='getBar' and count(parameter)=0]"
-		[Register ("getBar", "()I", "GetGetBarHandler:Com.Xamarin.Android.IParentInvoker, MyAssembly")] get;
+		[Register ("getBar", "()I", "GetGetBarHandler:Com.Xamarin.Android.IParentInvoker, MyAssembly")]
+		get; 
 	}
 
 }
 
 [global::Android.Runtime.Register ("com/xamarin/android/Parent", DoNotGenerateAcw=true)]
 internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
-
 	static readonly JniPeerMembers _members = new XAPeerMembers ("com/xamarin/android/Parent", typeof (IParentInvoker));
 
 	static IntPtr java_class_ref {
@@ -130,8 +126,7 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 	static IntPtr Validate (IntPtr handle)
 	{
 		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
-			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
-						JNIEnv.GetClassNameFromInstance (handle), "com.xamarin.android.Parent"));
+			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "com.xamarin.android.Parent"));
 		return handle;
 	}
 
@@ -176,4 +171,3 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 	}
 
 }
-

--- a/tests/generator-Tests/expected.ji/AccessModifiers/Xamarin.Test.BasePublicClass.cs
+++ b/tests/generator-Tests/expected.ji/AccessModifiers/Xamarin.Test.BasePublicClass.cs
@@ -8,12 +8,10 @@ namespace Xamarin.Test {
 	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='BasePublicClass']"
 	[global::Android.Runtime.Register ("xamarin/test/BasePublicClass", DoNotGenerateAcw=true)]
 	public partial class BasePublicClass : global::Java.Lang.Object {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/BasePublicClass", typeof (BasePublicClass));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -28,7 +26,9 @@ namespace Xamarin.Test {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected BasePublicClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected BasePublicClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 		static Delegate cb_baseMethod;
 #pragma warning disable 0169

--- a/tests/generator-Tests/expected.ji/AccessModifiers/Xamarin.Test.ExtendPublicClass.cs
+++ b/tests/generator-Tests/expected.ji/AccessModifiers/Xamarin.Test.ExtendPublicClass.cs
@@ -8,12 +8,10 @@ namespace Xamarin.Test {
 	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='ExtendPublicClass']"
 	[global::Android.Runtime.Register ("xamarin/test/ExtendPublicClass", DoNotGenerateAcw=true)]
 	public partial class ExtendPublicClass : global::Java.Lang.Object {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/ExtendPublicClass", typeof (ExtendPublicClass));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -28,12 +26,13 @@ namespace Xamarin.Test {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected ExtendPublicClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected ExtendPublicClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 		// Metadata.xml XPath constructor reference: path="/api/package[@name='xamarin.test']/class[@name='ExtendPublicClass']/constructor[@name='ExtendPublicClass' and count(parameter)=0]"
 		[Register (".ctor", "()V", "")]
-		public unsafe ExtendPublicClass ()
-			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		public unsafe ExtendPublicClass () : base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 		{
 			const string __id = "()V";
 

--- a/tests/generator-Tests/expected.ji/AccessModifiers/Xamarin.Test.PublicClass.cs
+++ b/tests/generator-Tests/expected.ji/AccessModifiers/Xamarin.Test.PublicClass.cs
@@ -8,11 +8,9 @@ namespace Xamarin.Test {
 	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='PublicClass']"
 	[global::Android.Runtime.Register ("xamarin/test/PublicClass", DoNotGenerateAcw=true)]
 	public partial class PublicClass : global::Java.Lang.Object {
-
 		// Metadata.xml XPath interface reference: path="/api/package[@name='xamarin.test']/interface[@name='PublicClass.ProtectedInterface']"
 		[Register ("xamarin/test/PublicClass$ProtectedInterface", "", "Xamarin.Test.PublicClass/IProtectedInterfaceInvoker")]
 		protected internal partial interface IProtectedInterface : IJavaObject, IJavaPeerable {
-
 			// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/interface[@name='PublicClass.ProtectedInterface']/method[@name='foo' and count(parameter)=0]"
 			[Register ("foo", "()V", "GetFooHandler:Xamarin.Test.PublicClass/IProtectedInterfaceInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
 			void Foo ();
@@ -21,7 +19,6 @@ namespace Xamarin.Test {
 
 		[global::Android.Runtime.Register ("xamarin/test/PublicClass$ProtectedInterface", DoNotGenerateAcw=true)]
 		internal partial class IProtectedInterfaceInvoker : global::Java.Lang.Object, IProtectedInterface {
-
 			static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/PublicClass$ProtectedInterface", typeof (IProtectedInterfaceInvoker));
 
 			static IntPtr java_class_ref {
@@ -50,8 +47,7 @@ namespace Xamarin.Test {
 			static IntPtr Validate (IntPtr handle)
 			{
 				if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
-					throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
-								JNIEnv.GetClassNameFromInstance (handle), "xamarin.test.PublicClass.ProtectedInterface"));
+					throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "xamarin.test.PublicClass.ProtectedInterface"));
 				return handle;
 			}
 
@@ -96,12 +92,10 @@ namespace Xamarin.Test {
 
 		}
 
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/PublicClass", typeof (PublicClass));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -116,12 +110,13 @@ namespace Xamarin.Test {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected PublicClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected PublicClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 		// Metadata.xml XPath constructor reference: path="/api/package[@name='xamarin.test']/class[@name='PublicClass']/constructor[@name='PublicClass' and count(parameter)=0]"
 		[Register (".ctor", "()V", "")]
-		public unsafe PublicClass ()
-			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		public unsafe PublicClass () : base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 		{
 			const string __id = "()V";
 

--- a/tests/generator-Tests/expected.ji/AccessModifiers/Xamarin.Test.PublicFinalClass.cs
+++ b/tests/generator-Tests/expected.ji/AccessModifiers/Xamarin.Test.PublicFinalClass.cs
@@ -8,12 +8,10 @@ namespace Xamarin.Test {
 	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='PublicFinalClass']"
 	[global::Android.Runtime.Register ("xamarin/test/PublicFinalClass", DoNotGenerateAcw=true)]
 	public sealed partial class PublicFinalClass : global::Xamarin.Test.BasePublicClass {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/PublicFinalClass", typeof (PublicFinalClass));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -28,7 +26,9 @@ namespace Xamarin.Test {
 			get { return _members.ManagedPeerType; }
 		}
 
-		internal PublicFinalClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		internal PublicFinalClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='PublicFinalClass']/method[@name='publicMethod' and count(parameter)=0]"
 		[Register ("publicMethod", "()V", "")]

--- a/tests/generator-Tests/expected.ji/Adapters/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/Adapters/Java.Lang.Object.cs
@@ -7,13 +7,11 @@ namespace Java.Lang {
 
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
-	public partial class Object  {
-
+	public partial class Object {
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+
 		internal static IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 	}

--- a/tests/generator-Tests/expected.ji/Adapters/Xamarin.Test.AbsSpinner.cs
+++ b/tests/generator-Tests/expected.ji/Adapters/Xamarin.Test.AbsSpinner.cs
@@ -8,12 +8,10 @@ namespace Xamarin.Test {
 	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='AbsSpinner']"
 	[global::Android.Runtime.Register ("xamarin/test/AbsSpinner", DoNotGenerateAcw=true)]
 	public abstract partial class AbsSpinner : Xamarin.Test.AdapterView<Xamarin.Test.ISpinnerAdapter> {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/AbsSpinner", typeof (AbsSpinner));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -28,7 +26,9 @@ namespace Xamarin.Test {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected AbsSpinner (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected AbsSpinner (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 		static Delegate cb_getAdapter;
 #pragma warning disable 0169
@@ -91,8 +91,9 @@ namespace Xamarin.Test {
 
 	[global::Android.Runtime.Register ("xamarin/test/AbsSpinner", DoNotGenerateAcw=true)]
 	internal partial class AbsSpinnerInvoker : AbsSpinner {
-
-		public AbsSpinnerInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
+		public AbsSpinnerInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
+		{
+		}
 
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/AbsSpinner", typeof (AbsSpinnerInvoker));
 
@@ -131,5 +132,4 @@ namespace Xamarin.Test {
 		}
 
 	}
-
 }

--- a/tests/generator-Tests/expected.ji/Adapters/Xamarin.Test.AdapterView.cs
+++ b/tests/generator-Tests/expected.ji/Adapters/Xamarin.Test.AdapterView.cs
@@ -9,12 +9,10 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/AdapterView", DoNotGenerateAcw=true)]
 	[global::Java.Interop.JavaTypeParameters (new string [] {"T extends xamarin.test.Adapter"})]
 	public abstract partial class AdapterView : global::Java.Lang.Object {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/AdapterView", typeof (AdapterView));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -29,7 +27,9 @@ namespace Xamarin.Test {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected AdapterView (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected AdapterView (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 		static Delegate cb_getAdapter;
 #pragma warning disable 0169
@@ -66,17 +66,21 @@ namespace Xamarin.Test {
 
 		protected abstract global::Java.Lang.Object RawAdapter {
 			// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='AdapterView']/method[@name='getAdapter' and count(parameter)=0]"
-			[Register ("getAdapter", "()Lxamarin/test/Adapter;", "GetGetAdapterHandler")] get;
+			[Register ("getAdapter", "()Lxamarin/test/Adapter;", "GetGetAdapterHandler")]
+			get; 
+
 			// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='AdapterView']/method[@name='setAdapter' and count(parameter)=1 and parameter[1][@type='T']]"
-			[Register ("setAdapter", "(Lxamarin/test/Adapter;)V", "GetSetAdapter_Lxamarin_test_Adapter_Handler")] set;
+			[Register ("setAdapter", "(Lxamarin/test/Adapter;)V", "GetSetAdapter_Lxamarin_test_Adapter_Handler")]
+			set; 
 		}
 
 	}
 
 	[global::Android.Runtime.Register ("xamarin/test/AdapterView", DoNotGenerateAcw=true)]
 	internal partial class AdapterViewInvoker : AdapterView {
-
-		public AdapterViewInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
+		public AdapterViewInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
+		{
+		}
 
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/AdapterView", typeof (AdapterViewInvoker));
 
@@ -115,5 +119,4 @@ namespace Xamarin.Test {
 		}
 
 	}
-
 }

--- a/tests/generator-Tests/expected.ji/Adapters/Xamarin.Test.GenericReturnObject.cs
+++ b/tests/generator-Tests/expected.ji/Adapters/Xamarin.Test.GenericReturnObject.cs
@@ -8,12 +8,10 @@ namespace Xamarin.Test {
 	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='GenericReturnObject']"
 	[global::Android.Runtime.Register ("xamarin/test/GenericReturnObject", DoNotGenerateAcw=true)]
 	public partial class GenericReturnObject : global::Java.Lang.Object {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/GenericReturnObject", typeof (GenericReturnObject));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -28,7 +26,9 @@ namespace Xamarin.Test {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected GenericReturnObject (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected GenericReturnObject (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 		static Delegate cb_GenericReturn;
 #pragma warning disable 0169

--- a/tests/generator-Tests/expected.ji/Adapters/Xamarin.Test.IAdapter.cs
+++ b/tests/generator-Tests/expected.ji/Adapters/Xamarin.Test.IAdapter.cs
@@ -8,12 +8,10 @@ namespace Xamarin.Test {
 	// Metadata.xml XPath interface reference: path="/api/package[@name='xamarin.test']/interface[@name='Adapter']"
 	[Register ("xamarin/test/Adapter", "", "Xamarin.Test.IAdapterInvoker")]
 	public partial interface IAdapter : IJavaObject, IJavaPeerable {
-
 	}
 
 	[global::Android.Runtime.Register ("xamarin/test/Adapter", DoNotGenerateAcw=true)]
 	internal partial class IAdapterInvoker : global::Java.Lang.Object, IAdapter {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/Adapter", typeof (IAdapterInvoker));
 
 		static IntPtr java_class_ref {
@@ -42,8 +40,7 @@ namespace Xamarin.Test {
 		static IntPtr Validate (IntPtr handle)
 		{
 			if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
-				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
-							JNIEnv.GetClassNameFromInstance (handle), "xamarin.test.Adapter"));
+				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "xamarin.test.Adapter"));
 			return handle;
 		}
 
@@ -63,5 +60,4 @@ namespace Xamarin.Test {
 		}
 
 	}
-
 }

--- a/tests/generator-Tests/expected.ji/Adapters/Xamarin.Test.ISpinnerAdapter.cs
+++ b/tests/generator-Tests/expected.ji/Adapters/Xamarin.Test.ISpinnerAdapter.cs
@@ -8,12 +8,10 @@ namespace Xamarin.Test {
 	// Metadata.xml XPath interface reference: path="/api/package[@name='xamarin.test']/interface[@name='SpinnerAdapter']"
 	[Register ("xamarin/test/SpinnerAdapter", "", "Xamarin.Test.ISpinnerAdapterInvoker")]
 	public partial interface ISpinnerAdapter : global::Xamarin.Test.IAdapter {
-
 	}
 
 	[global::Android.Runtime.Register ("xamarin/test/SpinnerAdapter", DoNotGenerateAcw=true)]
 	internal partial class ISpinnerAdapterInvoker : global::Java.Lang.Object, ISpinnerAdapter {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SpinnerAdapter", typeof (ISpinnerAdapterInvoker));
 
 		static IntPtr java_class_ref {
@@ -42,8 +40,7 @@ namespace Xamarin.Test {
 		static IntPtr Validate (IntPtr handle)
 		{
 			if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
-				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
-							JNIEnv.GetClassNameFromInstance (handle), "xamarin.test.SpinnerAdapter"));
+				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "xamarin.test.SpinnerAdapter"));
 			return handle;
 		}
 
@@ -63,5 +60,4 @@ namespace Xamarin.Test {
 		}
 
 	}
-
 }

--- a/tests/generator-Tests/expected.ji/Android.Graphics.Color/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/Android.Graphics.Color/Java.Lang.Object.cs
@@ -7,13 +7,11 @@ namespace Java.Lang {
 
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
-	public partial class Object  {
-
+	public partial class Object {
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+
 		internal static IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 	}

--- a/tests/generator-Tests/expected.ji/Android.Graphics.Color/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/Android.Graphics.Color/Xamarin.Test.SomeObject.cs
@@ -9,8 +9,6 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public abstract partial class SomeObject : global::Java.Lang.Object {
 
-
-
 		// Metadata.xml XPath field reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/field[@name='backColor']"
 		[Register ("backColor")]
 		public global::Android.Graphics.Color BackColor {
@@ -29,11 +27,11 @@ namespace Xamarin.Test {
 				}
 			}
 		}
+
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -48,7 +46,9 @@ namespace Xamarin.Test {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected SomeObject (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected SomeObject (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 		static Delegate cb_getSomeColor;
 #pragma warning disable 0169
@@ -85,17 +85,21 @@ namespace Xamarin.Test {
 
 		public abstract global::Android.Graphics.Color SomeColor {
 			// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/method[@name='getSomeColor' and count(parameter)=0]"
-			[Register ("getSomeColor", "()I", "GetGetSomeColorHandler")] get;
+			[Register ("getSomeColor", "()I", "GetGetSomeColorHandler")]
+			get; 
+
 			// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/method[@name='setSomeColor' and count(parameter)=1 and parameter[1][@type='Android.Graphics.Color']]"
-			[Register ("setSomeColor", "(I)V", "GetSetSomeColor_IHandler")] set;
+			[Register ("setSomeColor", "(I)V", "GetSetSomeColor_IHandler")]
+			set; 
 		}
 
 	}
 
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	internal partial class SomeObjectInvoker : SomeObject {
-
-		public SomeObjectInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
+		public SomeObjectInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
+		{
+		}
 
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObjectInvoker));
 
@@ -132,5 +136,4 @@ namespace Xamarin.Test {
 		}
 
 	}
-
 }

--- a/tests/generator-Tests/expected.ji/Arrays/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/Arrays/Java.Lang.Object.cs
@@ -7,13 +7,11 @@ namespace Java.Lang {
 
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
-	public partial class Object  {
-
+	public partial class Object {
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+
 		internal static IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 	}

--- a/tests/generator-Tests/expected.ji/Arrays/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/Arrays/Xamarin.Test.SomeObject.cs
@@ -9,8 +9,6 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public partial class SomeObject : global::Java.Lang.Object {
 
-
-
 		// Metadata.xml XPath field reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/field[@name='myStrings']"
 		[Register ("myStrings")]
 		public IList<string> MyStrings {
@@ -163,11 +161,11 @@ namespace Xamarin.Test {
 				}
 			}
 		}
+
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -182,7 +180,9 @@ namespace Xamarin.Test {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected SomeObject (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected SomeObject (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 	}
 }

--- a/tests/generator-Tests/expected.ji/CSharpKeywords/Xamarin.Test.CSharpKeywords.cs
+++ b/tests/generator-Tests/expected.ji/CSharpKeywords/Xamarin.Test.CSharpKeywords.cs
@@ -8,12 +8,10 @@ namespace Xamarin.Test {
 	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='CSharpKeywords']"
 	[global::Android.Runtime.Register ("xamarin/test/CSharpKeywords", DoNotGenerateAcw=true)]
 	public partial class CSharpKeywords : global::Java.Lang.Object {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/CSharpKeywords", typeof (CSharpKeywords));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -28,7 +26,9 @@ namespace Xamarin.Test {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected CSharpKeywords (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected CSharpKeywords (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 		static Delegate cb_usePartial_I;
 #pragma warning disable 0169

--- a/tests/generator-Tests/expected.ji/Constructors/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/Constructors/Java.Lang.Object.cs
@@ -7,13 +7,11 @@ namespace Java.Lang {
 
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
-	public partial class Object  {
-
+	public partial class Object {
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+
 		internal static IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 	}

--- a/tests/generator-Tests/expected.ji/Constructors/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/Constructors/Xamarin.Test.SomeObject.cs
@@ -8,12 +8,10 @@ namespace Xamarin.Test {
 	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']"
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public partial class SomeObject : global::Java.Lang.Object {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -28,13 +26,14 @@ namespace Xamarin.Test {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected SomeObject (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected SomeObject (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 		// Metadata.xml XPath constructor reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/constructor[@name='SomeObject' and count(parameter)=0]"
 		[Register (".ctor", "()V", "")]
 		[Obsolete (@"deprecated")]
-		public unsafe SomeObject ()
-			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		public unsafe SomeObject () : base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 		{
 			const string __id = "()V";
 
@@ -51,8 +50,7 @@ namespace Xamarin.Test {
 
 		// Metadata.xml XPath constructor reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/constructor[@name='SomeObject' and count(parameter)=1 and parameter[1][@type='int']]"
 		[Register (".ctor", "(I)V", "")]
-		public unsafe SomeObject (int aint)
-			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		public unsafe SomeObject (int aint) : base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 		{
 			const string __id = "(I)V";
 

--- a/tests/generator-Tests/expected.ji/Core_ClassParse/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/Core_ClassParse/Java.Lang.Object.cs
@@ -7,13 +7,11 @@ namespace Java.Lang {
 
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
-	public partial class Object  {
-
+	public partial class Object {
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+
 		internal static IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 	}

--- a/tests/generator-Tests/expected.ji/Core_ClassParse/Java.Lang.String.cs
+++ b/tests/generator-Tests/expected.ji/Core_ClassParse/Java.Lang.String.cs
@@ -8,12 +8,10 @@ namespace Java.Lang {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='String']"
 	[global::Android.Runtime.Register ("java/lang/String", DoNotGenerateAcw=true)]
 	public partial class String : global::Java.Lang.Object {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/String", typeof (String));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -28,7 +26,9 @@ namespace Java.Lang {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected String (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected String (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 	}
 }

--- a/tests/generator-Tests/expected.ji/Core_ClassParse/Xamarin.Test.Invalidnames.In.cs
+++ b/tests/generator-Tests/expected.ji/Core_ClassParse/Xamarin.Test.Invalidnames.In.cs
@@ -8,12 +8,10 @@ namespace Xamarin.Test.Invalidnames {
 	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test.invalidnames']/class[@name='in']"
 	[global::Android.Runtime.Register ("xamarin/test/invalidnames/in", DoNotGenerateAcw=true)]
 	public partial class In : global::Java.Lang.Object {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/invalidnames/in", typeof (In));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -28,7 +26,9 @@ namespace Xamarin.Test.Invalidnames {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected In (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected In (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 	}
 }

--- a/tests/generator-Tests/expected.ji/Core_ClassParse/Xamarin.Test.Invalidnames.InvalidNameMembers.cs
+++ b/tests/generator-Tests/expected.ji/Core_ClassParse/Xamarin.Test.Invalidnames.InvalidNameMembers.cs
@@ -8,12 +8,10 @@ namespace Xamarin.Test.Invalidnames {
 	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test.invalidnames']/class[@name='InvalidNameMembers']"
 	[global::Android.Runtime.Register ("xamarin/test/invalidnames/InvalidNameMembers", DoNotGenerateAcw=true)]
 	public partial class InvalidNameMembers : global::Java.Lang.Object {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/invalidnames/InvalidNameMembers", typeof (InvalidNameMembers));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -28,7 +26,9 @@ namespace Xamarin.Test.Invalidnames {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected InvalidNameMembers (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected InvalidNameMembers (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 	}
 }

--- a/tests/generator-Tests/expected.ji/Core_Jar2Xml/Android.Text.ISpannable.cs
+++ b/tests/generator-Tests/expected.ji/Core_Jar2Xml/Android.Text.ISpannable.cs
@@ -8,12 +8,10 @@ namespace Android.Text {
 	// Metadata.xml XPath interface reference: path="/api/package[@name='android.text']/interface[@name='Spannable']"
 	[Register ("android/text/Spannable", "", "Android.Text.ISpannableInvoker")]
 	public partial interface ISpannable : global::Android.Text.ISpanned {
-
 	}
 
 	[global::Android.Runtime.Register ("android/text/Spannable", DoNotGenerateAcw=true)]
 	internal partial class ISpannableInvoker : global::Java.Lang.Object, ISpannable {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("android/text/Spannable", typeof (ISpannableInvoker));
 
 		static IntPtr java_class_ref {
@@ -42,8 +40,7 @@ namespace Android.Text {
 		static IntPtr Validate (IntPtr handle)
 		{
 			if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
-				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
-							JNIEnv.GetClassNameFromInstance (handle), "android.text.Spannable"));
+				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "android.text.Spannable"));
 			return handle;
 		}
 
@@ -92,5 +89,4 @@ namespace Android.Text {
 		}
 
 	}
-
 }

--- a/tests/generator-Tests/expected.ji/Core_Jar2Xml/Android.Text.ISpanned.cs
+++ b/tests/generator-Tests/expected.ji/Core_Jar2Xml/Android.Text.ISpanned.cs
@@ -8,7 +8,6 @@ namespace Android.Text {
 	// Metadata.xml XPath interface reference: path="/api/package[@name='android.text']/interface[@name='Spanned']"
 	[Register ("android/text/Spanned", "", "Android.Text.ISpannedInvoker")]
 	public partial interface ISpanned : IJavaObject, IJavaPeerable {
-
 		// Metadata.xml XPath method reference: path="/api/package[@name='android.text']/interface[@name='Spanned']/method[@name='getSpanFlags' and count(parameter)=1 and parameter[1][@type='java.lang.Object']]"
 		[return:global::Android.Runtime.GeneratedEnum]
 		[Register ("getSpanFlags", "(Ljava/lang/Object;)I", "GetGetSpanFlags_Ljava_lang_Object_Handler:Android.Text.ISpannedInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
@@ -18,7 +17,6 @@ namespace Android.Text {
 
 	[global::Android.Runtime.Register ("android/text/Spanned", DoNotGenerateAcw=true)]
 	internal partial class ISpannedInvoker : global::Java.Lang.Object, ISpanned {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("android/text/Spanned", typeof (ISpannedInvoker));
 
 		static IntPtr java_class_ref {
@@ -47,8 +45,7 @@ namespace Android.Text {
 		static IntPtr Validate (IntPtr handle)
 		{
 			if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
-				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
-							JNIEnv.GetClassNameFromInstance (handle), "android.text.Spanned"));
+				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "android.text.Spanned"));
 			return handle;
 		}
 
@@ -97,5 +94,4 @@ namespace Android.Text {
 		}
 
 	}
-
 }

--- a/tests/generator-Tests/expected.ji/Core_Jar2Xml/Android.Text.SpannableString.cs
+++ b/tests/generator-Tests/expected.ji/Core_Jar2Xml/Android.Text.SpannableString.cs
@@ -8,12 +8,10 @@ namespace Android.Text {
 	// Metadata.xml XPath class reference: path="/api/package[@name='android.text']/class[@name='SpannableString']"
 	[global::Android.Runtime.Register ("android/text/SpannableString", DoNotGenerateAcw=true)]
 	public partial class SpannableString : global::Android.Text.SpannableStringInternal, global::Android.Text.ISpannable {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("android/text/SpannableString", typeof (SpannableString));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -28,12 +26,13 @@ namespace Android.Text {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected SpannableString (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected SpannableString (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 		// Metadata.xml XPath constructor reference: path="/api/package[@name='android.text']/class[@name='SpannableString']/constructor[@name='SpannableString' and count(parameter)=1 and parameter[1][@type='java.lang.CharSequence']]"
 		[Register (".ctor", "(Ljava/lang/CharSequence;)V", "")]
-		public unsafe SpannableString (global::Java.Lang.ICharSequence source)
-			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		public unsafe SpannableString (global::Java.Lang.ICharSequence source) : base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 		{
 			const string __id = "(Ljava/lang/CharSequence;)V";
 
@@ -53,8 +52,7 @@ namespace Android.Text {
 		}
 
 		[Register (".ctor", "(Ljava/lang/CharSequence;)V", "")]
-		public unsafe SpannableString (string source)
-			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		public unsafe SpannableString (string source) : base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 		{
 			const string __id = "(Ljava/lang/CharSequence;)V";
 

--- a/tests/generator-Tests/expected.ji/Core_Jar2Xml/Android.Text.SpannableStringInternal.cs
+++ b/tests/generator-Tests/expected.ji/Core_Jar2Xml/Android.Text.SpannableStringInternal.cs
@@ -8,12 +8,10 @@ namespace Android.Text {
 	// Metadata.xml XPath class reference: path="/api/package[@name='android.text']/class[@name='SpannableStringInternal']"
 	[global::Android.Runtime.Register ("android/text/SpannableStringInternal", DoNotGenerateAcw=true)]
 	public abstract partial class SpannableStringInternal : global::Java.Lang.Object {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("android/text/SpannableStringInternal", typeof (SpannableStringInternal));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -28,7 +26,9 @@ namespace Android.Text {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected SpannableStringInternal (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected SpannableStringInternal (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 		static Delegate cb_getSpanFlags_Ljava_lang_Object_;
 #pragma warning disable 0169
@@ -67,8 +67,9 @@ namespace Android.Text {
 
 	[global::Android.Runtime.Register ("android/text/SpannableStringInternal", DoNotGenerateAcw=true)]
 	internal partial class SpannableStringInternalInvoker : SpannableStringInternal {
-
-		public SpannableStringInternalInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
+		public SpannableStringInternalInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
+		{
+		}
 
 		static readonly JniPeerMembers _members = new JniPeerMembers ("android/text/SpannableStringInternal", typeof (SpannableStringInternalInvoker));
 
@@ -81,5 +82,4 @@ namespace Android.Text {
 		}
 
 	}
-
 }

--- a/tests/generator-Tests/expected.ji/Core_Jar2Xml/Android.Views.View.cs
+++ b/tests/generator-Tests/expected.ji/Core_Jar2Xml/Android.Views.View.cs
@@ -8,11 +8,9 @@ namespace Android.Views {
 	// Metadata.xml XPath class reference: path="/api/package[@name='android.view']/class[@name='View']"
 	[global::Android.Runtime.Register ("android/view/View", DoNotGenerateAcw=true)]
 	public partial class View : global::Java.Lang.Object {
-
 		// Metadata.xml XPath interface reference: path="/api/package[@name='android.view']/interface[@name='View.OnClickListener']"
 		[Register ("android/view/View$OnClickListener", "", "Android.Views.View/IOnClickListenerInvoker")]
 		public partial interface IOnClickListener : IJavaObject, IJavaPeerable {
-
 			// Metadata.xml XPath method reference: path="/api/package[@name='android.view']/interface[@name='View.OnClickListener']/method[@name='onClick' and count(parameter)=1 and parameter[1][@type='android.view.View']]"
 			[Register ("onClick", "(Landroid/view/View;)V", "GetOnClick_Landroid_view_View_Handler:Android.Views.View/IOnClickListenerInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
 			void OnClick (global::Android.Views.View v);
@@ -21,7 +19,6 @@ namespace Android.Views {
 
 		[global::Android.Runtime.Register ("android/view/View$OnClickListener", DoNotGenerateAcw=true)]
 		internal partial class IOnClickListenerInvoker : global::Java.Lang.Object, IOnClickListener {
-
 			static readonly JniPeerMembers _members = new JniPeerMembers ("android/view/View$OnClickListener", typeof (IOnClickListenerInvoker));
 
 			static IntPtr java_class_ref {
@@ -50,8 +47,7 @@ namespace Android.Views {
 			static IntPtr Validate (IntPtr handle)
 			{
 				if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
-					throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
-								JNIEnv.GetClassNameFromInstance (handle), "android.view.View.OnClickListener"));
+					throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "android.view.View.OnClickListener"));
 				return handle;
 			}
 
@@ -101,18 +97,14 @@ namespace Android.Views {
 
 		[global::Android.Runtime.Register ("mono/android/view/View_OnClickListenerImplementor")]
 		internal sealed partial class IOnClickListenerImplementor : global::Java.Lang.Object, IOnClickListener {
-
-			public IOnClickListenerImplementor ()
-				: base (
-					global::Android.Runtime.JNIEnv.StartCreateInstance ("mono/android/view/View_OnClickListenerImplementor", "()V"),
-					JniHandleOwnership.TransferLocalRef)
+			public IOnClickListenerImplementor () : base (global::Android.Runtime.JNIEnv.StartCreateInstance ("mono/android/view/View_OnClickListenerImplementor", "()V"), JniHandleOwnership.TransferLocalRef)
 			{
 				global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "()V");
 			}
 
-#pragma warning disable 0649
+			#pragma warning disable 0649
 			public EventHandler Handler;
-#pragma warning restore 0649
+			#pragma warning restore 0649
 
 			public void OnClick (global::Android.Views.View v)
 			{
@@ -125,14 +117,13 @@ namespace Android.Views {
 			{
 				return value.Handler == null;
 			}
+
 		}
 
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("android/view/View", typeof (View));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -147,7 +138,9 @@ namespace Android.Views {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected View (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected View (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 		static Delegate cb_setOnClickListener_Landroid_view_View_OnClickListener_;
 #pragma warning disable 0169
@@ -241,21 +234,22 @@ namespace Android.Views {
 			}
 		}
 
-#region "Event implementation for Android.Views.View.IOnClickListener"
+		#region "Event implementation for Android.Views.View.IOnClickListener"
+
 		public event EventHandler Click {
 			add {
 				global::Java.Interop.EventHelper.AddEventHandler<global::Android.Views.View.IOnClickListener, global::Android.Views.View.IOnClickListenerImplementor>(
-						ref weak_implementor_SetOnClickListener,
-						__CreateIOnClickListenerImplementor,
-						SetOnClickListener,
-						__h => __h.Handler += value);
+				ref weak_implementor_SetOnClickListener,
+				__CreateIOnClickListenerImplementor,
+				SetOnClickListener,
+				__h => __h.Handler += value);
 			}
 			remove {
 				global::Java.Interop.EventHelper.RemoveEventHandler<global::Android.Views.View.IOnClickListener, global::Android.Views.View.IOnClickListenerImplementor>(
-						ref weak_implementor_SetOnClickListener,
-						global::Android.Views.View.IOnClickListenerImplementor.__IsEmpty,
-						__v => SetOnClickListener (null),
-						__h => __h.Handler -= value);
+				ref weak_implementor_SetOnClickListener,
+				global::Android.Views.View.IOnClickListenerImplementor.__IsEmpty,
+				__v => SetOnClickListener (null),
+				__h => __h.Handler -= value);
 			}
 		}
 
@@ -265,6 +259,8 @@ namespace Android.Views {
 		{
 			return new global::Android.Views.View.IOnClickListenerImplementor ();
 		}
-#endregion
+
+		#endregion
+
 	}
 }

--- a/tests/generator-Tests/expected.ji/Core_Jar2Xml/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/Core_Jar2Xml/Java.Lang.Object.cs
@@ -7,13 +7,11 @@ namespace Java.Lang {
 
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
-	public partial class Object  {
-
+	public partial class Object {
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+
 		internal static IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 	}

--- a/tests/generator-Tests/expected.ji/GenericArguments/Com.Google.Android.Exoplayer.Drm.FrameworkMediaDrm.cs
+++ b/tests/generator-Tests/expected.ji/GenericArguments/Com.Google.Android.Exoplayer.Drm.FrameworkMediaDrm.cs
@@ -8,12 +8,10 @@ namespace Com.Google.Android.Exoplayer.Drm {
 	// Metadata.xml XPath class reference: path="/api/package[@name='com.google.android.exoplayer.drm']/class[@name='FrameworkMediaDrm']"
 	[global::Android.Runtime.Register ("com/google/android/exoplayer/drm/FrameworkMediaDrm", DoNotGenerateAcw=true)]
 	public sealed partial class FrameworkMediaDrm : global::Java.Lang.Object, global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("com/google/android/exoplayer/drm/FrameworkMediaDrm", typeof (FrameworkMediaDrm));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -28,12 +26,13 @@ namespace Com.Google.Android.Exoplayer.Drm {
 			get { return _members.ManagedPeerType; }
 		}
 
-		internal FrameworkMediaDrm (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		internal FrameworkMediaDrm (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 		// Metadata.xml XPath constructor reference: path="/api/package[@name='com.google.android.exoplayer.drm']/class[@name='FrameworkMediaDrm']/constructor[@name='FrameworkMediaDrm' and count(parameter)=0]"
 		[Register (".ctor", "()V", "")]
-		public unsafe FrameworkMediaDrm ()
-			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		public unsafe FrameworkMediaDrm () : base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 		{
 			const string __id = "()V";
 

--- a/tests/generator-Tests/expected.ji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
+++ b/tests/generator-Tests/expected.ji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
@@ -9,7 +9,6 @@ namespace Com.Google.Android.Exoplayer.Drm {
 	[Register ("com/google/android/exoplayer/drm/ExoMediaDrm$OnEventListener", "", "Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListenerInvoker")]
 	[global::Java.Interop.JavaTypeParameters (new string [] {"T extends com.google.android.exoplayer.drm.ExoMediaCrypto"})]
 	public partial interface IExoMediaDrmOnEventListener : IJavaObject, IJavaPeerable {
-
 		// Metadata.xml XPath method reference: path="/api/package[@name='com.google.android.exoplayer.drm']/interface[@name='ExoMediaDrm.OnEventListener']/method[@name='onEvent' and count(parameter)=5 and parameter[1][@type='com.google.android.exoplayer.drm.ExoMediaDrm&lt;T&gt;'] and parameter[2][@type='byte[]'] and parameter[3][@type='int'] and parameter[4][@type='int'] and parameter[5][@type='byte[]']]"
 		[Register ("onEvent", "(Lcom/google/android/exoplayer/drm/ExoMediaDrm;[BII[B)V", "GetOnEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayBHandler:Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListenerInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
 		void OnEvent (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm p0, byte[] p1, int p2, int p3, byte[] p4);
@@ -18,7 +17,6 @@ namespace Com.Google.Android.Exoplayer.Drm {
 
 	[global::Android.Runtime.Register ("com/google/android/exoplayer/drm/ExoMediaDrm$OnEventListener", DoNotGenerateAcw=true)]
 	internal partial class IExoMediaDrmOnEventListenerInvoker : global::Java.Lang.Object, IExoMediaDrmOnEventListener {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("com/google/android/exoplayer/drm/ExoMediaDrm$OnEventListener", typeof (IExoMediaDrmOnEventListenerInvoker));
 
 		static IntPtr java_class_ref {
@@ -47,8 +45,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 		static IntPtr Validate (IntPtr handle)
 		{
 			if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
-				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
-							JNIEnv.GetClassNameFromInstance (handle), "com.google.android.exoplayer.drm.ExoMediaDrm.OnEventListener"));
+				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "com.google.android.exoplayer.drm.ExoMediaDrm.OnEventListener"));
 			return handle;
 		}
 
@@ -118,7 +115,6 @@ namespace Com.Google.Android.Exoplayer.Drm {
 
 	// event args for com.google.android.exoplayer.drm.ExoMediaDrm.OnEventListener.onEvent
 	public partial class ExoMediaDrmOnEventEventArgs : global::System.EventArgs {
-
 		public ExoMediaDrmOnEventEventArgs (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm p0, byte[] p1, int p2, int p3, byte[] p4)
 		{
 			this.p0 = p0;
@@ -129,29 +125,35 @@ namespace Com.Google.Android.Exoplayer.Drm {
 		}
 
 		global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm p0;
+
 		public global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm P0 {
 			get { return p0; }
 		}
 
 		byte[] p1;
+
 		public byte[] P1 {
 			get { return p1; }
 		}
 
 		int p2;
+
 		public int P2 {
 			get { return p2; }
 		}
 
 		int p3;
+
 		public int P3 {
 			get { return p3; }
 		}
 
 		byte[] p4;
+
 		public byte[] P4 {
 			get { return p4; }
 		}
+
 	}
 
 	[global::Android.Runtime.Register ("mono/com/google/android/exoplayer/drm/ExoMediaDrm_OnEventListenerImplementor")]
@@ -159,18 +161,15 @@ namespace Com.Google.Android.Exoplayer.Drm {
 
 		object sender;
 
-		public IExoMediaDrmOnEventListenerImplementor (object sender)
-			: base (
-				global::Android.Runtime.JNIEnv.StartCreateInstance ("mono/com/google/android/exoplayer/drm/ExoMediaDrm_OnEventListenerImplementor", "()V"),
-				JniHandleOwnership.TransferLocalRef)
+		public IExoMediaDrmOnEventListenerImplementor (object sender) : base (global::Android.Runtime.JNIEnv.StartCreateInstance ("mono/com/google/android/exoplayer/drm/ExoMediaDrm_OnEventListenerImplementor", "()V"), JniHandleOwnership.TransferLocalRef)
 		{
 			global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "()V");
 			this.sender = sender;
 		}
 
-#pragma warning disable 0649
+		#pragma warning disable 0649
 		public EventHandler<ExoMediaDrmOnEventEventArgs> Handler;
-#pragma warning restore 0649
+		#pragma warning restore 0649
 
 		public void OnEvent (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm p0, byte[] p1, int p2, int p3, byte[] p4)
 		{
@@ -183,14 +182,13 @@ namespace Com.Google.Android.Exoplayer.Drm {
 		{
 			return value.Handler == null;
 		}
-	}
 
+	}
 
 	// Metadata.xml XPath interface reference: path="/api/package[@name='com.google.android.exoplayer.drm']/interface[@name='ExoMediaDrm']"
 	[Register ("com/google/android/exoplayer/drm/ExoMediaDrm", "", "Com.Google.Android.Exoplayer.Drm.IExoMediaDrmInvoker")]
 	[global::Java.Interop.JavaTypeParameters (new string [] {"T extends com.google.android.exoplayer.drm.ExoMediaCrypto"})]
 	public partial interface IExoMediaDrm : IJavaObject, IJavaPeerable {
-
 		// Metadata.xml XPath method reference: path="/api/package[@name='com.google.android.exoplayer.drm']/interface[@name='ExoMediaDrm']/method[@name='setOnEventListener' and count(parameter)=1 and parameter[1][@type='com.google.android.exoplayer.drm.ExoMediaDrm.OnEventListener&lt;T&gt;']]"
 		[Register ("setOnEventListener", "(Lcom/google/android/exoplayer/drm/ExoMediaDrm$OnEventListener;)V", "GetSetOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_Handler:Com.Google.Android.Exoplayer.Drm.IExoMediaDrmInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
 		void SetOnEventListener (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener p0);
@@ -199,7 +197,6 @@ namespace Com.Google.Android.Exoplayer.Drm {
 
 	[global::Android.Runtime.Register ("com/google/android/exoplayer/drm/ExoMediaDrm", DoNotGenerateAcw=true)]
 	internal partial class IExoMediaDrmInvoker : global::Java.Lang.Object, IExoMediaDrm {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("com/google/android/exoplayer/drm/ExoMediaDrm", typeof (IExoMediaDrmInvoker));
 
 		static IntPtr java_class_ref {
@@ -228,8 +225,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 		static IntPtr Validate (IntPtr handle)
 		{
 			if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
-				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
-							JNIEnv.GetClassNameFromInstance (handle), "com.google.android.exoplayer.drm.ExoMediaDrm"));
+				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "com.google.android.exoplayer.drm.ExoMediaDrm"));
 			return handle;
 		}
 
@@ -276,5 +272,4 @@ namespace Com.Google.Android.Exoplayer.Drm {
 		}
 
 	}
-
 }

--- a/tests/generator-Tests/expected.ji/GenericArguments/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/GenericArguments/Java.Lang.Object.cs
@@ -7,13 +7,11 @@ namespace Java.Lang {
 
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
-	public partial class Object  {
-
+	public partial class Object {
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+
 		internal static IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 	}

--- a/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.II1.cs
+++ b/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.II1.cs
@@ -8,7 +8,6 @@ namespace Xamarin.Test {
 	// Metadata.xml XPath interface reference: path="/api/package[@name='xamarin.test']/interface[@name='I1']"
 	[Register ("xamarin/test/I1", "", "Xamarin.Test.II1Invoker")]
 	public partial interface II1 : IJavaObject, IJavaPeerable {
-
 		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/interface[@name='I1']/method[@name='close' and count(parameter)=0]"
 		[Register ("close", "()V", "GetCloseHandler:Xamarin.Test.II1Invoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
 		void Close ();
@@ -17,7 +16,6 @@ namespace Xamarin.Test {
 
 	[global::Android.Runtime.Register ("xamarin/test/I1", DoNotGenerateAcw=true)]
 	internal partial class II1Invoker : global::Java.Lang.Object, II1 {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/I1", typeof (II1Invoker));
 
 		static IntPtr java_class_ref {
@@ -46,8 +44,7 @@ namespace Xamarin.Test {
 		static IntPtr Validate (IntPtr handle)
 		{
 			if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
-				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
-							JNIEnv.GetClassNameFromInstance (handle), "xamarin.test.I1"));
+				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "xamarin.test.I1"));
 			return handle;
 		}
 
@@ -91,5 +88,4 @@ namespace Xamarin.Test {
 		}
 
 	}
-
 }

--- a/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.II2.cs
+++ b/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.II2.cs
@@ -8,7 +8,6 @@ namespace Xamarin.Test {
 	// Metadata.xml XPath interface reference: path="/api/package[@name='xamarin.test']/interface[@name='I2']"
 	[Register ("xamarin/test/I2", "", "Xamarin.Test.II2Invoker")]
 	public partial interface II2 : IJavaObject, IJavaPeerable {
-
 		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/interface[@name='I2']/method[@name='close' and count(parameter)=0]"
 		[Register ("close", "()V", "GetCloseHandler:Xamarin.Test.II2Invoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
 		void Close ();
@@ -17,7 +16,6 @@ namespace Xamarin.Test {
 
 	[global::Android.Runtime.Register ("xamarin/test/I2", DoNotGenerateAcw=true)]
 	internal partial class II2Invoker : global::Java.Lang.Object, II2 {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/I2", typeof (II2Invoker));
 
 		static IntPtr java_class_ref {
@@ -46,8 +44,7 @@ namespace Xamarin.Test {
 		static IntPtr Validate (IntPtr handle)
 		{
 			if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
-				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
-							JNIEnv.GetClassNameFromInstance (handle), "xamarin.test.I2"));
+				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "xamarin.test.I2"));
 			return handle;
 		}
 
@@ -91,5 +88,4 @@ namespace Xamarin.Test {
 		}
 
 	}
-
 }

--- a/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.SomeObject.cs
@@ -8,12 +8,10 @@ namespace Xamarin.Test {
 	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']"
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public partial class SomeObject : global::Java.Lang.Object, global::Xamarin.Test.II1, global::Xamarin.Test.II2 {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -28,7 +26,9 @@ namespace Xamarin.Test {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected SomeObject (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected SomeObject (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 		static Delegate cb_close;
 #pragma warning disable 0169

--- a/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.SomeObject2.cs
+++ b/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/Xamarin.Test.SomeObject2.cs
@@ -8,12 +8,10 @@ namespace Xamarin.Test {
 	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject2']"
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject2", DoNotGenerateAcw=true)]
 	public abstract partial class SomeObject2 : global::Java.Lang.Object, global::Xamarin.Test.II1, global::Xamarin.Test.II2 {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject2", typeof (SomeObject2));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -28,7 +26,9 @@ namespace Xamarin.Test {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected SomeObject2 (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected SomeObject2 (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 		static Delegate cb_irrelevant;
 #pragma warning disable 0169
@@ -81,8 +81,9 @@ namespace Xamarin.Test {
 
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject2", DoNotGenerateAcw=true)]
 	internal partial class SomeObject2Invoker : SomeObject2 {
-
-		public SomeObject2Invoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
+		public SomeObject2Invoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
+		{
+		}
 
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject2", typeof (SomeObject2Invoker));
 
@@ -106,5 +107,4 @@ namespace Xamarin.Test {
 		}
 
 	}
-
 }

--- a/tests/generator-Tests/expected.ji/NestedTypes/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/NestedTypes/Java.Lang.Object.cs
@@ -7,13 +7,11 @@ namespace Java.Lang {
 
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
-	public partial class Object  {
-
+	public partial class Object {
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+
 		internal static IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 	}

--- a/tests/generator-Tests/expected.ji/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
+++ b/tests/generator-Tests/expected.ji/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
@@ -8,15 +8,12 @@ namespace Xamarin.Test {
 	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='NotificationCompatBase']"
 	[global::Android.Runtime.Register ("xamarin/test/NotificationCompatBase", DoNotGenerateAcw=true)]
 	public partial class NotificationCompatBase : global::Java.Lang.Object {
-
 		// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='NotificationCompatBase.Action']"
 		[global::Android.Runtime.Register ("xamarin/test/NotificationCompatBase$Action", DoNotGenerateAcw=true)]
 		public abstract partial class Action : global::Java.Lang.Object {
-
 			// Metadata.xml XPath interface reference: path="/api/package[@name='xamarin.test']/interface[@name='NotificationCompatBase.Action.Factory']"
 			[Register ("xamarin/test/NotificationCompatBase$Action$Factory", "", "Xamarin.Test.NotificationCompatBase/Action/IFactoryInvoker")]
 			public partial interface IFactory : IJavaObject, IJavaPeerable {
-
 				// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/interface[@name='NotificationCompatBase.Action.Factory']/method[@name='build' and count(parameter)=1 and parameter[1][@type='int']]"
 				[Register ("build", "(I)Lxamarin/test/NotificationCompatBase$Action;", "GetBuild_IHandler:Xamarin.Test.NotificationCompatBase/Action/IFactoryInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
 				global::Xamarin.Test.NotificationCompatBase.Action Build (int p0);
@@ -25,7 +22,6 @@ namespace Xamarin.Test {
 
 			[global::Android.Runtime.Register ("xamarin/test/NotificationCompatBase$Action$Factory", DoNotGenerateAcw=true)]
 			internal partial class IFactoryInvoker : global::Java.Lang.Object, IFactory {
-
 				static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/NotificationCompatBase$Action$Factory", typeof (IFactoryInvoker));
 
 				static IntPtr java_class_ref {
@@ -54,8 +50,7 @@ namespace Xamarin.Test {
 				static IntPtr Validate (IntPtr handle)
 				{
 					if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
-						throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
-									JNIEnv.GetClassNameFromInstance (handle), "xamarin.test.NotificationCompatBase.Action.Factory"));
+						throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "xamarin.test.NotificationCompatBase.Action.Factory"));
 					return handle;
 				}
 
@@ -102,12 +97,10 @@ namespace Xamarin.Test {
 
 			}
 
-
 			static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/NotificationCompatBase$Action", typeof (Action));
+
 			internal static new IntPtr class_ref {
-				get {
-					return _members.JniPeerType.PeerReference.Handle;
-				}
+				get { return _members.JniPeerType.PeerReference.Handle; }
 			}
 
 			public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -122,14 +115,17 @@ namespace Xamarin.Test {
 				get { return _members.ManagedPeerType; }
 			}
 
-			protected Action (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+			protected Action (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+			{
+			}
 
 		}
 
 		[global::Android.Runtime.Register ("xamarin/test/NotificationCompatBase$Action", DoNotGenerateAcw=true)]
 		internal partial class ActionInvoker : Action {
-
-			public ActionInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
+			public ActionInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
+			{
+			}
 
 			static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/NotificationCompatBase$Action", typeof (ActionInvoker));
 
@@ -143,16 +139,13 @@ namespace Xamarin.Test {
 
 		}
 
-
 		// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='NotificationCompatBase.InstanceInner']"
 		[global::Android.Runtime.Register ("xamarin/test/NotificationCompatBase$InstanceInner", DoNotGenerateAcw=true)]
 		public abstract partial class InstanceInner : global::Java.Lang.Object {
-
 			static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/NotificationCompatBase$InstanceInner", typeof (InstanceInner));
+
 			internal static new IntPtr class_ref {
-				get {
-					return _members.JniPeerType.PeerReference.Handle;
-				}
+				get { return _members.JniPeerType.PeerReference.Handle; }
 			}
 
 			public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -167,12 +160,13 @@ namespace Xamarin.Test {
 				get { return _members.ManagedPeerType; }
 			}
 
-			protected InstanceInner (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+			protected InstanceInner (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+			{
+			}
 
 			// Metadata.xml XPath constructor reference: path="/api/package[@name='xamarin.test']/class[@name='NotificationCompatBase.InstanceInner']/constructor[@name='NotificationCompatBase.InstanceInner' and count(parameter)=1 and parameter[1][@type='xamarin.test.NotificationCompatBase']]"
 			[Register (".ctor", "(Lxamarin/test/NotificationCompatBase;)V", "")]
-			public unsafe InstanceInner (global::Xamarin.Test.NotificationCompatBase __self)
-				: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+			public unsafe InstanceInner (global::Xamarin.Test.NotificationCompatBase __self) : base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 			{
 				string __id = "(L" + global::Android.Runtime.JNIEnv.GetJniName (GetType ().DeclaringType) + ";)V";
 
@@ -193,8 +187,9 @@ namespace Xamarin.Test {
 
 		[global::Android.Runtime.Register ("xamarin/test/NotificationCompatBase$InstanceInner", DoNotGenerateAcw=true)]
 		internal partial class InstanceInnerInvoker : InstanceInner {
-
-			public InstanceInnerInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
+			public InstanceInnerInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
+			{
+			}
 
 			static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/NotificationCompatBase$InstanceInner", typeof (InstanceInnerInvoker));
 
@@ -208,12 +203,10 @@ namespace Xamarin.Test {
 
 		}
 
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/NotificationCompatBase", typeof (NotificationCompatBase));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -228,7 +221,9 @@ namespace Xamarin.Test {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected NotificationCompatBase (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected NotificationCompatBase (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 	}
 }

--- a/tests/generator-Tests/expected.ji/NonStaticFields/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/NonStaticFields/Java.Lang.Object.cs
@@ -7,13 +7,11 @@ namespace Java.Lang {
 
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
-	public partial class Object  {
-
+	public partial class Object {
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+
 		internal static IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 	}

--- a/tests/generator-Tests/expected.ji/NonStaticFields/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/NonStaticFields/Xamarin.Test.SomeObject.cs
@@ -9,8 +9,6 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public partial class SomeObject : global::Java.Lang.Object {
 
-
-
 		// Metadata.xml XPath field reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/field[@name='Value']"
 		[Register ("Value")]
 		public int Value {
@@ -29,11 +27,11 @@ namespace Xamarin.Test {
 				}
 			}
 		}
+
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -48,7 +46,9 @@ namespace Xamarin.Test {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected SomeObject (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected SomeObject (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 	}
 }

--- a/tests/generator-Tests/expected.ji/NormalMethods/Java.Lang.Class.cs
+++ b/tests/generator-Tests/expected.ji/NormalMethods/Java.Lang.Class.cs
@@ -9,12 +9,10 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Class", DoNotGenerateAcw=true)]
 	[global::Java.Interop.JavaTypeParameters (new string [] {"T"})]
 	public partial class Class : global::Java.Lang.Object {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Class", typeof (Class));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -29,7 +27,9 @@ namespace Java.Lang {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected Class (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected Class (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 	}
 }

--- a/tests/generator-Tests/expected.ji/NormalMethods/Java.Lang.Integer.cs
+++ b/tests/generator-Tests/expected.ji/NormalMethods/Java.Lang.Integer.cs
@@ -8,12 +8,10 @@ namespace Java.Lang {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Integer']"
 	[global::Android.Runtime.Register ("java/lang/Integer", DoNotGenerateAcw=true)]
 	public partial class Integer : global::Java.Lang.Object {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Integer", typeof (Integer));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -28,7 +26,9 @@ namespace Java.Lang {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected Integer (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected Integer (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 	}
 }

--- a/tests/generator-Tests/expected.ji/NormalMethods/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/NormalMethods/Java.Lang.Object.cs
@@ -7,13 +7,11 @@ namespace Java.Lang {
 
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
-	public partial class Object  {
-
+	public partial class Object {
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+
 		internal static IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 	}

--- a/tests/generator-Tests/expected.ji/NormalMethods/Java.Lang.Throwable.cs
+++ b/tests/generator-Tests/expected.ji/NormalMethods/Java.Lang.Throwable.cs
@@ -7,13 +7,11 @@ namespace Java.Lang {
 
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Throwable']"
 	[global::Android.Runtime.Register ("java/lang/Throwable", DoNotGenerateAcw=true)]
-	public partial class Throwable  {
-
+	public partial class Throwable {
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Throwable", typeof (Throwable));
+
 		internal static IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 	}

--- a/tests/generator-Tests/expected.ji/NormalMethods/Xamarin.Test.A.cs
+++ b/tests/generator-Tests/expected.ji/NormalMethods/Xamarin.Test.A.cs
@@ -8,17 +8,14 @@ namespace Xamarin.Test {
 	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='A']"
 	[global::Android.Runtime.Register ("xamarin/test/A", DoNotGenerateAcw=true)]
 	public partial class A : global::Java.Lang.Object {
-
 		// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='A.B']"
 		[global::Android.Runtime.Register ("xamarin/test/A$B", DoNotGenerateAcw=true)]
 		[global::Java.Interop.JavaTypeParameters (new string [] {"T extends xamarin.test.A.B"})]
 		public partial class B : global::Java.Lang.Object {
-
 			static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/A$B", typeof (B));
+
 			internal static new IntPtr class_ref {
-				get {
-					return _members.JniPeerType.PeerReference.Handle;
-				}
+				get { return _members.JniPeerType.PeerReference.Handle; }
 			}
 
 			public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -33,7 +30,9 @@ namespace Xamarin.Test {
 				get { return _members.ManagedPeerType; }
 			}
 
-			protected B (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+			protected B (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+			{
+			}
 
 			static Delegate cb_setCustomDimension_I;
 #pragma warning disable 0169
@@ -68,10 +67,9 @@ namespace Xamarin.Test {
 		}
 
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/A", typeof (A));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -86,7 +84,9 @@ namespace Xamarin.Test {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected A (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected A (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 		static Delegate cb_getHandle;
 #pragma warning disable 0169

--- a/tests/generator-Tests/expected.ji/NormalMethods/Xamarin.Test.C.cs
+++ b/tests/generator-Tests/expected.ji/NormalMethods/Xamarin.Test.C.cs
@@ -9,12 +9,10 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/C", DoNotGenerateAcw=true)]
 	[global::Java.Interop.JavaTypeParameters (new string [] {"T extends xamarin.test.C"})]
 	public partial class C : global::Java.Lang.Object {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/C", typeof (C));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -29,7 +27,9 @@ namespace Xamarin.Test {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected C (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected C (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 		static Delegate cb_setCustomDimension_I;
 #pragma warning disable 0169

--- a/tests/generator-Tests/expected.ji/NormalMethods/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/NormalMethods/Xamarin.Test.SomeObject.cs
@@ -8,12 +8,10 @@ namespace Xamarin.Test {
 	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']"
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public partial class SomeObject : global::Java.Lang.Object {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -28,12 +26,13 @@ namespace Xamarin.Test {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected SomeObject (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected SomeObject (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 		// Metadata.xml XPath constructor reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/constructor[@name='SomeObject' and count(parameter)=1 and parameter[1][@type='java.lang.Class&lt;? extends xamarin.test.SomeObject&gt;']]"
 		[Register (".ctor", "(Ljava/lang/Class;)V", "")]
-		public unsafe SomeObject (global::Java.Lang.Class c)
-			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		public unsafe SomeObject (global::Java.Lang.Class c) : base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 		{
 			const string __id = "(Ljava/lang/Class;)V";
 

--- a/tests/generator-Tests/expected.ji/NormalProperties/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/NormalProperties/Java.Lang.Object.cs
@@ -7,13 +7,11 @@ namespace Java.Lang {
 
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
-	public partial class Object  {
-
+	public partial class Object {
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+
 		internal static IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 	}

--- a/tests/generator-Tests/expected.ji/NormalProperties/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/NormalProperties/Xamarin.Test.SomeObject.cs
@@ -8,12 +8,10 @@ namespace Xamarin.Test {
 	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']"
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public abstract partial class SomeObject : global::Java.Lang.Object {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -28,7 +26,9 @@ namespace Xamarin.Test {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected SomeObject (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected SomeObject (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 		static Delegate cb_getSomeInteger;
 #pragma warning disable 0169
@@ -64,9 +64,12 @@ namespace Xamarin.Test {
 
 		public abstract int SomeInteger {
 			// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/method[@name='getSomeInteger' and count(parameter)=0]"
-			[Register ("getSomeInteger", "()I", "GetGetSomeIntegerHandler")] get;
+			[Register ("getSomeInteger", "()I", "GetGetSomeIntegerHandler")]
+			get; 
+
 			// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/method[@name='setSomeInteger' and count(parameter)=1 and parameter[1][@type='int']]"
-			[Register ("setSomeInteger", "(I)V", "GetSetSomeInteger_IHandler")] set;
+			[Register ("setSomeInteger", "(I)V", "GetSetSomeInteger_IHandler")]
+			set; 
 		}
 
 		static Delegate cb_getSomeObjectProperty;
@@ -104,9 +107,12 @@ namespace Xamarin.Test {
 
 		public abstract global::Java.Lang.Object SomeObjectProperty {
 			// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/method[@name='getSomeObjectProperty' and count(parameter)=0]"
-			[Register ("getSomeObjectProperty", "()Ljava/lang/Object;", "GetGetSomeObjectPropertyHandler")] get;
+			[Register ("getSomeObjectProperty", "()Ljava/lang/Object;", "GetGetSomeObjectPropertyHandler")]
+			get; 
+
 			// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/method[@name='setSomeObjectProperty' and count(parameter)=1 and parameter[1][@type='java.lang.Object']]"
-			[Register ("setSomeObjectProperty", "(Ljava/lang/Object;)V", "GetSetSomeObjectProperty_Ljava_lang_Object_Handler")] set;
+			[Register ("setSomeObjectProperty", "(Ljava/lang/Object;)V", "GetSetSomeObjectProperty_Ljava_lang_Object_Handler")]
+			set; 
 		}
 
 		static Delegate cb_getSomeString;
@@ -144,17 +150,21 @@ namespace Xamarin.Test {
 
 		public abstract string SomeString {
 			// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/method[@name='getSomeString' and count(parameter)=0]"
-			[Register ("getSomeString", "()Ljava/lang/String;", "GetGetSomeStringHandler")] get;
+			[Register ("getSomeString", "()Ljava/lang/String;", "GetGetSomeStringHandler")]
+			get; 
+
 			// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/method[@name='setSomeString' and count(parameter)=1 and parameter[1][@type='java.lang.String']]"
-			[Register ("setSomeString", "(Ljava/lang/String;)V", "GetSetSomeString_Ljava_lang_String_Handler")] set;
+			[Register ("setSomeString", "(Ljava/lang/String;)V", "GetSetSomeString_Ljava_lang_String_Handler")]
+			set; 
 		}
 
 	}
 
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	internal partial class SomeObjectInvoker : SomeObject {
-
-		public SomeObjectInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
+		public SomeObjectInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
+		{
+		}
 
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObjectInvoker));
 
@@ -241,5 +251,4 @@ namespace Xamarin.Test {
 		}
 
 	}
-
 }

--- a/tests/generator-Tests/expected.ji/ParameterXPath/Java.Lang.Integer.cs
+++ b/tests/generator-Tests/expected.ji/ParameterXPath/Java.Lang.Integer.cs
@@ -8,12 +8,10 @@ namespace Java.Lang {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Integer']"
 	[global::Android.Runtime.Register ("java/lang/Integer", DoNotGenerateAcw=true)]
 	public partial class Integer : global::Java.Lang.Object {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Integer", typeof (Integer));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -28,7 +26,9 @@ namespace Java.Lang {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected Integer (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected Integer (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 	}
 }

--- a/tests/generator-Tests/expected.ji/ParameterXPath/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/ParameterXPath/Java.Lang.Object.cs
@@ -7,13 +7,11 @@ namespace Java.Lang {
 
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
-	public partial class Object  {
-
+	public partial class Object {
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+
 		internal static IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 	}

--- a/tests/generator-Tests/expected.ji/ParameterXPath/Xamarin.Test.A.cs
+++ b/tests/generator-Tests/expected.ji/ParameterXPath/Xamarin.Test.A.cs
@@ -9,12 +9,10 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/A", DoNotGenerateAcw=true)]
 	[global::Java.Interop.JavaTypeParameters (new string [] {"T extends java.lang.Object"})]
 	public partial class A : global::Java.Lang.Object {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/A", typeof (A));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -29,7 +27,9 @@ namespace Xamarin.Test {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected A (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected A (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 		static Delegate cb_setA_Ljava_lang_Object_;
 #pragma warning disable 0169

--- a/tests/generator-Tests/expected.ji/StaticFields/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/StaticFields/Java.Lang.Object.cs
@@ -7,13 +7,11 @@ namespace Java.Lang {
 
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
-	public partial class Object  {
-
+	public partial class Object {
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+
 		internal static IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 	}

--- a/tests/generator-Tests/expected.ji/StaticFields/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/StaticFields/Xamarin.Test.SomeObject.cs
@@ -9,8 +9,6 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public partial class SomeObject : global::Java.Lang.Object {
 
-
-
 		// Metadata.xml XPath field reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/field[@name='Value']"
 		[Register ("Value")]
 		public static int Value {
@@ -41,11 +39,11 @@ namespace Xamarin.Test {
 				}
 			}
 		}
+
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -60,7 +58,9 @@ namespace Xamarin.Test {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected SomeObject (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected SomeObject (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 	}
 }

--- a/tests/generator-Tests/expected.ji/StaticMethods/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/StaticMethods/Java.Lang.Object.cs
@@ -7,13 +7,11 @@ namespace Java.Lang {
 
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
-	public partial class Object  {
-
+	public partial class Object {
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+
 		internal static IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 	}

--- a/tests/generator-Tests/expected.ji/StaticMethods/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/StaticMethods/Xamarin.Test.SomeObject.cs
@@ -8,12 +8,10 @@ namespace Xamarin.Test {
 	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']"
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public partial class SomeObject : global::Java.Lang.Object {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -28,7 +26,9 @@ namespace Xamarin.Test {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected SomeObject (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected SomeObject (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/method[@name='methodAsInt' and count(parameter)=0]"
 		[Register ("methodAsInt", "()I", "")]

--- a/tests/generator-Tests/expected.ji/StaticProperties/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/StaticProperties/Java.Lang.Object.cs
@@ -7,13 +7,11 @@ namespace Java.Lang {
 
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
-	public partial class Object  {
-
+	public partial class Object {
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+
 		internal static IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 	}

--- a/tests/generator-Tests/expected.ji/StaticProperties/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/StaticProperties/Xamarin.Test.SomeObject.cs
@@ -8,12 +8,10 @@ namespace Xamarin.Test {
 	// Metadata.xml XPath class reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']"
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public partial class SomeObject : global::Java.Lang.Object {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -28,7 +26,9 @@ namespace Xamarin.Test {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected SomeObject (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected SomeObject (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 		public static unsafe int SomeInteger {
 			// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/method[@name='getSomeInteger' and count(parameter)=0]"

--- a/tests/generator-Tests/expected.ji/Streams/Java.IO.FilterOutputStream.cs
+++ b/tests/generator-Tests/expected.ji/Streams/Java.IO.FilterOutputStream.cs
@@ -8,12 +8,10 @@ namespace Java.IO {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.io']/class[@name='FilterOutputStream']"
 	[global::Android.Runtime.Register ("java/io/FilterOutputStream", DoNotGenerateAcw=true)]
 	public partial class FilterOutputStream : global::Java.IO.OutputStream {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/io/FilterOutputStream", typeof (FilterOutputStream));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -28,12 +26,13 @@ namespace Java.IO {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected FilterOutputStream (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected FilterOutputStream (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 		// Metadata.xml XPath constructor reference: path="/api/package[@name='java.io']/class[@name='FilterOutputStream']/constructor[@name='FilterOutputStream' and count(parameter)=1 and parameter[1][@type='java.io.OutputStream']]"
 		[Register (".ctor", "(Ljava/io/OutputStream;)V", "")]
-		public unsafe FilterOutputStream (global::System.IO.Stream @out)
-			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		public unsafe FilterOutputStream (global::System.IO.Stream @out) : base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 		{
 			const string __id = "(Ljava/io/OutputStream;)V";
 

--- a/tests/generator-Tests/expected.ji/Streams/Java.IO.IOException.cs
+++ b/tests/generator-Tests/expected.ji/Streams/Java.IO.IOException.cs
@@ -8,12 +8,10 @@ namespace Java.IO {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.io']/class[@name='IOException']"
 	[global::Android.Runtime.Register ("java/io/IOException", DoNotGenerateAcw=true)]
 	public abstract partial class IOException : global::Java.Lang.Throwable {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/io/IOException", typeof (IOException));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -28,7 +26,9 @@ namespace Java.IO {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected IOException (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected IOException (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 		static Delegate cb_printStackTrace;
 #pragma warning disable 0169
@@ -61,8 +61,9 @@ namespace Java.IO {
 
 	[global::Android.Runtime.Register ("java/io/IOException", DoNotGenerateAcw=true)]
 	internal partial class IOExceptionInvoker : IOException {
-
-		public IOExceptionInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
+		public IOExceptionInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
+		{
+		}
 
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/io/IOException", typeof (IOExceptionInvoker));
 
@@ -75,5 +76,4 @@ namespace Java.IO {
 		}
 
 	}
-
 }

--- a/tests/generator-Tests/expected.ji/Streams/Java.IO.InputStream.cs
+++ b/tests/generator-Tests/expected.ji/Streams/Java.IO.InputStream.cs
@@ -8,12 +8,10 @@ namespace Java.IO {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.io']/class[@name='InputStream']"
 	[global::Android.Runtime.Register ("java/io/InputStream", DoNotGenerateAcw=true)]
 	public abstract partial class InputStream : global::Java.Lang.Object {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/io/InputStream", typeof (InputStream));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -28,12 +26,13 @@ namespace Java.IO {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected InputStream (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected InputStream (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 		// Metadata.xml XPath constructor reference: path="/api/package[@name='java.io']/class[@name='InputStream']/constructor[@name='InputStream' and count(parameter)=0]"
 		[Register (".ctor", "()V", "")]
-		public unsafe InputStream ()
-			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		public unsafe InputStream () : base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 		{
 			const string __id = "()V";
 
@@ -321,8 +320,9 @@ namespace Java.IO {
 
 	[global::Android.Runtime.Register ("java/io/InputStream", DoNotGenerateAcw=true)]
 	internal partial class InputStreamInvoker : InputStream {
-
-		public InputStreamInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
+		public InputStreamInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
+		{
+		}
 
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/io/InputStream", typeof (InputStreamInvoker));
 
@@ -347,5 +347,4 @@ namespace Java.IO {
 		}
 
 	}
-
 }

--- a/tests/generator-Tests/expected.ji/Streams/Java.IO.OutputStream.cs
+++ b/tests/generator-Tests/expected.ji/Streams/Java.IO.OutputStream.cs
@@ -8,12 +8,10 @@ namespace Java.IO {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.io']/class[@name='OutputStream']"
 	[global::Android.Runtime.Register ("java/io/OutputStream", DoNotGenerateAcw=true)]
 	public abstract partial class OutputStream : global::Java.Lang.Object {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/io/OutputStream", typeof (OutputStream));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -28,12 +26,13 @@ namespace Java.IO {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected OutputStream (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected OutputStream (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 		// Metadata.xml XPath constructor reference: path="/api/package[@name='java.io']/class[@name='OutputStream']/constructor[@name='OutputStream' and count(parameter)=0]"
 		[Register (".ctor", "()V", "")]
-		public unsafe OutputStream ()
-			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		public unsafe OutputStream () : base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 		{
 			const string __id = "()V";
 
@@ -202,8 +201,9 @@ namespace Java.IO {
 
 	[global::Android.Runtime.Register ("java/io/OutputStream", DoNotGenerateAcw=true)]
 	internal partial class OutputStreamInvoker : OutputStream {
-
-		public OutputStreamInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
+		public OutputStreamInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
+		{
+		}
 
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/io/OutputStream", typeof (OutputStreamInvoker));
 
@@ -229,5 +229,4 @@ namespace Java.IO {
 		}
 
 	}
-
 }

--- a/tests/generator-Tests/expected.ji/Streams/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/Streams/Java.Lang.Object.cs
@@ -7,13 +7,11 @@ namespace Java.Lang {
 
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
-	public partial class Object  {
-
+	public partial class Object {
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+
 		internal static IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 	}

--- a/tests/generator-Tests/expected.ji/Streams/Java.Lang.Throwable.cs
+++ b/tests/generator-Tests/expected.ji/Streams/Java.Lang.Throwable.cs
@@ -7,13 +7,11 @@ namespace Java.Lang {
 
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Throwable']"
 	[global::Android.Runtime.Register ("java/lang/Throwable", DoNotGenerateAcw=true)]
-	public partial class Throwable  {
-
+	public partial class Throwable {
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Throwable", typeof (Throwable));
+
 		internal static IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		static Delegate cb_getMessage;

--- a/tests/generator-Tests/expected.ji/TestInterface/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Java.Lang.Object.cs
@@ -7,13 +7,11 @@ namespace Java.Lang {
 
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
-	public partial class Object  {
-
+	public partial class Object {
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+
 		internal static IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 	}

--- a/tests/generator-Tests/expected.ji/TestInterface/Java.Lang.String.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Java.Lang.String.cs
@@ -8,12 +8,10 @@ namespace Java.Lang {
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='String']"
 	[global::Android.Runtime.Register ("java/lang/String", DoNotGenerateAcw=true)]
 	public sealed partial class String : global::Java.Lang.Object {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/String", typeof (String));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -28,7 +26,9 @@ namespace Java.Lang {
 			get { return _members.ManagedPeerType; }
 		}
 
-		internal String (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		internal String (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 	}
 }

--- a/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericImplementation.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericImplementation.cs
@@ -8,12 +8,10 @@ namespace Test.ME {
 	// Metadata.xml XPath class reference: path="/api/package[@name='test.me']/class[@name='GenericImplementation']"
 	[global::Android.Runtime.Register ("test/me/GenericImplementation", DoNotGenerateAcw=true)]
 	public partial class GenericImplementation : global::Java.Lang.Object, global::Test.ME.IGenericInterface {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("test/me/GenericImplementation", typeof (GenericImplementation));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -28,12 +26,13 @@ namespace Test.ME {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected GenericImplementation (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected GenericImplementation (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 		// Metadata.xml XPath constructor reference: path="/api/package[@name='test.me']/class[@name='GenericImplementation']/constructor[@name='GenericImplementation' and count(parameter)=0]"
 		[Register (".ctor", "()V", "")]
-		public unsafe GenericImplementation ()
-			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		public unsafe GenericImplementation () : base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 		{
 			const string __id = "()V";
 

--- a/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericObjectPropertyImplementation.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericObjectPropertyImplementation.cs
@@ -8,12 +8,10 @@ namespace Test.ME {
 	// Metadata.xml XPath class reference: path="/api/package[@name='test.me']/class[@name='GenericObjectPropertyImplementation']"
 	[global::Android.Runtime.Register ("test/me/GenericObjectPropertyImplementation", DoNotGenerateAcw=true)]
 	public partial class GenericObjectPropertyImplementation : global::Java.Lang.Object, global::Test.ME.IGenericPropertyInterface {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("test/me/GenericObjectPropertyImplementation", typeof (GenericObjectPropertyImplementation));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -28,12 +26,13 @@ namespace Test.ME {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected GenericObjectPropertyImplementation (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected GenericObjectPropertyImplementation (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 		// Metadata.xml XPath constructor reference: path="/api/package[@name='test.me']/class[@name='GenericObjectPropertyImplementation']/constructor[@name='GenericObjectPropertyImplementation' and count(parameter)=0]"
 		[Register (".ctor", "()V", "")]
-		public unsafe GenericObjectPropertyImplementation ()
-			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		public unsafe GenericObjectPropertyImplementation () : base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 		{
 			const string __id = "()V";
 

--- a/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericStringImplementation.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericStringImplementation.cs
@@ -8,12 +8,10 @@ namespace Test.ME {
 	// Metadata.xml XPath class reference: path="/api/package[@name='test.me']/class[@name='GenericStringImplementation']"
 	[global::Android.Runtime.Register ("test/me/GenericStringImplementation", DoNotGenerateAcw=true)]
 	public partial class GenericStringImplementation : global::Java.Lang.Object, global::Test.ME.IGenericInterface {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("test/me/GenericStringImplementation", typeof (GenericStringImplementation));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -28,12 +26,13 @@ namespace Test.ME {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected GenericStringImplementation (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected GenericStringImplementation (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 		// Metadata.xml XPath constructor reference: path="/api/package[@name='test.me']/class[@name='GenericStringImplementation']/constructor[@name='GenericStringImplementation' and count(parameter)=0]"
 		[Register (".ctor", "()V", "")]
-		public unsafe GenericStringImplementation ()
-			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		public unsafe GenericStringImplementation () : base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 		{
 			const string __id = "()V";
 

--- a/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericStringPropertyImplementation.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericStringPropertyImplementation.cs
@@ -8,12 +8,10 @@ namespace Test.ME {
 	// Metadata.xml XPath class reference: path="/api/package[@name='test.me']/class[@name='GenericStringPropertyImplementation']"
 	[global::Android.Runtime.Register ("test/me/GenericStringPropertyImplementation", DoNotGenerateAcw=true)]
 	public partial class GenericStringPropertyImplementation : global::Java.Lang.Object, global::Test.ME.IGenericPropertyInterface {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("test/me/GenericStringPropertyImplementation", typeof (GenericStringPropertyImplementation));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -28,12 +26,13 @@ namespace Test.ME {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected GenericStringPropertyImplementation (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected GenericStringPropertyImplementation (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 		// Metadata.xml XPath constructor reference: path="/api/package[@name='test.me']/class[@name='GenericStringPropertyImplementation']/constructor[@name='GenericStringPropertyImplementation' and count(parameter)=0]"
 		[Register (".ctor", "()V", "")]
-		public unsafe GenericStringPropertyImplementation ()
-			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		public unsafe GenericStringPropertyImplementation () : base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 		{
 			const string __id = "()V";
 
@@ -110,13 +109,11 @@ namespace Test.ME {
 		// This method is explicitly implemented as a member of an instantiated Test.ME.IGenericPropertyInterface
 		global::Java.Lang.Object global::Test.ME.IGenericPropertyInterface.Object {
 			// Metadata.xml XPath method reference: path="/api/package[@name='test.me']/interface[@name='GenericPropertyInterface']/method[@name='getObject' and count(parameter)=0]"
-			[Register ("getObject", "()Ljava/lang/Object;", "GetGetObjectHandler:Test.ME.IGenericPropertyInterfaceInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")] get {
-				return Object;
-			}
+			[Register ("getObject", "()Ljava/lang/Object;", "GetGetObjectHandler:Test.ME.IGenericPropertyInterfaceInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
+			get { return Object; }
 			// Metadata.xml XPath method reference: path="/api/package[@name='test.me']/interface[@name='GenericPropertyInterface']/method[@name='setObject' and count(parameter)=1 and parameter[1][@type='T']]"
-			[Register ("setObject", "(Ljava/lang/Object;)V", "GetSetObject_Ljava_lang_Object_Handler:Test.ME.IGenericPropertyInterfaceInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")] set {
-				Object = value.ToString ();
-			}
+			[Register ("setObject", "(Ljava/lang/Object;)V", "GetSetObject_Ljava_lang_Object_Handler:Test.ME.IGenericPropertyInterfaceInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
+			set { Object = value.ToString (); }
 		}
 
 	}

--- a/tests/generator-Tests/expected.ji/TestInterface/Test.ME.IGenericInterface.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Test.ME.IGenericInterface.cs
@@ -9,7 +9,6 @@ namespace Test.ME {
 	[Register ("test/me/GenericInterface", "", "Test.ME.IGenericInterfaceInvoker")]
 	[global::Java.Interop.JavaTypeParameters (new string [] {"T"})]
 	public partial interface IGenericInterface : IJavaObject, IJavaPeerable {
-
 		// Metadata.xml XPath method reference: path="/api/package[@name='test.me']/interface[@name='GenericInterface']/method[@name='SetObject' and count(parameter)=1 and parameter[1][@type='T']]"
 		[Register ("SetObject", "(Ljava/lang/Object;)V", "GetSetObject_Ljava_lang_Object_Handler:Test.ME.IGenericInterfaceInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
 		void SetObject (global::Java.Lang.Object value);
@@ -18,7 +17,6 @@ namespace Test.ME {
 
 	[global::Android.Runtime.Register ("test/me/GenericInterface", DoNotGenerateAcw=true)]
 	internal partial class IGenericInterfaceInvoker : global::Java.Lang.Object, IGenericInterface {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("test/me/GenericInterface", typeof (IGenericInterfaceInvoker));
 
 		static IntPtr java_class_ref {
@@ -47,8 +45,7 @@ namespace Test.ME {
 		static IntPtr Validate (IntPtr handle)
 		{
 			if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
-				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
-							JNIEnv.GetClassNameFromInstance (handle), "test.me.GenericInterface"));
+				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "test.me.GenericInterface"));
 			return handle;
 		}
 
@@ -97,5 +94,4 @@ namespace Test.ME {
 		}
 
 	}
-
 }

--- a/tests/generator-Tests/expected.ji/TestInterface/Test.ME.IGenericPropertyInterface.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Test.ME.IGenericPropertyInterface.cs
@@ -9,19 +9,20 @@ namespace Test.ME {
 	[Register ("test/me/GenericPropertyInterface", "", "Test.ME.IGenericPropertyInterfaceInvoker")]
 	[global::Java.Interop.JavaTypeParameters (new string [] {"T"})]
 	public partial interface IGenericPropertyInterface : IJavaObject, IJavaPeerable {
-
 		global::Java.Lang.Object Object {
 			// Metadata.xml XPath method reference: path="/api/package[@name='test.me']/interface[@name='GenericPropertyInterface']/method[@name='getObject' and count(parameter)=0]"
-			[Register ("getObject", "()Ljava/lang/Object;", "GetGetObjectHandler:Test.ME.IGenericPropertyInterfaceInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")] get;
+			[Register ("getObject", "()Ljava/lang/Object;", "GetGetObjectHandler:Test.ME.IGenericPropertyInterfaceInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
+			get; 
+
 			// Metadata.xml XPath method reference: path="/api/package[@name='test.me']/interface[@name='GenericPropertyInterface']/method[@name='setObject' and count(parameter)=1 and parameter[1][@type='T']]"
-			[Register ("setObject", "(Ljava/lang/Object;)V", "GetSetObject_Ljava_lang_Object_Handler:Test.ME.IGenericPropertyInterfaceInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")] set;
+			[Register ("setObject", "(Ljava/lang/Object;)V", "GetSetObject_Ljava_lang_Object_Handler:Test.ME.IGenericPropertyInterfaceInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
+			set; 
 		}
 
 	}
 
 	[global::Android.Runtime.Register ("test/me/GenericPropertyInterface", DoNotGenerateAcw=true)]
 	internal partial class IGenericPropertyInterfaceInvoker : global::Java.Lang.Object, IGenericPropertyInterface {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("test/me/GenericPropertyInterface", typeof (IGenericPropertyInterfaceInvoker));
 
 		static IntPtr java_class_ref {
@@ -50,8 +51,7 @@ namespace Test.ME {
 		static IntPtr Validate (IntPtr handle)
 		{
 			if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
-				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
-							JNIEnv.GetClassNameFromInstance (handle), "test.me.GenericPropertyInterface"));
+				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "test.me.GenericPropertyInterface"));
 			return handle;
 		}
 
@@ -123,5 +123,4 @@ namespace Test.ME {
 		}
 
 	}
-
 }

--- a/tests/generator-Tests/expected.ji/TestInterface/Test.ME.ITestInterface.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Test.ME.ITestInterface.cs
@@ -7,7 +7,6 @@ namespace Test.ME {
 
 	[Register ("test/me/TestInterface", DoNotGenerateAcw=true)]
 	public abstract class TestInterface : Java.Lang.Object {
-
 		internal TestInterface ()
 		{
 		}
@@ -29,21 +28,21 @@ namespace Test.ME {
 		}
 
 		static readonly JniPeerMembers _members = new JniPeerMembers ("test/me/TestInterface", typeof (TestInterface));
+
 	}
 
 	[Register ("test/me/TestInterface", DoNotGenerateAcw=true)]
 	[global::System.Obsolete ("Use the 'TestInterface' type. This type will be removed in a future release.", error: true)]
 	public abstract class TestInterfaceConsts : TestInterface {
-
 		private TestInterfaceConsts ()
 		{
 		}
+
 	}
 
 	// Metadata.xml XPath interface reference: path="/api/package[@name='test.me']/interface[@name='TestInterface']"
 	[Register ("test/me/TestInterface", "", "Test.ME.ITestInterfaceInvoker")]
 	public partial interface ITestInterface : IJavaObject, IJavaPeerable {
-
 		// Metadata.xml XPath method reference: path="/api/package[@name='test.me']/interface[@name='TestInterface']/method[@name='getSpanFlags' and count(parameter)=1 and parameter[1][@type='java.lang.Object']]"
 		[Register ("getSpanFlags", "(Ljava/lang/Object;)I", "GetGetSpanFlags_Ljava_lang_Object_Handler:Test.ME.ITestInterfaceInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
 		int GetSpanFlags (global::Java.Lang.Object tag);
@@ -59,7 +58,6 @@ namespace Test.ME {
 	}
 
 	public static partial class ITestInterfaceExtensions {
-
 		public static void Append (this Test.ME.ITestInterface self, string value)
 		{
 			var jls_value = value == null ? null : new global::Java.Lang.String (value);
@@ -75,11 +73,11 @@ namespace Test.ME {
 			jls_value?.Dispose ();
 			return __rsval;
 		}
+
 	}
 
 	[global::Android.Runtime.Register ("test/me/TestInterface", DoNotGenerateAcw=true)]
 	internal partial class ITestInterfaceInvoker : global::Java.Lang.Object, ITestInterface {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("test/me/TestInterface", typeof (ITestInterfaceInvoker));
 
 		static IntPtr java_class_ref {
@@ -108,8 +106,7 @@ namespace Test.ME {
 		static IntPtr Validate (IntPtr handle)
 		{
 			if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
-				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
-							JNIEnv.GetClassNameFromInstance (handle), "test.me.TestInterface"));
+				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "test.me.TestInterface"));
 			return handle;
 		}
 
@@ -218,5 +215,4 @@ namespace Test.ME {
 		}
 
 	}
-
 }

--- a/tests/generator-Tests/expected.ji/TestInterface/Test.ME.TestInterfaceImplementation.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Test.ME.TestInterfaceImplementation.cs
@@ -8,10 +8,7 @@ namespace Test.ME {
 	// Metadata.xml XPath class reference: path="/api/package[@name='test.me']/class[@name='TestInterfaceImplementation']"
 	[global::Android.Runtime.Register ("test/me/TestInterfaceImplementation", DoNotGenerateAcw=true)]
 	public abstract partial class TestInterfaceImplementation : global::Java.Lang.Object, global::Test.ME.ITestInterface {
-
-
 		public static class InterfaceConsts {
-
 			// The following are fields from: test.me.TestInterface
 
 			// Metadata.xml XPath field reference: path="/api/package[@name='test.me']/interface[@name='TestInterface']/field[@name='SPAN_COMPOSING']"
@@ -29,13 +26,13 @@ namespace Test.ME {
 					return global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (__v.Handle, JniHandleOwnership.TransferLocalRef);
 				}
 			}
+
 		}
 
 		static readonly JniPeerMembers _members = new JniPeerMembers ("test/me/TestInterfaceImplementation", typeof (TestInterfaceImplementation));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -50,12 +47,13 @@ namespace Test.ME {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected TestInterfaceImplementation (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected TestInterfaceImplementation (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 		// Metadata.xml XPath constructor reference: path="/api/package[@name='test.me']/class[@name='TestInterfaceImplementation']/constructor[@name='TestInterfaceImplementation' and count(parameter)=0]"
 		[Register (".ctor", "()V", "")]
-		public unsafe TestInterfaceImplementation ()
-			: base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
+		public unsafe TestInterfaceImplementation () : base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 		{
 			const string __id = "()V";
 
@@ -155,8 +153,9 @@ namespace Test.ME {
 
 	[global::Android.Runtime.Register ("test/me/TestInterfaceImplementation", DoNotGenerateAcw=true)]
 	internal partial class TestInterfaceImplementationInvoker : TestInterfaceImplementation {
-
-		public TestInterfaceImplementationInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
+		public TestInterfaceImplementationInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
+		{
+		}
 
 		static readonly JniPeerMembers _members = new JniPeerMembers ("test/me/TestInterfaceImplementation", typeof (TestInterfaceImplementationInvoker));
 
@@ -214,5 +213,4 @@ namespace Test.ME {
 		}
 
 	}
-
 }

--- a/tests/generator-Tests/expected.ji/java.lang.Enum/Java.Lang.Enum.cs
+++ b/tests/generator-Tests/expected.ji/java.lang.Enum/Java.Lang.Enum.cs
@@ -9,12 +9,10 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/Enum", DoNotGenerateAcw=true)]
 	[global::Java.Interop.JavaTypeParameters (new string [] {"E extends java.lang.Enum<E>"})]
 	public abstract partial class Enum : global::Java.Lang.Object, global::Java.Lang.IComparable {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Enum", typeof (Enum));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -29,7 +27,9 @@ namespace Java.Lang {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected Enum (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected Enum (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.lang']/class[@name='Enum']/method[@name='compareTo' and count(parameter)=1 and parameter[1][@type='E']]"
 		[Register ("compareTo", "(Ljava/lang/Enum;)I", "")]
@@ -51,8 +51,9 @@ namespace Java.Lang {
 
 	[global::Android.Runtime.Register ("java/lang/Enum", DoNotGenerateAcw=true)]
 	internal partial class EnumInvoker : Enum, global::Java.Lang.IComparable {
-
-		public EnumInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) {}
+		public EnumInvoker (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer)
+		{
+		}
 
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Enum", typeof (EnumInvoker));
 
@@ -65,5 +66,4 @@ namespace Java.Lang {
 		}
 
 	}
-
 }

--- a/tests/generator-Tests/expected.ji/java.lang.Enum/Java.Lang.IComparable.cs
+++ b/tests/generator-Tests/expected.ji/java.lang.Enum/Java.Lang.IComparable.cs
@@ -9,7 +9,6 @@ namespace Java.Lang {
 	[Register ("java/lang/Comparable", "", "Java.Lang.IComparableInvoker")]
 	[global::Java.Interop.JavaTypeParameters (new string [] {"T"})]
 	public partial interface IComparable : IJavaObject, IJavaPeerable {
-
 		// Metadata.xml XPath method reference: path="/api/package[@name='java.lang']/interface[@name='Comparable']/method[@name='compareTo' and count(parameter)=1 and parameter[1][@type='T']]"
 		[Register ("compareTo", "(Ljava/lang/Object;)I", "GetCompareTo_Ljava_lang_Object_Handler:Java.Lang.IComparableInvoker, Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
 		int CompareTo (global::Java.Lang.Object another);
@@ -18,7 +17,6 @@ namespace Java.Lang {
 
 	[global::Android.Runtime.Register ("java/lang/Comparable", DoNotGenerateAcw=true)]
 	internal partial class IComparableInvoker : global::Java.Lang.Object, IComparable {
-
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Comparable", typeof (IComparableInvoker));
 
 		static IntPtr java_class_ref {
@@ -47,8 +45,7 @@ namespace Java.Lang {
 		static IntPtr Validate (IntPtr handle)
 		{
 			if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
-				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.",
-							JNIEnv.GetClassNameFromInstance (handle), "java.lang.Comparable"));
+				throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "java.lang.Comparable"));
 			return handle;
 		}
 
@@ -99,5 +96,4 @@ namespace Java.Lang {
 		}
 
 	}
-
 }

--- a/tests/generator-Tests/expected.ji/java.lang.Enum/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/java.lang.Enum/Java.Lang.Object.cs
@@ -7,13 +7,11 @@ namespace Java.Lang {
 
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
-	public partial class Object  {
-
+	public partial class Object {
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+
 		internal static IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 	}

--- a/tests/generator-Tests/expected.ji/java.lang.Enum/Java.Lang.State.cs
+++ b/tests/generator-Tests/expected.ji/java.lang.Enum/Java.Lang.State.cs
@@ -9,8 +9,6 @@ namespace Java.Lang {
 	[global::Android.Runtime.Register ("java/lang/State", DoNotGenerateAcw=true)]
 	public sealed partial class State : global::Java.Lang.Enum {
 
-
-
 		// Metadata.xml XPath field reference: path="/api/package[@name='java.lang']/class[@name='State']/field[@name='BLOCKED']"
 		[Register ("BLOCKED")]
 		public static global::Java.Lang.State Blocked {
@@ -81,11 +79,11 @@ namespace Java.Lang {
 				return global::Java.Lang.Object.GetObject<global::Java.Lang.State> (__v.Handle, JniHandleOwnership.TransferLocalRef);
 			}
 		}
+
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/State", typeof (State));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -100,7 +98,9 @@ namespace Java.Lang {
 			get { return _members.ManagedPeerType; }
 		}
 
-		internal State (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		internal State (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 	}
 }

--- a/tests/generator-Tests/expected.ji/java.lang.Object/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/java.lang.Object/Java.Lang.Object.cs
@@ -7,13 +7,11 @@ namespace Java.Lang {
 
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
-	public partial class Object  {
-
+	public partial class Object {
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+
 		internal static IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 	}

--- a/tests/generator-Tests/expected.ji/java.util.List/Java.Lang.Object.cs
+++ b/tests/generator-Tests/expected.ji/java.util.List/Java.Lang.Object.cs
@@ -7,13 +7,11 @@ namespace Java.Lang {
 
 	// Metadata.xml XPath class reference: path="/api/package[@name='java.lang']/class[@name='Object']"
 	[global::Android.Runtime.Register ("java/lang/Object", DoNotGenerateAcw=true)]
-	public partial class Object  {
-
+	public partial class Object {
 		static readonly JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (Object));
+
 		internal static IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 	}

--- a/tests/generator-Tests/expected.ji/java.util.List/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/java.util.List/Xamarin.Test.SomeObject.cs
@@ -9,8 +9,6 @@ namespace Xamarin.Test {
 	[global::Android.Runtime.Register ("xamarin/test/SomeObject", DoNotGenerateAcw=true)]
 	public partial class SomeObject : global::Java.Lang.Object {
 
-
-
 		// Metadata.xml XPath field reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/field[@name='myStrings']"
 		[Register ("myStrings")]
 		public global::System.Collections.Generic.IList<string> MyStrings {
@@ -163,11 +161,11 @@ namespace Xamarin.Test {
 				}
 			}
 		}
+
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
+
 		internal static new IntPtr class_ref {
-			get {
-				return _members.JniPeerType.PeerReference.Handle;
-			}
+			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
 		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
@@ -182,7 +180,9 @@ namespace Xamarin.Test {
 			get { return _members.ManagedPeerType; }
 		}
 
-		protected SomeObject (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+		protected SomeObject (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
 
 	}
 }

--- a/tools/generator/SourceWriters/BoundClass.cs
+++ b/tools/generator/SourceWriters/BoundClass.cs
@@ -369,8 +369,10 @@ namespace generator.SourceWriters
 
 		public void WriteSiblingClasses (CodeWriter writer)
 		{
-			foreach (var sibling in sibling_types)
+			foreach (var sibling in sibling_types) {
+				writer.WriteLine ();
 				sibling.Write (writer);
+			}
 		}
 	}
 }

--- a/tools/generator/SourceWriters/BoundInterface.cs
+++ b/tools/generator/SourceWriters/BoundInterface.cs
@@ -158,7 +158,7 @@ namespace generator.SourceWriters
 		void AddProperties (InterfaceGen iface, CodeGenerationOptions opt)
 		{
 			foreach (var prop in iface.Properties.Where (p => !p.Getter.IsStatic && !p.Getter.IsInterfaceDefaultMethod))
-				Properties.Add (new BoundInterfacePropertyDeclaration(iface, prop, iface.AssemblyQualifiedName + "Invoker", opt));
+				Properties.Add (new BoundInterfacePropertyDeclaration (iface, prop, iface.AssemblyQualifiedName + "Invoker", opt));
 
 			if (!opt.SupportDefaultInterfaceMethods)
 				return;
@@ -197,7 +197,7 @@ namespace generator.SourceWriters
 				if (m.Name == iface.Name || iface.ContainsProperty (m.Name, true))
 					m.Name = "Invoke" + m.Name;
 
-				Methods.Add (new BoundInterfaceMethodDeclaration(m, iface.AssemblyQualifiedName + "Invoker", opt));
+				Methods.Add (new BoundInterfaceMethodDeclaration (m, iface.AssemblyQualifiedName + "Invoker", opt));
 			}
 
 			if (!opt.SupportDefaultInterfaceMethods)
@@ -207,7 +207,7 @@ namespace generator.SourceWriters
 				if (!method.IsValid)
 					continue;
 
-				Methods.Add (new BoundMethod(iface, method, opt, true));
+				Methods.Add (new BoundMethod (iface, method, opt, true));
 
 				var name_and_jnisig = method.JavaName + method.JniSignature.Replace ("java/lang/CharSequence", "java/lang/String");
 				var gen_string_overload = !method.IsOverride && method.Parameters.HasCharSequence && !iface.ContainsMethod (name_and_jnisig);
@@ -241,14 +241,18 @@ namespace generator.SourceWriters
 
 		public void WritePreSiblingClasses (CodeWriter writer)
 		{
-			foreach (var sibling in pre_sibling_types)
+			foreach (var sibling in pre_sibling_types) {
 				sibling.Write (writer);
+				writer.WriteLine ();
+			}
 		}
 
 		public void WritePostSiblingClasses (CodeWriter writer)
 		{
-			foreach (var sibling in post_sibling_types)
+			foreach (var sibling in post_sibling_types) {
+				writer.WriteLine ();
 				sibling.Write (writer);
+			}
 		}
 	}
 }

--- a/tools/generator/SourceWriters/InterfaceMemberAlternativeClass.cs
+++ b/tools/generator/SourceWriters/InterfaceMemberAlternativeClass.cs
@@ -159,8 +159,10 @@ namespace generator.SourceWriters
 
 		public void WriteSiblingClasses (CodeWriter writer)
 		{
-			foreach (var sibling in sibling_classes)
+			foreach (var sibling in sibling_classes) {
+				writer.WriteLine ();
 				sibling.Write (writer);
+			}
 		}
 	}
 

--- a/tools/generator/SourceWriters/MethodCallback.cs
+++ b/tools/generator/SourceWriters/MethodCallback.cs
@@ -83,12 +83,16 @@ namespace generator.SourceWriters
 		public override void Write (CodeWriter writer)
 		{
 			delegate_field.Write (writer);
-			writer.WriteLine ("#pragma warning disable 0169");
+
+			writer.WriteLineNoIndent ("#pragma warning disable 0169");
 
 			delegate_getter.Write (writer);
+			writer.WriteLine ();
+
 			base.Write (writer);
 
-			writer.WriteLine ("#pragma warning restore 0169");
+			writer.WriteLineNoIndent ("#pragma warning restore 0169");
+			writer.WriteLine ();
 		}
 	}
 


### PR DESCRIPTION
The recent `generator` refactor (https://github.com/xamarin/java.interop/pull/674) caused there to be differences in how whitespace is generated in bindings.  In order to minimize distractions in an already hard to review PR, the test infrastructure was changed to ignore whitespace differences.  This made it possible to ensure there were no non-whitespace changes caused by the refactor.

This PR cleans up the generated whitespace to be closer to the original.

Note that the test diffs weren't updated when the original `generator` refactor was committed (to keep the PR slightly more readable).  Thus the test expected output changes in **this** PR are not caused by the code changes in **this** PR, they already exist in `master`.  The code changes in this PR cause there to be **fewer** test diffs than there would be, by making our output closer to the pre-refactor version.