### PR TITLE
[jcw-gen] Make MSBuild warning/error strings localizable.

### DIFF
--- a/src/Java.Interop.Localization/Resources.Designer.cs
+++ b/src/Java.Interop.Localization/Resources.Designer.cs
@@ -61,6 +61,15 @@ namespace Java.Interop.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Error while loading assembly: &apos;{0}&apos;..
+        /// </summary>
+        public static string CecilResolver_XA0009 {
+            get {
+                return ResourceManager.GetString("CecilResolver_XA0009", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to remove old constants: {0}..
         /// </summary>
         public static string Generator_BG4000 {
@@ -381,6 +390,87 @@ namespace Java.Interop.Localization {
         public static string Generator_BG8C01 {
             get {
                 return ResourceManager.GetString("Generator_BG8C01", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot generate Java wrapper for type &apos;{0}&apos;, only &apos;class&apos; types are supported..
+        /// </summary>
+        public static string JavaCallableWrappers_XA4200 {
+            get {
+                return ResourceManager.GetString("JavaCallableWrappers_XA4200", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot determine JNI name for type &apos;{0}&apos;..
+        /// </summary>
+        public static string JavaCallableWrappers_XA4201 {
+            get {
+                return ResourceManager.GetString("JavaCallableWrappers_XA4201", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The &apos;Name&apos; property must be a fully qualified &apos;package.TypeName&apos; value, and no package was found for &apos;{0}&apos;..
+        /// </summary>
+        public static string JavaCallableWrappers_XA4203 {
+            get {
+                return ResourceManager.GetString("JavaCallableWrappers_XA4203", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to resolve interface type &apos;{0}&apos;. Are you missing an assembly reference?.
+        /// </summary>
+        public static string JavaCallableWrappers_XA4204 {
+            get {
+                return ResourceManager.GetString("JavaCallableWrappers_XA4204", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [ExportField] can only be used on methods with 0 parameters..
+        /// </summary>
+        public static string JavaCallableWrappers_XA4205 {
+            get {
+                return ResourceManager.GetString("JavaCallableWrappers_XA4205", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [Export] cannot be used on a generic type..
+        /// </summary>
+        public static string JavaCallableWrappers_XA4206 {
+            get {
+                return ResourceManager.GetString("JavaCallableWrappers_XA4206", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [ExportField] cannot be used on a generic type..
+        /// </summary>
+        public static string JavaCallableWrappers_XA4207 {
+            get {
+                return ResourceManager.GetString("JavaCallableWrappers_XA4207", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [ExportField] cannot be used on a method returning void..
+        /// </summary>
+        public static string JavaCallableWrappers_XA4208 {
+            get {
+                return ResourceManager.GetString("JavaCallableWrappers_XA4208", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot override Kotlin-generated method &apos;{0}&apos; because it is not a valid Java method name. This method can only be overridden from Kotlin..
+        /// </summary>
+        public static string JavaCallableWrappers_XA4217 {
+            get {
+                return ResourceManager.GetString("JavaCallableWrappers_XA4217", resourceCulture);
             }
         }
     }

--- a/src/Java.Interop.Localization/Resources.Designer.cs
+++ b/src/Java.Interop.Localization/Resources.Designer.cs
@@ -394,7 +394,7 @@ namespace Java.Interop.Localization {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot generate Java wrapper for type &apos;{0}&apos;, only &apos;class&apos; types are supported..
+        ///   Looks up a localized string similar to Cannot generate Java wrapper for type &apos;{0}&apos;. Only &apos;class&apos; types are supported..
         /// </summary>
         public static string JavaCallableWrappers_XA4200 {
             get {
@@ -412,7 +412,7 @@ namespace Java.Interop.Localization {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The &apos;Name&apos; property must be a fully qualified &apos;package.TypeName&apos; value, and no package was found for &apos;{0}&apos;..
+        ///   Looks up a localized string similar to The &apos;Name&apos; property must be a fully qualified type like &apos;com.example.MyClass&apos; and no package was found for &apos;{0}&apos;..
         /// </summary>
         public static string JavaCallableWrappers_XA4203 {
             get {
@@ -457,7 +457,7 @@ namespace Java.Interop.Localization {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [ExportField] cannot be used on a method returning void..
+        ///   Looks up a localized string similar to [ExportField] cannot be used on a method returning &apos;void&apos;..
         /// </summary>
         public static string JavaCallableWrappers_XA4208 {
             get {

--- a/src/Java.Interop.Localization/Resources.resx
+++ b/src/Java.Interop.Localization/Resources.resx
@@ -117,6 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="CecilResolver_XA0009" xml:space="preserve">
+    <value>Error while loading assembly: '{0}'.</value>
+    <comment>{0} - File name</comment>
+  </data>
   <data name="Generator_BG4000" xml:space="preserve">
     <value>Failed to remove old constants: {0}.</value>
     <comment>{0} - The list of constants that could not be removed.
@@ -286,5 +290,40 @@ The following terms should not be translated: Metadata.xml.</comment>
   <data name="Generator_BG8C01" xml:space="preserve">
     <value>For type '{0}', base interface '{1}' is invalid.</value>
     <comment>{0}, {1} - .NET types.</comment>
+  </data>
+  <data name="JavaCallableWrappers_XA4200" xml:space="preserve">
+    <value>Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</value>
+    <comment>{0} - Java type.
+The following terms should not be translated: class.</comment>
+  </data>
+  <data name="JavaCallableWrappers_XA4201" xml:space="preserve">
+    <value>Cannot determine JNI name for type '{0}'.</value>
+    <comment>{0} - Java type.
+The following terms should not be translated: JNI.</comment>
+  </data>
+  <data name="JavaCallableWrappers_XA4203" xml:space="preserve">
+    <value>The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</value>
+    <comment>{0} - Java type.
+The following terms should not be translated: Name.</comment>
+  </data>
+  <data name="JavaCallableWrappers_XA4204" xml:space="preserve">
+    <value>Unable to resolve interface type '{0}'. Are you missing an assembly reference?</value>
+    <comment>{0} - Java interface.</comment>
+  </data>
+  <data name="JavaCallableWrappers_XA4205" xml:space="preserve">
+    <value>[ExportField] can only be used on methods with 0 parameters.</value>
+  </data>
+  <data name="JavaCallableWrappers_XA4206" xml:space="preserve">
+    <value>[Export] cannot be used on a generic type.</value>
+  </data>
+  <data name="JavaCallableWrappers_XA4207" xml:space="preserve">
+    <value>[ExportField] cannot be used on a generic type.</value>
+  </data>
+  <data name="JavaCallableWrappers_XA4208" xml:space="preserve">
+    <value>[ExportField] cannot be used on a method returning void.</value>
+  </data>
+  <data name="JavaCallableWrappers_XA4217" xml:space="preserve">
+    <value>Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</value>
+    <comment>{0} - Kotlin method name.</comment>
   </data>
 </root>

--- a/src/Java.Interop.Localization/Resources.resx
+++ b/src/Java.Interop.Localization/Resources.resx
@@ -292,9 +292,10 @@ The following terms should not be translated: Metadata.xml.</comment>
     <comment>{0}, {1} - .NET types.</comment>
   </data>
   <data name="JavaCallableWrappers_XA4200" xml:space="preserve">
-    <value>Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</value>
+    <value>Cannot generate Java wrapper for type '{0}'. Only 'class' types are supported.</value>
     <comment>{0} - Java type.
-The following terms should not be translated: class.</comment>
+The following terms should not be translated:
+class.</comment>
   </data>
   <data name="JavaCallableWrappers_XA4201" xml:space="preserve">
     <value>Cannot determine JNI name for type '{0}'.</value>
@@ -302,9 +303,10 @@ The following terms should not be translated: class.</comment>
 The following terms should not be translated: JNI.</comment>
   </data>
   <data name="JavaCallableWrappers_XA4203" xml:space="preserve">
-    <value>The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</value>
+    <value>The 'Name' property must be a fully qualified type like 'com.example.MyClass' and no package was found for '{0}'.</value>
     <comment>{0} - Java type.
-The following terms should not be translated: Name.</comment>
+The following terms should not be translated:
+Name, com.example.MyClass.</comment>
   </data>
   <data name="JavaCallableWrappers_XA4204" xml:space="preserve">
     <value>Unable to resolve interface type '{0}'. Are you missing an assembly reference?</value>
@@ -312,15 +314,19 @@ The following terms should not be translated: Name.</comment>
   </data>
   <data name="JavaCallableWrappers_XA4205" xml:space="preserve">
     <value>[ExportField] can only be used on methods with 0 parameters.</value>
+    <comment>The following terms should not be translated: [ExportField].</comment>
   </data>
   <data name="JavaCallableWrappers_XA4206" xml:space="preserve">
     <value>[Export] cannot be used on a generic type.</value>
+    <comment>The following terms should not be translated: [Export].</comment>
   </data>
   <data name="JavaCallableWrappers_XA4207" xml:space="preserve">
     <value>[ExportField] cannot be used on a generic type.</value>
+    <comment>The following terms should not be translated: [ExportField].</comment>
   </data>
   <data name="JavaCallableWrappers_XA4208" xml:space="preserve">
-    <value>[ExportField] cannot be used on a method returning void.</value>
+    <value>[ExportField] cannot be used on a method returning 'void'.</value>
+    <comment>The following terms should not be translated: [ExportField], void.</comment>
   </data>
   <data name="JavaCallableWrappers_XA4217" xml:space="preserve">
     <value>Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</value>

--- a/src/Java.Interop.Localization/xlf/Resources.cs.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.cs.xlf
@@ -214,10 +214,11 @@ The following terms should not be translated: Metadata.xml.</note>
         <note>{0}, {1} - .NET types.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4200">
-        <source>Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</source>
-        <target state="new">Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</target>
+        <source>Cannot generate Java wrapper for type '{0}'. Only 'class' types are supported.</source>
+        <target state="new">Cannot generate Java wrapper for type '{0}'. Only 'class' types are supported.</target>
         <note>{0} - Java type.
-The following terms should not be translated: class.</note>
+The following terms should not be translated:
+class.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4201">
         <source>Cannot determine JNI name for type '{0}'.</source>
@@ -226,10 +227,11 @@ The following terms should not be translated: class.</note>
 The following terms should not be translated: JNI.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4203">
-        <source>The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</source>
-        <target state="new">The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</target>
+        <source>The 'Name' property must be a fully qualified type like 'com.example.MyClass' and no package was found for '{0}'.</source>
+        <target state="new">The 'Name' property must be a fully qualified type like 'com.example.MyClass' and no package was found for '{0}'.</target>
         <note>{0} - Java type.
-The following terms should not be translated: Name.</note>
+The following terms should not be translated:
+Name, com.example.MyClass.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4204">
         <source>Unable to resolve interface type '{0}'. Are you missing an assembly reference?</source>
@@ -239,22 +241,22 @@ The following terms should not be translated: Name.</note>
       <trans-unit id="JavaCallableWrappers_XA4205">
         <source>[ExportField] can only be used on methods with 0 parameters.</source>
         <target state="new">[ExportField] can only be used on methods with 0 parameters.</target>
-        <note />
+        <note>The following terms should not be translated: [ExportField].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4206">
         <source>[Export] cannot be used on a generic type.</source>
         <target state="new">[Export] cannot be used on a generic type.</target>
-        <note />
+        <note>The following terms should not be translated: [Export].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4207">
         <source>[ExportField] cannot be used on a generic type.</source>
         <target state="new">[ExportField] cannot be used on a generic type.</target>
-        <note />
+        <note>The following terms should not be translated: [ExportField].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4208">
-        <source>[ExportField] cannot be used on a method returning void.</source>
-        <target state="new">[ExportField] cannot be used on a method returning void.</target>
-        <note />
+        <source>[ExportField] cannot be used on a method returning 'void'.</source>
+        <target state="new">[ExportField] cannot be used on a method returning 'void'.</target>
+        <note>The following terms should not be translated: [ExportField], void.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4217">
         <source>Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</source>

--- a/src/Java.Interop.Localization/xlf/Resources.cs.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Resources.resx">
     <body>
+      <trans-unit id="CecilResolver_XA0009">
+        <source>Error while loading assembly: '{0}'.</source>
+        <target state="new">Error while loading assembly: '{0}'.</target>
+        <note>{0} - File name</note>
+      </trans-unit>
       <trans-unit id="Generator_BG4000">
         <source>Failed to remove old constants: {0}.</source>
         <target state="new">Failed to remove old constants: {0}.</target>
@@ -207,6 +212,54 @@ The following terms should not be translated: Metadata.xml.</note>
         <source>For type '{0}', base interface '{1}' is invalid.</source>
         <target state="new">For type '{0}', base interface '{1}' is invalid.</target>
         <note>{0}, {1} - .NET types.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4200">
+        <source>Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</source>
+        <target state="new">Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: class.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4201">
+        <source>Cannot determine JNI name for type '{0}'.</source>
+        <target state="new">Cannot determine JNI name for type '{0}'.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: JNI.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4203">
+        <source>The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</source>
+        <target state="new">The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: Name.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4204">
+        <source>Unable to resolve interface type '{0}'. Are you missing an assembly reference?</source>
+        <target state="new">Unable to resolve interface type '{0}'. Are you missing an assembly reference?</target>
+        <note>{0} - Java interface.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4205">
+        <source>[ExportField] can only be used on methods with 0 parameters.</source>
+        <target state="new">[ExportField] can only be used on methods with 0 parameters.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4206">
+        <source>[Export] cannot be used on a generic type.</source>
+        <target state="new">[Export] cannot be used on a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4207">
+        <source>[ExportField] cannot be used on a generic type.</source>
+        <target state="new">[ExportField] cannot be used on a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4208">
+        <source>[ExportField] cannot be used on a method returning void.</source>
+        <target state="new">[ExportField] cannot be used on a method returning void.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4217">
+        <source>Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</source>
+        <target state="new">Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</target>
+        <note>{0} - Kotlin method name.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Java.Interop.Localization/xlf/Resources.de.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Resources.resx">
     <body>
+      <trans-unit id="CecilResolver_XA0009">
+        <source>Error while loading assembly: '{0}'.</source>
+        <target state="new">Error while loading assembly: '{0}'.</target>
+        <note>{0} - File name</note>
+      </trans-unit>
       <trans-unit id="Generator_BG4000">
         <source>Failed to remove old constants: {0}.</source>
         <target state="new">Failed to remove old constants: {0}.</target>
@@ -207,6 +212,54 @@ The following terms should not be translated: Metadata.xml.</note>
         <source>For type '{0}', base interface '{1}' is invalid.</source>
         <target state="new">For type '{0}', base interface '{1}' is invalid.</target>
         <note>{0}, {1} - .NET types.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4200">
+        <source>Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</source>
+        <target state="new">Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: class.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4201">
+        <source>Cannot determine JNI name for type '{0}'.</source>
+        <target state="new">Cannot determine JNI name for type '{0}'.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: JNI.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4203">
+        <source>The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</source>
+        <target state="new">The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: Name.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4204">
+        <source>Unable to resolve interface type '{0}'. Are you missing an assembly reference?</source>
+        <target state="new">Unable to resolve interface type '{0}'. Are you missing an assembly reference?</target>
+        <note>{0} - Java interface.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4205">
+        <source>[ExportField] can only be used on methods with 0 parameters.</source>
+        <target state="new">[ExportField] can only be used on methods with 0 parameters.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4206">
+        <source>[Export] cannot be used on a generic type.</source>
+        <target state="new">[Export] cannot be used on a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4207">
+        <source>[ExportField] cannot be used on a generic type.</source>
+        <target state="new">[ExportField] cannot be used on a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4208">
+        <source>[ExportField] cannot be used on a method returning void.</source>
+        <target state="new">[ExportField] cannot be used on a method returning void.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4217">
+        <source>Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</source>
+        <target state="new">Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</target>
+        <note>{0} - Kotlin method name.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Java.Interop.Localization/xlf/Resources.de.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.de.xlf
@@ -214,10 +214,11 @@ The following terms should not be translated: Metadata.xml.</note>
         <note>{0}, {1} - .NET types.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4200">
-        <source>Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</source>
-        <target state="new">Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</target>
+        <source>Cannot generate Java wrapper for type '{0}'. Only 'class' types are supported.</source>
+        <target state="new">Cannot generate Java wrapper for type '{0}'. Only 'class' types are supported.</target>
         <note>{0} - Java type.
-The following terms should not be translated: class.</note>
+The following terms should not be translated:
+class.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4201">
         <source>Cannot determine JNI name for type '{0}'.</source>
@@ -226,10 +227,11 @@ The following terms should not be translated: class.</note>
 The following terms should not be translated: JNI.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4203">
-        <source>The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</source>
-        <target state="new">The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</target>
+        <source>The 'Name' property must be a fully qualified type like 'com.example.MyClass' and no package was found for '{0}'.</source>
+        <target state="new">The 'Name' property must be a fully qualified type like 'com.example.MyClass' and no package was found for '{0}'.</target>
         <note>{0} - Java type.
-The following terms should not be translated: Name.</note>
+The following terms should not be translated:
+Name, com.example.MyClass.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4204">
         <source>Unable to resolve interface type '{0}'. Are you missing an assembly reference?</source>
@@ -239,22 +241,22 @@ The following terms should not be translated: Name.</note>
       <trans-unit id="JavaCallableWrappers_XA4205">
         <source>[ExportField] can only be used on methods with 0 parameters.</source>
         <target state="new">[ExportField] can only be used on methods with 0 parameters.</target>
-        <note />
+        <note>The following terms should not be translated: [ExportField].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4206">
         <source>[Export] cannot be used on a generic type.</source>
         <target state="new">[Export] cannot be used on a generic type.</target>
-        <note />
+        <note>The following terms should not be translated: [Export].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4207">
         <source>[ExportField] cannot be used on a generic type.</source>
         <target state="new">[ExportField] cannot be used on a generic type.</target>
-        <note />
+        <note>The following terms should not be translated: [ExportField].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4208">
-        <source>[ExportField] cannot be used on a method returning void.</source>
-        <target state="new">[ExportField] cannot be used on a method returning void.</target>
-        <note />
+        <source>[ExportField] cannot be used on a method returning 'void'.</source>
+        <target state="new">[ExportField] cannot be used on a method returning 'void'.</target>
+        <note>The following terms should not be translated: [ExportField], void.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4217">
         <source>Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</source>

--- a/src/Java.Interop.Localization/xlf/Resources.es.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Resources.resx">
     <body>
+      <trans-unit id="CecilResolver_XA0009">
+        <source>Error while loading assembly: '{0}'.</source>
+        <target state="new">Error while loading assembly: '{0}'.</target>
+        <note>{0} - File name</note>
+      </trans-unit>
       <trans-unit id="Generator_BG4000">
         <source>Failed to remove old constants: {0}.</source>
         <target state="new">Failed to remove old constants: {0}.</target>
@@ -207,6 +212,54 @@ The following terms should not be translated: Metadata.xml.</note>
         <source>For type '{0}', base interface '{1}' is invalid.</source>
         <target state="new">For type '{0}', base interface '{1}' is invalid.</target>
         <note>{0}, {1} - .NET types.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4200">
+        <source>Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</source>
+        <target state="new">Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: class.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4201">
+        <source>Cannot determine JNI name for type '{0}'.</source>
+        <target state="new">Cannot determine JNI name for type '{0}'.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: JNI.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4203">
+        <source>The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</source>
+        <target state="new">The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: Name.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4204">
+        <source>Unable to resolve interface type '{0}'. Are you missing an assembly reference?</source>
+        <target state="new">Unable to resolve interface type '{0}'. Are you missing an assembly reference?</target>
+        <note>{0} - Java interface.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4205">
+        <source>[ExportField] can only be used on methods with 0 parameters.</source>
+        <target state="new">[ExportField] can only be used on methods with 0 parameters.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4206">
+        <source>[Export] cannot be used on a generic type.</source>
+        <target state="new">[Export] cannot be used on a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4207">
+        <source>[ExportField] cannot be used on a generic type.</source>
+        <target state="new">[ExportField] cannot be used on a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4208">
+        <source>[ExportField] cannot be used on a method returning void.</source>
+        <target state="new">[ExportField] cannot be used on a method returning void.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4217">
+        <source>Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</source>
+        <target state="new">Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</target>
+        <note>{0} - Kotlin method name.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Java.Interop.Localization/xlf/Resources.es.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.es.xlf
@@ -214,10 +214,11 @@ The following terms should not be translated: Metadata.xml.</note>
         <note>{0}, {1} - .NET types.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4200">
-        <source>Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</source>
-        <target state="new">Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</target>
+        <source>Cannot generate Java wrapper for type '{0}'. Only 'class' types are supported.</source>
+        <target state="new">Cannot generate Java wrapper for type '{0}'. Only 'class' types are supported.</target>
         <note>{0} - Java type.
-The following terms should not be translated: class.</note>
+The following terms should not be translated:
+class.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4201">
         <source>Cannot determine JNI name for type '{0}'.</source>
@@ -226,10 +227,11 @@ The following terms should not be translated: class.</note>
 The following terms should not be translated: JNI.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4203">
-        <source>The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</source>
-        <target state="new">The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</target>
+        <source>The 'Name' property must be a fully qualified type like 'com.example.MyClass' and no package was found for '{0}'.</source>
+        <target state="new">The 'Name' property must be a fully qualified type like 'com.example.MyClass' and no package was found for '{0}'.</target>
         <note>{0} - Java type.
-The following terms should not be translated: Name.</note>
+The following terms should not be translated:
+Name, com.example.MyClass.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4204">
         <source>Unable to resolve interface type '{0}'. Are you missing an assembly reference?</source>
@@ -239,22 +241,22 @@ The following terms should not be translated: Name.</note>
       <trans-unit id="JavaCallableWrappers_XA4205">
         <source>[ExportField] can only be used on methods with 0 parameters.</source>
         <target state="new">[ExportField] can only be used on methods with 0 parameters.</target>
-        <note />
+        <note>The following terms should not be translated: [ExportField].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4206">
         <source>[Export] cannot be used on a generic type.</source>
         <target state="new">[Export] cannot be used on a generic type.</target>
-        <note />
+        <note>The following terms should not be translated: [Export].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4207">
         <source>[ExportField] cannot be used on a generic type.</source>
         <target state="new">[ExportField] cannot be used on a generic type.</target>
-        <note />
+        <note>The following terms should not be translated: [ExportField].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4208">
-        <source>[ExportField] cannot be used on a method returning void.</source>
-        <target state="new">[ExportField] cannot be used on a method returning void.</target>
-        <note />
+        <source>[ExportField] cannot be used on a method returning 'void'.</source>
+        <target state="new">[ExportField] cannot be used on a method returning 'void'.</target>
+        <note>The following terms should not be translated: [ExportField], void.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4217">
         <source>Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</source>

--- a/src/Java.Interop.Localization/xlf/Resources.fr.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.fr.xlf
@@ -214,10 +214,11 @@ The following terms should not be translated: Metadata.xml.</note>
         <note>{0}, {1} - .NET types.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4200">
-        <source>Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</source>
-        <target state="new">Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</target>
+        <source>Cannot generate Java wrapper for type '{0}'. Only 'class' types are supported.</source>
+        <target state="new">Cannot generate Java wrapper for type '{0}'. Only 'class' types are supported.</target>
         <note>{0} - Java type.
-The following terms should not be translated: class.</note>
+The following terms should not be translated:
+class.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4201">
         <source>Cannot determine JNI name for type '{0}'.</source>
@@ -226,10 +227,11 @@ The following terms should not be translated: class.</note>
 The following terms should not be translated: JNI.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4203">
-        <source>The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</source>
-        <target state="new">The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</target>
+        <source>The 'Name' property must be a fully qualified type like 'com.example.MyClass' and no package was found for '{0}'.</source>
+        <target state="new">The 'Name' property must be a fully qualified type like 'com.example.MyClass' and no package was found for '{0}'.</target>
         <note>{0} - Java type.
-The following terms should not be translated: Name.</note>
+The following terms should not be translated:
+Name, com.example.MyClass.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4204">
         <source>Unable to resolve interface type '{0}'. Are you missing an assembly reference?</source>
@@ -239,22 +241,22 @@ The following terms should not be translated: Name.</note>
       <trans-unit id="JavaCallableWrappers_XA4205">
         <source>[ExportField] can only be used on methods with 0 parameters.</source>
         <target state="new">[ExportField] can only be used on methods with 0 parameters.</target>
-        <note />
+        <note>The following terms should not be translated: [ExportField].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4206">
         <source>[Export] cannot be used on a generic type.</source>
         <target state="new">[Export] cannot be used on a generic type.</target>
-        <note />
+        <note>The following terms should not be translated: [Export].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4207">
         <source>[ExportField] cannot be used on a generic type.</source>
         <target state="new">[ExportField] cannot be used on a generic type.</target>
-        <note />
+        <note>The following terms should not be translated: [ExportField].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4208">
-        <source>[ExportField] cannot be used on a method returning void.</source>
-        <target state="new">[ExportField] cannot be used on a method returning void.</target>
-        <note />
+        <source>[ExportField] cannot be used on a method returning 'void'.</source>
+        <target state="new">[ExportField] cannot be used on a method returning 'void'.</target>
+        <note>The following terms should not be translated: [ExportField], void.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4217">
         <source>Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</source>

--- a/src/Java.Interop.Localization/xlf/Resources.fr.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Resources.resx">
     <body>
+      <trans-unit id="CecilResolver_XA0009">
+        <source>Error while loading assembly: '{0}'.</source>
+        <target state="new">Error while loading assembly: '{0}'.</target>
+        <note>{0} - File name</note>
+      </trans-unit>
       <trans-unit id="Generator_BG4000">
         <source>Failed to remove old constants: {0}.</source>
         <target state="new">Failed to remove old constants: {0}.</target>
@@ -207,6 +212,54 @@ The following terms should not be translated: Metadata.xml.</note>
         <source>For type '{0}', base interface '{1}' is invalid.</source>
         <target state="new">For type '{0}', base interface '{1}' is invalid.</target>
         <note>{0}, {1} - .NET types.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4200">
+        <source>Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</source>
+        <target state="new">Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: class.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4201">
+        <source>Cannot determine JNI name for type '{0}'.</source>
+        <target state="new">Cannot determine JNI name for type '{0}'.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: JNI.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4203">
+        <source>The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</source>
+        <target state="new">The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: Name.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4204">
+        <source>Unable to resolve interface type '{0}'. Are you missing an assembly reference?</source>
+        <target state="new">Unable to resolve interface type '{0}'. Are you missing an assembly reference?</target>
+        <note>{0} - Java interface.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4205">
+        <source>[ExportField] can only be used on methods with 0 parameters.</source>
+        <target state="new">[ExportField] can only be used on methods with 0 parameters.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4206">
+        <source>[Export] cannot be used on a generic type.</source>
+        <target state="new">[Export] cannot be used on a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4207">
+        <source>[ExportField] cannot be used on a generic type.</source>
+        <target state="new">[ExportField] cannot be used on a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4208">
+        <source>[ExportField] cannot be used on a method returning void.</source>
+        <target state="new">[ExportField] cannot be used on a method returning void.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4217">
+        <source>Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</source>
+        <target state="new">Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</target>
+        <note>{0} - Kotlin method name.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Java.Interop.Localization/xlf/Resources.it.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.it.xlf
@@ -214,10 +214,11 @@ The following terms should not be translated: Metadata.xml.</note>
         <note>{0}, {1} - .NET types.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4200">
-        <source>Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</source>
-        <target state="new">Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</target>
+        <source>Cannot generate Java wrapper for type '{0}'. Only 'class' types are supported.</source>
+        <target state="new">Cannot generate Java wrapper for type '{0}'. Only 'class' types are supported.</target>
         <note>{0} - Java type.
-The following terms should not be translated: class.</note>
+The following terms should not be translated:
+class.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4201">
         <source>Cannot determine JNI name for type '{0}'.</source>
@@ -226,10 +227,11 @@ The following terms should not be translated: class.</note>
 The following terms should not be translated: JNI.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4203">
-        <source>The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</source>
-        <target state="new">The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</target>
+        <source>The 'Name' property must be a fully qualified type like 'com.example.MyClass' and no package was found for '{0}'.</source>
+        <target state="new">The 'Name' property must be a fully qualified type like 'com.example.MyClass' and no package was found for '{0}'.</target>
         <note>{0} - Java type.
-The following terms should not be translated: Name.</note>
+The following terms should not be translated:
+Name, com.example.MyClass.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4204">
         <source>Unable to resolve interface type '{0}'. Are you missing an assembly reference?</source>
@@ -239,22 +241,22 @@ The following terms should not be translated: Name.</note>
       <trans-unit id="JavaCallableWrappers_XA4205">
         <source>[ExportField] can only be used on methods with 0 parameters.</source>
         <target state="new">[ExportField] can only be used on methods with 0 parameters.</target>
-        <note />
+        <note>The following terms should not be translated: [ExportField].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4206">
         <source>[Export] cannot be used on a generic type.</source>
         <target state="new">[Export] cannot be used on a generic type.</target>
-        <note />
+        <note>The following terms should not be translated: [Export].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4207">
         <source>[ExportField] cannot be used on a generic type.</source>
         <target state="new">[ExportField] cannot be used on a generic type.</target>
-        <note />
+        <note>The following terms should not be translated: [ExportField].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4208">
-        <source>[ExportField] cannot be used on a method returning void.</source>
-        <target state="new">[ExportField] cannot be used on a method returning void.</target>
-        <note />
+        <source>[ExportField] cannot be used on a method returning 'void'.</source>
+        <target state="new">[ExportField] cannot be used on a method returning 'void'.</target>
+        <note>The following terms should not be translated: [ExportField], void.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4217">
         <source>Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</source>

--- a/src/Java.Interop.Localization/xlf/Resources.it.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Resources.resx">
     <body>
+      <trans-unit id="CecilResolver_XA0009">
+        <source>Error while loading assembly: '{0}'.</source>
+        <target state="new">Error while loading assembly: '{0}'.</target>
+        <note>{0} - File name</note>
+      </trans-unit>
       <trans-unit id="Generator_BG4000">
         <source>Failed to remove old constants: {0}.</source>
         <target state="new">Failed to remove old constants: {0}.</target>
@@ -207,6 +212,54 @@ The following terms should not be translated: Metadata.xml.</note>
         <source>For type '{0}', base interface '{1}' is invalid.</source>
         <target state="new">For type '{0}', base interface '{1}' is invalid.</target>
         <note>{0}, {1} - .NET types.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4200">
+        <source>Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</source>
+        <target state="new">Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: class.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4201">
+        <source>Cannot determine JNI name for type '{0}'.</source>
+        <target state="new">Cannot determine JNI name for type '{0}'.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: JNI.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4203">
+        <source>The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</source>
+        <target state="new">The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: Name.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4204">
+        <source>Unable to resolve interface type '{0}'. Are you missing an assembly reference?</source>
+        <target state="new">Unable to resolve interface type '{0}'. Are you missing an assembly reference?</target>
+        <note>{0} - Java interface.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4205">
+        <source>[ExportField] can only be used on methods with 0 parameters.</source>
+        <target state="new">[ExportField] can only be used on methods with 0 parameters.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4206">
+        <source>[Export] cannot be used on a generic type.</source>
+        <target state="new">[Export] cannot be used on a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4207">
+        <source>[ExportField] cannot be used on a generic type.</source>
+        <target state="new">[ExportField] cannot be used on a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4208">
+        <source>[ExportField] cannot be used on a method returning void.</source>
+        <target state="new">[ExportField] cannot be used on a method returning void.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4217">
+        <source>Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</source>
+        <target state="new">Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</target>
+        <note>{0} - Kotlin method name.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Java.Interop.Localization/xlf/Resources.ja.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.ja.xlf
@@ -214,10 +214,11 @@ The following terms should not be translated: Metadata.xml.</note>
         <note>{0}, {1} - .NET types.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4200">
-        <source>Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</source>
-        <target state="new">Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</target>
+        <source>Cannot generate Java wrapper for type '{0}'. Only 'class' types are supported.</source>
+        <target state="new">Cannot generate Java wrapper for type '{0}'. Only 'class' types are supported.</target>
         <note>{0} - Java type.
-The following terms should not be translated: class.</note>
+The following terms should not be translated:
+class.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4201">
         <source>Cannot determine JNI name for type '{0}'.</source>
@@ -226,10 +227,11 @@ The following terms should not be translated: class.</note>
 The following terms should not be translated: JNI.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4203">
-        <source>The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</source>
-        <target state="new">The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</target>
+        <source>The 'Name' property must be a fully qualified type like 'com.example.MyClass' and no package was found for '{0}'.</source>
+        <target state="new">The 'Name' property must be a fully qualified type like 'com.example.MyClass' and no package was found for '{0}'.</target>
         <note>{0} - Java type.
-The following terms should not be translated: Name.</note>
+The following terms should not be translated:
+Name, com.example.MyClass.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4204">
         <source>Unable to resolve interface type '{0}'. Are you missing an assembly reference?</source>
@@ -239,22 +241,22 @@ The following terms should not be translated: Name.</note>
       <trans-unit id="JavaCallableWrappers_XA4205">
         <source>[ExportField] can only be used on methods with 0 parameters.</source>
         <target state="new">[ExportField] can only be used on methods with 0 parameters.</target>
-        <note />
+        <note>The following terms should not be translated: [ExportField].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4206">
         <source>[Export] cannot be used on a generic type.</source>
         <target state="new">[Export] cannot be used on a generic type.</target>
-        <note />
+        <note>The following terms should not be translated: [Export].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4207">
         <source>[ExportField] cannot be used on a generic type.</source>
         <target state="new">[ExportField] cannot be used on a generic type.</target>
-        <note />
+        <note>The following terms should not be translated: [ExportField].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4208">
-        <source>[ExportField] cannot be used on a method returning void.</source>
-        <target state="new">[ExportField] cannot be used on a method returning void.</target>
-        <note />
+        <source>[ExportField] cannot be used on a method returning 'void'.</source>
+        <target state="new">[ExportField] cannot be used on a method returning 'void'.</target>
+        <note>The following terms should not be translated: [ExportField], void.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4217">
         <source>Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</source>

--- a/src/Java.Interop.Localization/xlf/Resources.ja.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Resources.resx">
     <body>
+      <trans-unit id="CecilResolver_XA0009">
+        <source>Error while loading assembly: '{0}'.</source>
+        <target state="new">Error while loading assembly: '{0}'.</target>
+        <note>{0} - File name</note>
+      </trans-unit>
       <trans-unit id="Generator_BG4000">
         <source>Failed to remove old constants: {0}.</source>
         <target state="new">Failed to remove old constants: {0}.</target>
@@ -207,6 +212,54 @@ The following terms should not be translated: Metadata.xml.</note>
         <source>For type '{0}', base interface '{1}' is invalid.</source>
         <target state="new">For type '{0}', base interface '{1}' is invalid.</target>
         <note>{0}, {1} - .NET types.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4200">
+        <source>Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</source>
+        <target state="new">Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: class.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4201">
+        <source>Cannot determine JNI name for type '{0}'.</source>
+        <target state="new">Cannot determine JNI name for type '{0}'.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: JNI.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4203">
+        <source>The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</source>
+        <target state="new">The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: Name.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4204">
+        <source>Unable to resolve interface type '{0}'. Are you missing an assembly reference?</source>
+        <target state="new">Unable to resolve interface type '{0}'. Are you missing an assembly reference?</target>
+        <note>{0} - Java interface.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4205">
+        <source>[ExportField] can only be used on methods with 0 parameters.</source>
+        <target state="new">[ExportField] can only be used on methods with 0 parameters.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4206">
+        <source>[Export] cannot be used on a generic type.</source>
+        <target state="new">[Export] cannot be used on a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4207">
+        <source>[ExportField] cannot be used on a generic type.</source>
+        <target state="new">[ExportField] cannot be used on a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4208">
+        <source>[ExportField] cannot be used on a method returning void.</source>
+        <target state="new">[ExportField] cannot be used on a method returning void.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4217">
+        <source>Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</source>
+        <target state="new">Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</target>
+        <note>{0} - Kotlin method name.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Java.Interop.Localization/xlf/Resources.ko.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.ko.xlf
@@ -214,10 +214,11 @@ The following terms should not be translated: Metadata.xml.</note>
         <note>{0}, {1} - .NET types.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4200">
-        <source>Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</source>
-        <target state="new">Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</target>
+        <source>Cannot generate Java wrapper for type '{0}'. Only 'class' types are supported.</source>
+        <target state="new">Cannot generate Java wrapper for type '{0}'. Only 'class' types are supported.</target>
         <note>{0} - Java type.
-The following terms should not be translated: class.</note>
+The following terms should not be translated:
+class.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4201">
         <source>Cannot determine JNI name for type '{0}'.</source>
@@ -226,10 +227,11 @@ The following terms should not be translated: class.</note>
 The following terms should not be translated: JNI.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4203">
-        <source>The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</source>
-        <target state="new">The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</target>
+        <source>The 'Name' property must be a fully qualified type like 'com.example.MyClass' and no package was found for '{0}'.</source>
+        <target state="new">The 'Name' property must be a fully qualified type like 'com.example.MyClass' and no package was found for '{0}'.</target>
         <note>{0} - Java type.
-The following terms should not be translated: Name.</note>
+The following terms should not be translated:
+Name, com.example.MyClass.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4204">
         <source>Unable to resolve interface type '{0}'. Are you missing an assembly reference?</source>
@@ -239,22 +241,22 @@ The following terms should not be translated: Name.</note>
       <trans-unit id="JavaCallableWrappers_XA4205">
         <source>[ExportField] can only be used on methods with 0 parameters.</source>
         <target state="new">[ExportField] can only be used on methods with 0 parameters.</target>
-        <note />
+        <note>The following terms should not be translated: [ExportField].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4206">
         <source>[Export] cannot be used on a generic type.</source>
         <target state="new">[Export] cannot be used on a generic type.</target>
-        <note />
+        <note>The following terms should not be translated: [Export].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4207">
         <source>[ExportField] cannot be used on a generic type.</source>
         <target state="new">[ExportField] cannot be used on a generic type.</target>
-        <note />
+        <note>The following terms should not be translated: [ExportField].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4208">
-        <source>[ExportField] cannot be used on a method returning void.</source>
-        <target state="new">[ExportField] cannot be used on a method returning void.</target>
-        <note />
+        <source>[ExportField] cannot be used on a method returning 'void'.</source>
+        <target state="new">[ExportField] cannot be used on a method returning 'void'.</target>
+        <note>The following terms should not be translated: [ExportField], void.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4217">
         <source>Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</source>

--- a/src/Java.Interop.Localization/xlf/Resources.ko.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Resources.resx">
     <body>
+      <trans-unit id="CecilResolver_XA0009">
+        <source>Error while loading assembly: '{0}'.</source>
+        <target state="new">Error while loading assembly: '{0}'.</target>
+        <note>{0} - File name</note>
+      </trans-unit>
       <trans-unit id="Generator_BG4000">
         <source>Failed to remove old constants: {0}.</source>
         <target state="new">Failed to remove old constants: {0}.</target>
@@ -207,6 +212,54 @@ The following terms should not be translated: Metadata.xml.</note>
         <source>For type '{0}', base interface '{1}' is invalid.</source>
         <target state="new">For type '{0}', base interface '{1}' is invalid.</target>
         <note>{0}, {1} - .NET types.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4200">
+        <source>Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</source>
+        <target state="new">Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: class.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4201">
+        <source>Cannot determine JNI name for type '{0}'.</source>
+        <target state="new">Cannot determine JNI name for type '{0}'.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: JNI.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4203">
+        <source>The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</source>
+        <target state="new">The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: Name.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4204">
+        <source>Unable to resolve interface type '{0}'. Are you missing an assembly reference?</source>
+        <target state="new">Unable to resolve interface type '{0}'. Are you missing an assembly reference?</target>
+        <note>{0} - Java interface.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4205">
+        <source>[ExportField] can only be used on methods with 0 parameters.</source>
+        <target state="new">[ExportField] can only be used on methods with 0 parameters.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4206">
+        <source>[Export] cannot be used on a generic type.</source>
+        <target state="new">[Export] cannot be used on a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4207">
+        <source>[ExportField] cannot be used on a generic type.</source>
+        <target state="new">[ExportField] cannot be used on a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4208">
+        <source>[ExportField] cannot be used on a method returning void.</source>
+        <target state="new">[ExportField] cannot be used on a method returning void.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4217">
+        <source>Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</source>
+        <target state="new">Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</target>
+        <note>{0} - Kotlin method name.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Java.Interop.Localization/xlf/Resources.pl.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.pl.xlf
@@ -214,10 +214,11 @@ The following terms should not be translated: Metadata.xml.</note>
         <note>{0}, {1} - .NET types.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4200">
-        <source>Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</source>
-        <target state="new">Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</target>
+        <source>Cannot generate Java wrapper for type '{0}'. Only 'class' types are supported.</source>
+        <target state="new">Cannot generate Java wrapper for type '{0}'. Only 'class' types are supported.</target>
         <note>{0} - Java type.
-The following terms should not be translated: class.</note>
+The following terms should not be translated:
+class.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4201">
         <source>Cannot determine JNI name for type '{0}'.</source>
@@ -226,10 +227,11 @@ The following terms should not be translated: class.</note>
 The following terms should not be translated: JNI.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4203">
-        <source>The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</source>
-        <target state="new">The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</target>
+        <source>The 'Name' property must be a fully qualified type like 'com.example.MyClass' and no package was found for '{0}'.</source>
+        <target state="new">The 'Name' property must be a fully qualified type like 'com.example.MyClass' and no package was found for '{0}'.</target>
         <note>{0} - Java type.
-The following terms should not be translated: Name.</note>
+The following terms should not be translated:
+Name, com.example.MyClass.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4204">
         <source>Unable to resolve interface type '{0}'. Are you missing an assembly reference?</source>
@@ -239,22 +241,22 @@ The following terms should not be translated: Name.</note>
       <trans-unit id="JavaCallableWrappers_XA4205">
         <source>[ExportField] can only be used on methods with 0 parameters.</source>
         <target state="new">[ExportField] can only be used on methods with 0 parameters.</target>
-        <note />
+        <note>The following terms should not be translated: [ExportField].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4206">
         <source>[Export] cannot be used on a generic type.</source>
         <target state="new">[Export] cannot be used on a generic type.</target>
-        <note />
+        <note>The following terms should not be translated: [Export].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4207">
         <source>[ExportField] cannot be used on a generic type.</source>
         <target state="new">[ExportField] cannot be used on a generic type.</target>
-        <note />
+        <note>The following terms should not be translated: [ExportField].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4208">
-        <source>[ExportField] cannot be used on a method returning void.</source>
-        <target state="new">[ExportField] cannot be used on a method returning void.</target>
-        <note />
+        <source>[ExportField] cannot be used on a method returning 'void'.</source>
+        <target state="new">[ExportField] cannot be used on a method returning 'void'.</target>
+        <note>The following terms should not be translated: [ExportField], void.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4217">
         <source>Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</source>

--- a/src/Java.Interop.Localization/xlf/Resources.pl.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Resources.resx">
     <body>
+      <trans-unit id="CecilResolver_XA0009">
+        <source>Error while loading assembly: '{0}'.</source>
+        <target state="new">Error while loading assembly: '{0}'.</target>
+        <note>{0} - File name</note>
+      </trans-unit>
       <trans-unit id="Generator_BG4000">
         <source>Failed to remove old constants: {0}.</source>
         <target state="new">Failed to remove old constants: {0}.</target>
@@ -207,6 +212,54 @@ The following terms should not be translated: Metadata.xml.</note>
         <source>For type '{0}', base interface '{1}' is invalid.</source>
         <target state="new">For type '{0}', base interface '{1}' is invalid.</target>
         <note>{0}, {1} - .NET types.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4200">
+        <source>Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</source>
+        <target state="new">Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: class.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4201">
+        <source>Cannot determine JNI name for type '{0}'.</source>
+        <target state="new">Cannot determine JNI name for type '{0}'.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: JNI.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4203">
+        <source>The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</source>
+        <target state="new">The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: Name.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4204">
+        <source>Unable to resolve interface type '{0}'. Are you missing an assembly reference?</source>
+        <target state="new">Unable to resolve interface type '{0}'. Are you missing an assembly reference?</target>
+        <note>{0} - Java interface.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4205">
+        <source>[ExportField] can only be used on methods with 0 parameters.</source>
+        <target state="new">[ExportField] can only be used on methods with 0 parameters.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4206">
+        <source>[Export] cannot be used on a generic type.</source>
+        <target state="new">[Export] cannot be used on a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4207">
+        <source>[ExportField] cannot be used on a generic type.</source>
+        <target state="new">[ExportField] cannot be used on a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4208">
+        <source>[ExportField] cannot be used on a method returning void.</source>
+        <target state="new">[ExportField] cannot be used on a method returning void.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4217">
+        <source>Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</source>
+        <target state="new">Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</target>
+        <note>{0} - Kotlin method name.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Java.Interop.Localization/xlf/Resources.pt-BR.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.pt-BR.xlf
@@ -214,10 +214,11 @@ The following terms should not be translated: Metadata.xml.</note>
         <note>{0}, {1} - .NET types.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4200">
-        <source>Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</source>
-        <target state="new">Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</target>
+        <source>Cannot generate Java wrapper for type '{0}'. Only 'class' types are supported.</source>
+        <target state="new">Cannot generate Java wrapper for type '{0}'. Only 'class' types are supported.</target>
         <note>{0} - Java type.
-The following terms should not be translated: class.</note>
+The following terms should not be translated:
+class.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4201">
         <source>Cannot determine JNI name for type '{0}'.</source>
@@ -226,10 +227,11 @@ The following terms should not be translated: class.</note>
 The following terms should not be translated: JNI.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4203">
-        <source>The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</source>
-        <target state="new">The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</target>
+        <source>The 'Name' property must be a fully qualified type like 'com.example.MyClass' and no package was found for '{0}'.</source>
+        <target state="new">The 'Name' property must be a fully qualified type like 'com.example.MyClass' and no package was found for '{0}'.</target>
         <note>{0} - Java type.
-The following terms should not be translated: Name.</note>
+The following terms should not be translated:
+Name, com.example.MyClass.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4204">
         <source>Unable to resolve interface type '{0}'. Are you missing an assembly reference?</source>
@@ -239,22 +241,22 @@ The following terms should not be translated: Name.</note>
       <trans-unit id="JavaCallableWrappers_XA4205">
         <source>[ExportField] can only be used on methods with 0 parameters.</source>
         <target state="new">[ExportField] can only be used on methods with 0 parameters.</target>
-        <note />
+        <note>The following terms should not be translated: [ExportField].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4206">
         <source>[Export] cannot be used on a generic type.</source>
         <target state="new">[Export] cannot be used on a generic type.</target>
-        <note />
+        <note>The following terms should not be translated: [Export].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4207">
         <source>[ExportField] cannot be used on a generic type.</source>
         <target state="new">[ExportField] cannot be used on a generic type.</target>
-        <note />
+        <note>The following terms should not be translated: [ExportField].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4208">
-        <source>[ExportField] cannot be used on a method returning void.</source>
-        <target state="new">[ExportField] cannot be used on a method returning void.</target>
-        <note />
+        <source>[ExportField] cannot be used on a method returning 'void'.</source>
+        <target state="new">[ExportField] cannot be used on a method returning 'void'.</target>
+        <note>The following terms should not be translated: [ExportField], void.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4217">
         <source>Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</source>

--- a/src/Java.Interop.Localization/xlf/Resources.pt-BR.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Resources.resx">
     <body>
+      <trans-unit id="CecilResolver_XA0009">
+        <source>Error while loading assembly: '{0}'.</source>
+        <target state="new">Error while loading assembly: '{0}'.</target>
+        <note>{0} - File name</note>
+      </trans-unit>
       <trans-unit id="Generator_BG4000">
         <source>Failed to remove old constants: {0}.</source>
         <target state="new">Failed to remove old constants: {0}.</target>
@@ -207,6 +212,54 @@ The following terms should not be translated: Metadata.xml.</note>
         <source>For type '{0}', base interface '{1}' is invalid.</source>
         <target state="new">For type '{0}', base interface '{1}' is invalid.</target>
         <note>{0}, {1} - .NET types.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4200">
+        <source>Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</source>
+        <target state="new">Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: class.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4201">
+        <source>Cannot determine JNI name for type '{0}'.</source>
+        <target state="new">Cannot determine JNI name for type '{0}'.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: JNI.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4203">
+        <source>The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</source>
+        <target state="new">The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: Name.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4204">
+        <source>Unable to resolve interface type '{0}'. Are you missing an assembly reference?</source>
+        <target state="new">Unable to resolve interface type '{0}'. Are you missing an assembly reference?</target>
+        <note>{0} - Java interface.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4205">
+        <source>[ExportField] can only be used on methods with 0 parameters.</source>
+        <target state="new">[ExportField] can only be used on methods with 0 parameters.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4206">
+        <source>[Export] cannot be used on a generic type.</source>
+        <target state="new">[Export] cannot be used on a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4207">
+        <source>[ExportField] cannot be used on a generic type.</source>
+        <target state="new">[ExportField] cannot be used on a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4208">
+        <source>[ExportField] cannot be used on a method returning void.</source>
+        <target state="new">[ExportField] cannot be used on a method returning void.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4217">
+        <source>Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</source>
+        <target state="new">Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</target>
+        <note>{0} - Kotlin method name.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Java.Interop.Localization/xlf/Resources.ru.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Resources.resx">
     <body>
+      <trans-unit id="CecilResolver_XA0009">
+        <source>Error while loading assembly: '{0}'.</source>
+        <target state="new">Error while loading assembly: '{0}'.</target>
+        <note>{0} - File name</note>
+      </trans-unit>
       <trans-unit id="Generator_BG4000">
         <source>Failed to remove old constants: {0}.</source>
         <target state="new">Failed to remove old constants: {0}.</target>
@@ -207,6 +212,54 @@ The following terms should not be translated: Metadata.xml.</note>
         <source>For type '{0}', base interface '{1}' is invalid.</source>
         <target state="new">For type '{0}', base interface '{1}' is invalid.</target>
         <note>{0}, {1} - .NET types.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4200">
+        <source>Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</source>
+        <target state="new">Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: class.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4201">
+        <source>Cannot determine JNI name for type '{0}'.</source>
+        <target state="new">Cannot determine JNI name for type '{0}'.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: JNI.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4203">
+        <source>The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</source>
+        <target state="new">The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: Name.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4204">
+        <source>Unable to resolve interface type '{0}'. Are you missing an assembly reference?</source>
+        <target state="new">Unable to resolve interface type '{0}'. Are you missing an assembly reference?</target>
+        <note>{0} - Java interface.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4205">
+        <source>[ExportField] can only be used on methods with 0 parameters.</source>
+        <target state="new">[ExportField] can only be used on methods with 0 parameters.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4206">
+        <source>[Export] cannot be used on a generic type.</source>
+        <target state="new">[Export] cannot be used on a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4207">
+        <source>[ExportField] cannot be used on a generic type.</source>
+        <target state="new">[ExportField] cannot be used on a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4208">
+        <source>[ExportField] cannot be used on a method returning void.</source>
+        <target state="new">[ExportField] cannot be used on a method returning void.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4217">
+        <source>Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</source>
+        <target state="new">Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</target>
+        <note>{0} - Kotlin method name.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Java.Interop.Localization/xlf/Resources.ru.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.ru.xlf
@@ -214,10 +214,11 @@ The following terms should not be translated: Metadata.xml.</note>
         <note>{0}, {1} - .NET types.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4200">
-        <source>Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</source>
-        <target state="new">Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</target>
+        <source>Cannot generate Java wrapper for type '{0}'. Only 'class' types are supported.</source>
+        <target state="new">Cannot generate Java wrapper for type '{0}'. Only 'class' types are supported.</target>
         <note>{0} - Java type.
-The following terms should not be translated: class.</note>
+The following terms should not be translated:
+class.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4201">
         <source>Cannot determine JNI name for type '{0}'.</source>
@@ -226,10 +227,11 @@ The following terms should not be translated: class.</note>
 The following terms should not be translated: JNI.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4203">
-        <source>The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</source>
-        <target state="new">The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</target>
+        <source>The 'Name' property must be a fully qualified type like 'com.example.MyClass' and no package was found for '{0}'.</source>
+        <target state="new">The 'Name' property must be a fully qualified type like 'com.example.MyClass' and no package was found for '{0}'.</target>
         <note>{0} - Java type.
-The following terms should not be translated: Name.</note>
+The following terms should not be translated:
+Name, com.example.MyClass.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4204">
         <source>Unable to resolve interface type '{0}'. Are you missing an assembly reference?</source>
@@ -239,22 +241,22 @@ The following terms should not be translated: Name.</note>
       <trans-unit id="JavaCallableWrappers_XA4205">
         <source>[ExportField] can only be used on methods with 0 parameters.</source>
         <target state="new">[ExportField] can only be used on methods with 0 parameters.</target>
-        <note />
+        <note>The following terms should not be translated: [ExportField].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4206">
         <source>[Export] cannot be used on a generic type.</source>
         <target state="new">[Export] cannot be used on a generic type.</target>
-        <note />
+        <note>The following terms should not be translated: [Export].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4207">
         <source>[ExportField] cannot be used on a generic type.</source>
         <target state="new">[ExportField] cannot be used on a generic type.</target>
-        <note />
+        <note>The following terms should not be translated: [ExportField].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4208">
-        <source>[ExportField] cannot be used on a method returning void.</source>
-        <target state="new">[ExportField] cannot be used on a method returning void.</target>
-        <note />
+        <source>[ExportField] cannot be used on a method returning 'void'.</source>
+        <target state="new">[ExportField] cannot be used on a method returning 'void'.</target>
+        <note>The following terms should not be translated: [ExportField], void.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4217">
         <source>Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</source>

--- a/src/Java.Interop.Localization/xlf/Resources.tr.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Resources.resx">
     <body>
+      <trans-unit id="CecilResolver_XA0009">
+        <source>Error while loading assembly: '{0}'.</source>
+        <target state="new">Error while loading assembly: '{0}'.</target>
+        <note>{0} - File name</note>
+      </trans-unit>
       <trans-unit id="Generator_BG4000">
         <source>Failed to remove old constants: {0}.</source>
         <target state="new">Failed to remove old constants: {0}.</target>
@@ -207,6 +212,54 @@ The following terms should not be translated: Metadata.xml.</note>
         <source>For type '{0}', base interface '{1}' is invalid.</source>
         <target state="new">For type '{0}', base interface '{1}' is invalid.</target>
         <note>{0}, {1} - .NET types.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4200">
+        <source>Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</source>
+        <target state="new">Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: class.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4201">
+        <source>Cannot determine JNI name for type '{0}'.</source>
+        <target state="new">Cannot determine JNI name for type '{0}'.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: JNI.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4203">
+        <source>The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</source>
+        <target state="new">The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: Name.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4204">
+        <source>Unable to resolve interface type '{0}'. Are you missing an assembly reference?</source>
+        <target state="new">Unable to resolve interface type '{0}'. Are you missing an assembly reference?</target>
+        <note>{0} - Java interface.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4205">
+        <source>[ExportField] can only be used on methods with 0 parameters.</source>
+        <target state="new">[ExportField] can only be used on methods with 0 parameters.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4206">
+        <source>[Export] cannot be used on a generic type.</source>
+        <target state="new">[Export] cannot be used on a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4207">
+        <source>[ExportField] cannot be used on a generic type.</source>
+        <target state="new">[ExportField] cannot be used on a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4208">
+        <source>[ExportField] cannot be used on a method returning void.</source>
+        <target state="new">[ExportField] cannot be used on a method returning void.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4217">
+        <source>Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</source>
+        <target state="new">Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</target>
+        <note>{0} - Kotlin method name.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Java.Interop.Localization/xlf/Resources.tr.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.tr.xlf
@@ -214,10 +214,11 @@ The following terms should not be translated: Metadata.xml.</note>
         <note>{0}, {1} - .NET types.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4200">
-        <source>Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</source>
-        <target state="new">Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</target>
+        <source>Cannot generate Java wrapper for type '{0}'. Only 'class' types are supported.</source>
+        <target state="new">Cannot generate Java wrapper for type '{0}'. Only 'class' types are supported.</target>
         <note>{0} - Java type.
-The following terms should not be translated: class.</note>
+The following terms should not be translated:
+class.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4201">
         <source>Cannot determine JNI name for type '{0}'.</source>
@@ -226,10 +227,11 @@ The following terms should not be translated: class.</note>
 The following terms should not be translated: JNI.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4203">
-        <source>The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</source>
-        <target state="new">The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</target>
+        <source>The 'Name' property must be a fully qualified type like 'com.example.MyClass' and no package was found for '{0}'.</source>
+        <target state="new">The 'Name' property must be a fully qualified type like 'com.example.MyClass' and no package was found for '{0}'.</target>
         <note>{0} - Java type.
-The following terms should not be translated: Name.</note>
+The following terms should not be translated:
+Name, com.example.MyClass.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4204">
         <source>Unable to resolve interface type '{0}'. Are you missing an assembly reference?</source>
@@ -239,22 +241,22 @@ The following terms should not be translated: Name.</note>
       <trans-unit id="JavaCallableWrappers_XA4205">
         <source>[ExportField] can only be used on methods with 0 parameters.</source>
         <target state="new">[ExportField] can only be used on methods with 0 parameters.</target>
-        <note />
+        <note>The following terms should not be translated: [ExportField].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4206">
         <source>[Export] cannot be used on a generic type.</source>
         <target state="new">[Export] cannot be used on a generic type.</target>
-        <note />
+        <note>The following terms should not be translated: [Export].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4207">
         <source>[ExportField] cannot be used on a generic type.</source>
         <target state="new">[ExportField] cannot be used on a generic type.</target>
-        <note />
+        <note>The following terms should not be translated: [ExportField].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4208">
-        <source>[ExportField] cannot be used on a method returning void.</source>
-        <target state="new">[ExportField] cannot be used on a method returning void.</target>
-        <note />
+        <source>[ExportField] cannot be used on a method returning 'void'.</source>
+        <target state="new">[ExportField] cannot be used on a method returning 'void'.</target>
+        <note>The following terms should not be translated: [ExportField], void.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4217">
         <source>Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</source>

--- a/src/Java.Interop.Localization/xlf/Resources.zh-Hans.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.zh-Hans.xlf
@@ -214,10 +214,11 @@ The following terms should not be translated: Metadata.xml.</note>
         <note>{0}, {1} - .NET types.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4200">
-        <source>Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</source>
-        <target state="new">Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</target>
+        <source>Cannot generate Java wrapper for type '{0}'. Only 'class' types are supported.</source>
+        <target state="new">Cannot generate Java wrapper for type '{0}'. Only 'class' types are supported.</target>
         <note>{0} - Java type.
-The following terms should not be translated: class.</note>
+The following terms should not be translated:
+class.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4201">
         <source>Cannot determine JNI name for type '{0}'.</source>
@@ -226,10 +227,11 @@ The following terms should not be translated: class.</note>
 The following terms should not be translated: JNI.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4203">
-        <source>The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</source>
-        <target state="new">The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</target>
+        <source>The 'Name' property must be a fully qualified type like 'com.example.MyClass' and no package was found for '{0}'.</source>
+        <target state="new">The 'Name' property must be a fully qualified type like 'com.example.MyClass' and no package was found for '{0}'.</target>
         <note>{0} - Java type.
-The following terms should not be translated: Name.</note>
+The following terms should not be translated:
+Name, com.example.MyClass.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4204">
         <source>Unable to resolve interface type '{0}'. Are you missing an assembly reference?</source>
@@ -239,22 +241,22 @@ The following terms should not be translated: Name.</note>
       <trans-unit id="JavaCallableWrappers_XA4205">
         <source>[ExportField] can only be used on methods with 0 parameters.</source>
         <target state="new">[ExportField] can only be used on methods with 0 parameters.</target>
-        <note />
+        <note>The following terms should not be translated: [ExportField].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4206">
         <source>[Export] cannot be used on a generic type.</source>
         <target state="new">[Export] cannot be used on a generic type.</target>
-        <note />
+        <note>The following terms should not be translated: [Export].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4207">
         <source>[ExportField] cannot be used on a generic type.</source>
         <target state="new">[ExportField] cannot be used on a generic type.</target>
-        <note />
+        <note>The following terms should not be translated: [ExportField].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4208">
-        <source>[ExportField] cannot be used on a method returning void.</source>
-        <target state="new">[ExportField] cannot be used on a method returning void.</target>
-        <note />
+        <source>[ExportField] cannot be used on a method returning 'void'.</source>
+        <target state="new">[ExportField] cannot be used on a method returning 'void'.</target>
+        <note>The following terms should not be translated: [ExportField], void.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4217">
         <source>Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</source>

--- a/src/Java.Interop.Localization/xlf/Resources.zh-Hans.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Resources.resx">
     <body>
+      <trans-unit id="CecilResolver_XA0009">
+        <source>Error while loading assembly: '{0}'.</source>
+        <target state="new">Error while loading assembly: '{0}'.</target>
+        <note>{0} - File name</note>
+      </trans-unit>
       <trans-unit id="Generator_BG4000">
         <source>Failed to remove old constants: {0}.</source>
         <target state="new">Failed to remove old constants: {0}.</target>
@@ -207,6 +212,54 @@ The following terms should not be translated: Metadata.xml.</note>
         <source>For type '{0}', base interface '{1}' is invalid.</source>
         <target state="new">For type '{0}', base interface '{1}' is invalid.</target>
         <note>{0}, {1} - .NET types.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4200">
+        <source>Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</source>
+        <target state="new">Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: class.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4201">
+        <source>Cannot determine JNI name for type '{0}'.</source>
+        <target state="new">Cannot determine JNI name for type '{0}'.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: JNI.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4203">
+        <source>The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</source>
+        <target state="new">The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: Name.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4204">
+        <source>Unable to resolve interface type '{0}'. Are you missing an assembly reference?</source>
+        <target state="new">Unable to resolve interface type '{0}'. Are you missing an assembly reference?</target>
+        <note>{0} - Java interface.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4205">
+        <source>[ExportField] can only be used on methods with 0 parameters.</source>
+        <target state="new">[ExportField] can only be used on methods with 0 parameters.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4206">
+        <source>[Export] cannot be used on a generic type.</source>
+        <target state="new">[Export] cannot be used on a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4207">
+        <source>[ExportField] cannot be used on a generic type.</source>
+        <target state="new">[ExportField] cannot be used on a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4208">
+        <source>[ExportField] cannot be used on a method returning void.</source>
+        <target state="new">[ExportField] cannot be used on a method returning void.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4217">
+        <source>Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</source>
+        <target state="new">Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</target>
+        <note>{0} - Kotlin method name.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Java.Interop.Localization/xlf/Resources.zh-Hant.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Resources.resx">
     <body>
+      <trans-unit id="CecilResolver_XA0009">
+        <source>Error while loading assembly: '{0}'.</source>
+        <target state="new">Error while loading assembly: '{0}'.</target>
+        <note>{0} - File name</note>
+      </trans-unit>
       <trans-unit id="Generator_BG4000">
         <source>Failed to remove old constants: {0}.</source>
         <target state="new">Failed to remove old constants: {0}.</target>
@@ -207,6 +212,54 @@ The following terms should not be translated: Metadata.xml.</note>
         <source>For type '{0}', base interface '{1}' is invalid.</source>
         <target state="new">For type '{0}', base interface '{1}' is invalid.</target>
         <note>{0}, {1} - .NET types.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4200">
+        <source>Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</source>
+        <target state="new">Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: class.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4201">
+        <source>Cannot determine JNI name for type '{0}'.</source>
+        <target state="new">Cannot determine JNI name for type '{0}'.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: JNI.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4203">
+        <source>The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</source>
+        <target state="new">The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</target>
+        <note>{0} - Java type.
+The following terms should not be translated: Name.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4204">
+        <source>Unable to resolve interface type '{0}'. Are you missing an assembly reference?</source>
+        <target state="new">Unable to resolve interface type '{0}'. Are you missing an assembly reference?</target>
+        <note>{0} - Java interface.</note>
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4205">
+        <source>[ExportField] can only be used on methods with 0 parameters.</source>
+        <target state="new">[ExportField] can only be used on methods with 0 parameters.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4206">
+        <source>[Export] cannot be used on a generic type.</source>
+        <target state="new">[Export] cannot be used on a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4207">
+        <source>[ExportField] cannot be used on a generic type.</source>
+        <target state="new">[ExportField] cannot be used on a generic type.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4208">
+        <source>[ExportField] cannot be used on a method returning void.</source>
+        <target state="new">[ExportField] cannot be used on a method returning void.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JavaCallableWrappers_XA4217">
+        <source>Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</source>
+        <target state="new">Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</target>
+        <note>{0} - Kotlin method name.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Java.Interop.Localization/xlf/Resources.zh-Hant.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.zh-Hant.xlf
@@ -214,10 +214,11 @@ The following terms should not be translated: Metadata.xml.</note>
         <note>{0}, {1} - .NET types.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4200">
-        <source>Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</source>
-        <target state="new">Cannot generate Java wrapper for type '{0}', only 'class' types are supported.</target>
+        <source>Cannot generate Java wrapper for type '{0}'. Only 'class' types are supported.</source>
+        <target state="new">Cannot generate Java wrapper for type '{0}'. Only 'class' types are supported.</target>
         <note>{0} - Java type.
-The following terms should not be translated: class.</note>
+The following terms should not be translated:
+class.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4201">
         <source>Cannot determine JNI name for type '{0}'.</source>
@@ -226,10 +227,11 @@ The following terms should not be translated: class.</note>
 The following terms should not be translated: JNI.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4203">
-        <source>The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</source>
-        <target state="new">The 'Name' property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.</target>
+        <source>The 'Name' property must be a fully qualified type like 'com.example.MyClass' and no package was found for '{0}'.</source>
+        <target state="new">The 'Name' property must be a fully qualified type like 'com.example.MyClass' and no package was found for '{0}'.</target>
         <note>{0} - Java type.
-The following terms should not be translated: Name.</note>
+The following terms should not be translated:
+Name, com.example.MyClass.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4204">
         <source>Unable to resolve interface type '{0}'. Are you missing an assembly reference?</source>
@@ -239,22 +241,22 @@ The following terms should not be translated: Name.</note>
       <trans-unit id="JavaCallableWrappers_XA4205">
         <source>[ExportField] can only be used on methods with 0 parameters.</source>
         <target state="new">[ExportField] can only be used on methods with 0 parameters.</target>
-        <note />
+        <note>The following terms should not be translated: [ExportField].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4206">
         <source>[Export] cannot be used on a generic type.</source>
         <target state="new">[Export] cannot be used on a generic type.</target>
-        <note />
+        <note>The following terms should not be translated: [Export].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4207">
         <source>[ExportField] cannot be used on a generic type.</source>
         <target state="new">[ExportField] cannot be used on a generic type.</target>
-        <note />
+        <note>The following terms should not be translated: [ExportField].</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4208">
-        <source>[ExportField] cannot be used on a method returning void.</source>
-        <target state="new">[ExportField] cannot be used on a method returning void.</target>
-        <note />
+        <source>[ExportField] cannot be used on a method returning 'void'.</source>
+        <target state="new">[ExportField] cannot be used on a method returning 'void'.</target>
+        <note>The following terms should not be translated: [ExportField], void.</note>
       </trans-unit>
       <trans-unit id="JavaCallableWrappers_XA4217">
         <source>Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</source>

--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil.csproj
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Java.Interop.Localization\Java.Interop.Localization.csproj" />
     <ProjectReference Include="..\Java.Interop.Tools.Diagnostics\Java.Interop.Tools.Diagnostics.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/DirectoryAssemblyResolver.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/DirectoryAssemblyResolver.cs
@@ -135,7 +135,7 @@ namespace Java.Interop.Tools.Cecil {
 			try {
 				assembly  = ReadAssembly (fileName);
 			} catch (Exception e) {
-				Diagnostic.Error (9, e, "Error while loading assembly: {0}", fileName);
+				Diagnostic.Error (9, e, Localization.Resources.CecilResolver_XA0009, fileName);
 			}
 			cache [name] = assembly;
 			return assembly;

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers.csproj
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers.csproj
@@ -31,6 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Java.Interop.Localization\Java.Interop.Localization.csproj" />
     <ProjectReference Include="..\Java.Interop.Tools.Cecil\Java.Interop.Tools.Cecil.csproj" />
     <ProjectReference Include="..\Java.Interop.Tools.Diagnostics\Java.Interop.Tools.Diagnostics.csproj" />
   </ItemGroup>

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
@@ -110,11 +110,11 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 			this.cache = cache ?? new TypeDefinitionCache ();
 
 			if (type.IsEnum || type.IsInterface || type.IsValueType)
-				Diagnostic.Error (4200, LookupSource (type), "Can only generate Java wrappers for 'class' types, not type '{0}'.", type.FullName);
+				Diagnostic.Error (4200, LookupSource (type), Localization.Resources.JavaCallableWrappers_XA4200, type.FullName);
 
 			string jniName = JavaNativeTypeManager.ToJniName (type);
 			if (jniName == null)
-				Diagnostic.Error (4201, LookupSource (type), "Unable to determine Java name for type {0}", type.FullName);
+				Diagnostic.Error (4201, LookupSource (type), Localization.Resources.JavaCallableWrappers_XA4201, type.FullName);
 			if (!string.IsNullOrEmpty (outerType)) {
 				string p;
 				jniName = jniName.Substring (outerType.Length + 1);
@@ -127,7 +127,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 					 type.IsSubclassOf ("Android.App.Service", cache) ||
 					 type.IsSubclassOf ("Android.Content.BroadcastReceiver", cache) ||
 					 type.IsSubclassOf ("Android.Content.ContentProvider", cache)))
-				Diagnostic.Error (4203, LookupSource (type), "The Name property must be a fully qualified 'package.TypeName' value, and no package was found for '{0}'.", jniName);
+				Diagnostic.Error (4203, LookupSource (type), Localization.Resources.JavaCallableWrappers_XA4203, jniName);
 
 			foreach (MethodDefinition minfo in type.Methods.Where (m => !m.IsConstructor)) {
 				var baseRegisteredMethod = GetBaseRegisteredMethod (minfo);
@@ -148,7 +148,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 						if (d == null)
 							Diagnostic.Error (4204,
 									LookupSource (type),
-									"Unable to resolve interface type '{0}'. Are you missing an assembly reference?",
+									Localization.Resources.JavaCallableWrappers_XA4204,
 									r.FullName);
 						return d;
 					})
@@ -372,7 +372,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 				foreach (RegisterAttribute attr in GetRegisterAttributes (registeredMethod)) {
 					// Check for Kotlin-mangled methods that cannot be overridden
 					if (attr.Name.Contains ("-impl") || (attr.Name.Length > 7 && attr.Name[attr.Name.Length - 8] == '-'))
-						Diagnostic.Error (4217, LookupSource (implementedMethod), $"Cannot override Kotlin-generated method '{attr.Name}' because it is not a valid Java method name. This method can only be overridden from Kotlin.");
+						Diagnostic.Error (4217, LookupSource (implementedMethod), Localization.Resources.JavaCallableWrappers_XA4217, attr.Name);
 
 					var msig = new Signature (implementedMethod, attr);
 					if (!registeredMethod.IsConstructor && !methods.Any (m => m.Name == msig.Name && m.Params == msig.Params))
@@ -380,7 +380,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 				}
 			foreach (ExportAttribute attr in GetExportAttributes (implementedMethod)) {
 				if (type.HasGenericParameters)
-					Diagnostic.Error (4206, LookupSource (implementedMethod), "[Export] cannot be used on a generic type.");
+					Diagnostic.Error (4206, LookupSource (implementedMethod), Localization.Resources.JavaCallableWrappers_XA4206);
 
 				var msig = new Signature (implementedMethod, attr, cache);
 				if (!string.IsNullOrEmpty (attr.SuperArgumentsString)) {
@@ -391,7 +391,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 			}
 			foreach (ExportFieldAttribute attr in GetExportFieldAttributes (implementedMethod)) {
 				if (type.HasGenericParameters)
-					Diagnostic.Error (4207, LookupSource (implementedMethod), "[ExportField] cannot be used on a generic type.");
+					Diagnostic.Error (4207, LookupSource (implementedMethod), Localization.Resources.JavaCallableWrappers_XA4207);
 
 				var msig = new Signature (implementedMethod, attr, cache);
 				if (!implementedMethod.IsConstructor && !methods.Any (m => m.Name == msig.Name && m.Params == msig.Params)) {
@@ -635,7 +635,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 			TypeDefinition d = r.Resolve ();
 			string jniName = JavaNativeTypeManager.ToJniName (d);
 			if (jniName == null)
-				Diagnostic.Error (4201, "Unable to determine JNI name for type {0}.", r.FullName);
+				Diagnostic.Error (4201, Localization.Resources.JavaCallableWrappers_XA4201, r.FullName);
 			return jniName.Replace ('/', '.').Replace ('$', '.');
 		}
 
@@ -669,9 +669,9 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 				: this (method.Name, GetJniSignature (method, cache), "__export__", null, null, null)
 			{
 				if (method.HasParameters)
-					Diagnostic.Error (4205, JavaCallableWrapperGenerator.LookupSource (method), "[ExportField] can only be used on methods with 0 parameters.");
+					Diagnostic.Error (4205, JavaCallableWrapperGenerator.LookupSource (method), Localization.Resources.JavaCallableWrappers_XA4205);
 				if (method.ReturnType.MetadataType == MetadataType.Void)
-					Diagnostic.Error (4208, JavaCallableWrapperGenerator.LookupSource (method), "[ExportField] cannot be used on a method returning void.");
+					Diagnostic.Error (4208, JavaCallableWrapperGenerator.LookupSource (method), Localization.Resources.JavaCallableWrappers_XA4208);
 				IsExport = true;
 				IsStatic = method.IsStatic;
 				JavaAccess = JavaCallableWrapperGenerator.GetJavaAccess (method.Attributes & MethodAttributes.MemberAccessMask);


### PR DESCRIPTION
Updates MSBuild warnings and errors in  `Java.Interop.Tools.JavaCallableWrappers` and `Java.Interop.Tools.Cecil` to be localizable, building on work done in https://github.com/xamarin/java.interop/pull/689.