### PR TITLE
[ApiXmlAdjuster, Bytecode] Make error/warning strings localizable.

### DIFF
--- a/src/Java.Interop.Localization/Resources.Designer.cs
+++ b/src/Java.Interop.Localization/Resources.Designer.cs
@@ -61,6 +61,195 @@ namespace Java.Interop.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Warning: method &apos;{0}&apos; in type &apos;{1}&apos; has unnamed parameters..
+        /// </summary>
+        public static string ApiXmlAdjuster_0001 {
+            get {
+                return ResourceManager.GetString("ApiXmlAdjuster_0001", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Warning: &apos;{0}&apos; is referenced as base type of &apos;{1}&apos; and expected to have generic type parameters, but it does not..
+        /// </summary>
+        public static string ApiXmlAdjuster_0002 {
+            get {
+                return ResourceManager.GetString("ApiXmlAdjuster_0002", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error while processing Java class &apos;{0}&apos;: {1}..
+        /// </summary>
+        public static string ApiXmlAdjuster_0003 {
+            get {
+                return ResourceManager.GetString("ApiXmlAdjuster_0003", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error while processing Java interface &apos;{0}&apos;: {1}..
+        /// </summary>
+        public static string ApiXmlAdjuster_0004 {
+            get {
+                return ResourceManager.GetString("ApiXmlAdjuster_0004", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error while resolving &apos;{0}&apos; in &apos;{1}&apos;: {2}..
+        /// </summary>
+        public static string ApiXmlAdjuster_0005 {
+            get {
+                return ResourceManager.GetString("ApiXmlAdjuster_0005", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Warning: failed to resolve generic constraint: &apos;{0}&apos;: {1}..
+        /// </summary>
+        public static string ApiXmlAdjuster_0006 {
+            get {
+                return ResourceManager.GetString("ApiXmlAdjuster_0006", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to For &apos;{0}.{1}&apos;, referenced generic arguments count does not match the base type parameters definition..
+        /// </summary>
+        public static string ApiXmlAdjuster_0007 {
+            get {
+                return ResourceManager.GetString("ApiXmlAdjuster_0007", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Type &apos;{0}&apos; was not found..
+        /// </summary>
+        public static string ApiXmlAdjuster_0008 {
+            get {
+                return ResourceManager.GetString("ApiXmlAdjuster_0008", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Internal error: XmlReader should be positioned on attribute, but it is on &apos;{0}&apos;..
+        /// </summary>
+        public static string ApiXmlAdjuster_0009 {
+            get {
+                return ResourceManager.GetString("ApiXmlAdjuster_0009", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0}: Element &apos;{1}&apos; requires attribute &apos;{2}&apos;..
+        /// </summary>
+        public static string ApiXmlAdjuster_0010 {
+            get {
+                return ResourceManager.GetString("ApiXmlAdjuster_0010", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0}: EndElement of &apos;{1}&apos; was expected, but is type &apos;{2}&apos; with name &apos;{3}&apos; instead..
+        /// </summary>
+        public static string ApiXmlAdjuster_0011 {
+            get {
+                return ResourceManager.GetString("ApiXmlAdjuster_0011", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0}: Unexpected element or content in &apos;{1}&apos;: node is &apos;{2}&apos;, name is &apos;{3}&apos;. Allowed elements are: &apos;{4}&apos;..
+        /// </summary>
+        public static string ApiXmlAdjuster_0012 {
+            get {
+                return ResourceManager.GetString("ApiXmlAdjuster_0012", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0}: Element &apos;{1}&apos; has an unexpected attribute: &apos;{2}&apos;. Allowed attributes are: &apos;{3}&apos;..
+        /// </summary>
+        public static string ApiXmlAdjuster_0013 {
+            get {
+                return ResourceManager.GetString("ApiXmlAdjuster_0013", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not load .jar entry &apos;{0}&apos;: {1}..
+        /// </summary>
+        public static string Bytecode_0001 {
+            get {
+                return ResourceManager.GetString("Bytecode_0001", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Documentation file not found: &apos;{0}&apos;..
+        /// </summary>
+        public static string Bytecode_0002 {
+            get {
+                return ResourceManager.GetString("Bytecode_0002", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to match expression &apos;{0}&apos;, expected {1} parameter(s) but got {2} parameter(s)..
+        /// </summary>
+        public static string Bytecode_0003 {
+            get {
+                return ResourceManager.GetString("Bytecode_0003", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No parameter match for &apos;{0}.{1}&apos;. (expression: &apos;{2}&apos;).
+        /// </summary>
+        public static string Bytecode_0004 {
+            get {
+                return ResourceManager.GetString("Bytecode_0004", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to parse Kotlin metadata on &apos;{0}&apos;: {1}..
+        /// </summary>
+        public static string Bytecode_0005 {
+            get {
+                return ResourceManager.GetString("Bytecode_0005", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Differing number of &apos;throws&apos; declarations on &apos;{0}{1}&apos;..
+        /// </summary>
+        public static string Bytecode_0006 {
+            get {
+                return ResourceManager.GetString("Bytecode_0006", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to get parameter names for &apos;{0}.{1}&apos;: {2}..
+        /// </summary>
+        public static string Bytecode_0007 {
+            get {
+                return ResourceManager.GetString("Bytecode_0007", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to parse annotation XML file: {0}..
+        /// </summary>
+        public static string Bytecode_0008 {
+            get {
+                return ResourceManager.GetString("Bytecode_0008", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to remove old constants: {0}..
         /// </summary>
         public static string Generator_BG4000 {

--- a/src/Java.Interop.Localization/Resources.resx
+++ b/src/Java.Interop.Localization/Resources.resx
@@ -117,6 +117,119 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="ApiXmlAdjuster_0001" xml:space="preserve">
+    <value>Warning: method '{0}' in type '{1}' has unnamed parameters.</value>
+    <comment>{0} - Java method name.
+{1} - Java type name.</comment>
+  </data>
+  <data name="ApiXmlAdjuster_0002" xml:space="preserve">
+    <value>Warning: '{0}' is referenced as base type of '{1}' and expected to have generic type parameters, but it does not.</value>
+    <comment>{0}, {1} - Java type names.</comment>
+  </data>
+  <data name="ApiXmlAdjuster_0003" xml:space="preserve">
+    <value>Error while processing Java class '{0}': {1}.</value>
+    <comment>{0} - Java class name.
+{1} - Exception message.</comment>
+  </data>
+  <data name="ApiXmlAdjuster_0004" xml:space="preserve">
+    <value>Error while processing Java interface '{0}': {1}.</value>
+    <comment>{0} - Java interface name.
+{1} - Exception message.</comment>
+  </data>
+  <data name="ApiXmlAdjuster_0005" xml:space="preserve">
+    <value>Error while resolving '{0}' in '{1}': {2}.</value>
+    <comment>{0} - Java member.
+{1} - Java type.
+{2} - Exception message.</comment>
+  </data>
+  <data name="ApiXmlAdjuster_0006" xml:space="preserve">
+    <value>Warning: failed to resolve generic constraint: '{0}': {1}.</value>
+    <comment>{0} - Java constraint type.
+{1} - Exception message.</comment>
+  </data>
+  <data name="ApiXmlAdjuster_0007" xml:space="preserve">
+    <value>For '{0}.{1}', referenced generic arguments count does not match the base type parameters definition.</value>
+    <comment>{0} - Java type.
+{1} - Java member.</comment>
+  </data>
+  <data name="ApiXmlAdjuster_0008" xml:space="preserve">
+    <value>Type '{0}' was not found.</value>
+    <comment>{0} - Java type.</comment>
+  </data>
+  <data name="ApiXmlAdjuster_0009" xml:space="preserve">
+    <value>Internal error: XmlReader should be positioned on attribute, but it is on '{0}'.</value>
+    <comment>{0} - XML node type.
+The following are literal type names and should not be translated: XmlReader.</comment>
+  </data>
+  <data name="ApiXmlAdjuster_0010" xml:space="preserve">
+    <value>{0}: Element '{1}' requires attribute '{2}'.</value>
+    <comment>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML attribute name.</comment>
+  </data>
+  <data name="ApiXmlAdjuster_0011" xml:space="preserve">
+    <value>{0}: EndElement of '{1}' was expected, but is type '{2}' with name '{3}' instead.</value>
+    <comment>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML node type.
+{3} - XML element name.</comment>
+  </data>
+  <data name="ApiXmlAdjuster_0012" xml:space="preserve">
+    <value>{0}: Unexpected element or content in '{1}': node is '{2}', name is '{3}'. Allowed elements are: '{4}'.</value>
+    <comment>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML node type.
+{3} - XML element name.
+{4} - Allowed XML element names.</comment>
+  </data>
+  <data name="ApiXmlAdjuster_0013" xml:space="preserve">
+    <value>{0}: Element '{1}' has an unexpected attribute: '{2}'. Allowed attributes are: '{3}'.</value>
+    <comment>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML attribute name.
+{3} - Allowed XML attribute names.</comment>
+  </data>
+  <data name="Bytecode_0001" xml:space="preserve">
+    <value>Could not load .jar entry '{0}': {1}.</value>
+    <comment>{0} - Java .jar entry.
+{1} - .NET exception.</comment>
+  </data>
+  <data name="Bytecode_0002" xml:space="preserve">
+    <value>Documentation file not found: '{0}'.</value>
+    <comment>{0} - File name.</comment>
+  </data>
+  <data name="Bytecode_0003" xml:space="preserve">
+    <value>Failed to match expression '{0}', expected {1} parameter(s) but got {2} parameter(s).</value>
+    <comment>{0} - Regex expression.
+{1}, {2} - Integer.</comment>
+  </data>
+  <data name="Bytecode_0004" xml:space="preserve">
+    <value>No parameter match for '{0}.{1}'. (expression: '{2}')</value>
+    <comment>{0} - Java type.
+{1} - Java method.
+{2} - Regex expression.</comment>
+  </data>
+  <data name="Bytecode_0005" xml:space="preserve">
+    <value>Unable to parse Kotlin metadata on '{0}': {1}.</value>
+    <comment>{0} - Java type.
+{1} - Exception.</comment>
+  </data>
+  <data name="Bytecode_0006" xml:space="preserve">
+    <value>Differing number of 'throws' declarations on '{0}{1}'.</value>
+    <comment>{0} - Java type name.
+{1} - Java type descriptor.
+The following are literal names and should not be translated: throws.</comment>
+  </data>
+  <data name="Bytecode_0007" xml:space="preserve">
+    <value>Failed to get parameter names for '{0}.{1}': {2}.</value>
+    <comment>{0} - Java type.
+{1} - Java method.
+{2} - Exception.</comment>
+  </data>
+  <data name="Bytecode_0008" xml:space="preserve">
+    <value>Failed to parse annotation XML file: {0}.</value>
+    <comment>{0} - Exception.</comment>
+  </data>
   <data name="Generator_BG4000" xml:space="preserve">
     <value>Failed to remove old constants: {0}.</value>
     <comment>{0} - The list of constants that could not be removed.

--- a/src/Java.Interop.Localization/xlf/Resources.cs.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.cs.xlf
@@ -2,6 +2,140 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Resources.resx">
     <body>
+      <trans-unit id="ApiXmlAdjuster_0001">
+        <source>Warning: method '{0}' in type '{1}' has unnamed parameters.</source>
+        <target state="new">Warning: method '{0}' in type '{1}' has unnamed parameters.</target>
+        <note>{0} - Java method name.
+{1} - Java type name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0002">
+        <source>Warning: '{0}' is referenced as base type of '{1}' and expected to have generic type parameters, but it does not.</source>
+        <target state="new">Warning: '{0}' is referenced as base type of '{1}' and expected to have generic type parameters, but it does not.</target>
+        <note>{0}, {1} - Java type names.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0003">
+        <source>Error while processing Java class '{0}': {1}.</source>
+        <target state="new">Error while processing Java class '{0}': {1}.</target>
+        <note>{0} - Java class name.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0004">
+        <source>Error while processing Java interface '{0}': {1}.</source>
+        <target state="new">Error while processing Java interface '{0}': {1}.</target>
+        <note>{0} - Java interface name.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0005">
+        <source>Error while resolving '{0}' in '{1}': {2}.</source>
+        <target state="new">Error while resolving '{0}' in '{1}': {2}.</target>
+        <note>{0} - Java member.
+{1} - Java type.
+{2} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0006">
+        <source>Warning: failed to resolve generic constraint: '{0}': {1}.</source>
+        <target state="new">Warning: failed to resolve generic constraint: '{0}': {1}.</target>
+        <note>{0} - Java constraint type.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0007">
+        <source>For '{0}.{1}', referenced generic arguments count does not match the base type parameters definition.</source>
+        <target state="new">For '{0}.{1}', referenced generic arguments count does not match the base type parameters definition.</target>
+        <note>{0} - Java type.
+{1} - Java member.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0008">
+        <source>Type '{0}' was not found.</source>
+        <target state="new">Type '{0}' was not found.</target>
+        <note>{0} - Java type.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0009">
+        <source>Internal error: XmlReader should be positioned on attribute, but it is on '{0}'.</source>
+        <target state="new">Internal error: XmlReader should be positioned on attribute, but it is on '{0}'.</target>
+        <note>{0} - XML node type.
+The following are literal type names and should not be translated: XmlReader.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0010">
+        <source>{0}: Element '{1}' requires attribute '{2}'.</source>
+        <target state="new">{0}: Element '{1}' requires attribute '{2}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML attribute name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0011">
+        <source>{0}: EndElement of '{1}' was expected, but is type '{2}' with name '{3}' instead.</source>
+        <target state="new">{0}: EndElement of '{1}' was expected, but is type '{2}' with name '{3}' instead.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML node type.
+{3} - XML element name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0012">
+        <source>{0}: Unexpected element or content in '{1}': node is '{2}', name is '{3}'. Allowed elements are: '{4}'.</source>
+        <target state="new">{0}: Unexpected element or content in '{1}': node is '{2}', name is '{3}'. Allowed elements are: '{4}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML node type.
+{3} - XML element name.
+{4} - Allowed XML element names.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0013">
+        <source>{0}: Element '{1}' has an unexpected attribute: '{2}'. Allowed attributes are: '{3}'.</source>
+        <target state="new">{0}: Element '{1}' has an unexpected attribute: '{2}'. Allowed attributes are: '{3}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML attribute name.
+{3} - Allowed XML attribute names.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0001">
+        <source>Could not load .jar entry '{0}': {1}.</source>
+        <target state="new">Could not load .jar entry '{0}': {1}.</target>
+        <note>{0} - Java .jar entry.
+{1} - .NET exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0002">
+        <source>Documentation file not found: '{0}'.</source>
+        <target state="new">Documentation file not found: '{0}'.</target>
+        <note>{0} - File name.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0003">
+        <source>Failed to match expression '{0}', expected {1} parameter(s) but got {2} parameter(s).</source>
+        <target state="new">Failed to match expression '{0}', expected {1} parameter(s) but got {2} parameter(s).</target>
+        <note>{0} - Regex expression.
+{1}, {2} - Integer.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0004">
+        <source>No parameter match for '{0}.{1}'. (expression: '{2}')</source>
+        <target state="new">No parameter match for '{0}.{1}'. (expression: '{2}')</target>
+        <note>{0} - Java type.
+{1} - Java method.
+{2} - Regex expression.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0005">
+        <source>Unable to parse Kotlin metadata on '{0}': {1}.</source>
+        <target state="new">Unable to parse Kotlin metadata on '{0}': {1}.</target>
+        <note>{0} - Java type.
+{1} - Exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0006">
+        <source>Differing number of 'throws' declarations on '{0}{1}'.</source>
+        <target state="new">Differing number of 'throws' declarations on '{0}{1}'.</target>
+        <note>{0} - Java type name.
+{1} - Java type descriptor.
+The following are literal names and should not be translated: throws.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0007">
+        <source>Failed to get parameter names for '{0}.{1}': {2}.</source>
+        <target state="new">Failed to get parameter names for '{0}.{1}': {2}.</target>
+        <note>{0} - Java type.
+{1} - Java method.
+{2} - Exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0008">
+        <source>Failed to parse annotation XML file: {0}.</source>
+        <target state="new">Failed to parse annotation XML file: {0}.</target>
+        <note>{0} - Exception.</note>
+      </trans-unit>
       <trans-unit id="Generator_BG4000">
         <source>Failed to remove old constants: {0}.</source>
         <target state="new">Failed to remove old constants: {0}.</target>

--- a/src/Java.Interop.Localization/xlf/Resources.de.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.de.xlf
@@ -2,6 +2,140 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Resources.resx">
     <body>
+      <trans-unit id="ApiXmlAdjuster_0001">
+        <source>Warning: method '{0}' in type '{1}' has unnamed parameters.</source>
+        <target state="new">Warning: method '{0}' in type '{1}' has unnamed parameters.</target>
+        <note>{0} - Java method name.
+{1} - Java type name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0002">
+        <source>Warning: '{0}' is referenced as base type of '{1}' and expected to have generic type parameters, but it does not.</source>
+        <target state="new">Warning: '{0}' is referenced as base type of '{1}' and expected to have generic type parameters, but it does not.</target>
+        <note>{0}, {1} - Java type names.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0003">
+        <source>Error while processing Java class '{0}': {1}.</source>
+        <target state="new">Error while processing Java class '{0}': {1}.</target>
+        <note>{0} - Java class name.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0004">
+        <source>Error while processing Java interface '{0}': {1}.</source>
+        <target state="new">Error while processing Java interface '{0}': {1}.</target>
+        <note>{0} - Java interface name.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0005">
+        <source>Error while resolving '{0}' in '{1}': {2}.</source>
+        <target state="new">Error while resolving '{0}' in '{1}': {2}.</target>
+        <note>{0} - Java member.
+{1} - Java type.
+{2} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0006">
+        <source>Warning: failed to resolve generic constraint: '{0}': {1}.</source>
+        <target state="new">Warning: failed to resolve generic constraint: '{0}': {1}.</target>
+        <note>{0} - Java constraint type.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0007">
+        <source>For '{0}.{1}', referenced generic arguments count does not match the base type parameters definition.</source>
+        <target state="new">For '{0}.{1}', referenced generic arguments count does not match the base type parameters definition.</target>
+        <note>{0} - Java type.
+{1} - Java member.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0008">
+        <source>Type '{0}' was not found.</source>
+        <target state="new">Type '{0}' was not found.</target>
+        <note>{0} - Java type.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0009">
+        <source>Internal error: XmlReader should be positioned on attribute, but it is on '{0}'.</source>
+        <target state="new">Internal error: XmlReader should be positioned on attribute, but it is on '{0}'.</target>
+        <note>{0} - XML node type.
+The following are literal type names and should not be translated: XmlReader.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0010">
+        <source>{0}: Element '{1}' requires attribute '{2}'.</source>
+        <target state="new">{0}: Element '{1}' requires attribute '{2}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML attribute name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0011">
+        <source>{0}: EndElement of '{1}' was expected, but is type '{2}' with name '{3}' instead.</source>
+        <target state="new">{0}: EndElement of '{1}' was expected, but is type '{2}' with name '{3}' instead.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML node type.
+{3} - XML element name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0012">
+        <source>{0}: Unexpected element or content in '{1}': node is '{2}', name is '{3}'. Allowed elements are: '{4}'.</source>
+        <target state="new">{0}: Unexpected element or content in '{1}': node is '{2}', name is '{3}'. Allowed elements are: '{4}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML node type.
+{3} - XML element name.
+{4} - Allowed XML element names.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0013">
+        <source>{0}: Element '{1}' has an unexpected attribute: '{2}'. Allowed attributes are: '{3}'.</source>
+        <target state="new">{0}: Element '{1}' has an unexpected attribute: '{2}'. Allowed attributes are: '{3}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML attribute name.
+{3} - Allowed XML attribute names.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0001">
+        <source>Could not load .jar entry '{0}': {1}.</source>
+        <target state="new">Could not load .jar entry '{0}': {1}.</target>
+        <note>{0} - Java .jar entry.
+{1} - .NET exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0002">
+        <source>Documentation file not found: '{0}'.</source>
+        <target state="new">Documentation file not found: '{0}'.</target>
+        <note>{0} - File name.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0003">
+        <source>Failed to match expression '{0}', expected {1} parameter(s) but got {2} parameter(s).</source>
+        <target state="new">Failed to match expression '{0}', expected {1} parameter(s) but got {2} parameter(s).</target>
+        <note>{0} - Regex expression.
+{1}, {2} - Integer.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0004">
+        <source>No parameter match for '{0}.{1}'. (expression: '{2}')</source>
+        <target state="new">No parameter match for '{0}.{1}'. (expression: '{2}')</target>
+        <note>{0} - Java type.
+{1} - Java method.
+{2} - Regex expression.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0005">
+        <source>Unable to parse Kotlin metadata on '{0}': {1}.</source>
+        <target state="new">Unable to parse Kotlin metadata on '{0}': {1}.</target>
+        <note>{0} - Java type.
+{1} - Exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0006">
+        <source>Differing number of 'throws' declarations on '{0}{1}'.</source>
+        <target state="new">Differing number of 'throws' declarations on '{0}{1}'.</target>
+        <note>{0} - Java type name.
+{1} - Java type descriptor.
+The following are literal names and should not be translated: throws.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0007">
+        <source>Failed to get parameter names for '{0}.{1}': {2}.</source>
+        <target state="new">Failed to get parameter names for '{0}.{1}': {2}.</target>
+        <note>{0} - Java type.
+{1} - Java method.
+{2} - Exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0008">
+        <source>Failed to parse annotation XML file: {0}.</source>
+        <target state="new">Failed to parse annotation XML file: {0}.</target>
+        <note>{0} - Exception.</note>
+      </trans-unit>
       <trans-unit id="Generator_BG4000">
         <source>Failed to remove old constants: {0}.</source>
         <target state="new">Failed to remove old constants: {0}.</target>

--- a/src/Java.Interop.Localization/xlf/Resources.es.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.es.xlf
@@ -2,6 +2,140 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Resources.resx">
     <body>
+      <trans-unit id="ApiXmlAdjuster_0001">
+        <source>Warning: method '{0}' in type '{1}' has unnamed parameters.</source>
+        <target state="new">Warning: method '{0}' in type '{1}' has unnamed parameters.</target>
+        <note>{0} - Java method name.
+{1} - Java type name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0002">
+        <source>Warning: '{0}' is referenced as base type of '{1}' and expected to have generic type parameters, but it does not.</source>
+        <target state="new">Warning: '{0}' is referenced as base type of '{1}' and expected to have generic type parameters, but it does not.</target>
+        <note>{0}, {1} - Java type names.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0003">
+        <source>Error while processing Java class '{0}': {1}.</source>
+        <target state="new">Error while processing Java class '{0}': {1}.</target>
+        <note>{0} - Java class name.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0004">
+        <source>Error while processing Java interface '{0}': {1}.</source>
+        <target state="new">Error while processing Java interface '{0}': {1}.</target>
+        <note>{0} - Java interface name.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0005">
+        <source>Error while resolving '{0}' in '{1}': {2}.</source>
+        <target state="new">Error while resolving '{0}' in '{1}': {2}.</target>
+        <note>{0} - Java member.
+{1} - Java type.
+{2} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0006">
+        <source>Warning: failed to resolve generic constraint: '{0}': {1}.</source>
+        <target state="new">Warning: failed to resolve generic constraint: '{0}': {1}.</target>
+        <note>{0} - Java constraint type.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0007">
+        <source>For '{0}.{1}', referenced generic arguments count does not match the base type parameters definition.</source>
+        <target state="new">For '{0}.{1}', referenced generic arguments count does not match the base type parameters definition.</target>
+        <note>{0} - Java type.
+{1} - Java member.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0008">
+        <source>Type '{0}' was not found.</source>
+        <target state="new">Type '{0}' was not found.</target>
+        <note>{0} - Java type.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0009">
+        <source>Internal error: XmlReader should be positioned on attribute, but it is on '{0}'.</source>
+        <target state="new">Internal error: XmlReader should be positioned on attribute, but it is on '{0}'.</target>
+        <note>{0} - XML node type.
+The following are literal type names and should not be translated: XmlReader.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0010">
+        <source>{0}: Element '{1}' requires attribute '{2}'.</source>
+        <target state="new">{0}: Element '{1}' requires attribute '{2}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML attribute name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0011">
+        <source>{0}: EndElement of '{1}' was expected, but is type '{2}' with name '{3}' instead.</source>
+        <target state="new">{0}: EndElement of '{1}' was expected, but is type '{2}' with name '{3}' instead.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML node type.
+{3} - XML element name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0012">
+        <source>{0}: Unexpected element or content in '{1}': node is '{2}', name is '{3}'. Allowed elements are: '{4}'.</source>
+        <target state="new">{0}: Unexpected element or content in '{1}': node is '{2}', name is '{3}'. Allowed elements are: '{4}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML node type.
+{3} - XML element name.
+{4} - Allowed XML element names.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0013">
+        <source>{0}: Element '{1}' has an unexpected attribute: '{2}'. Allowed attributes are: '{3}'.</source>
+        <target state="new">{0}: Element '{1}' has an unexpected attribute: '{2}'. Allowed attributes are: '{3}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML attribute name.
+{3} - Allowed XML attribute names.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0001">
+        <source>Could not load .jar entry '{0}': {1}.</source>
+        <target state="new">Could not load .jar entry '{0}': {1}.</target>
+        <note>{0} - Java .jar entry.
+{1} - .NET exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0002">
+        <source>Documentation file not found: '{0}'.</source>
+        <target state="new">Documentation file not found: '{0}'.</target>
+        <note>{0} - File name.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0003">
+        <source>Failed to match expression '{0}', expected {1} parameter(s) but got {2} parameter(s).</source>
+        <target state="new">Failed to match expression '{0}', expected {1} parameter(s) but got {2} parameter(s).</target>
+        <note>{0} - Regex expression.
+{1}, {2} - Integer.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0004">
+        <source>No parameter match for '{0}.{1}'. (expression: '{2}')</source>
+        <target state="new">No parameter match for '{0}.{1}'. (expression: '{2}')</target>
+        <note>{0} - Java type.
+{1} - Java method.
+{2} - Regex expression.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0005">
+        <source>Unable to parse Kotlin metadata on '{0}': {1}.</source>
+        <target state="new">Unable to parse Kotlin metadata on '{0}': {1}.</target>
+        <note>{0} - Java type.
+{1} - Exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0006">
+        <source>Differing number of 'throws' declarations on '{0}{1}'.</source>
+        <target state="new">Differing number of 'throws' declarations on '{0}{1}'.</target>
+        <note>{0} - Java type name.
+{1} - Java type descriptor.
+The following are literal names and should not be translated: throws.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0007">
+        <source>Failed to get parameter names for '{0}.{1}': {2}.</source>
+        <target state="new">Failed to get parameter names for '{0}.{1}': {2}.</target>
+        <note>{0} - Java type.
+{1} - Java method.
+{2} - Exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0008">
+        <source>Failed to parse annotation XML file: {0}.</source>
+        <target state="new">Failed to parse annotation XML file: {0}.</target>
+        <note>{0} - Exception.</note>
+      </trans-unit>
       <trans-unit id="Generator_BG4000">
         <source>Failed to remove old constants: {0}.</source>
         <target state="new">Failed to remove old constants: {0}.</target>

--- a/src/Java.Interop.Localization/xlf/Resources.fr.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.fr.xlf
@@ -2,6 +2,140 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Resources.resx">
     <body>
+      <trans-unit id="ApiXmlAdjuster_0001">
+        <source>Warning: method '{0}' in type '{1}' has unnamed parameters.</source>
+        <target state="new">Warning: method '{0}' in type '{1}' has unnamed parameters.</target>
+        <note>{0} - Java method name.
+{1} - Java type name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0002">
+        <source>Warning: '{0}' is referenced as base type of '{1}' and expected to have generic type parameters, but it does not.</source>
+        <target state="new">Warning: '{0}' is referenced as base type of '{1}' and expected to have generic type parameters, but it does not.</target>
+        <note>{0}, {1} - Java type names.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0003">
+        <source>Error while processing Java class '{0}': {1}.</source>
+        <target state="new">Error while processing Java class '{0}': {1}.</target>
+        <note>{0} - Java class name.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0004">
+        <source>Error while processing Java interface '{0}': {1}.</source>
+        <target state="new">Error while processing Java interface '{0}': {1}.</target>
+        <note>{0} - Java interface name.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0005">
+        <source>Error while resolving '{0}' in '{1}': {2}.</source>
+        <target state="new">Error while resolving '{0}' in '{1}': {2}.</target>
+        <note>{0} - Java member.
+{1} - Java type.
+{2} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0006">
+        <source>Warning: failed to resolve generic constraint: '{0}': {1}.</source>
+        <target state="new">Warning: failed to resolve generic constraint: '{0}': {1}.</target>
+        <note>{0} - Java constraint type.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0007">
+        <source>For '{0}.{1}', referenced generic arguments count does not match the base type parameters definition.</source>
+        <target state="new">For '{0}.{1}', referenced generic arguments count does not match the base type parameters definition.</target>
+        <note>{0} - Java type.
+{1} - Java member.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0008">
+        <source>Type '{0}' was not found.</source>
+        <target state="new">Type '{0}' was not found.</target>
+        <note>{0} - Java type.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0009">
+        <source>Internal error: XmlReader should be positioned on attribute, but it is on '{0}'.</source>
+        <target state="new">Internal error: XmlReader should be positioned on attribute, but it is on '{0}'.</target>
+        <note>{0} - XML node type.
+The following are literal type names and should not be translated: XmlReader.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0010">
+        <source>{0}: Element '{1}' requires attribute '{2}'.</source>
+        <target state="new">{0}: Element '{1}' requires attribute '{2}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML attribute name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0011">
+        <source>{0}: EndElement of '{1}' was expected, but is type '{2}' with name '{3}' instead.</source>
+        <target state="new">{0}: EndElement of '{1}' was expected, but is type '{2}' with name '{3}' instead.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML node type.
+{3} - XML element name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0012">
+        <source>{0}: Unexpected element or content in '{1}': node is '{2}', name is '{3}'. Allowed elements are: '{4}'.</source>
+        <target state="new">{0}: Unexpected element or content in '{1}': node is '{2}', name is '{3}'. Allowed elements are: '{4}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML node type.
+{3} - XML element name.
+{4} - Allowed XML element names.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0013">
+        <source>{0}: Element '{1}' has an unexpected attribute: '{2}'. Allowed attributes are: '{3}'.</source>
+        <target state="new">{0}: Element '{1}' has an unexpected attribute: '{2}'. Allowed attributes are: '{3}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML attribute name.
+{3} - Allowed XML attribute names.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0001">
+        <source>Could not load .jar entry '{0}': {1}.</source>
+        <target state="new">Could not load .jar entry '{0}': {1}.</target>
+        <note>{0} - Java .jar entry.
+{1} - .NET exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0002">
+        <source>Documentation file not found: '{0}'.</source>
+        <target state="new">Documentation file not found: '{0}'.</target>
+        <note>{0} - File name.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0003">
+        <source>Failed to match expression '{0}', expected {1} parameter(s) but got {2} parameter(s).</source>
+        <target state="new">Failed to match expression '{0}', expected {1} parameter(s) but got {2} parameter(s).</target>
+        <note>{0} - Regex expression.
+{1}, {2} - Integer.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0004">
+        <source>No parameter match for '{0}.{1}'. (expression: '{2}')</source>
+        <target state="new">No parameter match for '{0}.{1}'. (expression: '{2}')</target>
+        <note>{0} - Java type.
+{1} - Java method.
+{2} - Regex expression.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0005">
+        <source>Unable to parse Kotlin metadata on '{0}': {1}.</source>
+        <target state="new">Unable to parse Kotlin metadata on '{0}': {1}.</target>
+        <note>{0} - Java type.
+{1} - Exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0006">
+        <source>Differing number of 'throws' declarations on '{0}{1}'.</source>
+        <target state="new">Differing number of 'throws' declarations on '{0}{1}'.</target>
+        <note>{0} - Java type name.
+{1} - Java type descriptor.
+The following are literal names and should not be translated: throws.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0007">
+        <source>Failed to get parameter names for '{0}.{1}': {2}.</source>
+        <target state="new">Failed to get parameter names for '{0}.{1}': {2}.</target>
+        <note>{0} - Java type.
+{1} - Java method.
+{2} - Exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0008">
+        <source>Failed to parse annotation XML file: {0}.</source>
+        <target state="new">Failed to parse annotation XML file: {0}.</target>
+        <note>{0} - Exception.</note>
+      </trans-unit>
       <trans-unit id="Generator_BG4000">
         <source>Failed to remove old constants: {0}.</source>
         <target state="new">Failed to remove old constants: {0}.</target>

--- a/src/Java.Interop.Localization/xlf/Resources.it.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.it.xlf
@@ -2,6 +2,140 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Resources.resx">
     <body>
+      <trans-unit id="ApiXmlAdjuster_0001">
+        <source>Warning: method '{0}' in type '{1}' has unnamed parameters.</source>
+        <target state="new">Warning: method '{0}' in type '{1}' has unnamed parameters.</target>
+        <note>{0} - Java method name.
+{1} - Java type name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0002">
+        <source>Warning: '{0}' is referenced as base type of '{1}' and expected to have generic type parameters, but it does not.</source>
+        <target state="new">Warning: '{0}' is referenced as base type of '{1}' and expected to have generic type parameters, but it does not.</target>
+        <note>{0}, {1} - Java type names.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0003">
+        <source>Error while processing Java class '{0}': {1}.</source>
+        <target state="new">Error while processing Java class '{0}': {1}.</target>
+        <note>{0} - Java class name.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0004">
+        <source>Error while processing Java interface '{0}': {1}.</source>
+        <target state="new">Error while processing Java interface '{0}': {1}.</target>
+        <note>{0} - Java interface name.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0005">
+        <source>Error while resolving '{0}' in '{1}': {2}.</source>
+        <target state="new">Error while resolving '{0}' in '{1}': {2}.</target>
+        <note>{0} - Java member.
+{1} - Java type.
+{2} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0006">
+        <source>Warning: failed to resolve generic constraint: '{0}': {1}.</source>
+        <target state="new">Warning: failed to resolve generic constraint: '{0}': {1}.</target>
+        <note>{0} - Java constraint type.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0007">
+        <source>For '{0}.{1}', referenced generic arguments count does not match the base type parameters definition.</source>
+        <target state="new">For '{0}.{1}', referenced generic arguments count does not match the base type parameters definition.</target>
+        <note>{0} - Java type.
+{1} - Java member.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0008">
+        <source>Type '{0}' was not found.</source>
+        <target state="new">Type '{0}' was not found.</target>
+        <note>{0} - Java type.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0009">
+        <source>Internal error: XmlReader should be positioned on attribute, but it is on '{0}'.</source>
+        <target state="new">Internal error: XmlReader should be positioned on attribute, but it is on '{0}'.</target>
+        <note>{0} - XML node type.
+The following are literal type names and should not be translated: XmlReader.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0010">
+        <source>{0}: Element '{1}' requires attribute '{2}'.</source>
+        <target state="new">{0}: Element '{1}' requires attribute '{2}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML attribute name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0011">
+        <source>{0}: EndElement of '{1}' was expected, but is type '{2}' with name '{3}' instead.</source>
+        <target state="new">{0}: EndElement of '{1}' was expected, but is type '{2}' with name '{3}' instead.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML node type.
+{3} - XML element name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0012">
+        <source>{0}: Unexpected element or content in '{1}': node is '{2}', name is '{3}'. Allowed elements are: '{4}'.</source>
+        <target state="new">{0}: Unexpected element or content in '{1}': node is '{2}', name is '{3}'. Allowed elements are: '{4}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML node type.
+{3} - XML element name.
+{4} - Allowed XML element names.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0013">
+        <source>{0}: Element '{1}' has an unexpected attribute: '{2}'. Allowed attributes are: '{3}'.</source>
+        <target state="new">{0}: Element '{1}' has an unexpected attribute: '{2}'. Allowed attributes are: '{3}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML attribute name.
+{3} - Allowed XML attribute names.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0001">
+        <source>Could not load .jar entry '{0}': {1}.</source>
+        <target state="new">Could not load .jar entry '{0}': {1}.</target>
+        <note>{0} - Java .jar entry.
+{1} - .NET exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0002">
+        <source>Documentation file not found: '{0}'.</source>
+        <target state="new">Documentation file not found: '{0}'.</target>
+        <note>{0} - File name.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0003">
+        <source>Failed to match expression '{0}', expected {1} parameter(s) but got {2} parameter(s).</source>
+        <target state="new">Failed to match expression '{0}', expected {1} parameter(s) but got {2} parameter(s).</target>
+        <note>{0} - Regex expression.
+{1}, {2} - Integer.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0004">
+        <source>No parameter match for '{0}.{1}'. (expression: '{2}')</source>
+        <target state="new">No parameter match for '{0}.{1}'. (expression: '{2}')</target>
+        <note>{0} - Java type.
+{1} - Java method.
+{2} - Regex expression.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0005">
+        <source>Unable to parse Kotlin metadata on '{0}': {1}.</source>
+        <target state="new">Unable to parse Kotlin metadata on '{0}': {1}.</target>
+        <note>{0} - Java type.
+{1} - Exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0006">
+        <source>Differing number of 'throws' declarations on '{0}{1}'.</source>
+        <target state="new">Differing number of 'throws' declarations on '{0}{1}'.</target>
+        <note>{0} - Java type name.
+{1} - Java type descriptor.
+The following are literal names and should not be translated: throws.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0007">
+        <source>Failed to get parameter names for '{0}.{1}': {2}.</source>
+        <target state="new">Failed to get parameter names for '{0}.{1}': {2}.</target>
+        <note>{0} - Java type.
+{1} - Java method.
+{2} - Exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0008">
+        <source>Failed to parse annotation XML file: {0}.</source>
+        <target state="new">Failed to parse annotation XML file: {0}.</target>
+        <note>{0} - Exception.</note>
+      </trans-unit>
       <trans-unit id="Generator_BG4000">
         <source>Failed to remove old constants: {0}.</source>
         <target state="new">Failed to remove old constants: {0}.</target>

--- a/src/Java.Interop.Localization/xlf/Resources.ja.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.ja.xlf
@@ -2,6 +2,140 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Resources.resx">
     <body>
+      <trans-unit id="ApiXmlAdjuster_0001">
+        <source>Warning: method '{0}' in type '{1}' has unnamed parameters.</source>
+        <target state="new">Warning: method '{0}' in type '{1}' has unnamed parameters.</target>
+        <note>{0} - Java method name.
+{1} - Java type name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0002">
+        <source>Warning: '{0}' is referenced as base type of '{1}' and expected to have generic type parameters, but it does not.</source>
+        <target state="new">Warning: '{0}' is referenced as base type of '{1}' and expected to have generic type parameters, but it does not.</target>
+        <note>{0}, {1} - Java type names.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0003">
+        <source>Error while processing Java class '{0}': {1}.</source>
+        <target state="new">Error while processing Java class '{0}': {1}.</target>
+        <note>{0} - Java class name.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0004">
+        <source>Error while processing Java interface '{0}': {1}.</source>
+        <target state="new">Error while processing Java interface '{0}': {1}.</target>
+        <note>{0} - Java interface name.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0005">
+        <source>Error while resolving '{0}' in '{1}': {2}.</source>
+        <target state="new">Error while resolving '{0}' in '{1}': {2}.</target>
+        <note>{0} - Java member.
+{1} - Java type.
+{2} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0006">
+        <source>Warning: failed to resolve generic constraint: '{0}': {1}.</source>
+        <target state="new">Warning: failed to resolve generic constraint: '{0}': {1}.</target>
+        <note>{0} - Java constraint type.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0007">
+        <source>For '{0}.{1}', referenced generic arguments count does not match the base type parameters definition.</source>
+        <target state="new">For '{0}.{1}', referenced generic arguments count does not match the base type parameters definition.</target>
+        <note>{0} - Java type.
+{1} - Java member.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0008">
+        <source>Type '{0}' was not found.</source>
+        <target state="new">Type '{0}' was not found.</target>
+        <note>{0} - Java type.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0009">
+        <source>Internal error: XmlReader should be positioned on attribute, but it is on '{0}'.</source>
+        <target state="new">Internal error: XmlReader should be positioned on attribute, but it is on '{0}'.</target>
+        <note>{0} - XML node type.
+The following are literal type names and should not be translated: XmlReader.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0010">
+        <source>{0}: Element '{1}' requires attribute '{2}'.</source>
+        <target state="new">{0}: Element '{1}' requires attribute '{2}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML attribute name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0011">
+        <source>{0}: EndElement of '{1}' was expected, but is type '{2}' with name '{3}' instead.</source>
+        <target state="new">{0}: EndElement of '{1}' was expected, but is type '{2}' with name '{3}' instead.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML node type.
+{3} - XML element name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0012">
+        <source>{0}: Unexpected element or content in '{1}': node is '{2}', name is '{3}'. Allowed elements are: '{4}'.</source>
+        <target state="new">{0}: Unexpected element or content in '{1}': node is '{2}', name is '{3}'. Allowed elements are: '{4}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML node type.
+{3} - XML element name.
+{4} - Allowed XML element names.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0013">
+        <source>{0}: Element '{1}' has an unexpected attribute: '{2}'. Allowed attributes are: '{3}'.</source>
+        <target state="new">{0}: Element '{1}' has an unexpected attribute: '{2}'. Allowed attributes are: '{3}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML attribute name.
+{3} - Allowed XML attribute names.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0001">
+        <source>Could not load .jar entry '{0}': {1}.</source>
+        <target state="new">Could not load .jar entry '{0}': {1}.</target>
+        <note>{0} - Java .jar entry.
+{1} - .NET exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0002">
+        <source>Documentation file not found: '{0}'.</source>
+        <target state="new">Documentation file not found: '{0}'.</target>
+        <note>{0} - File name.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0003">
+        <source>Failed to match expression '{0}', expected {1} parameter(s) but got {2} parameter(s).</source>
+        <target state="new">Failed to match expression '{0}', expected {1} parameter(s) but got {2} parameter(s).</target>
+        <note>{0} - Regex expression.
+{1}, {2} - Integer.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0004">
+        <source>No parameter match for '{0}.{1}'. (expression: '{2}')</source>
+        <target state="new">No parameter match for '{0}.{1}'. (expression: '{2}')</target>
+        <note>{0} - Java type.
+{1} - Java method.
+{2} - Regex expression.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0005">
+        <source>Unable to parse Kotlin metadata on '{0}': {1}.</source>
+        <target state="new">Unable to parse Kotlin metadata on '{0}': {1}.</target>
+        <note>{0} - Java type.
+{1} - Exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0006">
+        <source>Differing number of 'throws' declarations on '{0}{1}'.</source>
+        <target state="new">Differing number of 'throws' declarations on '{0}{1}'.</target>
+        <note>{0} - Java type name.
+{1} - Java type descriptor.
+The following are literal names and should not be translated: throws.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0007">
+        <source>Failed to get parameter names for '{0}.{1}': {2}.</source>
+        <target state="new">Failed to get parameter names for '{0}.{1}': {2}.</target>
+        <note>{0} - Java type.
+{1} - Java method.
+{2} - Exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0008">
+        <source>Failed to parse annotation XML file: {0}.</source>
+        <target state="new">Failed to parse annotation XML file: {0}.</target>
+        <note>{0} - Exception.</note>
+      </trans-unit>
       <trans-unit id="Generator_BG4000">
         <source>Failed to remove old constants: {0}.</source>
         <target state="new">Failed to remove old constants: {0}.</target>

--- a/src/Java.Interop.Localization/xlf/Resources.ko.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.ko.xlf
@@ -2,6 +2,140 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Resources.resx">
     <body>
+      <trans-unit id="ApiXmlAdjuster_0001">
+        <source>Warning: method '{0}' in type '{1}' has unnamed parameters.</source>
+        <target state="new">Warning: method '{0}' in type '{1}' has unnamed parameters.</target>
+        <note>{0} - Java method name.
+{1} - Java type name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0002">
+        <source>Warning: '{0}' is referenced as base type of '{1}' and expected to have generic type parameters, but it does not.</source>
+        <target state="new">Warning: '{0}' is referenced as base type of '{1}' and expected to have generic type parameters, but it does not.</target>
+        <note>{0}, {1} - Java type names.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0003">
+        <source>Error while processing Java class '{0}': {1}.</source>
+        <target state="new">Error while processing Java class '{0}': {1}.</target>
+        <note>{0} - Java class name.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0004">
+        <source>Error while processing Java interface '{0}': {1}.</source>
+        <target state="new">Error while processing Java interface '{0}': {1}.</target>
+        <note>{0} - Java interface name.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0005">
+        <source>Error while resolving '{0}' in '{1}': {2}.</source>
+        <target state="new">Error while resolving '{0}' in '{1}': {2}.</target>
+        <note>{0} - Java member.
+{1} - Java type.
+{2} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0006">
+        <source>Warning: failed to resolve generic constraint: '{0}': {1}.</source>
+        <target state="new">Warning: failed to resolve generic constraint: '{0}': {1}.</target>
+        <note>{0} - Java constraint type.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0007">
+        <source>For '{0}.{1}', referenced generic arguments count does not match the base type parameters definition.</source>
+        <target state="new">For '{0}.{1}', referenced generic arguments count does not match the base type parameters definition.</target>
+        <note>{0} - Java type.
+{1} - Java member.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0008">
+        <source>Type '{0}' was not found.</source>
+        <target state="new">Type '{0}' was not found.</target>
+        <note>{0} - Java type.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0009">
+        <source>Internal error: XmlReader should be positioned on attribute, but it is on '{0}'.</source>
+        <target state="new">Internal error: XmlReader should be positioned on attribute, but it is on '{0}'.</target>
+        <note>{0} - XML node type.
+The following are literal type names and should not be translated: XmlReader.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0010">
+        <source>{0}: Element '{1}' requires attribute '{2}'.</source>
+        <target state="new">{0}: Element '{1}' requires attribute '{2}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML attribute name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0011">
+        <source>{0}: EndElement of '{1}' was expected, but is type '{2}' with name '{3}' instead.</source>
+        <target state="new">{0}: EndElement of '{1}' was expected, but is type '{2}' with name '{3}' instead.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML node type.
+{3} - XML element name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0012">
+        <source>{0}: Unexpected element or content in '{1}': node is '{2}', name is '{3}'. Allowed elements are: '{4}'.</source>
+        <target state="new">{0}: Unexpected element or content in '{1}': node is '{2}', name is '{3}'. Allowed elements are: '{4}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML node type.
+{3} - XML element name.
+{4} - Allowed XML element names.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0013">
+        <source>{0}: Element '{1}' has an unexpected attribute: '{2}'. Allowed attributes are: '{3}'.</source>
+        <target state="new">{0}: Element '{1}' has an unexpected attribute: '{2}'. Allowed attributes are: '{3}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML attribute name.
+{3} - Allowed XML attribute names.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0001">
+        <source>Could not load .jar entry '{0}': {1}.</source>
+        <target state="new">Could not load .jar entry '{0}': {1}.</target>
+        <note>{0} - Java .jar entry.
+{1} - .NET exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0002">
+        <source>Documentation file not found: '{0}'.</source>
+        <target state="new">Documentation file not found: '{0}'.</target>
+        <note>{0} - File name.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0003">
+        <source>Failed to match expression '{0}', expected {1} parameter(s) but got {2} parameter(s).</source>
+        <target state="new">Failed to match expression '{0}', expected {1} parameter(s) but got {2} parameter(s).</target>
+        <note>{0} - Regex expression.
+{1}, {2} - Integer.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0004">
+        <source>No parameter match for '{0}.{1}'. (expression: '{2}')</source>
+        <target state="new">No parameter match for '{0}.{1}'. (expression: '{2}')</target>
+        <note>{0} - Java type.
+{1} - Java method.
+{2} - Regex expression.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0005">
+        <source>Unable to parse Kotlin metadata on '{0}': {1}.</source>
+        <target state="new">Unable to parse Kotlin metadata on '{0}': {1}.</target>
+        <note>{0} - Java type.
+{1} - Exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0006">
+        <source>Differing number of 'throws' declarations on '{0}{1}'.</source>
+        <target state="new">Differing number of 'throws' declarations on '{0}{1}'.</target>
+        <note>{0} - Java type name.
+{1} - Java type descriptor.
+The following are literal names and should not be translated: throws.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0007">
+        <source>Failed to get parameter names for '{0}.{1}': {2}.</source>
+        <target state="new">Failed to get parameter names for '{0}.{1}': {2}.</target>
+        <note>{0} - Java type.
+{1} - Java method.
+{2} - Exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0008">
+        <source>Failed to parse annotation XML file: {0}.</source>
+        <target state="new">Failed to parse annotation XML file: {0}.</target>
+        <note>{0} - Exception.</note>
+      </trans-unit>
       <trans-unit id="Generator_BG4000">
         <source>Failed to remove old constants: {0}.</source>
         <target state="new">Failed to remove old constants: {0}.</target>

--- a/src/Java.Interop.Localization/xlf/Resources.pl.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.pl.xlf
@@ -2,6 +2,140 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Resources.resx">
     <body>
+      <trans-unit id="ApiXmlAdjuster_0001">
+        <source>Warning: method '{0}' in type '{1}' has unnamed parameters.</source>
+        <target state="new">Warning: method '{0}' in type '{1}' has unnamed parameters.</target>
+        <note>{0} - Java method name.
+{1} - Java type name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0002">
+        <source>Warning: '{0}' is referenced as base type of '{1}' and expected to have generic type parameters, but it does not.</source>
+        <target state="new">Warning: '{0}' is referenced as base type of '{1}' and expected to have generic type parameters, but it does not.</target>
+        <note>{0}, {1} - Java type names.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0003">
+        <source>Error while processing Java class '{0}': {1}.</source>
+        <target state="new">Error while processing Java class '{0}': {1}.</target>
+        <note>{0} - Java class name.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0004">
+        <source>Error while processing Java interface '{0}': {1}.</source>
+        <target state="new">Error while processing Java interface '{0}': {1}.</target>
+        <note>{0} - Java interface name.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0005">
+        <source>Error while resolving '{0}' in '{1}': {2}.</source>
+        <target state="new">Error while resolving '{0}' in '{1}': {2}.</target>
+        <note>{0} - Java member.
+{1} - Java type.
+{2} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0006">
+        <source>Warning: failed to resolve generic constraint: '{0}': {1}.</source>
+        <target state="new">Warning: failed to resolve generic constraint: '{0}': {1}.</target>
+        <note>{0} - Java constraint type.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0007">
+        <source>For '{0}.{1}', referenced generic arguments count does not match the base type parameters definition.</source>
+        <target state="new">For '{0}.{1}', referenced generic arguments count does not match the base type parameters definition.</target>
+        <note>{0} - Java type.
+{1} - Java member.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0008">
+        <source>Type '{0}' was not found.</source>
+        <target state="new">Type '{0}' was not found.</target>
+        <note>{0} - Java type.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0009">
+        <source>Internal error: XmlReader should be positioned on attribute, but it is on '{0}'.</source>
+        <target state="new">Internal error: XmlReader should be positioned on attribute, but it is on '{0}'.</target>
+        <note>{0} - XML node type.
+The following are literal type names and should not be translated: XmlReader.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0010">
+        <source>{0}: Element '{1}' requires attribute '{2}'.</source>
+        <target state="new">{0}: Element '{1}' requires attribute '{2}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML attribute name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0011">
+        <source>{0}: EndElement of '{1}' was expected, but is type '{2}' with name '{3}' instead.</source>
+        <target state="new">{0}: EndElement of '{1}' was expected, but is type '{2}' with name '{3}' instead.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML node type.
+{3} - XML element name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0012">
+        <source>{0}: Unexpected element or content in '{1}': node is '{2}', name is '{3}'. Allowed elements are: '{4}'.</source>
+        <target state="new">{0}: Unexpected element or content in '{1}': node is '{2}', name is '{3}'. Allowed elements are: '{4}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML node type.
+{3} - XML element name.
+{4} - Allowed XML element names.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0013">
+        <source>{0}: Element '{1}' has an unexpected attribute: '{2}'. Allowed attributes are: '{3}'.</source>
+        <target state="new">{0}: Element '{1}' has an unexpected attribute: '{2}'. Allowed attributes are: '{3}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML attribute name.
+{3} - Allowed XML attribute names.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0001">
+        <source>Could not load .jar entry '{0}': {1}.</source>
+        <target state="new">Could not load .jar entry '{0}': {1}.</target>
+        <note>{0} - Java .jar entry.
+{1} - .NET exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0002">
+        <source>Documentation file not found: '{0}'.</source>
+        <target state="new">Documentation file not found: '{0}'.</target>
+        <note>{0} - File name.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0003">
+        <source>Failed to match expression '{0}', expected {1} parameter(s) but got {2} parameter(s).</source>
+        <target state="new">Failed to match expression '{0}', expected {1} parameter(s) but got {2} parameter(s).</target>
+        <note>{0} - Regex expression.
+{1}, {2} - Integer.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0004">
+        <source>No parameter match for '{0}.{1}'. (expression: '{2}')</source>
+        <target state="new">No parameter match for '{0}.{1}'. (expression: '{2}')</target>
+        <note>{0} - Java type.
+{1} - Java method.
+{2} - Regex expression.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0005">
+        <source>Unable to parse Kotlin metadata on '{0}': {1}.</source>
+        <target state="new">Unable to parse Kotlin metadata on '{0}': {1}.</target>
+        <note>{0} - Java type.
+{1} - Exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0006">
+        <source>Differing number of 'throws' declarations on '{0}{1}'.</source>
+        <target state="new">Differing number of 'throws' declarations on '{0}{1}'.</target>
+        <note>{0} - Java type name.
+{1} - Java type descriptor.
+The following are literal names and should not be translated: throws.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0007">
+        <source>Failed to get parameter names for '{0}.{1}': {2}.</source>
+        <target state="new">Failed to get parameter names for '{0}.{1}': {2}.</target>
+        <note>{0} - Java type.
+{1} - Java method.
+{2} - Exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0008">
+        <source>Failed to parse annotation XML file: {0}.</source>
+        <target state="new">Failed to parse annotation XML file: {0}.</target>
+        <note>{0} - Exception.</note>
+      </trans-unit>
       <trans-unit id="Generator_BG4000">
         <source>Failed to remove old constants: {0}.</source>
         <target state="new">Failed to remove old constants: {0}.</target>

--- a/src/Java.Interop.Localization/xlf/Resources.pt-BR.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.pt-BR.xlf
@@ -2,6 +2,140 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Resources.resx">
     <body>
+      <trans-unit id="ApiXmlAdjuster_0001">
+        <source>Warning: method '{0}' in type '{1}' has unnamed parameters.</source>
+        <target state="new">Warning: method '{0}' in type '{1}' has unnamed parameters.</target>
+        <note>{0} - Java method name.
+{1} - Java type name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0002">
+        <source>Warning: '{0}' is referenced as base type of '{1}' and expected to have generic type parameters, but it does not.</source>
+        <target state="new">Warning: '{0}' is referenced as base type of '{1}' and expected to have generic type parameters, but it does not.</target>
+        <note>{0}, {1} - Java type names.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0003">
+        <source>Error while processing Java class '{0}': {1}.</source>
+        <target state="new">Error while processing Java class '{0}': {1}.</target>
+        <note>{0} - Java class name.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0004">
+        <source>Error while processing Java interface '{0}': {1}.</source>
+        <target state="new">Error while processing Java interface '{0}': {1}.</target>
+        <note>{0} - Java interface name.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0005">
+        <source>Error while resolving '{0}' in '{1}': {2}.</source>
+        <target state="new">Error while resolving '{0}' in '{1}': {2}.</target>
+        <note>{0} - Java member.
+{1} - Java type.
+{2} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0006">
+        <source>Warning: failed to resolve generic constraint: '{0}': {1}.</source>
+        <target state="new">Warning: failed to resolve generic constraint: '{0}': {1}.</target>
+        <note>{0} - Java constraint type.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0007">
+        <source>For '{0}.{1}', referenced generic arguments count does not match the base type parameters definition.</source>
+        <target state="new">For '{0}.{1}', referenced generic arguments count does not match the base type parameters definition.</target>
+        <note>{0} - Java type.
+{1} - Java member.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0008">
+        <source>Type '{0}' was not found.</source>
+        <target state="new">Type '{0}' was not found.</target>
+        <note>{0} - Java type.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0009">
+        <source>Internal error: XmlReader should be positioned on attribute, but it is on '{0}'.</source>
+        <target state="new">Internal error: XmlReader should be positioned on attribute, but it is on '{0}'.</target>
+        <note>{0} - XML node type.
+The following are literal type names and should not be translated: XmlReader.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0010">
+        <source>{0}: Element '{1}' requires attribute '{2}'.</source>
+        <target state="new">{0}: Element '{1}' requires attribute '{2}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML attribute name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0011">
+        <source>{0}: EndElement of '{1}' was expected, but is type '{2}' with name '{3}' instead.</source>
+        <target state="new">{0}: EndElement of '{1}' was expected, but is type '{2}' with name '{3}' instead.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML node type.
+{3} - XML element name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0012">
+        <source>{0}: Unexpected element or content in '{1}': node is '{2}', name is '{3}'. Allowed elements are: '{4}'.</source>
+        <target state="new">{0}: Unexpected element or content in '{1}': node is '{2}', name is '{3}'. Allowed elements are: '{4}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML node type.
+{3} - XML element name.
+{4} - Allowed XML element names.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0013">
+        <source>{0}: Element '{1}' has an unexpected attribute: '{2}'. Allowed attributes are: '{3}'.</source>
+        <target state="new">{0}: Element '{1}' has an unexpected attribute: '{2}'. Allowed attributes are: '{3}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML attribute name.
+{3} - Allowed XML attribute names.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0001">
+        <source>Could not load .jar entry '{0}': {1}.</source>
+        <target state="new">Could not load .jar entry '{0}': {1}.</target>
+        <note>{0} - Java .jar entry.
+{1} - .NET exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0002">
+        <source>Documentation file not found: '{0}'.</source>
+        <target state="new">Documentation file not found: '{0}'.</target>
+        <note>{0} - File name.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0003">
+        <source>Failed to match expression '{0}', expected {1} parameter(s) but got {2} parameter(s).</source>
+        <target state="new">Failed to match expression '{0}', expected {1} parameter(s) but got {2} parameter(s).</target>
+        <note>{0} - Regex expression.
+{1}, {2} - Integer.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0004">
+        <source>No parameter match for '{0}.{1}'. (expression: '{2}')</source>
+        <target state="new">No parameter match for '{0}.{1}'. (expression: '{2}')</target>
+        <note>{0} - Java type.
+{1} - Java method.
+{2} - Regex expression.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0005">
+        <source>Unable to parse Kotlin metadata on '{0}': {1}.</source>
+        <target state="new">Unable to parse Kotlin metadata on '{0}': {1}.</target>
+        <note>{0} - Java type.
+{1} - Exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0006">
+        <source>Differing number of 'throws' declarations on '{0}{1}'.</source>
+        <target state="new">Differing number of 'throws' declarations on '{0}{1}'.</target>
+        <note>{0} - Java type name.
+{1} - Java type descriptor.
+The following are literal names and should not be translated: throws.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0007">
+        <source>Failed to get parameter names for '{0}.{1}': {2}.</source>
+        <target state="new">Failed to get parameter names for '{0}.{1}': {2}.</target>
+        <note>{0} - Java type.
+{1} - Java method.
+{2} - Exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0008">
+        <source>Failed to parse annotation XML file: {0}.</source>
+        <target state="new">Failed to parse annotation XML file: {0}.</target>
+        <note>{0} - Exception.</note>
+      </trans-unit>
       <trans-unit id="Generator_BG4000">
         <source>Failed to remove old constants: {0}.</source>
         <target state="new">Failed to remove old constants: {0}.</target>

--- a/src/Java.Interop.Localization/xlf/Resources.ru.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.ru.xlf
@@ -2,6 +2,140 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Resources.resx">
     <body>
+      <trans-unit id="ApiXmlAdjuster_0001">
+        <source>Warning: method '{0}' in type '{1}' has unnamed parameters.</source>
+        <target state="new">Warning: method '{0}' in type '{1}' has unnamed parameters.</target>
+        <note>{0} - Java method name.
+{1} - Java type name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0002">
+        <source>Warning: '{0}' is referenced as base type of '{1}' and expected to have generic type parameters, but it does not.</source>
+        <target state="new">Warning: '{0}' is referenced as base type of '{1}' and expected to have generic type parameters, but it does not.</target>
+        <note>{0}, {1} - Java type names.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0003">
+        <source>Error while processing Java class '{0}': {1}.</source>
+        <target state="new">Error while processing Java class '{0}': {1}.</target>
+        <note>{0} - Java class name.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0004">
+        <source>Error while processing Java interface '{0}': {1}.</source>
+        <target state="new">Error while processing Java interface '{0}': {1}.</target>
+        <note>{0} - Java interface name.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0005">
+        <source>Error while resolving '{0}' in '{1}': {2}.</source>
+        <target state="new">Error while resolving '{0}' in '{1}': {2}.</target>
+        <note>{0} - Java member.
+{1} - Java type.
+{2} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0006">
+        <source>Warning: failed to resolve generic constraint: '{0}': {1}.</source>
+        <target state="new">Warning: failed to resolve generic constraint: '{0}': {1}.</target>
+        <note>{0} - Java constraint type.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0007">
+        <source>For '{0}.{1}', referenced generic arguments count does not match the base type parameters definition.</source>
+        <target state="new">For '{0}.{1}', referenced generic arguments count does not match the base type parameters definition.</target>
+        <note>{0} - Java type.
+{1} - Java member.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0008">
+        <source>Type '{0}' was not found.</source>
+        <target state="new">Type '{0}' was not found.</target>
+        <note>{0} - Java type.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0009">
+        <source>Internal error: XmlReader should be positioned on attribute, but it is on '{0}'.</source>
+        <target state="new">Internal error: XmlReader should be positioned on attribute, but it is on '{0}'.</target>
+        <note>{0} - XML node type.
+The following are literal type names and should not be translated: XmlReader.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0010">
+        <source>{0}: Element '{1}' requires attribute '{2}'.</source>
+        <target state="new">{0}: Element '{1}' requires attribute '{2}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML attribute name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0011">
+        <source>{0}: EndElement of '{1}' was expected, but is type '{2}' with name '{3}' instead.</source>
+        <target state="new">{0}: EndElement of '{1}' was expected, but is type '{2}' with name '{3}' instead.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML node type.
+{3} - XML element name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0012">
+        <source>{0}: Unexpected element or content in '{1}': node is '{2}', name is '{3}'. Allowed elements are: '{4}'.</source>
+        <target state="new">{0}: Unexpected element or content in '{1}': node is '{2}', name is '{3}'. Allowed elements are: '{4}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML node type.
+{3} - XML element name.
+{4} - Allowed XML element names.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0013">
+        <source>{0}: Element '{1}' has an unexpected attribute: '{2}'. Allowed attributes are: '{3}'.</source>
+        <target state="new">{0}: Element '{1}' has an unexpected attribute: '{2}'. Allowed attributes are: '{3}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML attribute name.
+{3} - Allowed XML attribute names.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0001">
+        <source>Could not load .jar entry '{0}': {1}.</source>
+        <target state="new">Could not load .jar entry '{0}': {1}.</target>
+        <note>{0} - Java .jar entry.
+{1} - .NET exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0002">
+        <source>Documentation file not found: '{0}'.</source>
+        <target state="new">Documentation file not found: '{0}'.</target>
+        <note>{0} - File name.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0003">
+        <source>Failed to match expression '{0}', expected {1} parameter(s) but got {2} parameter(s).</source>
+        <target state="new">Failed to match expression '{0}', expected {1} parameter(s) but got {2} parameter(s).</target>
+        <note>{0} - Regex expression.
+{1}, {2} - Integer.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0004">
+        <source>No parameter match for '{0}.{1}'. (expression: '{2}')</source>
+        <target state="new">No parameter match for '{0}.{1}'. (expression: '{2}')</target>
+        <note>{0} - Java type.
+{1} - Java method.
+{2} - Regex expression.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0005">
+        <source>Unable to parse Kotlin metadata on '{0}': {1}.</source>
+        <target state="new">Unable to parse Kotlin metadata on '{0}': {1}.</target>
+        <note>{0} - Java type.
+{1} - Exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0006">
+        <source>Differing number of 'throws' declarations on '{0}{1}'.</source>
+        <target state="new">Differing number of 'throws' declarations on '{0}{1}'.</target>
+        <note>{0} - Java type name.
+{1} - Java type descriptor.
+The following are literal names and should not be translated: throws.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0007">
+        <source>Failed to get parameter names for '{0}.{1}': {2}.</source>
+        <target state="new">Failed to get parameter names for '{0}.{1}': {2}.</target>
+        <note>{0} - Java type.
+{1} - Java method.
+{2} - Exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0008">
+        <source>Failed to parse annotation XML file: {0}.</source>
+        <target state="new">Failed to parse annotation XML file: {0}.</target>
+        <note>{0} - Exception.</note>
+      </trans-unit>
       <trans-unit id="Generator_BG4000">
         <source>Failed to remove old constants: {0}.</source>
         <target state="new">Failed to remove old constants: {0}.</target>

--- a/src/Java.Interop.Localization/xlf/Resources.tr.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.tr.xlf
@@ -2,6 +2,140 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Resources.resx">
     <body>
+      <trans-unit id="ApiXmlAdjuster_0001">
+        <source>Warning: method '{0}' in type '{1}' has unnamed parameters.</source>
+        <target state="new">Warning: method '{0}' in type '{1}' has unnamed parameters.</target>
+        <note>{0} - Java method name.
+{1} - Java type name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0002">
+        <source>Warning: '{0}' is referenced as base type of '{1}' and expected to have generic type parameters, but it does not.</source>
+        <target state="new">Warning: '{0}' is referenced as base type of '{1}' and expected to have generic type parameters, but it does not.</target>
+        <note>{0}, {1} - Java type names.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0003">
+        <source>Error while processing Java class '{0}': {1}.</source>
+        <target state="new">Error while processing Java class '{0}': {1}.</target>
+        <note>{0} - Java class name.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0004">
+        <source>Error while processing Java interface '{0}': {1}.</source>
+        <target state="new">Error while processing Java interface '{0}': {1}.</target>
+        <note>{0} - Java interface name.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0005">
+        <source>Error while resolving '{0}' in '{1}': {2}.</source>
+        <target state="new">Error while resolving '{0}' in '{1}': {2}.</target>
+        <note>{0} - Java member.
+{1} - Java type.
+{2} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0006">
+        <source>Warning: failed to resolve generic constraint: '{0}': {1}.</source>
+        <target state="new">Warning: failed to resolve generic constraint: '{0}': {1}.</target>
+        <note>{0} - Java constraint type.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0007">
+        <source>For '{0}.{1}', referenced generic arguments count does not match the base type parameters definition.</source>
+        <target state="new">For '{0}.{1}', referenced generic arguments count does not match the base type parameters definition.</target>
+        <note>{0} - Java type.
+{1} - Java member.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0008">
+        <source>Type '{0}' was not found.</source>
+        <target state="new">Type '{0}' was not found.</target>
+        <note>{0} - Java type.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0009">
+        <source>Internal error: XmlReader should be positioned on attribute, but it is on '{0}'.</source>
+        <target state="new">Internal error: XmlReader should be positioned on attribute, but it is on '{0}'.</target>
+        <note>{0} - XML node type.
+The following are literal type names and should not be translated: XmlReader.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0010">
+        <source>{0}: Element '{1}' requires attribute '{2}'.</source>
+        <target state="new">{0}: Element '{1}' requires attribute '{2}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML attribute name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0011">
+        <source>{0}: EndElement of '{1}' was expected, but is type '{2}' with name '{3}' instead.</source>
+        <target state="new">{0}: EndElement of '{1}' was expected, but is type '{2}' with name '{3}' instead.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML node type.
+{3} - XML element name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0012">
+        <source>{0}: Unexpected element or content in '{1}': node is '{2}', name is '{3}'. Allowed elements are: '{4}'.</source>
+        <target state="new">{0}: Unexpected element or content in '{1}': node is '{2}', name is '{3}'. Allowed elements are: '{4}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML node type.
+{3} - XML element name.
+{4} - Allowed XML element names.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0013">
+        <source>{0}: Element '{1}' has an unexpected attribute: '{2}'. Allowed attributes are: '{3}'.</source>
+        <target state="new">{0}: Element '{1}' has an unexpected attribute: '{2}'. Allowed attributes are: '{3}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML attribute name.
+{3} - Allowed XML attribute names.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0001">
+        <source>Could not load .jar entry '{0}': {1}.</source>
+        <target state="new">Could not load .jar entry '{0}': {1}.</target>
+        <note>{0} - Java .jar entry.
+{1} - .NET exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0002">
+        <source>Documentation file not found: '{0}'.</source>
+        <target state="new">Documentation file not found: '{0}'.</target>
+        <note>{0} - File name.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0003">
+        <source>Failed to match expression '{0}', expected {1} parameter(s) but got {2} parameter(s).</source>
+        <target state="new">Failed to match expression '{0}', expected {1} parameter(s) but got {2} parameter(s).</target>
+        <note>{0} - Regex expression.
+{1}, {2} - Integer.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0004">
+        <source>No parameter match for '{0}.{1}'. (expression: '{2}')</source>
+        <target state="new">No parameter match for '{0}.{1}'. (expression: '{2}')</target>
+        <note>{0} - Java type.
+{1} - Java method.
+{2} - Regex expression.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0005">
+        <source>Unable to parse Kotlin metadata on '{0}': {1}.</source>
+        <target state="new">Unable to parse Kotlin metadata on '{0}': {1}.</target>
+        <note>{0} - Java type.
+{1} - Exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0006">
+        <source>Differing number of 'throws' declarations on '{0}{1}'.</source>
+        <target state="new">Differing number of 'throws' declarations on '{0}{1}'.</target>
+        <note>{0} - Java type name.
+{1} - Java type descriptor.
+The following are literal names and should not be translated: throws.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0007">
+        <source>Failed to get parameter names for '{0}.{1}': {2}.</source>
+        <target state="new">Failed to get parameter names for '{0}.{1}': {2}.</target>
+        <note>{0} - Java type.
+{1} - Java method.
+{2} - Exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0008">
+        <source>Failed to parse annotation XML file: {0}.</source>
+        <target state="new">Failed to parse annotation XML file: {0}.</target>
+        <note>{0} - Exception.</note>
+      </trans-unit>
       <trans-unit id="Generator_BG4000">
         <source>Failed to remove old constants: {0}.</source>
         <target state="new">Failed to remove old constants: {0}.</target>

--- a/src/Java.Interop.Localization/xlf/Resources.zh-Hans.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.zh-Hans.xlf
@@ -2,6 +2,140 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Resources.resx">
     <body>
+      <trans-unit id="ApiXmlAdjuster_0001">
+        <source>Warning: method '{0}' in type '{1}' has unnamed parameters.</source>
+        <target state="new">Warning: method '{0}' in type '{1}' has unnamed parameters.</target>
+        <note>{0} - Java method name.
+{1} - Java type name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0002">
+        <source>Warning: '{0}' is referenced as base type of '{1}' and expected to have generic type parameters, but it does not.</source>
+        <target state="new">Warning: '{0}' is referenced as base type of '{1}' and expected to have generic type parameters, but it does not.</target>
+        <note>{0}, {1} - Java type names.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0003">
+        <source>Error while processing Java class '{0}': {1}.</source>
+        <target state="new">Error while processing Java class '{0}': {1}.</target>
+        <note>{0} - Java class name.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0004">
+        <source>Error while processing Java interface '{0}': {1}.</source>
+        <target state="new">Error while processing Java interface '{0}': {1}.</target>
+        <note>{0} - Java interface name.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0005">
+        <source>Error while resolving '{0}' in '{1}': {2}.</source>
+        <target state="new">Error while resolving '{0}' in '{1}': {2}.</target>
+        <note>{0} - Java member.
+{1} - Java type.
+{2} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0006">
+        <source>Warning: failed to resolve generic constraint: '{0}': {1}.</source>
+        <target state="new">Warning: failed to resolve generic constraint: '{0}': {1}.</target>
+        <note>{0} - Java constraint type.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0007">
+        <source>For '{0}.{1}', referenced generic arguments count does not match the base type parameters definition.</source>
+        <target state="new">For '{0}.{1}', referenced generic arguments count does not match the base type parameters definition.</target>
+        <note>{0} - Java type.
+{1} - Java member.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0008">
+        <source>Type '{0}' was not found.</source>
+        <target state="new">Type '{0}' was not found.</target>
+        <note>{0} - Java type.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0009">
+        <source>Internal error: XmlReader should be positioned on attribute, but it is on '{0}'.</source>
+        <target state="new">Internal error: XmlReader should be positioned on attribute, but it is on '{0}'.</target>
+        <note>{0} - XML node type.
+The following are literal type names and should not be translated: XmlReader.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0010">
+        <source>{0}: Element '{1}' requires attribute '{2}'.</source>
+        <target state="new">{0}: Element '{1}' requires attribute '{2}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML attribute name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0011">
+        <source>{0}: EndElement of '{1}' was expected, but is type '{2}' with name '{3}' instead.</source>
+        <target state="new">{0}: EndElement of '{1}' was expected, but is type '{2}' with name '{3}' instead.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML node type.
+{3} - XML element name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0012">
+        <source>{0}: Unexpected element or content in '{1}': node is '{2}', name is '{3}'. Allowed elements are: '{4}'.</source>
+        <target state="new">{0}: Unexpected element or content in '{1}': node is '{2}', name is '{3}'. Allowed elements are: '{4}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML node type.
+{3} - XML element name.
+{4} - Allowed XML element names.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0013">
+        <source>{0}: Element '{1}' has an unexpected attribute: '{2}'. Allowed attributes are: '{3}'.</source>
+        <target state="new">{0}: Element '{1}' has an unexpected attribute: '{2}'. Allowed attributes are: '{3}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML attribute name.
+{3} - Allowed XML attribute names.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0001">
+        <source>Could not load .jar entry '{0}': {1}.</source>
+        <target state="new">Could not load .jar entry '{0}': {1}.</target>
+        <note>{0} - Java .jar entry.
+{1} - .NET exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0002">
+        <source>Documentation file not found: '{0}'.</source>
+        <target state="new">Documentation file not found: '{0}'.</target>
+        <note>{0} - File name.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0003">
+        <source>Failed to match expression '{0}', expected {1} parameter(s) but got {2} parameter(s).</source>
+        <target state="new">Failed to match expression '{0}', expected {1} parameter(s) but got {2} parameter(s).</target>
+        <note>{0} - Regex expression.
+{1}, {2} - Integer.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0004">
+        <source>No parameter match for '{0}.{1}'. (expression: '{2}')</source>
+        <target state="new">No parameter match for '{0}.{1}'. (expression: '{2}')</target>
+        <note>{0} - Java type.
+{1} - Java method.
+{2} - Regex expression.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0005">
+        <source>Unable to parse Kotlin metadata on '{0}': {1}.</source>
+        <target state="new">Unable to parse Kotlin metadata on '{0}': {1}.</target>
+        <note>{0} - Java type.
+{1} - Exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0006">
+        <source>Differing number of 'throws' declarations on '{0}{1}'.</source>
+        <target state="new">Differing number of 'throws' declarations on '{0}{1}'.</target>
+        <note>{0} - Java type name.
+{1} - Java type descriptor.
+The following are literal names and should not be translated: throws.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0007">
+        <source>Failed to get parameter names for '{0}.{1}': {2}.</source>
+        <target state="new">Failed to get parameter names for '{0}.{1}': {2}.</target>
+        <note>{0} - Java type.
+{1} - Java method.
+{2} - Exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0008">
+        <source>Failed to parse annotation XML file: {0}.</source>
+        <target state="new">Failed to parse annotation XML file: {0}.</target>
+        <note>{0} - Exception.</note>
+      </trans-unit>
       <trans-unit id="Generator_BG4000">
         <source>Failed to remove old constants: {0}.</source>
         <target state="new">Failed to remove old constants: {0}.</target>

--- a/src/Java.Interop.Localization/xlf/Resources.zh-Hant.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.zh-Hant.xlf
@@ -2,6 +2,140 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Resources.resx">
     <body>
+      <trans-unit id="ApiXmlAdjuster_0001">
+        <source>Warning: method '{0}' in type '{1}' has unnamed parameters.</source>
+        <target state="new">Warning: method '{0}' in type '{1}' has unnamed parameters.</target>
+        <note>{0} - Java method name.
+{1} - Java type name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0002">
+        <source>Warning: '{0}' is referenced as base type of '{1}' and expected to have generic type parameters, but it does not.</source>
+        <target state="new">Warning: '{0}' is referenced as base type of '{1}' and expected to have generic type parameters, but it does not.</target>
+        <note>{0}, {1} - Java type names.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0003">
+        <source>Error while processing Java class '{0}': {1}.</source>
+        <target state="new">Error while processing Java class '{0}': {1}.</target>
+        <note>{0} - Java class name.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0004">
+        <source>Error while processing Java interface '{0}': {1}.</source>
+        <target state="new">Error while processing Java interface '{0}': {1}.</target>
+        <note>{0} - Java interface name.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0005">
+        <source>Error while resolving '{0}' in '{1}': {2}.</source>
+        <target state="new">Error while resolving '{0}' in '{1}': {2}.</target>
+        <note>{0} - Java member.
+{1} - Java type.
+{2} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0006">
+        <source>Warning: failed to resolve generic constraint: '{0}': {1}.</source>
+        <target state="new">Warning: failed to resolve generic constraint: '{0}': {1}.</target>
+        <note>{0} - Java constraint type.
+{1} - Exception message.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0007">
+        <source>For '{0}.{1}', referenced generic arguments count does not match the base type parameters definition.</source>
+        <target state="new">For '{0}.{1}', referenced generic arguments count does not match the base type parameters definition.</target>
+        <note>{0} - Java type.
+{1} - Java member.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0008">
+        <source>Type '{0}' was not found.</source>
+        <target state="new">Type '{0}' was not found.</target>
+        <note>{0} - Java type.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0009">
+        <source>Internal error: XmlReader should be positioned on attribute, but it is on '{0}'.</source>
+        <target state="new">Internal error: XmlReader should be positioned on attribute, but it is on '{0}'.</target>
+        <note>{0} - XML node type.
+The following are literal type names and should not be translated: XmlReader.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0010">
+        <source>{0}: Element '{1}' requires attribute '{2}'.</source>
+        <target state="new">{0}: Element '{1}' requires attribute '{2}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML attribute name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0011">
+        <source>{0}: EndElement of '{1}' was expected, but is type '{2}' with name '{3}' instead.</source>
+        <target state="new">{0}: EndElement of '{1}' was expected, but is type '{2}' with name '{3}' instead.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML node type.
+{3} - XML element name.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0012">
+        <source>{0}: Unexpected element or content in '{1}': node is '{2}', name is '{3}'. Allowed elements are: '{4}'.</source>
+        <target state="new">{0}: Unexpected element or content in '{1}': node is '{2}', name is '{3}'. Allowed elements are: '{4}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML node type.
+{3} - XML element name.
+{4} - Allowed XML element names.</note>
+      </trans-unit>
+      <trans-unit id="ApiXmlAdjuster_0013">
+        <source>{0}: Element '{1}' has an unexpected attribute: '{2}'. Allowed attributes are: '{3}'.</source>
+        <target state="new">{0}: Element '{1}' has an unexpected attribute: '{2}'. Allowed attributes are: '{3}'.</target>
+        <note>{0} - File/line/column of error.
+{1} - XML element name.
+{2} - XML attribute name.
+{3} - Allowed XML attribute names.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0001">
+        <source>Could not load .jar entry '{0}': {1}.</source>
+        <target state="new">Could not load .jar entry '{0}': {1}.</target>
+        <note>{0} - Java .jar entry.
+{1} - .NET exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0002">
+        <source>Documentation file not found: '{0}'.</source>
+        <target state="new">Documentation file not found: '{0}'.</target>
+        <note>{0} - File name.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0003">
+        <source>Failed to match expression '{0}', expected {1} parameter(s) but got {2} parameter(s).</source>
+        <target state="new">Failed to match expression '{0}', expected {1} parameter(s) but got {2} parameter(s).</target>
+        <note>{0} - Regex expression.
+{1}, {2} - Integer.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0004">
+        <source>No parameter match for '{0}.{1}'. (expression: '{2}')</source>
+        <target state="new">No parameter match for '{0}.{1}'. (expression: '{2}')</target>
+        <note>{0} - Java type.
+{1} - Java method.
+{2} - Regex expression.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0005">
+        <source>Unable to parse Kotlin metadata on '{0}': {1}.</source>
+        <target state="new">Unable to parse Kotlin metadata on '{0}': {1}.</target>
+        <note>{0} - Java type.
+{1} - Exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0006">
+        <source>Differing number of 'throws' declarations on '{0}{1}'.</source>
+        <target state="new">Differing number of 'throws' declarations on '{0}{1}'.</target>
+        <note>{0} - Java type name.
+{1} - Java type descriptor.
+The following are literal names and should not be translated: throws.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0007">
+        <source>Failed to get parameter names for '{0}.{1}': {2}.</source>
+        <target state="new">Failed to get parameter names for '{0}.{1}': {2}.</target>
+        <note>{0} - Java type.
+{1} - Java method.
+{2} - Exception.</note>
+      </trans-unit>
+      <trans-unit id="Bytecode_0008">
+        <source>Failed to parse annotation XML file: {0}.</source>
+        <target state="new">Failed to parse annotation XML file: {0}.</target>
+        <note>{0} - Exception.</note>
+      </trans-unit>
       <trans-unit id="Generator_BG4000">
         <source>Failed to remove old constants: {0}.</source>
         <target state="new">Failed to remove old constants: {0}.</target>

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiDefectFinderExtensions.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiDefectFinderExtensions.cs
@@ -19,10 +19,9 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		
 		static void FindParametersDefects (this JavaMethodBase methodBase)
 		{
-			int dummy;
 			foreach (var p in methodBase.Parameters) {
-				if (p.Name.StartsWith ("p", StringComparison.Ordinal) && int.TryParse (p.Name.Substring (1), out dummy)) {
-					Log.LogWarning ("Warning: {0} in {1} has 'unnamed' parameters", methodBase.Parent, methodBase);
+				if (p.Name.StartsWith ("p", StringComparison.Ordinal) && int.TryParse (p.Name.Substring (1), out var _)) {
+					Log.LogWarning (Java.Interop.Localization.Resources.ApiXmlAdjuster_0001, methodBase.Parent, methodBase);
 					break; // reporting once is enough.
 				}
 			}

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiGenericInheritanceMapperExtensions.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiGenericInheritanceMapperExtensions.cs
@@ -30,12 +30,11 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 					cls.GenericInheritanceMapping = empty;
 				else if (cls.ResolvedExtends.ReferencedType.TypeParameters == null) {
 					// FIXME: I guess this should not happen. But this still happens.
-					Log.LogWarning ("Warning: '{0}' is referenced as base type of '{1}' and expected to have generic type parameters, but it does not.", cls.ExtendsGeneric, cls.FullName);
+					Log.LogWarning (Java.Interop.Localization.Resources.ApiXmlAdjuster_0002, cls.ExtendsGeneric, cls.FullName);
 					cls.GenericInheritanceMapping = empty;
 				} else {
 					if (cls.ResolvedExtends.ReferencedType.TypeParameters.TypeParameters.Count != cls.ResolvedExtends.TypeParameters.Count)
-						throw new Exception (string.Format ("On {0}.{1}, referenced generic arguments count do not match the base type parameters definition",
-							cls.Parent.Name, cls.Name));
+						throw new Exception (string.Format (Java.Interop.Localization.Resources.ApiXmlAdjuster_0007, cls.Parent.Name, cls.Name));
 					var dic = empty;
 					foreach (var kvp in cls.ResolvedExtends.ReferencedType.TypeParameters.TypeParameters.Zip (
 						 cls.ResolvedExtends.TypeParameters,

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiTypeResolverExtensions.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiTypeResolverExtensions.cs
@@ -45,7 +45,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 				                 .SelectMany (p => p.Types)
 				                 .FirstOrDefault (t => t.FullName == name);
 			if (ret == null)
-				throw new JavaTypeResolutionException (string.Format ("Type '{0}' was not found.", name));
+				throw new JavaTypeResolutionException (string.Format (Java.Interop.Localization.Resources.ApiXmlAdjuster_0008, name));
 			return ret;
 		}
 
@@ -71,9 +71,9 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			while (true) {
 				bool errors = false;
 				foreach (var t in api.Packages.SelectMany (p => p.Types).OfType<JavaClass> ().ToArray ())
-					try { t.Resolve (); } catch (JavaTypeResolutionException ex) { Log.LogError ("Error while processing type '{0}': {1}", t, ex.Message); errors = true; t.Parent.Types.Remove (t); }
+					try { t.Resolve (); } catch (JavaTypeResolutionException ex) { Log.LogError (Java.Interop.Localization.Resources.ApiXmlAdjuster_0003, t, ex.Message); errors = true; t.Parent.Types.Remove (t); }
 				foreach (var t in api.Packages.SelectMany (p => p.Types).OfType<JavaInterface> ().ToArray ())
-					try { t.Resolve (); } catch (JavaTypeResolutionException ex) { Log.LogError ("Error while processing type '{0}': {1}", t, ex.Message); errors = true; t.Parent.Types.Remove (t); }
+					try { t.Resolve (); } catch (JavaTypeResolutionException ex) { Log.LogError (Java.Interop.Localization.Resources.ApiXmlAdjuster_0004, t, ex.Message); errors = true; t.Parent.Types.Remove (t); }
 				if (!errors)
 					break;
 			}
@@ -106,7 +106,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			try {
 				resolve ();
 			} catch (JavaTypeResolutionException ex) {
-				Log.LogError ("Error while processing '{0}' in '{1}': {2}", m, m.Parent, ex.Message);
+				Log.LogError (Java.Interop.Localization.Resources.ApiXmlAdjuster_0005, m, m.Parent, ex.Message);
 				m.Parent.Members.Remove (m);
 			}
 		}
@@ -145,7 +145,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			foreach (var t in tp.TypeParameters)
 				if (t.GenericConstraints != null)
 					foreach (var g in t.GenericConstraints.GenericConstraints)
-						try { g.ResolvedType = api.Parse (g.Type, additionalTypeParameters); } catch (JavaTypeResolutionException ex) { Log.LogWarning ("Warning: failed to resolve generic constraint: '{0}': {1}", g.Type, ex.Message); }
+						try { g.ResolvedType = api.Parse (g.Type, additionalTypeParameters); } catch (JavaTypeResolutionException ex) { Log.LogWarning (Java.Interop.Localization.Resources.ApiXmlAdjuster_0006, g.Type, ex.Message); }
 		}
 	}
 }

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaTypeReference.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaTypeReference.cs
@@ -76,7 +76,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		public JavaTypeReference (JavaTypeReference referencedType, string arrayPart, string wildcardBoundsType, IEnumerable<JavaTypeReference> wildcardConstraints)
 		{
 			if (referencedType == null)
-				throw new ArgumentNullException ("referencedType");
+				throw new ArgumentNullException (nameof (referencedType));
 			SpecialName = referencedType.SpecialName;
 			WildcardBoundsType = wildcardBoundsType;
 			WildcardConstraints = wildcardConstraints?.ToList ();
@@ -89,7 +89,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		public JavaTypeReference (JavaTypeParameter referencedTypeParameter, string arrayPart)
 		{
 			if (referencedTypeParameter == null)
-				throw new ArgumentNullException ("referencedTypeParameter");
+				throw new ArgumentNullException (nameof (referencedTypeParameter));
 			ReferencedTypeParameter = referencedTypeParameter;
 			ArrayPart = arrayPart;
 		}
@@ -97,7 +97,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		public JavaTypeReference (JavaType referencedType, IList<JavaTypeReference> typeParameters, string arrayPart)
 		{
 			if (referencedType == null)
-				throw new ArgumentNullException ("referencedType");
+				throw new ArgumentNullException (nameof (referencedType));
 			ReferencedType = referencedType;
 			TypeParameters = typeParameters;
 			ArrayPart = arrayPart;

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaTypeResolutionUtil.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaTypeResolutionUtil.cs
@@ -21,7 +21,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		public static bool IsImplementing (this JavaMethod derived, JavaMethod basis, IDictionary<JavaTypeReference,JavaTypeReference> genericInstantiation)
 		{
 			if (genericInstantiation == null)
-				throw new ArgumentNullException ("genericInstantiation");
+				throw new ArgumentNullException (nameof (genericInstantiation));
 
 			if (basis.Name != derived.Name)
 				return false;

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/Xamarin.Android.Tools.ApiXmlAdjuster.csproj
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/Xamarin.Android.Tools.ApiXmlAdjuster.csproj
@@ -8,4 +8,8 @@
     <OutputPath>$(TestOutputFullPath)</OutputPath>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Java.Interop.Localization\Java.Interop.Localization.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/XmlUtil.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/XmlUtil.cs
@@ -16,15 +16,15 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		
 		public static Exception UnexpectedElementOrContent (string elementName, XmlReader reader, params string [] expected)
 		{
-			return new Exception (string.Format ("{0}: Unexpected element or content in '{1}': node is {2}, name is '{3}'. Expected elements are: {4}",
+			return new Exception (string.Format (Java.Interop.Localization.Resources.ApiXmlAdjuster_0012,
 				GetLocation (reader), elementName ?? "(top level)", reader.NodeType, reader.LocalName, string.Join (", ", expected)));
 		}
 		
 		public static Exception UnexpectedAttribute (XmlReader reader, string elementName, params string [] expected)
 		{
 			if (reader.NodeType != XmlNodeType.Attribute)
-				throw new ArgumentException (string.Format ("Internal error: XmlReader should be positioned on attribute, but it is on {0}", reader.NodeType));
-			return new Exception (string.Format ("{0}: Element '{1}' has an unexpected attribute: '{2}'. Expected attributes are: {3}",
+				throw new ArgumentException (string.Format (Java.Interop.Localization.Resources.ApiXmlAdjuster_0009, reader.NodeType));
+			return new Exception (string.Format (Java.Interop.Localization.Resources.ApiXmlAdjuster_0013,
 				GetLocation (reader), elementName, reader.LocalName, string.Join (", ", expected)));
 		}
 
@@ -32,14 +32,14 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		{
 			var value = reader.GetAttribute (name);
 			if (value == null)
-				throw new Exception (string.Format ("{0}: Element '{1}' requires attribute '{2}'", GetLocation (reader), reader.LocalName, name));
+				throw new Exception (string.Format (Java.Interop.Localization.Resources.ApiXmlAdjuster_0010, GetLocation (reader), reader.LocalName, name));
 			return value;
 		}
 
 		internal static void VerifyEndElement (XmlReader reader, string elementName)
 		{
 			if (reader.NodeType != XmlNodeType.EndElement || reader.LocalName != elementName)
-				throw new Exception (string.Format ("{0}: EndElement of '{1}' was expected, but got {2} with name '{3}' instead.",
+				throw new Exception (string.Format (Java.Interop.Localization.Resources.ApiXmlAdjuster_0011,
 					GetLocation (reader), elementName, reader.NodeType, reader.LocalName));
 		}
 

--- a/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
@@ -69,8 +69,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 							var c   = new ClassFile (s);
 							Add (c);
 						} catch (Exception e) {
-							Log.Warning (0, "class-parse: warning: Could not load .jar entry '{0}': {1}",
-									entry.Name, e);
+							Log.Warning (0, Java.Interop.Localization.Resources.Bytecode_0001, entry.Name, e);
 						}
 					}
 				}

--- a/src/Xamarin.Android.Tools.Bytecode/JavaDocumentScraper.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/JavaDocumentScraper.cs
@@ -197,7 +197,7 @@ namespace Xamarin.Android.Tools.Bytecode
 			string path = package.Replace ('.', '/') + '/' + type.Replace ('$', '.') + ".html";
 			string file = Path.Combine (root, path);
 			if (!File.Exists (file)) {
-				Log.Warning (1,"Warning: no document found : " + file);
+				Log.Warning (1, Java.Interop.Localization.Resources.Bytecode_0002, file);
 				return null;
 			}
 	
@@ -238,7 +238,7 @@ namespace Xamarin.Android.Tools.Bytecode
 						var plist = matcher.Groups [1];
 						String[] parms = StripTagsFromParameters (plist.Value).Split (new string [] { ", " }, StringSplitOptions.RemoveEmptyEntries);
 						if (parms.Length != ptypes.Length) {
-							Log.Warning (1, "failed matching {0} (expected {1} params, got {2} params)", buffer, ptypes.Length, parms.Length);
+							Log.Warning (1, Java.Interop.Localization.Resources.Bytecode_0003, buffer, ptypes.Length, parms.Length);
 							return null;
 						}
 						String[] result = new String [ptypes.Length];
@@ -254,11 +254,11 @@ namespace Xamarin.Android.Tools.Bytecode
 						prev = text;
 				}
 			} catch (Exception e) {
-				Log.Error ("ERROR in {0}.{1}: {2}", type, method, e);
+				Log.Error (Java.Interop.Localization.Resources.Bytecode_0007, type, method, e);
 				return null;
 			}
 	
-			Log.Warning (1, "Warning : no match for {0}.{1} (rex: {2})", type, method, buffer);
+			Log.Warning (1, Java.Interop.Localization.Resources.Bytecode_0004, type, method, buffer);
 			return null;
 		}
 		
@@ -287,7 +287,7 @@ namespace Xamarin.Android.Tools.Bytecode
 				}
 			
 			} catch (Exception ex) {
-				Log.Error ("Annotations parser error: " + ex);
+				Log.Error (Java.Interop.Localization.Resources.Bytecode_0008, ex);
 			}
 		}
 	}

--- a/src/Xamarin.Android.Tools.Bytecode/Kotlin/KotlinFixups.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/Kotlin/KotlinFixups.cs
@@ -57,7 +57,7 @@ namespace Xamarin.Android.Tools.Bytecode
 					}
 
 				} catch (Exception ex) {
-					Log.Warning (0, $"class-parse: warning: Unable to parse Kotlin metadata on '{c.ThisClass.Name}': {ex}");
+					Log.Warning (0, Java.Interop.Localization.Resources.Bytecode_0005, c.ThisClass.Name, ex);
 				}
 			}
 		}

--- a/src/Xamarin.Android.Tools.Bytecode/Log.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/Log.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Android.Tools.Bytecode
 			var log = OnLog;
 			if (log == null)
 				return;
-			log (TraceLevel.Warning, verbosity, format, args);
+			log (TraceLevel.Warning, verbosity, "class-parse: warning: " + format, args);
 		}
 
 		public static void Error (string format, params object[] args)
@@ -20,7 +20,7 @@ namespace Xamarin.Android.Tools.Bytecode
 			var log = OnLog;
 			if (log == null)
 				return;
-			log (TraceLevel.Error, 0, format, args);
+			log (TraceLevel.Error, 0, "class-parse: error: " + format, args);
 		}
 
 		public static void Message (string format, params object[] args)

--- a/src/Xamarin.Android.Tools.Bytecode/Methods.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/Methods.cs
@@ -196,8 +196,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 				return throws;
 
 			if (signature.Throws.Count > 0 && throws.Count != signature.Throws.Count) {
-				Log.Warning (1, "class-parse: warning: differing number of `throws` declarations on `{0}{1}`!",
-						Name, Descriptor);
+				Log.Warning (1, Java.Interop.Localization.Resources.Bytecode_0006, Name, Descriptor);
 			}
 			int c = Math.Min (signature.Throws.Count, throws.Count);
 			for (int i = 0; i < c; ++i)

--- a/src/Xamarin.Android.Tools.Bytecode/Xamarin.Android.Tools.Bytecode.csproj
+++ b/src/Xamarin.Android.Tools.Bytecode/Xamarin.Android.Tools.Bytecode.csproj
@@ -12,4 +12,8 @@
     <PackageReference Include="protobuf-net" Version="2.4.4" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Java.Interop.Localization\Java.Interop.Localization.csproj" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Updates `Xamarin.Android.Tools.ApiXmlAdjuster` and `Xamarin.Android.Tools.Bytecode` to be localizable, building on work done in https://github.com/xamarin/java.interop/pull/689.