### PR TITLE
[jnimarshalmethod-gen] Localizable errors

### DIFF
--- a/src/Java.Interop.Localization/Resources.Designer.cs
+++ b/src/Java.Interop.Localization/Resources.Designer.cs
@@ -538,7 +538,7 @@ namespace Java.Interop.Localization {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Type Load exception{0}{1}.
+        ///   Looks up a localized string similar to Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}.
         /// </summary>
         public static string JniMarshalMethodGen_JM8003 {
             get {
@@ -547,7 +547,7 @@ namespace Java.Interop.Localization {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to find cecil&apos;s TypeDefinition of type {0}.
+        ///   Looks up a localized string similar to Unable to find cecil&apos;s TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option..
         /// </summary>
         public static string JniMarshalMethodGen_JM8004 {
             get {
@@ -565,7 +565,7 @@ namespace Java.Interop.Localization {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to find cecil&apos;s MethodDefinition of method {0}.
+        ///   Looks up a localized string similar to Unable to find cecil&apos;s MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option..
         /// </summary>
         public static string JniMarshalMethodGen_JM8006 {
             get {
@@ -574,29 +574,11 @@ namespace Java.Interop.Localization {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to find System.Console::WriteLine method. Disabling debug injection..
+        ///   Looks up a localized string similar to Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option..
         /// </summary>
         public static string JniMarshalMethodGen_JM8007 {
             get {
                 return ResourceManager.GetString("JniMarshalMethodGen_JM8007", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to No type was moved =&gt; nothing to write, no new assembly created..
-        /// </summary>
-        public static string JniMarshalMethodGen_JM8008 {
-            get {
-                return ResourceManager.GetString("JniMarshalMethodGen_JM8008", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Method {0} was not improved. There should have been at least 2 improvements in this registration method..
-        /// </summary>
-        public static string JniMarshalMethodGen_JM8009 {
-            get {
-                return ResourceManager.GetString("JniMarshalMethodGen_JM8009", resourceCulture);
             }
         }
     }

--- a/src/Java.Interop.Localization/Resources.Designer.cs
+++ b/src/Java.Interop.Localization/Resources.Designer.cs
@@ -473,5 +473,140 @@ namespace Java.Interop.Localization {
                 return ResourceManager.GetString("JavaCallableWrappers_XA4217", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to preload reference &apos;{0}&apos;..
+        /// </summary>
+        public static string JniMarshalMethodGen_JM4001 {
+            get {
+                return ResourceManager.GetString("JniMarshalMethodGen_JM4001", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Please specify at least one ASSEMBLY to process..
+        /// </summary>
+        public static string JniMarshalMethodGen_JM4002 {
+            get {
+                return ResourceManager.GetString("JniMarshalMethodGen_JM4002", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to create Java VM{0}{1}.
+        /// </summary>
+        public static string JniMarshalMethodGen_JM4003 {
+            get {
+                return ResourceManager.GetString("JniMarshalMethodGen_JM4003", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to read profile &apos;{0}&apos;.{1}{2}.
+        /// </summary>
+        public static string JniMarshalMethodGen_JM4004 {
+            get {
+                return ResourceManager.GetString("JniMarshalMethodGen_JM4004", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Path &apos;{0}&apos; does not exist..
+        /// </summary>
+        public static string JniMarshalMethodGen_JM4005 {
+            get {
+                return ResourceManager.GetString("JniMarshalMethodGen_JM4005", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to process assembly &apos;{0}&apos;{1}{2}{1}{3}.
+        /// </summary>
+        public static string JniMarshalMethodGen_JM4006 {
+            get {
+                return ResourceManager.GetString("JniMarshalMethodGen_JM4006", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Couln&apos;t find interface {0}.
+        /// </summary>
+        public static string JniMarshalMethodGen_JM8001 {
+            get {
+                return ResourceManager.GetString("JniMarshalMethodGen_JM8001", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to read assembly &apos;{0}&apos; with symbols. Retrying to load it without them..
+        /// </summary>
+        public static string JniMarshalMethodGen_JM8002 {
+            get {
+                return ResourceManager.GetString("JniMarshalMethodGen_JM8002", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Type Load exception{0}{1}.
+        /// </summary>
+        public static string JniMarshalMethodGen_JM8003 {
+            get {
+                return ResourceManager.GetString("JniMarshalMethodGen_JM8003", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to find cecil&apos;s TypeDefinition of type {0}.
+        /// </summary>
+        public static string JniMarshalMethodGen_JM8004 {
+            get {
+                return ResourceManager.GetString("JniMarshalMethodGen_JM8004", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Marshal methods type &apos;{0}&apos; already exists. Skipped generation of marshal methods in assembly &apos;{1}&apos;. Use -f to force regeneration when desired..
+        /// </summary>
+        public static string JniMarshalMethodGen_JM8005 {
+            get {
+                return ResourceManager.GetString("JniMarshalMethodGen_JM8005", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to find cecil&apos;s MethodDefinition of method {0}.
+        /// </summary>
+        public static string JniMarshalMethodGen_JM8006 {
+            get {
+                return ResourceManager.GetString("JniMarshalMethodGen_JM8006", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to find System.Console::WriteLine method. Disabling debug injection..
+        /// </summary>
+        public static string JniMarshalMethodGen_JM8007 {
+            get {
+                return ResourceManager.GetString("JniMarshalMethodGen_JM8007", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No type was moved =&gt; nothing to write, no new assembly created..
+        /// </summary>
+        public static string JniMarshalMethodGen_JM8008 {
+            get {
+                return ResourceManager.GetString("JniMarshalMethodGen_JM8008", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Method {0} was not improved. There should have been at least 2 improvements in this registration method..
+        /// </summary>
+        public static string JniMarshalMethodGen_JM8009 {
+            get {
+                return ResourceManager.GetString("JniMarshalMethodGen_JM8009", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Java.Interop.Localization/Resources.Designer.cs
+++ b/src/Java.Interop.Localization/Resources.Designer.cs
@@ -502,7 +502,7 @@ namespace Java.Interop.Localization {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to read profile &apos;{0}&apos;.{1}{2}.
+        ///   Looks up a localized string similar to Unable to read profile file &apos;{0}&apos;.{1}{2}.
         /// </summary>
         public static string JniMarshalMethodGen_JM4004 {
             get {
@@ -534,15 +534,6 @@ namespace Java.Interop.Localization {
         public static string JniMarshalMethodGen_JM8001 {
             get {
                 return ResourceManager.GetString("JniMarshalMethodGen_JM8001", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Unable to read assembly &apos;{0}&apos; with symbols. Retrying to load it without them..
-        /// </summary>
-        public static string JniMarshalMethodGen_JM8002 {
-            get {
-                return ResourceManager.GetString("JniMarshalMethodGen_JM8002", resourceCulture);
             }
         }
         

--- a/src/Java.Interop.Localization/Resources.Designer.cs
+++ b/src/Java.Interop.Localization/Resources.Designer.cs
@@ -538,7 +538,7 @@ namespace Java.Interop.Localization {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}.
+        ///   Looks up a localized string similar to Caught an exception while loading types. The types that cannot be loaded will not be processed. Make sure that any additional assembly references required for those types are provided using the -r option. Exception:{0}{1}.
         /// </summary>
         public static string JniMarshalMethodGen_JM8003 {
             get {
@@ -547,7 +547,7 @@ namespace Java.Interop.Localization {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to find type &apos;{0}&apos;. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option..
+        ///   Looks up a localized string similar to Unable to find type &apos;{0}&apos;. The type will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option..
         /// </summary>
         public static string JniMarshalMethodGen_JM8004 {
             get {
@@ -565,7 +565,7 @@ namespace Java.Interop.Localization {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option..
+        ///   Looks up a localized string similar to Unable to find definition of method &apos;{0}&apos; in assembly metadata. It will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option..
         /// </summary>
         public static string JniMarshalMethodGen_JM8006 {
             get {
@@ -574,7 +574,7 @@ namespace Java.Interop.Localization {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option..
+        ///   Looks up a localized string similar to Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the directory containing mscorlib is provided with the -L option..
         /// </summary>
         public static string JniMarshalMethodGen_JM8007 {
             get {

--- a/src/Java.Interop.Localization/Resources.Designer.cs
+++ b/src/Java.Interop.Localization/Resources.Designer.cs
@@ -538,7 +538,7 @@ namespace Java.Interop.Localization {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}.
+        ///   Looks up a localized string similar to Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}.
         /// </summary>
         public static string JniMarshalMethodGen_JM8003 {
             get {
@@ -547,7 +547,7 @@ namespace Java.Interop.Localization {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to find cecil&apos;s TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option..
+        ///   Looks up a localized string similar to Unable to find type &apos;{0}&apos;. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option..
         /// </summary>
         public static string JniMarshalMethodGen_JM8004 {
             get {
@@ -565,7 +565,7 @@ namespace Java.Interop.Localization {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to find cecil&apos;s MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option..
+        ///   Looks up a localized string similar to Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option..
         /// </summary>
         public static string JniMarshalMethodGen_JM8006 {
             get {
@@ -574,7 +574,7 @@ namespace Java.Interop.Localization {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option..
+        ///   Looks up a localized string similar to Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option..
         /// </summary>
         public static string JniMarshalMethodGen_JM8007 {
             get {

--- a/src/Java.Interop.Localization/Resources.resx
+++ b/src/Java.Interop.Localization/Resources.resx
@@ -361,11 +361,11 @@ Name, com.example.MyClass.</comment>
     <comment>{0} - interface name</comment>
   </data>
   <data name="JniMarshalMethodGen_JM8003" xml:space="preserve">
-    <value>Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</value>
-    <comment>{0} - newline, {1} - exception</comment>
+    <value>Caught an exception while loading types. The types that cannot be loaded will not be processed. Make sure that any additional assembly references required for those types are provided using the -r option. Exception:{0}{1}</value>
+    <comment>{0} - newline, {1} - exception. The following terms should not be translated: -r</comment>
   </data>
   <data name="JniMarshalMethodGen_JM8004" xml:space="preserve">
-    <value>Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</value>
+    <value>Unable to find type '{0}'. The type will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</value>
     <comment>{0} - type
 The following terms should not be translated: -L</comment>
   </data>
@@ -374,12 +374,12 @@ The following terms should not be translated: -L</comment>
     <comment>{0} - type, {1} - assembly name. The following terms should not be translated: -f. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</comment>
   </data>
   <data name="JniMarshalMethodGen_JM8006" xml:space="preserve">
-    <value>Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</value>
+    <value>Unable to find definition of method '{0}' in assembly metadata. It will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</value>
     <comment>{0} - method
 The following terms should not be translated: -L</comment>
   </data>
   <data name="JniMarshalMethodGen_JM8007" xml:space="preserve">
-    <value>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</value>
+    <value>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the directory containing mscorlib is provided with the -L option.</value>
     <comment>The following terms should not be translated: -L</comment>
   </data>
 </root>

--- a/src/Java.Interop.Localization/Resources.resx
+++ b/src/Java.Interop.Localization/Resources.resx
@@ -361,22 +361,25 @@ Name, com.example.MyClass.</comment>
     <comment>{0} - interface name</comment>
   </data>
   <data name="JniMarshalMethodGen_JM8003" xml:space="preserve">
-    <value>Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</value>
+    <value>Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</value>
     <comment>{0} - newline, {1} - exception</comment>
   </data>
   <data name="JniMarshalMethodGen_JM8004" xml:space="preserve">
-    <value>Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</value>
-    <comment>{0} - type</comment>
+    <value>Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</value>
+    <comment>{0} - type
+The following terms should not be translated: -L</comment>
   </data>
   <data name="JniMarshalMethodGen_JM8005" xml:space="preserve">
     <value>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</value>
-    <comment>{0} - type, {1} - assembly name. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</comment>
+    <comment>{0} - type, {1} - assembly name. The following terms should not be translated: -f. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</comment>
   </data>
   <data name="JniMarshalMethodGen_JM8006" xml:space="preserve">
-    <value>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</value>
-    <comment>{0} - method</comment>
+    <value>Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</value>
+    <comment>{0} - method
+The following terms should not be translated: -L</comment>
   </data>
   <data name="JniMarshalMethodGen_JM8007" xml:space="preserve">
-    <value>Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</value>
+    <value>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</value>
+    <comment>The following terms should not be translated: -L</comment>
   </data>
 </root>

--- a/src/Java.Interop.Localization/Resources.resx
+++ b/src/Java.Interop.Localization/Resources.resx
@@ -361,11 +361,11 @@ Name, com.example.MyClass.</comment>
     <comment>{0} - interface name</comment>
   </data>
   <data name="JniMarshalMethodGen_JM8003" xml:space="preserve">
-    <value>Type Load exception{0}{1}</value>
+    <value>Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</value>
     <comment>{0} - newline, {1} - exception</comment>
   </data>
   <data name="JniMarshalMethodGen_JM8004" xml:space="preserve">
-    <value>Unable to find cecil's TypeDefinition of type {0}</value>
+    <value>Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</value>
     <comment>{0} - type</comment>
   </data>
   <data name="JniMarshalMethodGen_JM8005" xml:space="preserve">
@@ -373,17 +373,10 @@ Name, com.example.MyClass.</comment>
     <comment>{0} - type, {1} - assembly name</comment>
   </data>
   <data name="JniMarshalMethodGen_JM8006" xml:space="preserve">
-    <value>Unable to find cecil's MethodDefinition of method {0}</value>
+    <value>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</value>
     <comment>{0} - method</comment>
   </data>
   <data name="JniMarshalMethodGen_JM8007" xml:space="preserve">
-    <value>Unable to find System.Console::WriteLine method. Disabling debug injection.</value>
-  </data>
-  <data name="JniMarshalMethodGen_JM8008" xml:space="preserve">
-    <value>No type was moved =&gt; nothing to write, no new assembly created.</value>
-  </data>
-  <data name="JniMarshalMethodGen_JM8009" xml:space="preserve">
-    <value>Method {0} was not improved. There should have been at least 2 improvements in this registration method.</value>
-    <comment>{0} - method</comment>
+    <value>Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</value>
   </data>
 </root>

--- a/src/Java.Interop.Localization/Resources.resx
+++ b/src/Java.Interop.Localization/Resources.resx
@@ -332,4 +332,61 @@ Name, com.example.MyClass.</comment>
     <value>Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</value>
     <comment>{0} - Kotlin method name.</comment>
   </data>
+  <data name="JniMarshalMethodGen_JM4001" xml:space="preserve">
+    <value>Unable to preload reference '{0}'.</value>
+    <comment>{0} - assembly path</comment>
+  </data>
+  <data name="JniMarshalMethodGen_JM4002" xml:space="preserve">
+    <value>Please specify at least one ASSEMBLY to process.</value>
+  </data>
+  <data name="JniMarshalMethodGen_JM4003" xml:space="preserve">
+    <value>Unable to create Java VM{0}{1}</value>
+    <comment>{0} - newline, {1} - exception</comment>
+  </data>
+  <data name="JniMarshalMethodGen_JM4004" xml:space="preserve">
+    <value>Unable to read profile '{0}'.{1}{2}</value>
+    <comment>{0} - path, {1} - newline, {2} - exception</comment>
+  </data>
+  <data name="JniMarshalMethodGen_JM4005" xml:space="preserve">
+    <value>Path '{0}' does not exist.</value>
+    <comment>{0} - path</comment>
+  </data>
+  <data name="JniMarshalMethodGen_JM4006" xml:space="preserve">
+    <value>Unable to process assembly '{0}'{1}{2}{1}{3}</value>
+    <comment>{0} - assembly, {1} - newline, {2} - exception message, {3} exception</comment>
+  </data>
+  <data name="JniMarshalMethodGen_JM8001" xml:space="preserve">
+    <value>Couln't find interface {0}</value>
+    <comment>{0} - interface name</comment>
+  </data>
+  <data name="JniMarshalMethodGen_JM8002" xml:space="preserve">
+    <value>Unable to read assembly '{0}' with symbols. Retrying to load it without them.</value>
+    <comment>{0} - assembly</comment>
+  </data>
+  <data name="JniMarshalMethodGen_JM8003" xml:space="preserve">
+    <value>Type Load exception{0}{1}</value>
+    <comment>{0} - newline, {1} - exception</comment>
+  </data>
+  <data name="JniMarshalMethodGen_JM8004" xml:space="preserve">
+    <value>Unable to find cecil's TypeDefinition of type {0}</value>
+    <comment>{0} - type</comment>
+  </data>
+  <data name="JniMarshalMethodGen_JM8005" xml:space="preserve">
+    <value>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</value>
+    <comment>{0} - type, {1} - assembly name</comment>
+  </data>
+  <data name="JniMarshalMethodGen_JM8006" xml:space="preserve">
+    <value>Unable to find cecil's MethodDefinition of method {0}</value>
+    <comment>{0} - method</comment>
+  </data>
+  <data name="JniMarshalMethodGen_JM8007" xml:space="preserve">
+    <value>Unable to find System.Console::WriteLine method. Disabling debug injection.</value>
+  </data>
+  <data name="JniMarshalMethodGen_JM8008" xml:space="preserve">
+    <value>No type was moved =&gt; nothing to write, no new assembly created.</value>
+  </data>
+  <data name="JniMarshalMethodGen_JM8009" xml:space="preserve">
+    <value>Method {0} was not improved. There should have been at least 2 improvements in this registration method.</value>
+    <comment>{0} - method</comment>
+  </data>
 </root>

--- a/src/Java.Interop.Localization/Resources.resx
+++ b/src/Java.Interop.Localization/Resources.resx
@@ -338,14 +338,15 @@ Name, com.example.MyClass.</comment>
   </data>
   <data name="JniMarshalMethodGen_JM4002" xml:space="preserve">
     <value>Please specify at least one ASSEMBLY to process.</value>
+    <comment>The following terms should not be translated or have any capitalization changes: ASSEMBLY. This is a special case for this particular message. In most messages, "assembly" would be translated.</comment>
   </data>
   <data name="JniMarshalMethodGen_JM4003" xml:space="preserve">
     <value>Unable to create Java VM{0}{1}</value>
     <comment>{0} - newline, {1} - exception</comment>
   </data>
   <data name="JniMarshalMethodGen_JM4004" xml:space="preserve">
-    <value>Unable to read profile '{0}'.{1}{2}</value>
-    <comment>{0} - path, {1} - newline, {2} - exception</comment>
+    <value>Unable to read profile file '{0}'.{1}{2}</value>
+    <comment>{0} - path, {1} - newline, {2} - exception. In this message, the term "profile" refers to a customized list of types to process.</comment>
   </data>
   <data name="JniMarshalMethodGen_JM4005" xml:space="preserve">
     <value>Path '{0}' does not exist.</value>
@@ -358,10 +359,6 @@ Name, com.example.MyClass.</comment>
   <data name="JniMarshalMethodGen_JM8001" xml:space="preserve">
     <value>Couln't find interface {0}</value>
     <comment>{0} - interface name</comment>
-  </data>
-  <data name="JniMarshalMethodGen_JM8002" xml:space="preserve">
-    <value>Unable to read assembly '{0}' with symbols. Retrying to load it without them.</value>
-    <comment>{0} - assembly</comment>
   </data>
   <data name="JniMarshalMethodGen_JM8003" xml:space="preserve">
     <value>Type Load exception{0}{1}</value>

--- a/src/Java.Interop.Localization/Resources.resx
+++ b/src/Java.Interop.Localization/Resources.resx
@@ -370,7 +370,7 @@ Name, com.example.MyClass.</comment>
   </data>
   <data name="JniMarshalMethodGen_JM8005" xml:space="preserve">
     <value>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</value>
-    <comment>{0} - type, {1} - assembly name</comment>
+    <comment>{0} - type, {1} - assembly name. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</comment>
   </data>
   <data name="JniMarshalMethodGen_JM8006" xml:space="preserve">
     <value>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</value>

--- a/src/Java.Interop.Localization/xlf/Resources.cs.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.cs.xlf
@@ -263,6 +263,81 @@ Name, com.example.MyClass.</note>
         <target state="new">Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</target>
         <note>{0} - Kotlin method name.</note>
       </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4001">
+        <source>Unable to preload reference '{0}'.</source>
+        <target state="new">Unable to preload reference '{0}'.</target>
+        <note>{0} - assembly path</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4002">
+        <source>Please specify at least one ASSEMBLY to process.</source>
+        <target state="new">Please specify at least one ASSEMBLY to process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4003">
+        <source>Unable to create Java VM{0}{1}</source>
+        <target state="new">Unable to create Java VM{0}{1}</target>
+        <note>{0} - newline, {1} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4004">
+        <source>Unable to read profile '{0}'.{1}{2}</source>
+        <target state="new">Unable to read profile '{0}'.{1}{2}</target>
+        <note>{0} - path, {1} - newline, {2} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4005">
+        <source>Path '{0}' does not exist.</source>
+        <target state="new">Path '{0}' does not exist.</target>
+        <note>{0} - path</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4006">
+        <source>Unable to process assembly '{0}'{1}{2}{1}{3}</source>
+        <target state="new">Unable to process assembly '{0}'{1}{2}{1}{3}</target>
+        <note>{0} - assembly, {1} - newline, {2} - exception message, {3} exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8001">
+        <source>Couln't find interface {0}</source>
+        <target state="new">Couln't find interface {0}</target>
+        <note>{0} - interface name</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8002">
+        <source>Unable to read assembly '{0}' with symbols. Retrying to load it without them.</source>
+        <target state="new">Unable to read assembly '{0}' with symbols. Retrying to load it without them.</target>
+        <note>{0} - assembly</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8003">
+        <source>Type Load exception{0}{1}</source>
+        <target state="new">Type Load exception{0}{1}</target>
+        <note>{0} - newline, {1} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8004">
+        <source>Unable to find cecil's TypeDefinition of type {0}</source>
+        <target state="new">Unable to find cecil's TypeDefinition of type {0}</target>
+        <note>{0} - type</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8005">
+        <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
+        <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
+        <note>{0} - type, {1} - assembly name</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8006">
+        <source>Unable to find cecil's MethodDefinition of method {0}</source>
+        <target state="new">Unable to find cecil's MethodDefinition of method {0}</target>
+        <note>{0} - method</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8007">
+        <source>Unable to find System.Console::WriteLine method. Disabling debug injection.</source>
+        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8008">
+        <source>No type was moved =&gt; nothing to write, no new assembly created.</source>
+        <target state="new">No type was moved =&gt; nothing to write, no new assembly created.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8009">
+        <source>Method {0} was not improved. There should have been at least 2 improvements in this registration method.</source>
+        <target state="new">Method {0} was not improved. There should have been at least 2 improvements in this registration method.</target>
+        <note>{0} - method</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Java.Interop.Localization/xlf/Resources.cs.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.cs.xlf
@@ -311,7 +311,7 @@ Name, com.example.MyClass.</note>
       <trans-unit id="JniMarshalMethodGen_JM8005">
         <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
         <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
-        <note>{0} - type, {1} - assembly name</note>
+        <note>{0} - type, {1} - assembly name. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
         <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>

--- a/src/Java.Interop.Localization/xlf/Resources.cs.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.cs.xlf
@@ -271,7 +271,7 @@ Name, com.example.MyClass.</note>
       <trans-unit id="JniMarshalMethodGen_JM4002">
         <source>Please specify at least one ASSEMBLY to process.</source>
         <target state="new">Please specify at least one ASSEMBLY to process.</target>
-        <note />
+        <note>The following terms should not be translated or have any capitalization changes: ASSEMBLY. This is a special case for this particular message. In most messages, "assembly" would be translated.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4003">
         <source>Unable to create Java VM{0}{1}</source>
@@ -279,9 +279,9 @@ Name, com.example.MyClass.</note>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4004">
-        <source>Unable to read profile '{0}'.{1}{2}</source>
-        <target state="new">Unable to read profile '{0}'.{1}{2}</target>
-        <note>{0} - path, {1} - newline, {2} - exception</note>
+        <source>Unable to read profile file '{0}'.{1}{2}</source>
+        <target state="new">Unable to read profile file '{0}'.{1}{2}</target>
+        <note>{0} - path, {1} - newline, {2} - exception. In this message, the term "profile" refers to a customized list of types to process.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4005">
         <source>Path '{0}' does not exist.</source>
@@ -297,11 +297,6 @@ Name, com.example.MyClass.</note>
         <source>Couln't find interface {0}</source>
         <target state="new">Couln't find interface {0}</target>
         <note>{0} - interface name</note>
-      </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8002">
-        <source>Unable to read assembly '{0}' with symbols. Retrying to load it without them.</source>
-        <target state="new">Unable to read assembly '{0}' with symbols. Retrying to load it without them.</target>
-        <note>{0} - assembly</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
         <source>Type Load exception{0}{1}</source>

--- a/src/Java.Interop.Localization/xlf/Resources.cs.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.cs.xlf
@@ -299,29 +299,31 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</source>
-        <target state="new">Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</target>
+        <source>Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</source>
+        <target state="new">Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</target>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
-        <target state="new">Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
-        <note>{0} - type</note>
+        <source>Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <note>{0} - type
+The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8005">
         <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
         <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
-        <note>{0} - type, {1} - assembly name. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
+        <note>{0} - type, {1} - assembly name. The following terms should not be translated: -f. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
-        <target state="new">Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
-        <note>{0} - method</note>
+        <source>Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <note>{0} - method
+The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</source>
-        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
-        <note />
+        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</source>
+        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</target>
+        <note>The following terms should not be translated: -L</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Java.Interop.Localization/xlf/Resources.cs.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.cs.xlf
@@ -299,13 +299,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Type Load exception{0}{1}</source>
-        <target state="new">Type Load exception{0}{1}</target>
+        <source>Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</source>
+        <target state="new">Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</target>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find cecil's TypeDefinition of type {0}</source>
-        <target state="new">Unable to find cecil's TypeDefinition of type {0}</target>
+        <source>Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
+        <target state="new">Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
         <note>{0} - type</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8005">
@@ -314,18 +314,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - type, {1} - assembly name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find cecil's MethodDefinition of method {0}</source>
-        <target state="new">Unable to find cecil's MethodDefinition of method {0}</target>
+        <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
+        <target state="new">Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
         <note>{0} - method</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find System.Console::WriteLine method. Disabling debug injection.</source>
-        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8008">
-        <source>No type was moved =&gt; nothing to write, no new assembly created.</source>
-        <target state="new">No type was moved =&gt; nothing to write, no new assembly created.</target>
+        <source>Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</source>
+        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
         <note />
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8009">

--- a/src/Java.Interop.Localization/xlf/Resources.cs.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.cs.xlf
@@ -323,11 +323,6 @@ Name, com.example.MyClass.</note>
         <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
         <note />
       </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8009">
-        <source>Method {0} was not improved. There should have been at least 2 improvements in this registration method.</source>
-        <target state="new">Method {0} was not improved. There should have been at least 2 improvements in this registration method.</target>
-        <note>{0} - method</note>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Java.Interop.Localization/xlf/Resources.cs.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.cs.xlf
@@ -299,13 +299,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</source>
-        <target state="new">Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</target>
-        <note>{0} - newline, {1} - exception</note>
+        <source>Caught an exception while loading types. The types that cannot be loaded will not be processed. Make sure that any additional assembly references required for those types are provided using the -r option. Exception:{0}{1}</source>
+        <target state="new">Caught an exception while loading types. The types that cannot be loaded will not be processed. Make sure that any additional assembly references required for those types are provided using the -r option. Exception:{0}{1}</target>
+        <note>{0} - newline, {1} - exception. The following terms should not be translated: -r</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
-        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <source>Unable to find type '{0}'. The type will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</target>
         <note>{0} - type
 The following terms should not be translated: -L</note>
       </trans-unit>
@@ -315,14 +315,14 @@ The following terms should not be translated: -L</note>
         <note>{0} - type, {1} - assembly name. The following terms should not be translated: -f. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
-        <target state="new">Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <source>Unable to find definition of method '{0}' in assembly metadata. It will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find definition of method '{0}' in assembly metadata. It will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</target>
         <note>{0} - method
 The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</source>
-        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</target>
+        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the directory containing mscorlib is provided with the -L option.</source>
+        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the directory containing mscorlib is provided with the -L option.</target>
         <note>The following terms should not be translated: -L</note>
       </trans-unit>
     </body>

--- a/src/Java.Interop.Localization/xlf/Resources.de.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.de.xlf
@@ -263,6 +263,81 @@ Name, com.example.MyClass.</note>
         <target state="new">Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</target>
         <note>{0} - Kotlin method name.</note>
       </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4001">
+        <source>Unable to preload reference '{0}'.</source>
+        <target state="new">Unable to preload reference '{0}'.</target>
+        <note>{0} - assembly path</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4002">
+        <source>Please specify at least one ASSEMBLY to process.</source>
+        <target state="new">Please specify at least one ASSEMBLY to process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4003">
+        <source>Unable to create Java VM{0}{1}</source>
+        <target state="new">Unable to create Java VM{0}{1}</target>
+        <note>{0} - newline, {1} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4004">
+        <source>Unable to read profile '{0}'.{1}{2}</source>
+        <target state="new">Unable to read profile '{0}'.{1}{2}</target>
+        <note>{0} - path, {1} - newline, {2} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4005">
+        <source>Path '{0}' does not exist.</source>
+        <target state="new">Path '{0}' does not exist.</target>
+        <note>{0} - path</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4006">
+        <source>Unable to process assembly '{0}'{1}{2}{1}{3}</source>
+        <target state="new">Unable to process assembly '{0}'{1}{2}{1}{3}</target>
+        <note>{0} - assembly, {1} - newline, {2} - exception message, {3} exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8001">
+        <source>Couln't find interface {0}</source>
+        <target state="new">Couln't find interface {0}</target>
+        <note>{0} - interface name</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8002">
+        <source>Unable to read assembly '{0}' with symbols. Retrying to load it without them.</source>
+        <target state="new">Unable to read assembly '{0}' with symbols. Retrying to load it without them.</target>
+        <note>{0} - assembly</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8003">
+        <source>Type Load exception{0}{1}</source>
+        <target state="new">Type Load exception{0}{1}</target>
+        <note>{0} - newline, {1} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8004">
+        <source>Unable to find cecil's TypeDefinition of type {0}</source>
+        <target state="new">Unable to find cecil's TypeDefinition of type {0}</target>
+        <note>{0} - type</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8005">
+        <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
+        <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
+        <note>{0} - type, {1} - assembly name</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8006">
+        <source>Unable to find cecil's MethodDefinition of method {0}</source>
+        <target state="new">Unable to find cecil's MethodDefinition of method {0}</target>
+        <note>{0} - method</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8007">
+        <source>Unable to find System.Console::WriteLine method. Disabling debug injection.</source>
+        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8008">
+        <source>No type was moved =&gt; nothing to write, no new assembly created.</source>
+        <target state="new">No type was moved =&gt; nothing to write, no new assembly created.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8009">
+        <source>Method {0} was not improved. There should have been at least 2 improvements in this registration method.</source>
+        <target state="new">Method {0} was not improved. There should have been at least 2 improvements in this registration method.</target>
+        <note>{0} - method</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Java.Interop.Localization/xlf/Resources.de.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.de.xlf
@@ -311,7 +311,7 @@ Name, com.example.MyClass.</note>
       <trans-unit id="JniMarshalMethodGen_JM8005">
         <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
         <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
-        <note>{0} - type, {1} - assembly name</note>
+        <note>{0} - type, {1} - assembly name. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
         <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>

--- a/src/Java.Interop.Localization/xlf/Resources.de.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.de.xlf
@@ -271,7 +271,7 @@ Name, com.example.MyClass.</note>
       <trans-unit id="JniMarshalMethodGen_JM4002">
         <source>Please specify at least one ASSEMBLY to process.</source>
         <target state="new">Please specify at least one ASSEMBLY to process.</target>
-        <note />
+        <note>The following terms should not be translated or have any capitalization changes: ASSEMBLY. This is a special case for this particular message. In most messages, "assembly" would be translated.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4003">
         <source>Unable to create Java VM{0}{1}</source>
@@ -279,9 +279,9 @@ Name, com.example.MyClass.</note>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4004">
-        <source>Unable to read profile '{0}'.{1}{2}</source>
-        <target state="new">Unable to read profile '{0}'.{1}{2}</target>
-        <note>{0} - path, {1} - newline, {2} - exception</note>
+        <source>Unable to read profile file '{0}'.{1}{2}</source>
+        <target state="new">Unable to read profile file '{0}'.{1}{2}</target>
+        <note>{0} - path, {1} - newline, {2} - exception. In this message, the term "profile" refers to a customized list of types to process.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4005">
         <source>Path '{0}' does not exist.</source>
@@ -297,11 +297,6 @@ Name, com.example.MyClass.</note>
         <source>Couln't find interface {0}</source>
         <target state="new">Couln't find interface {0}</target>
         <note>{0} - interface name</note>
-      </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8002">
-        <source>Unable to read assembly '{0}' with symbols. Retrying to load it without them.</source>
-        <target state="new">Unable to read assembly '{0}' with symbols. Retrying to load it without them.</target>
-        <note>{0} - assembly</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
         <source>Type Load exception{0}{1}</source>

--- a/src/Java.Interop.Localization/xlf/Resources.de.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.de.xlf
@@ -299,29 +299,31 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</source>
-        <target state="new">Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</target>
+        <source>Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</source>
+        <target state="new">Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</target>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
-        <target state="new">Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
-        <note>{0} - type</note>
+        <source>Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <note>{0} - type
+The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8005">
         <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
         <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
-        <note>{0} - type, {1} - assembly name. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
+        <note>{0} - type, {1} - assembly name. The following terms should not be translated: -f. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
-        <target state="new">Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
-        <note>{0} - method</note>
+        <source>Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <note>{0} - method
+The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</source>
-        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
-        <note />
+        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</source>
+        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</target>
+        <note>The following terms should not be translated: -L</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Java.Interop.Localization/xlf/Resources.de.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.de.xlf
@@ -299,13 +299,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Type Load exception{0}{1}</source>
-        <target state="new">Type Load exception{0}{1}</target>
+        <source>Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</source>
+        <target state="new">Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</target>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find cecil's TypeDefinition of type {0}</source>
-        <target state="new">Unable to find cecil's TypeDefinition of type {0}</target>
+        <source>Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
+        <target state="new">Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
         <note>{0} - type</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8005">
@@ -314,18 +314,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - type, {1} - assembly name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find cecil's MethodDefinition of method {0}</source>
-        <target state="new">Unable to find cecil's MethodDefinition of method {0}</target>
+        <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
+        <target state="new">Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
         <note>{0} - method</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find System.Console::WriteLine method. Disabling debug injection.</source>
-        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8008">
-        <source>No type was moved =&gt; nothing to write, no new assembly created.</source>
-        <target state="new">No type was moved =&gt; nothing to write, no new assembly created.</target>
+        <source>Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</source>
+        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
         <note />
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8009">

--- a/src/Java.Interop.Localization/xlf/Resources.de.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.de.xlf
@@ -323,11 +323,6 @@ Name, com.example.MyClass.</note>
         <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
         <note />
       </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8009">
-        <source>Method {0} was not improved. There should have been at least 2 improvements in this registration method.</source>
-        <target state="new">Method {0} was not improved. There should have been at least 2 improvements in this registration method.</target>
-        <note>{0} - method</note>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Java.Interop.Localization/xlf/Resources.de.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.de.xlf
@@ -299,13 +299,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</source>
-        <target state="new">Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</target>
-        <note>{0} - newline, {1} - exception</note>
+        <source>Caught an exception while loading types. The types that cannot be loaded will not be processed. Make sure that any additional assembly references required for those types are provided using the -r option. Exception:{0}{1}</source>
+        <target state="new">Caught an exception while loading types. The types that cannot be loaded will not be processed. Make sure that any additional assembly references required for those types are provided using the -r option. Exception:{0}{1}</target>
+        <note>{0} - newline, {1} - exception. The following terms should not be translated: -r</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
-        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <source>Unable to find type '{0}'. The type will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</target>
         <note>{0} - type
 The following terms should not be translated: -L</note>
       </trans-unit>
@@ -315,14 +315,14 @@ The following terms should not be translated: -L</note>
         <note>{0} - type, {1} - assembly name. The following terms should not be translated: -f. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
-        <target state="new">Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <source>Unable to find definition of method '{0}' in assembly metadata. It will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find definition of method '{0}' in assembly metadata. It will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</target>
         <note>{0} - method
 The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</source>
-        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</target>
+        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the directory containing mscorlib is provided with the -L option.</source>
+        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the directory containing mscorlib is provided with the -L option.</target>
         <note>The following terms should not be translated: -L</note>
       </trans-unit>
     </body>

--- a/src/Java.Interop.Localization/xlf/Resources.es.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.es.xlf
@@ -263,6 +263,81 @@ Name, com.example.MyClass.</note>
         <target state="new">Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</target>
         <note>{0} - Kotlin method name.</note>
       </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4001">
+        <source>Unable to preload reference '{0}'.</source>
+        <target state="new">Unable to preload reference '{0}'.</target>
+        <note>{0} - assembly path</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4002">
+        <source>Please specify at least one ASSEMBLY to process.</source>
+        <target state="new">Please specify at least one ASSEMBLY to process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4003">
+        <source>Unable to create Java VM{0}{1}</source>
+        <target state="new">Unable to create Java VM{0}{1}</target>
+        <note>{0} - newline, {1} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4004">
+        <source>Unable to read profile '{0}'.{1}{2}</source>
+        <target state="new">Unable to read profile '{0}'.{1}{2}</target>
+        <note>{0} - path, {1} - newline, {2} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4005">
+        <source>Path '{0}' does not exist.</source>
+        <target state="new">Path '{0}' does not exist.</target>
+        <note>{0} - path</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4006">
+        <source>Unable to process assembly '{0}'{1}{2}{1}{3}</source>
+        <target state="new">Unable to process assembly '{0}'{1}{2}{1}{3}</target>
+        <note>{0} - assembly, {1} - newline, {2} - exception message, {3} exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8001">
+        <source>Couln't find interface {0}</source>
+        <target state="new">Couln't find interface {0}</target>
+        <note>{0} - interface name</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8002">
+        <source>Unable to read assembly '{0}' with symbols. Retrying to load it without them.</source>
+        <target state="new">Unable to read assembly '{0}' with symbols. Retrying to load it without them.</target>
+        <note>{0} - assembly</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8003">
+        <source>Type Load exception{0}{1}</source>
+        <target state="new">Type Load exception{0}{1}</target>
+        <note>{0} - newline, {1} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8004">
+        <source>Unable to find cecil's TypeDefinition of type {0}</source>
+        <target state="new">Unable to find cecil's TypeDefinition of type {0}</target>
+        <note>{0} - type</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8005">
+        <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
+        <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
+        <note>{0} - type, {1} - assembly name</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8006">
+        <source>Unable to find cecil's MethodDefinition of method {0}</source>
+        <target state="new">Unable to find cecil's MethodDefinition of method {0}</target>
+        <note>{0} - method</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8007">
+        <source>Unable to find System.Console::WriteLine method. Disabling debug injection.</source>
+        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8008">
+        <source>No type was moved =&gt; nothing to write, no new assembly created.</source>
+        <target state="new">No type was moved =&gt; nothing to write, no new assembly created.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8009">
+        <source>Method {0} was not improved. There should have been at least 2 improvements in this registration method.</source>
+        <target state="new">Method {0} was not improved. There should have been at least 2 improvements in this registration method.</target>
+        <note>{0} - method</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Java.Interop.Localization/xlf/Resources.es.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.es.xlf
@@ -311,7 +311,7 @@ Name, com.example.MyClass.</note>
       <trans-unit id="JniMarshalMethodGen_JM8005">
         <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
         <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
-        <note>{0} - type, {1} - assembly name</note>
+        <note>{0} - type, {1} - assembly name. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
         <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>

--- a/src/Java.Interop.Localization/xlf/Resources.es.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.es.xlf
@@ -271,7 +271,7 @@ Name, com.example.MyClass.</note>
       <trans-unit id="JniMarshalMethodGen_JM4002">
         <source>Please specify at least one ASSEMBLY to process.</source>
         <target state="new">Please specify at least one ASSEMBLY to process.</target>
-        <note />
+        <note>The following terms should not be translated or have any capitalization changes: ASSEMBLY. This is a special case for this particular message. In most messages, "assembly" would be translated.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4003">
         <source>Unable to create Java VM{0}{1}</source>
@@ -279,9 +279,9 @@ Name, com.example.MyClass.</note>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4004">
-        <source>Unable to read profile '{0}'.{1}{2}</source>
-        <target state="new">Unable to read profile '{0}'.{1}{2}</target>
-        <note>{0} - path, {1} - newline, {2} - exception</note>
+        <source>Unable to read profile file '{0}'.{1}{2}</source>
+        <target state="new">Unable to read profile file '{0}'.{1}{2}</target>
+        <note>{0} - path, {1} - newline, {2} - exception. In this message, the term "profile" refers to a customized list of types to process.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4005">
         <source>Path '{0}' does not exist.</source>
@@ -297,11 +297,6 @@ Name, com.example.MyClass.</note>
         <source>Couln't find interface {0}</source>
         <target state="new">Couln't find interface {0}</target>
         <note>{0} - interface name</note>
-      </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8002">
-        <source>Unable to read assembly '{0}' with symbols. Retrying to load it without them.</source>
-        <target state="new">Unable to read assembly '{0}' with symbols. Retrying to load it without them.</target>
-        <note>{0} - assembly</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
         <source>Type Load exception{0}{1}</source>

--- a/src/Java.Interop.Localization/xlf/Resources.es.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.es.xlf
@@ -299,29 +299,31 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</source>
-        <target state="new">Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</target>
+        <source>Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</source>
+        <target state="new">Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</target>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
-        <target state="new">Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
-        <note>{0} - type</note>
+        <source>Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <note>{0} - type
+The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8005">
         <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
         <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
-        <note>{0} - type, {1} - assembly name. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
+        <note>{0} - type, {1} - assembly name. The following terms should not be translated: -f. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
-        <target state="new">Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
-        <note>{0} - method</note>
+        <source>Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <note>{0} - method
+The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</source>
-        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
-        <note />
+        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</source>
+        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</target>
+        <note>The following terms should not be translated: -L</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Java.Interop.Localization/xlf/Resources.es.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.es.xlf
@@ -299,13 +299,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Type Load exception{0}{1}</source>
-        <target state="new">Type Load exception{0}{1}</target>
+        <source>Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</source>
+        <target state="new">Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</target>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find cecil's TypeDefinition of type {0}</source>
-        <target state="new">Unable to find cecil's TypeDefinition of type {0}</target>
+        <source>Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
+        <target state="new">Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
         <note>{0} - type</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8005">
@@ -314,18 +314,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - type, {1} - assembly name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find cecil's MethodDefinition of method {0}</source>
-        <target state="new">Unable to find cecil's MethodDefinition of method {0}</target>
+        <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
+        <target state="new">Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
         <note>{0} - method</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find System.Console::WriteLine method. Disabling debug injection.</source>
-        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8008">
-        <source>No type was moved =&gt; nothing to write, no new assembly created.</source>
-        <target state="new">No type was moved =&gt; nothing to write, no new assembly created.</target>
+        <source>Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</source>
+        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
         <note />
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8009">

--- a/src/Java.Interop.Localization/xlf/Resources.es.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.es.xlf
@@ -323,11 +323,6 @@ Name, com.example.MyClass.</note>
         <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
         <note />
       </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8009">
-        <source>Method {0} was not improved. There should have been at least 2 improvements in this registration method.</source>
-        <target state="new">Method {0} was not improved. There should have been at least 2 improvements in this registration method.</target>
-        <note>{0} - method</note>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Java.Interop.Localization/xlf/Resources.es.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.es.xlf
@@ -299,13 +299,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</source>
-        <target state="new">Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</target>
-        <note>{0} - newline, {1} - exception</note>
+        <source>Caught an exception while loading types. The types that cannot be loaded will not be processed. Make sure that any additional assembly references required for those types are provided using the -r option. Exception:{0}{1}</source>
+        <target state="new">Caught an exception while loading types. The types that cannot be loaded will not be processed. Make sure that any additional assembly references required for those types are provided using the -r option. Exception:{0}{1}</target>
+        <note>{0} - newline, {1} - exception. The following terms should not be translated: -r</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
-        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <source>Unable to find type '{0}'. The type will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</target>
         <note>{0} - type
 The following terms should not be translated: -L</note>
       </trans-unit>
@@ -315,14 +315,14 @@ The following terms should not be translated: -L</note>
         <note>{0} - type, {1} - assembly name. The following terms should not be translated: -f. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
-        <target state="new">Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <source>Unable to find definition of method '{0}' in assembly metadata. It will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find definition of method '{0}' in assembly metadata. It will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</target>
         <note>{0} - method
 The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</source>
-        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</target>
+        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the directory containing mscorlib is provided with the -L option.</source>
+        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the directory containing mscorlib is provided with the -L option.</target>
         <note>The following terms should not be translated: -L</note>
       </trans-unit>
     </body>

--- a/src/Java.Interop.Localization/xlf/Resources.fr.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.fr.xlf
@@ -263,6 +263,81 @@ Name, com.example.MyClass.</note>
         <target state="new">Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</target>
         <note>{0} - Kotlin method name.</note>
       </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4001">
+        <source>Unable to preload reference '{0}'.</source>
+        <target state="new">Unable to preload reference '{0}'.</target>
+        <note>{0} - assembly path</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4002">
+        <source>Please specify at least one ASSEMBLY to process.</source>
+        <target state="new">Please specify at least one ASSEMBLY to process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4003">
+        <source>Unable to create Java VM{0}{1}</source>
+        <target state="new">Unable to create Java VM{0}{1}</target>
+        <note>{0} - newline, {1} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4004">
+        <source>Unable to read profile '{0}'.{1}{2}</source>
+        <target state="new">Unable to read profile '{0}'.{1}{2}</target>
+        <note>{0} - path, {1} - newline, {2} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4005">
+        <source>Path '{0}' does not exist.</source>
+        <target state="new">Path '{0}' does not exist.</target>
+        <note>{0} - path</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4006">
+        <source>Unable to process assembly '{0}'{1}{2}{1}{3}</source>
+        <target state="new">Unable to process assembly '{0}'{1}{2}{1}{3}</target>
+        <note>{0} - assembly, {1} - newline, {2} - exception message, {3} exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8001">
+        <source>Couln't find interface {0}</source>
+        <target state="new">Couln't find interface {0}</target>
+        <note>{0} - interface name</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8002">
+        <source>Unable to read assembly '{0}' with symbols. Retrying to load it without them.</source>
+        <target state="new">Unable to read assembly '{0}' with symbols. Retrying to load it without them.</target>
+        <note>{0} - assembly</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8003">
+        <source>Type Load exception{0}{1}</source>
+        <target state="new">Type Load exception{0}{1}</target>
+        <note>{0} - newline, {1} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8004">
+        <source>Unable to find cecil's TypeDefinition of type {0}</source>
+        <target state="new">Unable to find cecil's TypeDefinition of type {0}</target>
+        <note>{0} - type</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8005">
+        <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
+        <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
+        <note>{0} - type, {1} - assembly name</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8006">
+        <source>Unable to find cecil's MethodDefinition of method {0}</source>
+        <target state="new">Unable to find cecil's MethodDefinition of method {0}</target>
+        <note>{0} - method</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8007">
+        <source>Unable to find System.Console::WriteLine method. Disabling debug injection.</source>
+        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8008">
+        <source>No type was moved =&gt; nothing to write, no new assembly created.</source>
+        <target state="new">No type was moved =&gt; nothing to write, no new assembly created.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8009">
+        <source>Method {0} was not improved. There should have been at least 2 improvements in this registration method.</source>
+        <target state="new">Method {0} was not improved. There should have been at least 2 improvements in this registration method.</target>
+        <note>{0} - method</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Java.Interop.Localization/xlf/Resources.fr.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.fr.xlf
@@ -311,7 +311,7 @@ Name, com.example.MyClass.</note>
       <trans-unit id="JniMarshalMethodGen_JM8005">
         <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
         <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
-        <note>{0} - type, {1} - assembly name</note>
+        <note>{0} - type, {1} - assembly name. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
         <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>

--- a/src/Java.Interop.Localization/xlf/Resources.fr.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.fr.xlf
@@ -271,7 +271,7 @@ Name, com.example.MyClass.</note>
       <trans-unit id="JniMarshalMethodGen_JM4002">
         <source>Please specify at least one ASSEMBLY to process.</source>
         <target state="new">Please specify at least one ASSEMBLY to process.</target>
-        <note />
+        <note>The following terms should not be translated or have any capitalization changes: ASSEMBLY. This is a special case for this particular message. In most messages, "assembly" would be translated.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4003">
         <source>Unable to create Java VM{0}{1}</source>
@@ -279,9 +279,9 @@ Name, com.example.MyClass.</note>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4004">
-        <source>Unable to read profile '{0}'.{1}{2}</source>
-        <target state="new">Unable to read profile '{0}'.{1}{2}</target>
-        <note>{0} - path, {1} - newline, {2} - exception</note>
+        <source>Unable to read profile file '{0}'.{1}{2}</source>
+        <target state="new">Unable to read profile file '{0}'.{1}{2}</target>
+        <note>{0} - path, {1} - newline, {2} - exception. In this message, the term "profile" refers to a customized list of types to process.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4005">
         <source>Path '{0}' does not exist.</source>
@@ -297,11 +297,6 @@ Name, com.example.MyClass.</note>
         <source>Couln't find interface {0}</source>
         <target state="new">Couln't find interface {0}</target>
         <note>{0} - interface name</note>
-      </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8002">
-        <source>Unable to read assembly '{0}' with symbols. Retrying to load it without them.</source>
-        <target state="new">Unable to read assembly '{0}' with symbols. Retrying to load it without them.</target>
-        <note>{0} - assembly</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
         <source>Type Load exception{0}{1}</source>

--- a/src/Java.Interop.Localization/xlf/Resources.fr.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.fr.xlf
@@ -299,29 +299,31 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</source>
-        <target state="new">Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</target>
+        <source>Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</source>
+        <target state="new">Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</target>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
-        <target state="new">Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
-        <note>{0} - type</note>
+        <source>Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <note>{0} - type
+The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8005">
         <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
         <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
-        <note>{0} - type, {1} - assembly name. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
+        <note>{0} - type, {1} - assembly name. The following terms should not be translated: -f. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
-        <target state="new">Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
-        <note>{0} - method</note>
+        <source>Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <note>{0} - method
+The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</source>
-        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
-        <note />
+        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</source>
+        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</target>
+        <note>The following terms should not be translated: -L</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Java.Interop.Localization/xlf/Resources.fr.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.fr.xlf
@@ -299,13 +299,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Type Load exception{0}{1}</source>
-        <target state="new">Type Load exception{0}{1}</target>
+        <source>Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</source>
+        <target state="new">Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</target>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find cecil's TypeDefinition of type {0}</source>
-        <target state="new">Unable to find cecil's TypeDefinition of type {0}</target>
+        <source>Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
+        <target state="new">Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
         <note>{0} - type</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8005">
@@ -314,18 +314,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - type, {1} - assembly name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find cecil's MethodDefinition of method {0}</source>
-        <target state="new">Unable to find cecil's MethodDefinition of method {0}</target>
+        <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
+        <target state="new">Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
         <note>{0} - method</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find System.Console::WriteLine method. Disabling debug injection.</source>
-        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8008">
-        <source>No type was moved =&gt; nothing to write, no new assembly created.</source>
-        <target state="new">No type was moved =&gt; nothing to write, no new assembly created.</target>
+        <source>Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</source>
+        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
         <note />
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8009">

--- a/src/Java.Interop.Localization/xlf/Resources.fr.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.fr.xlf
@@ -323,11 +323,6 @@ Name, com.example.MyClass.</note>
         <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
         <note />
       </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8009">
-        <source>Method {0} was not improved. There should have been at least 2 improvements in this registration method.</source>
-        <target state="new">Method {0} was not improved. There should have been at least 2 improvements in this registration method.</target>
-        <note>{0} - method</note>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Java.Interop.Localization/xlf/Resources.fr.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.fr.xlf
@@ -299,13 +299,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</source>
-        <target state="new">Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</target>
-        <note>{0} - newline, {1} - exception</note>
+        <source>Caught an exception while loading types. The types that cannot be loaded will not be processed. Make sure that any additional assembly references required for those types are provided using the -r option. Exception:{0}{1}</source>
+        <target state="new">Caught an exception while loading types. The types that cannot be loaded will not be processed. Make sure that any additional assembly references required for those types are provided using the -r option. Exception:{0}{1}</target>
+        <note>{0} - newline, {1} - exception. The following terms should not be translated: -r</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
-        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <source>Unable to find type '{0}'. The type will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</target>
         <note>{0} - type
 The following terms should not be translated: -L</note>
       </trans-unit>
@@ -315,14 +315,14 @@ The following terms should not be translated: -L</note>
         <note>{0} - type, {1} - assembly name. The following terms should not be translated: -f. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
-        <target state="new">Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <source>Unable to find definition of method '{0}' in assembly metadata. It will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find definition of method '{0}' in assembly metadata. It will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</target>
         <note>{0} - method
 The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</source>
-        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</target>
+        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the directory containing mscorlib is provided with the -L option.</source>
+        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the directory containing mscorlib is provided with the -L option.</target>
         <note>The following terms should not be translated: -L</note>
       </trans-unit>
     </body>

--- a/src/Java.Interop.Localization/xlf/Resources.it.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.it.xlf
@@ -263,6 +263,81 @@ Name, com.example.MyClass.</note>
         <target state="new">Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</target>
         <note>{0} - Kotlin method name.</note>
       </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4001">
+        <source>Unable to preload reference '{0}'.</source>
+        <target state="new">Unable to preload reference '{0}'.</target>
+        <note>{0} - assembly path</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4002">
+        <source>Please specify at least one ASSEMBLY to process.</source>
+        <target state="new">Please specify at least one ASSEMBLY to process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4003">
+        <source>Unable to create Java VM{0}{1}</source>
+        <target state="new">Unable to create Java VM{0}{1}</target>
+        <note>{0} - newline, {1} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4004">
+        <source>Unable to read profile '{0}'.{1}{2}</source>
+        <target state="new">Unable to read profile '{0}'.{1}{2}</target>
+        <note>{0} - path, {1} - newline, {2} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4005">
+        <source>Path '{0}' does not exist.</source>
+        <target state="new">Path '{0}' does not exist.</target>
+        <note>{0} - path</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4006">
+        <source>Unable to process assembly '{0}'{1}{2}{1}{3}</source>
+        <target state="new">Unable to process assembly '{0}'{1}{2}{1}{3}</target>
+        <note>{0} - assembly, {1} - newline, {2} - exception message, {3} exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8001">
+        <source>Couln't find interface {0}</source>
+        <target state="new">Couln't find interface {0}</target>
+        <note>{0} - interface name</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8002">
+        <source>Unable to read assembly '{0}' with symbols. Retrying to load it without them.</source>
+        <target state="new">Unable to read assembly '{0}' with symbols. Retrying to load it without them.</target>
+        <note>{0} - assembly</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8003">
+        <source>Type Load exception{0}{1}</source>
+        <target state="new">Type Load exception{0}{1}</target>
+        <note>{0} - newline, {1} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8004">
+        <source>Unable to find cecil's TypeDefinition of type {0}</source>
+        <target state="new">Unable to find cecil's TypeDefinition of type {0}</target>
+        <note>{0} - type</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8005">
+        <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
+        <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
+        <note>{0} - type, {1} - assembly name</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8006">
+        <source>Unable to find cecil's MethodDefinition of method {0}</source>
+        <target state="new">Unable to find cecil's MethodDefinition of method {0}</target>
+        <note>{0} - method</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8007">
+        <source>Unable to find System.Console::WriteLine method. Disabling debug injection.</source>
+        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8008">
+        <source>No type was moved =&gt; nothing to write, no new assembly created.</source>
+        <target state="new">No type was moved =&gt; nothing to write, no new assembly created.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8009">
+        <source>Method {0} was not improved. There should have been at least 2 improvements in this registration method.</source>
+        <target state="new">Method {0} was not improved. There should have been at least 2 improvements in this registration method.</target>
+        <note>{0} - method</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Java.Interop.Localization/xlf/Resources.it.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.it.xlf
@@ -311,7 +311,7 @@ Name, com.example.MyClass.</note>
       <trans-unit id="JniMarshalMethodGen_JM8005">
         <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
         <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
-        <note>{0} - type, {1} - assembly name</note>
+        <note>{0} - type, {1} - assembly name. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
         <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>

--- a/src/Java.Interop.Localization/xlf/Resources.it.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.it.xlf
@@ -271,7 +271,7 @@ Name, com.example.MyClass.</note>
       <trans-unit id="JniMarshalMethodGen_JM4002">
         <source>Please specify at least one ASSEMBLY to process.</source>
         <target state="new">Please specify at least one ASSEMBLY to process.</target>
-        <note />
+        <note>The following terms should not be translated or have any capitalization changes: ASSEMBLY. This is a special case for this particular message. In most messages, "assembly" would be translated.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4003">
         <source>Unable to create Java VM{0}{1}</source>
@@ -279,9 +279,9 @@ Name, com.example.MyClass.</note>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4004">
-        <source>Unable to read profile '{0}'.{1}{2}</source>
-        <target state="new">Unable to read profile '{0}'.{1}{2}</target>
-        <note>{0} - path, {1} - newline, {2} - exception</note>
+        <source>Unable to read profile file '{0}'.{1}{2}</source>
+        <target state="new">Unable to read profile file '{0}'.{1}{2}</target>
+        <note>{0} - path, {1} - newline, {2} - exception. In this message, the term "profile" refers to a customized list of types to process.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4005">
         <source>Path '{0}' does not exist.</source>
@@ -297,11 +297,6 @@ Name, com.example.MyClass.</note>
         <source>Couln't find interface {0}</source>
         <target state="new">Couln't find interface {0}</target>
         <note>{0} - interface name</note>
-      </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8002">
-        <source>Unable to read assembly '{0}' with symbols. Retrying to load it without them.</source>
-        <target state="new">Unable to read assembly '{0}' with symbols. Retrying to load it without them.</target>
-        <note>{0} - assembly</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
         <source>Type Load exception{0}{1}</source>

--- a/src/Java.Interop.Localization/xlf/Resources.it.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.it.xlf
@@ -299,29 +299,31 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</source>
-        <target state="new">Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</target>
+        <source>Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</source>
+        <target state="new">Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</target>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
-        <target state="new">Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
-        <note>{0} - type</note>
+        <source>Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <note>{0} - type
+The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8005">
         <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
         <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
-        <note>{0} - type, {1} - assembly name. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
+        <note>{0} - type, {1} - assembly name. The following terms should not be translated: -f. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
-        <target state="new">Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
-        <note>{0} - method</note>
+        <source>Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <note>{0} - method
+The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</source>
-        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
-        <note />
+        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</source>
+        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</target>
+        <note>The following terms should not be translated: -L</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Java.Interop.Localization/xlf/Resources.it.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.it.xlf
@@ -299,13 +299,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Type Load exception{0}{1}</source>
-        <target state="new">Type Load exception{0}{1}</target>
+        <source>Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</source>
+        <target state="new">Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</target>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find cecil's TypeDefinition of type {0}</source>
-        <target state="new">Unable to find cecil's TypeDefinition of type {0}</target>
+        <source>Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
+        <target state="new">Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
         <note>{0} - type</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8005">
@@ -314,18 +314,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - type, {1} - assembly name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find cecil's MethodDefinition of method {0}</source>
-        <target state="new">Unable to find cecil's MethodDefinition of method {0}</target>
+        <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
+        <target state="new">Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
         <note>{0} - method</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find System.Console::WriteLine method. Disabling debug injection.</source>
-        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8008">
-        <source>No type was moved =&gt; nothing to write, no new assembly created.</source>
-        <target state="new">No type was moved =&gt; nothing to write, no new assembly created.</target>
+        <source>Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</source>
+        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
         <note />
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8009">

--- a/src/Java.Interop.Localization/xlf/Resources.it.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.it.xlf
@@ -323,11 +323,6 @@ Name, com.example.MyClass.</note>
         <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
         <note />
       </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8009">
-        <source>Method {0} was not improved. There should have been at least 2 improvements in this registration method.</source>
-        <target state="new">Method {0} was not improved. There should have been at least 2 improvements in this registration method.</target>
-        <note>{0} - method</note>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Java.Interop.Localization/xlf/Resources.it.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.it.xlf
@@ -299,13 +299,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</source>
-        <target state="new">Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</target>
-        <note>{0} - newline, {1} - exception</note>
+        <source>Caught an exception while loading types. The types that cannot be loaded will not be processed. Make sure that any additional assembly references required for those types are provided using the -r option. Exception:{0}{1}</source>
+        <target state="new">Caught an exception while loading types. The types that cannot be loaded will not be processed. Make sure that any additional assembly references required for those types are provided using the -r option. Exception:{0}{1}</target>
+        <note>{0} - newline, {1} - exception. The following terms should not be translated: -r</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
-        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <source>Unable to find type '{0}'. The type will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</target>
         <note>{0} - type
 The following terms should not be translated: -L</note>
       </trans-unit>
@@ -315,14 +315,14 @@ The following terms should not be translated: -L</note>
         <note>{0} - type, {1} - assembly name. The following terms should not be translated: -f. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
-        <target state="new">Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <source>Unable to find definition of method '{0}' in assembly metadata. It will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find definition of method '{0}' in assembly metadata. It will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</target>
         <note>{0} - method
 The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</source>
-        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</target>
+        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the directory containing mscorlib is provided with the -L option.</source>
+        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the directory containing mscorlib is provided with the -L option.</target>
         <note>The following terms should not be translated: -L</note>
       </trans-unit>
     </body>

--- a/src/Java.Interop.Localization/xlf/Resources.ja.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.ja.xlf
@@ -263,6 +263,81 @@ Name, com.example.MyClass.</note>
         <target state="new">Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</target>
         <note>{0} - Kotlin method name.</note>
       </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4001">
+        <source>Unable to preload reference '{0}'.</source>
+        <target state="new">Unable to preload reference '{0}'.</target>
+        <note>{0} - assembly path</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4002">
+        <source>Please specify at least one ASSEMBLY to process.</source>
+        <target state="new">Please specify at least one ASSEMBLY to process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4003">
+        <source>Unable to create Java VM{0}{1}</source>
+        <target state="new">Unable to create Java VM{0}{1}</target>
+        <note>{0} - newline, {1} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4004">
+        <source>Unable to read profile '{0}'.{1}{2}</source>
+        <target state="new">Unable to read profile '{0}'.{1}{2}</target>
+        <note>{0} - path, {1} - newline, {2} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4005">
+        <source>Path '{0}' does not exist.</source>
+        <target state="new">Path '{0}' does not exist.</target>
+        <note>{0} - path</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4006">
+        <source>Unable to process assembly '{0}'{1}{2}{1}{3}</source>
+        <target state="new">Unable to process assembly '{0}'{1}{2}{1}{3}</target>
+        <note>{0} - assembly, {1} - newline, {2} - exception message, {3} exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8001">
+        <source>Couln't find interface {0}</source>
+        <target state="new">Couln't find interface {0}</target>
+        <note>{0} - interface name</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8002">
+        <source>Unable to read assembly '{0}' with symbols. Retrying to load it without them.</source>
+        <target state="new">Unable to read assembly '{0}' with symbols. Retrying to load it without them.</target>
+        <note>{0} - assembly</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8003">
+        <source>Type Load exception{0}{1}</source>
+        <target state="new">Type Load exception{0}{1}</target>
+        <note>{0} - newline, {1} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8004">
+        <source>Unable to find cecil's TypeDefinition of type {0}</source>
+        <target state="new">Unable to find cecil's TypeDefinition of type {0}</target>
+        <note>{0} - type</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8005">
+        <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
+        <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
+        <note>{0} - type, {1} - assembly name</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8006">
+        <source>Unable to find cecil's MethodDefinition of method {0}</source>
+        <target state="new">Unable to find cecil's MethodDefinition of method {0}</target>
+        <note>{0} - method</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8007">
+        <source>Unable to find System.Console::WriteLine method. Disabling debug injection.</source>
+        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8008">
+        <source>No type was moved =&gt; nothing to write, no new assembly created.</source>
+        <target state="new">No type was moved =&gt; nothing to write, no new assembly created.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8009">
+        <source>Method {0} was not improved. There should have been at least 2 improvements in this registration method.</source>
+        <target state="new">Method {0} was not improved. There should have been at least 2 improvements in this registration method.</target>
+        <note>{0} - method</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Java.Interop.Localization/xlf/Resources.ja.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.ja.xlf
@@ -311,7 +311,7 @@ Name, com.example.MyClass.</note>
       <trans-unit id="JniMarshalMethodGen_JM8005">
         <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
         <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
-        <note>{0} - type, {1} - assembly name</note>
+        <note>{0} - type, {1} - assembly name. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
         <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>

--- a/src/Java.Interop.Localization/xlf/Resources.ja.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.ja.xlf
@@ -271,7 +271,7 @@ Name, com.example.MyClass.</note>
       <trans-unit id="JniMarshalMethodGen_JM4002">
         <source>Please specify at least one ASSEMBLY to process.</source>
         <target state="new">Please specify at least one ASSEMBLY to process.</target>
-        <note />
+        <note>The following terms should not be translated or have any capitalization changes: ASSEMBLY. This is a special case for this particular message. In most messages, "assembly" would be translated.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4003">
         <source>Unable to create Java VM{0}{1}</source>
@@ -279,9 +279,9 @@ Name, com.example.MyClass.</note>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4004">
-        <source>Unable to read profile '{0}'.{1}{2}</source>
-        <target state="new">Unable to read profile '{0}'.{1}{2}</target>
-        <note>{0} - path, {1} - newline, {2} - exception</note>
+        <source>Unable to read profile file '{0}'.{1}{2}</source>
+        <target state="new">Unable to read profile file '{0}'.{1}{2}</target>
+        <note>{0} - path, {1} - newline, {2} - exception. In this message, the term "profile" refers to a customized list of types to process.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4005">
         <source>Path '{0}' does not exist.</source>
@@ -297,11 +297,6 @@ Name, com.example.MyClass.</note>
         <source>Couln't find interface {0}</source>
         <target state="new">Couln't find interface {0}</target>
         <note>{0} - interface name</note>
-      </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8002">
-        <source>Unable to read assembly '{0}' with symbols. Retrying to load it without them.</source>
-        <target state="new">Unable to read assembly '{0}' with symbols. Retrying to load it without them.</target>
-        <note>{0} - assembly</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
         <source>Type Load exception{0}{1}</source>

--- a/src/Java.Interop.Localization/xlf/Resources.ja.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.ja.xlf
@@ -299,29 +299,31 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</source>
-        <target state="new">Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</target>
+        <source>Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</source>
+        <target state="new">Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</target>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
-        <target state="new">Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
-        <note>{0} - type</note>
+        <source>Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <note>{0} - type
+The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8005">
         <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
         <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
-        <note>{0} - type, {1} - assembly name. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
+        <note>{0} - type, {1} - assembly name. The following terms should not be translated: -f. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
-        <target state="new">Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
-        <note>{0} - method</note>
+        <source>Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <note>{0} - method
+The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</source>
-        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
-        <note />
+        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</source>
+        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</target>
+        <note>The following terms should not be translated: -L</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Java.Interop.Localization/xlf/Resources.ja.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.ja.xlf
@@ -299,13 +299,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Type Load exception{0}{1}</source>
-        <target state="new">Type Load exception{0}{1}</target>
+        <source>Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</source>
+        <target state="new">Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</target>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find cecil's TypeDefinition of type {0}</source>
-        <target state="new">Unable to find cecil's TypeDefinition of type {0}</target>
+        <source>Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
+        <target state="new">Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
         <note>{0} - type</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8005">
@@ -314,18 +314,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - type, {1} - assembly name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find cecil's MethodDefinition of method {0}</source>
-        <target state="new">Unable to find cecil's MethodDefinition of method {0}</target>
+        <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
+        <target state="new">Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
         <note>{0} - method</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find System.Console::WriteLine method. Disabling debug injection.</source>
-        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8008">
-        <source>No type was moved =&gt; nothing to write, no new assembly created.</source>
-        <target state="new">No type was moved =&gt; nothing to write, no new assembly created.</target>
+        <source>Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</source>
+        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
         <note />
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8009">

--- a/src/Java.Interop.Localization/xlf/Resources.ja.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.ja.xlf
@@ -323,11 +323,6 @@ Name, com.example.MyClass.</note>
         <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
         <note />
       </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8009">
-        <source>Method {0} was not improved. There should have been at least 2 improvements in this registration method.</source>
-        <target state="new">Method {0} was not improved. There should have been at least 2 improvements in this registration method.</target>
-        <note>{0} - method</note>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Java.Interop.Localization/xlf/Resources.ja.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.ja.xlf
@@ -299,13 +299,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</source>
-        <target state="new">Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</target>
-        <note>{0} - newline, {1} - exception</note>
+        <source>Caught an exception while loading types. The types that cannot be loaded will not be processed. Make sure that any additional assembly references required for those types are provided using the -r option. Exception:{0}{1}</source>
+        <target state="new">Caught an exception while loading types. The types that cannot be loaded will not be processed. Make sure that any additional assembly references required for those types are provided using the -r option. Exception:{0}{1}</target>
+        <note>{0} - newline, {1} - exception. The following terms should not be translated: -r</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
-        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <source>Unable to find type '{0}'. The type will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</target>
         <note>{0} - type
 The following terms should not be translated: -L</note>
       </trans-unit>
@@ -315,14 +315,14 @@ The following terms should not be translated: -L</note>
         <note>{0} - type, {1} - assembly name. The following terms should not be translated: -f. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
-        <target state="new">Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <source>Unable to find definition of method '{0}' in assembly metadata. It will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find definition of method '{0}' in assembly metadata. It will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</target>
         <note>{0} - method
 The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</source>
-        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</target>
+        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the directory containing mscorlib is provided with the -L option.</source>
+        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the directory containing mscorlib is provided with the -L option.</target>
         <note>The following terms should not be translated: -L</note>
       </trans-unit>
     </body>

--- a/src/Java.Interop.Localization/xlf/Resources.ko.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.ko.xlf
@@ -263,6 +263,81 @@ Name, com.example.MyClass.</note>
         <target state="new">Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</target>
         <note>{0} - Kotlin method name.</note>
       </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4001">
+        <source>Unable to preload reference '{0}'.</source>
+        <target state="new">Unable to preload reference '{0}'.</target>
+        <note>{0} - assembly path</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4002">
+        <source>Please specify at least one ASSEMBLY to process.</source>
+        <target state="new">Please specify at least one ASSEMBLY to process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4003">
+        <source>Unable to create Java VM{0}{1}</source>
+        <target state="new">Unable to create Java VM{0}{1}</target>
+        <note>{0} - newline, {1} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4004">
+        <source>Unable to read profile '{0}'.{1}{2}</source>
+        <target state="new">Unable to read profile '{0}'.{1}{2}</target>
+        <note>{0} - path, {1} - newline, {2} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4005">
+        <source>Path '{0}' does not exist.</source>
+        <target state="new">Path '{0}' does not exist.</target>
+        <note>{0} - path</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4006">
+        <source>Unable to process assembly '{0}'{1}{2}{1}{3}</source>
+        <target state="new">Unable to process assembly '{0}'{1}{2}{1}{3}</target>
+        <note>{0} - assembly, {1} - newline, {2} - exception message, {3} exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8001">
+        <source>Couln't find interface {0}</source>
+        <target state="new">Couln't find interface {0}</target>
+        <note>{0} - interface name</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8002">
+        <source>Unable to read assembly '{0}' with symbols. Retrying to load it without them.</source>
+        <target state="new">Unable to read assembly '{0}' with symbols. Retrying to load it without them.</target>
+        <note>{0} - assembly</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8003">
+        <source>Type Load exception{0}{1}</source>
+        <target state="new">Type Load exception{0}{1}</target>
+        <note>{0} - newline, {1} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8004">
+        <source>Unable to find cecil's TypeDefinition of type {0}</source>
+        <target state="new">Unable to find cecil's TypeDefinition of type {0}</target>
+        <note>{0} - type</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8005">
+        <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
+        <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
+        <note>{0} - type, {1} - assembly name</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8006">
+        <source>Unable to find cecil's MethodDefinition of method {0}</source>
+        <target state="new">Unable to find cecil's MethodDefinition of method {0}</target>
+        <note>{0} - method</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8007">
+        <source>Unable to find System.Console::WriteLine method. Disabling debug injection.</source>
+        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8008">
+        <source>No type was moved =&gt; nothing to write, no new assembly created.</source>
+        <target state="new">No type was moved =&gt; nothing to write, no new assembly created.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8009">
+        <source>Method {0} was not improved. There should have been at least 2 improvements in this registration method.</source>
+        <target state="new">Method {0} was not improved. There should have been at least 2 improvements in this registration method.</target>
+        <note>{0} - method</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Java.Interop.Localization/xlf/Resources.ko.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.ko.xlf
@@ -311,7 +311,7 @@ Name, com.example.MyClass.</note>
       <trans-unit id="JniMarshalMethodGen_JM8005">
         <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
         <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
-        <note>{0} - type, {1} - assembly name</note>
+        <note>{0} - type, {1} - assembly name. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
         <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>

--- a/src/Java.Interop.Localization/xlf/Resources.ko.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.ko.xlf
@@ -271,7 +271,7 @@ Name, com.example.MyClass.</note>
       <trans-unit id="JniMarshalMethodGen_JM4002">
         <source>Please specify at least one ASSEMBLY to process.</source>
         <target state="new">Please specify at least one ASSEMBLY to process.</target>
-        <note />
+        <note>The following terms should not be translated or have any capitalization changes: ASSEMBLY. This is a special case for this particular message. In most messages, "assembly" would be translated.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4003">
         <source>Unable to create Java VM{0}{1}</source>
@@ -279,9 +279,9 @@ Name, com.example.MyClass.</note>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4004">
-        <source>Unable to read profile '{0}'.{1}{2}</source>
-        <target state="new">Unable to read profile '{0}'.{1}{2}</target>
-        <note>{0} - path, {1} - newline, {2} - exception</note>
+        <source>Unable to read profile file '{0}'.{1}{2}</source>
+        <target state="new">Unable to read profile file '{0}'.{1}{2}</target>
+        <note>{0} - path, {1} - newline, {2} - exception. In this message, the term "profile" refers to a customized list of types to process.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4005">
         <source>Path '{0}' does not exist.</source>
@@ -297,11 +297,6 @@ Name, com.example.MyClass.</note>
         <source>Couln't find interface {0}</source>
         <target state="new">Couln't find interface {0}</target>
         <note>{0} - interface name</note>
-      </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8002">
-        <source>Unable to read assembly '{0}' with symbols. Retrying to load it without them.</source>
-        <target state="new">Unable to read assembly '{0}' with symbols. Retrying to load it without them.</target>
-        <note>{0} - assembly</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
         <source>Type Load exception{0}{1}</source>

--- a/src/Java.Interop.Localization/xlf/Resources.ko.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.ko.xlf
@@ -299,29 +299,31 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</source>
-        <target state="new">Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</target>
+        <source>Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</source>
+        <target state="new">Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</target>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
-        <target state="new">Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
-        <note>{0} - type</note>
+        <source>Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <note>{0} - type
+The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8005">
         <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
         <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
-        <note>{0} - type, {1} - assembly name. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
+        <note>{0} - type, {1} - assembly name. The following terms should not be translated: -f. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
-        <target state="new">Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
-        <note>{0} - method</note>
+        <source>Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <note>{0} - method
+The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</source>
-        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
-        <note />
+        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</source>
+        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</target>
+        <note>The following terms should not be translated: -L</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Java.Interop.Localization/xlf/Resources.ko.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.ko.xlf
@@ -299,13 +299,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Type Load exception{0}{1}</source>
-        <target state="new">Type Load exception{0}{1}</target>
+        <source>Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</source>
+        <target state="new">Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</target>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find cecil's TypeDefinition of type {0}</source>
-        <target state="new">Unable to find cecil's TypeDefinition of type {0}</target>
+        <source>Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
+        <target state="new">Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
         <note>{0} - type</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8005">
@@ -314,18 +314,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - type, {1} - assembly name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find cecil's MethodDefinition of method {0}</source>
-        <target state="new">Unable to find cecil's MethodDefinition of method {0}</target>
+        <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
+        <target state="new">Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
         <note>{0} - method</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find System.Console::WriteLine method. Disabling debug injection.</source>
-        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8008">
-        <source>No type was moved =&gt; nothing to write, no new assembly created.</source>
-        <target state="new">No type was moved =&gt; nothing to write, no new assembly created.</target>
+        <source>Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</source>
+        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
         <note />
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8009">

--- a/src/Java.Interop.Localization/xlf/Resources.ko.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.ko.xlf
@@ -323,11 +323,6 @@ Name, com.example.MyClass.</note>
         <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
         <note />
       </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8009">
-        <source>Method {0} was not improved. There should have been at least 2 improvements in this registration method.</source>
-        <target state="new">Method {0} was not improved. There should have been at least 2 improvements in this registration method.</target>
-        <note>{0} - method</note>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Java.Interop.Localization/xlf/Resources.ko.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.ko.xlf
@@ -299,13 +299,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</source>
-        <target state="new">Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</target>
-        <note>{0} - newline, {1} - exception</note>
+        <source>Caught an exception while loading types. The types that cannot be loaded will not be processed. Make sure that any additional assembly references required for those types are provided using the -r option. Exception:{0}{1}</source>
+        <target state="new">Caught an exception while loading types. The types that cannot be loaded will not be processed. Make sure that any additional assembly references required for those types are provided using the -r option. Exception:{0}{1}</target>
+        <note>{0} - newline, {1} - exception. The following terms should not be translated: -r</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
-        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <source>Unable to find type '{0}'. The type will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</target>
         <note>{0} - type
 The following terms should not be translated: -L</note>
       </trans-unit>
@@ -315,14 +315,14 @@ The following terms should not be translated: -L</note>
         <note>{0} - type, {1} - assembly name. The following terms should not be translated: -f. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
-        <target state="new">Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <source>Unable to find definition of method '{0}' in assembly metadata. It will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find definition of method '{0}' in assembly metadata. It will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</target>
         <note>{0} - method
 The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</source>
-        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</target>
+        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the directory containing mscorlib is provided with the -L option.</source>
+        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the directory containing mscorlib is provided with the -L option.</target>
         <note>The following terms should not be translated: -L</note>
       </trans-unit>
     </body>

--- a/src/Java.Interop.Localization/xlf/Resources.pl.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.pl.xlf
@@ -263,6 +263,81 @@ Name, com.example.MyClass.</note>
         <target state="new">Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</target>
         <note>{0} - Kotlin method name.</note>
       </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4001">
+        <source>Unable to preload reference '{0}'.</source>
+        <target state="new">Unable to preload reference '{0}'.</target>
+        <note>{0} - assembly path</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4002">
+        <source>Please specify at least one ASSEMBLY to process.</source>
+        <target state="new">Please specify at least one ASSEMBLY to process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4003">
+        <source>Unable to create Java VM{0}{1}</source>
+        <target state="new">Unable to create Java VM{0}{1}</target>
+        <note>{0} - newline, {1} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4004">
+        <source>Unable to read profile '{0}'.{1}{2}</source>
+        <target state="new">Unable to read profile '{0}'.{1}{2}</target>
+        <note>{0} - path, {1} - newline, {2} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4005">
+        <source>Path '{0}' does not exist.</source>
+        <target state="new">Path '{0}' does not exist.</target>
+        <note>{0} - path</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4006">
+        <source>Unable to process assembly '{0}'{1}{2}{1}{3}</source>
+        <target state="new">Unable to process assembly '{0}'{1}{2}{1}{3}</target>
+        <note>{0} - assembly, {1} - newline, {2} - exception message, {3} exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8001">
+        <source>Couln't find interface {0}</source>
+        <target state="new">Couln't find interface {0}</target>
+        <note>{0} - interface name</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8002">
+        <source>Unable to read assembly '{0}' with symbols. Retrying to load it without them.</source>
+        <target state="new">Unable to read assembly '{0}' with symbols. Retrying to load it without them.</target>
+        <note>{0} - assembly</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8003">
+        <source>Type Load exception{0}{1}</source>
+        <target state="new">Type Load exception{0}{1}</target>
+        <note>{0} - newline, {1} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8004">
+        <source>Unable to find cecil's TypeDefinition of type {0}</source>
+        <target state="new">Unable to find cecil's TypeDefinition of type {0}</target>
+        <note>{0} - type</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8005">
+        <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
+        <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
+        <note>{0} - type, {1} - assembly name</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8006">
+        <source>Unable to find cecil's MethodDefinition of method {0}</source>
+        <target state="new">Unable to find cecil's MethodDefinition of method {0}</target>
+        <note>{0} - method</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8007">
+        <source>Unable to find System.Console::WriteLine method. Disabling debug injection.</source>
+        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8008">
+        <source>No type was moved =&gt; nothing to write, no new assembly created.</source>
+        <target state="new">No type was moved =&gt; nothing to write, no new assembly created.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8009">
+        <source>Method {0} was not improved. There should have been at least 2 improvements in this registration method.</source>
+        <target state="new">Method {0} was not improved. There should have been at least 2 improvements in this registration method.</target>
+        <note>{0} - method</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Java.Interop.Localization/xlf/Resources.pl.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.pl.xlf
@@ -311,7 +311,7 @@ Name, com.example.MyClass.</note>
       <trans-unit id="JniMarshalMethodGen_JM8005">
         <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
         <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
-        <note>{0} - type, {1} - assembly name</note>
+        <note>{0} - type, {1} - assembly name. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
         <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>

--- a/src/Java.Interop.Localization/xlf/Resources.pl.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.pl.xlf
@@ -271,7 +271,7 @@ Name, com.example.MyClass.</note>
       <trans-unit id="JniMarshalMethodGen_JM4002">
         <source>Please specify at least one ASSEMBLY to process.</source>
         <target state="new">Please specify at least one ASSEMBLY to process.</target>
-        <note />
+        <note>The following terms should not be translated or have any capitalization changes: ASSEMBLY. This is a special case for this particular message. In most messages, "assembly" would be translated.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4003">
         <source>Unable to create Java VM{0}{1}</source>
@@ -279,9 +279,9 @@ Name, com.example.MyClass.</note>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4004">
-        <source>Unable to read profile '{0}'.{1}{2}</source>
-        <target state="new">Unable to read profile '{0}'.{1}{2}</target>
-        <note>{0} - path, {1} - newline, {2} - exception</note>
+        <source>Unable to read profile file '{0}'.{1}{2}</source>
+        <target state="new">Unable to read profile file '{0}'.{1}{2}</target>
+        <note>{0} - path, {1} - newline, {2} - exception. In this message, the term "profile" refers to a customized list of types to process.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4005">
         <source>Path '{0}' does not exist.</source>
@@ -297,11 +297,6 @@ Name, com.example.MyClass.</note>
         <source>Couln't find interface {0}</source>
         <target state="new">Couln't find interface {0}</target>
         <note>{0} - interface name</note>
-      </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8002">
-        <source>Unable to read assembly '{0}' with symbols. Retrying to load it without them.</source>
-        <target state="new">Unable to read assembly '{0}' with symbols. Retrying to load it without them.</target>
-        <note>{0} - assembly</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
         <source>Type Load exception{0}{1}</source>

--- a/src/Java.Interop.Localization/xlf/Resources.pl.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.pl.xlf
@@ -299,29 +299,31 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</source>
-        <target state="new">Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</target>
+        <source>Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</source>
+        <target state="new">Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</target>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
-        <target state="new">Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
-        <note>{0} - type</note>
+        <source>Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <note>{0} - type
+The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8005">
         <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
         <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
-        <note>{0} - type, {1} - assembly name. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
+        <note>{0} - type, {1} - assembly name. The following terms should not be translated: -f. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
-        <target state="new">Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
-        <note>{0} - method</note>
+        <source>Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <note>{0} - method
+The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</source>
-        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
-        <note />
+        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</source>
+        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</target>
+        <note>The following terms should not be translated: -L</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Java.Interop.Localization/xlf/Resources.pl.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.pl.xlf
@@ -299,13 +299,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Type Load exception{0}{1}</source>
-        <target state="new">Type Load exception{0}{1}</target>
+        <source>Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</source>
+        <target state="new">Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</target>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find cecil's TypeDefinition of type {0}</source>
-        <target state="new">Unable to find cecil's TypeDefinition of type {0}</target>
+        <source>Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
+        <target state="new">Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
         <note>{0} - type</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8005">
@@ -314,18 +314,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - type, {1} - assembly name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find cecil's MethodDefinition of method {0}</source>
-        <target state="new">Unable to find cecil's MethodDefinition of method {0}</target>
+        <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
+        <target state="new">Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
         <note>{0} - method</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find System.Console::WriteLine method. Disabling debug injection.</source>
-        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8008">
-        <source>No type was moved =&gt; nothing to write, no new assembly created.</source>
-        <target state="new">No type was moved =&gt; nothing to write, no new assembly created.</target>
+        <source>Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</source>
+        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
         <note />
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8009">

--- a/src/Java.Interop.Localization/xlf/Resources.pl.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.pl.xlf
@@ -323,11 +323,6 @@ Name, com.example.MyClass.</note>
         <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
         <note />
       </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8009">
-        <source>Method {0} was not improved. There should have been at least 2 improvements in this registration method.</source>
-        <target state="new">Method {0} was not improved. There should have been at least 2 improvements in this registration method.</target>
-        <note>{0} - method</note>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Java.Interop.Localization/xlf/Resources.pl.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.pl.xlf
@@ -299,13 +299,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</source>
-        <target state="new">Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</target>
-        <note>{0} - newline, {1} - exception</note>
+        <source>Caught an exception while loading types. The types that cannot be loaded will not be processed. Make sure that any additional assembly references required for those types are provided using the -r option. Exception:{0}{1}</source>
+        <target state="new">Caught an exception while loading types. The types that cannot be loaded will not be processed. Make sure that any additional assembly references required for those types are provided using the -r option. Exception:{0}{1}</target>
+        <note>{0} - newline, {1} - exception. The following terms should not be translated: -r</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
-        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <source>Unable to find type '{0}'. The type will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</target>
         <note>{0} - type
 The following terms should not be translated: -L</note>
       </trans-unit>
@@ -315,14 +315,14 @@ The following terms should not be translated: -L</note>
         <note>{0} - type, {1} - assembly name. The following terms should not be translated: -f. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
-        <target state="new">Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <source>Unable to find definition of method '{0}' in assembly metadata. It will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find definition of method '{0}' in assembly metadata. It will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</target>
         <note>{0} - method
 The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</source>
-        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</target>
+        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the directory containing mscorlib is provided with the -L option.</source>
+        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the directory containing mscorlib is provided with the -L option.</target>
         <note>The following terms should not be translated: -L</note>
       </trans-unit>
     </body>

--- a/src/Java.Interop.Localization/xlf/Resources.pt-BR.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.pt-BR.xlf
@@ -263,6 +263,81 @@ Name, com.example.MyClass.</note>
         <target state="new">Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</target>
         <note>{0} - Kotlin method name.</note>
       </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4001">
+        <source>Unable to preload reference '{0}'.</source>
+        <target state="new">Unable to preload reference '{0}'.</target>
+        <note>{0} - assembly path</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4002">
+        <source>Please specify at least one ASSEMBLY to process.</source>
+        <target state="new">Please specify at least one ASSEMBLY to process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4003">
+        <source>Unable to create Java VM{0}{1}</source>
+        <target state="new">Unable to create Java VM{0}{1}</target>
+        <note>{0} - newline, {1} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4004">
+        <source>Unable to read profile '{0}'.{1}{2}</source>
+        <target state="new">Unable to read profile '{0}'.{1}{2}</target>
+        <note>{0} - path, {1} - newline, {2} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4005">
+        <source>Path '{0}' does not exist.</source>
+        <target state="new">Path '{0}' does not exist.</target>
+        <note>{0} - path</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4006">
+        <source>Unable to process assembly '{0}'{1}{2}{1}{3}</source>
+        <target state="new">Unable to process assembly '{0}'{1}{2}{1}{3}</target>
+        <note>{0} - assembly, {1} - newline, {2} - exception message, {3} exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8001">
+        <source>Couln't find interface {0}</source>
+        <target state="new">Couln't find interface {0}</target>
+        <note>{0} - interface name</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8002">
+        <source>Unable to read assembly '{0}' with symbols. Retrying to load it without them.</source>
+        <target state="new">Unable to read assembly '{0}' with symbols. Retrying to load it without them.</target>
+        <note>{0} - assembly</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8003">
+        <source>Type Load exception{0}{1}</source>
+        <target state="new">Type Load exception{0}{1}</target>
+        <note>{0} - newline, {1} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8004">
+        <source>Unable to find cecil's TypeDefinition of type {0}</source>
+        <target state="new">Unable to find cecil's TypeDefinition of type {0}</target>
+        <note>{0} - type</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8005">
+        <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
+        <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
+        <note>{0} - type, {1} - assembly name</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8006">
+        <source>Unable to find cecil's MethodDefinition of method {0}</source>
+        <target state="new">Unable to find cecil's MethodDefinition of method {0}</target>
+        <note>{0} - method</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8007">
+        <source>Unable to find System.Console::WriteLine method. Disabling debug injection.</source>
+        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8008">
+        <source>No type was moved =&gt; nothing to write, no new assembly created.</source>
+        <target state="new">No type was moved =&gt; nothing to write, no new assembly created.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8009">
+        <source>Method {0} was not improved. There should have been at least 2 improvements in this registration method.</source>
+        <target state="new">Method {0} was not improved. There should have been at least 2 improvements in this registration method.</target>
+        <note>{0} - method</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Java.Interop.Localization/xlf/Resources.pt-BR.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.pt-BR.xlf
@@ -311,7 +311,7 @@ Name, com.example.MyClass.</note>
       <trans-unit id="JniMarshalMethodGen_JM8005">
         <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
         <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
-        <note>{0} - type, {1} - assembly name</note>
+        <note>{0} - type, {1} - assembly name. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
         <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>

--- a/src/Java.Interop.Localization/xlf/Resources.pt-BR.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.pt-BR.xlf
@@ -271,7 +271,7 @@ Name, com.example.MyClass.</note>
       <trans-unit id="JniMarshalMethodGen_JM4002">
         <source>Please specify at least one ASSEMBLY to process.</source>
         <target state="new">Please specify at least one ASSEMBLY to process.</target>
-        <note />
+        <note>The following terms should not be translated or have any capitalization changes: ASSEMBLY. This is a special case for this particular message. In most messages, "assembly" would be translated.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4003">
         <source>Unable to create Java VM{0}{1}</source>
@@ -279,9 +279,9 @@ Name, com.example.MyClass.</note>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4004">
-        <source>Unable to read profile '{0}'.{1}{2}</source>
-        <target state="new">Unable to read profile '{0}'.{1}{2}</target>
-        <note>{0} - path, {1} - newline, {2} - exception</note>
+        <source>Unable to read profile file '{0}'.{1}{2}</source>
+        <target state="new">Unable to read profile file '{0}'.{1}{2}</target>
+        <note>{0} - path, {1} - newline, {2} - exception. In this message, the term "profile" refers to a customized list of types to process.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4005">
         <source>Path '{0}' does not exist.</source>
@@ -297,11 +297,6 @@ Name, com.example.MyClass.</note>
         <source>Couln't find interface {0}</source>
         <target state="new">Couln't find interface {0}</target>
         <note>{0} - interface name</note>
-      </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8002">
-        <source>Unable to read assembly '{0}' with symbols. Retrying to load it without them.</source>
-        <target state="new">Unable to read assembly '{0}' with symbols. Retrying to load it without them.</target>
-        <note>{0} - assembly</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
         <source>Type Load exception{0}{1}</source>

--- a/src/Java.Interop.Localization/xlf/Resources.pt-BR.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.pt-BR.xlf
@@ -299,29 +299,31 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</source>
-        <target state="new">Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</target>
+        <source>Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</source>
+        <target state="new">Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</target>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
-        <target state="new">Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
-        <note>{0} - type</note>
+        <source>Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <note>{0} - type
+The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8005">
         <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
         <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
-        <note>{0} - type, {1} - assembly name. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
+        <note>{0} - type, {1} - assembly name. The following terms should not be translated: -f. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
-        <target state="new">Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
-        <note>{0} - method</note>
+        <source>Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <note>{0} - method
+The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</source>
-        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
-        <note />
+        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</source>
+        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</target>
+        <note>The following terms should not be translated: -L</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Java.Interop.Localization/xlf/Resources.pt-BR.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.pt-BR.xlf
@@ -299,13 +299,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Type Load exception{0}{1}</source>
-        <target state="new">Type Load exception{0}{1}</target>
+        <source>Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</source>
+        <target state="new">Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</target>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find cecil's TypeDefinition of type {0}</source>
-        <target state="new">Unable to find cecil's TypeDefinition of type {0}</target>
+        <source>Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
+        <target state="new">Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
         <note>{0} - type</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8005">
@@ -314,18 +314,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - type, {1} - assembly name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find cecil's MethodDefinition of method {0}</source>
-        <target state="new">Unable to find cecil's MethodDefinition of method {0}</target>
+        <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
+        <target state="new">Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
         <note>{0} - method</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find System.Console::WriteLine method. Disabling debug injection.</source>
-        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8008">
-        <source>No type was moved =&gt; nothing to write, no new assembly created.</source>
-        <target state="new">No type was moved =&gt; nothing to write, no new assembly created.</target>
+        <source>Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</source>
+        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
         <note />
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8009">

--- a/src/Java.Interop.Localization/xlf/Resources.pt-BR.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.pt-BR.xlf
@@ -323,11 +323,6 @@ Name, com.example.MyClass.</note>
         <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
         <note />
       </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8009">
-        <source>Method {0} was not improved. There should have been at least 2 improvements in this registration method.</source>
-        <target state="new">Method {0} was not improved. There should have been at least 2 improvements in this registration method.</target>
-        <note>{0} - method</note>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Java.Interop.Localization/xlf/Resources.pt-BR.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.pt-BR.xlf
@@ -299,13 +299,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</source>
-        <target state="new">Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</target>
-        <note>{0} - newline, {1} - exception</note>
+        <source>Caught an exception while loading types. The types that cannot be loaded will not be processed. Make sure that any additional assembly references required for those types are provided using the -r option. Exception:{0}{1}</source>
+        <target state="new">Caught an exception while loading types. The types that cannot be loaded will not be processed. Make sure that any additional assembly references required for those types are provided using the -r option. Exception:{0}{1}</target>
+        <note>{0} - newline, {1} - exception. The following terms should not be translated: -r</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
-        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <source>Unable to find type '{0}'. The type will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</target>
         <note>{0} - type
 The following terms should not be translated: -L</note>
       </trans-unit>
@@ -315,14 +315,14 @@ The following terms should not be translated: -L</note>
         <note>{0} - type, {1} - assembly name. The following terms should not be translated: -f. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
-        <target state="new">Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <source>Unable to find definition of method '{0}' in assembly metadata. It will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find definition of method '{0}' in assembly metadata. It will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</target>
         <note>{0} - method
 The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</source>
-        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</target>
+        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the directory containing mscorlib is provided with the -L option.</source>
+        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the directory containing mscorlib is provided with the -L option.</target>
         <note>The following terms should not be translated: -L</note>
       </trans-unit>
     </body>

--- a/src/Java.Interop.Localization/xlf/Resources.ru.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.ru.xlf
@@ -263,6 +263,81 @@ Name, com.example.MyClass.</note>
         <target state="new">Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</target>
         <note>{0} - Kotlin method name.</note>
       </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4001">
+        <source>Unable to preload reference '{0}'.</source>
+        <target state="new">Unable to preload reference '{0}'.</target>
+        <note>{0} - assembly path</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4002">
+        <source>Please specify at least one ASSEMBLY to process.</source>
+        <target state="new">Please specify at least one ASSEMBLY to process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4003">
+        <source>Unable to create Java VM{0}{1}</source>
+        <target state="new">Unable to create Java VM{0}{1}</target>
+        <note>{0} - newline, {1} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4004">
+        <source>Unable to read profile '{0}'.{1}{2}</source>
+        <target state="new">Unable to read profile '{0}'.{1}{2}</target>
+        <note>{0} - path, {1} - newline, {2} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4005">
+        <source>Path '{0}' does not exist.</source>
+        <target state="new">Path '{0}' does not exist.</target>
+        <note>{0} - path</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4006">
+        <source>Unable to process assembly '{0}'{1}{2}{1}{3}</source>
+        <target state="new">Unable to process assembly '{0}'{1}{2}{1}{3}</target>
+        <note>{0} - assembly, {1} - newline, {2} - exception message, {3} exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8001">
+        <source>Couln't find interface {0}</source>
+        <target state="new">Couln't find interface {0}</target>
+        <note>{0} - interface name</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8002">
+        <source>Unable to read assembly '{0}' with symbols. Retrying to load it without them.</source>
+        <target state="new">Unable to read assembly '{0}' with symbols. Retrying to load it without them.</target>
+        <note>{0} - assembly</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8003">
+        <source>Type Load exception{0}{1}</source>
+        <target state="new">Type Load exception{0}{1}</target>
+        <note>{0} - newline, {1} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8004">
+        <source>Unable to find cecil's TypeDefinition of type {0}</source>
+        <target state="new">Unable to find cecil's TypeDefinition of type {0}</target>
+        <note>{0} - type</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8005">
+        <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
+        <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
+        <note>{0} - type, {1} - assembly name</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8006">
+        <source>Unable to find cecil's MethodDefinition of method {0}</source>
+        <target state="new">Unable to find cecil's MethodDefinition of method {0}</target>
+        <note>{0} - method</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8007">
+        <source>Unable to find System.Console::WriteLine method. Disabling debug injection.</source>
+        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8008">
+        <source>No type was moved =&gt; nothing to write, no new assembly created.</source>
+        <target state="new">No type was moved =&gt; nothing to write, no new assembly created.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8009">
+        <source>Method {0} was not improved. There should have been at least 2 improvements in this registration method.</source>
+        <target state="new">Method {0} was not improved. There should have been at least 2 improvements in this registration method.</target>
+        <note>{0} - method</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Java.Interop.Localization/xlf/Resources.ru.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.ru.xlf
@@ -311,7 +311,7 @@ Name, com.example.MyClass.</note>
       <trans-unit id="JniMarshalMethodGen_JM8005">
         <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
         <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
-        <note>{0} - type, {1} - assembly name</note>
+        <note>{0} - type, {1} - assembly name. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
         <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>

--- a/src/Java.Interop.Localization/xlf/Resources.ru.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.ru.xlf
@@ -271,7 +271,7 @@ Name, com.example.MyClass.</note>
       <trans-unit id="JniMarshalMethodGen_JM4002">
         <source>Please specify at least one ASSEMBLY to process.</source>
         <target state="new">Please specify at least one ASSEMBLY to process.</target>
-        <note />
+        <note>The following terms should not be translated or have any capitalization changes: ASSEMBLY. This is a special case for this particular message. In most messages, "assembly" would be translated.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4003">
         <source>Unable to create Java VM{0}{1}</source>
@@ -279,9 +279,9 @@ Name, com.example.MyClass.</note>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4004">
-        <source>Unable to read profile '{0}'.{1}{2}</source>
-        <target state="new">Unable to read profile '{0}'.{1}{2}</target>
-        <note>{0} - path, {1} - newline, {2} - exception</note>
+        <source>Unable to read profile file '{0}'.{1}{2}</source>
+        <target state="new">Unable to read profile file '{0}'.{1}{2}</target>
+        <note>{0} - path, {1} - newline, {2} - exception. In this message, the term "profile" refers to a customized list of types to process.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4005">
         <source>Path '{0}' does not exist.</source>
@@ -297,11 +297,6 @@ Name, com.example.MyClass.</note>
         <source>Couln't find interface {0}</source>
         <target state="new">Couln't find interface {0}</target>
         <note>{0} - interface name</note>
-      </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8002">
-        <source>Unable to read assembly '{0}' with symbols. Retrying to load it without them.</source>
-        <target state="new">Unable to read assembly '{0}' with symbols. Retrying to load it without them.</target>
-        <note>{0} - assembly</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
         <source>Type Load exception{0}{1}</source>

--- a/src/Java.Interop.Localization/xlf/Resources.ru.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.ru.xlf
@@ -299,29 +299,31 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</source>
-        <target state="new">Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</target>
+        <source>Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</source>
+        <target state="new">Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</target>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
-        <target state="new">Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
-        <note>{0} - type</note>
+        <source>Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <note>{0} - type
+The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8005">
         <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
         <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
-        <note>{0} - type, {1} - assembly name. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
+        <note>{0} - type, {1} - assembly name. The following terms should not be translated: -f. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
-        <target state="new">Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
-        <note>{0} - method</note>
+        <source>Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <note>{0} - method
+The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</source>
-        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
-        <note />
+        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</source>
+        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</target>
+        <note>The following terms should not be translated: -L</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Java.Interop.Localization/xlf/Resources.ru.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.ru.xlf
@@ -299,13 +299,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Type Load exception{0}{1}</source>
-        <target state="new">Type Load exception{0}{1}</target>
+        <source>Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</source>
+        <target state="new">Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</target>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find cecil's TypeDefinition of type {0}</source>
-        <target state="new">Unable to find cecil's TypeDefinition of type {0}</target>
+        <source>Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
+        <target state="new">Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
         <note>{0} - type</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8005">
@@ -314,18 +314,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - type, {1} - assembly name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find cecil's MethodDefinition of method {0}</source>
-        <target state="new">Unable to find cecil's MethodDefinition of method {0}</target>
+        <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
+        <target state="new">Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
         <note>{0} - method</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find System.Console::WriteLine method. Disabling debug injection.</source>
-        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8008">
-        <source>No type was moved =&gt; nothing to write, no new assembly created.</source>
-        <target state="new">No type was moved =&gt; nothing to write, no new assembly created.</target>
+        <source>Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</source>
+        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
         <note />
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8009">

--- a/src/Java.Interop.Localization/xlf/Resources.ru.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.ru.xlf
@@ -323,11 +323,6 @@ Name, com.example.MyClass.</note>
         <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
         <note />
       </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8009">
-        <source>Method {0} was not improved. There should have been at least 2 improvements in this registration method.</source>
-        <target state="new">Method {0} was not improved. There should have been at least 2 improvements in this registration method.</target>
-        <note>{0} - method</note>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Java.Interop.Localization/xlf/Resources.ru.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.ru.xlf
@@ -299,13 +299,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</source>
-        <target state="new">Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</target>
-        <note>{0} - newline, {1} - exception</note>
+        <source>Caught an exception while loading types. The types that cannot be loaded will not be processed. Make sure that any additional assembly references required for those types are provided using the -r option. Exception:{0}{1}</source>
+        <target state="new">Caught an exception while loading types. The types that cannot be loaded will not be processed. Make sure that any additional assembly references required for those types are provided using the -r option. Exception:{0}{1}</target>
+        <note>{0} - newline, {1} - exception. The following terms should not be translated: -r</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
-        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <source>Unable to find type '{0}'. The type will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</target>
         <note>{0} - type
 The following terms should not be translated: -L</note>
       </trans-unit>
@@ -315,14 +315,14 @@ The following terms should not be translated: -L</note>
         <note>{0} - type, {1} - assembly name. The following terms should not be translated: -f. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
-        <target state="new">Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <source>Unable to find definition of method '{0}' in assembly metadata. It will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find definition of method '{0}' in assembly metadata. It will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</target>
         <note>{0} - method
 The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</source>
-        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</target>
+        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the directory containing mscorlib is provided with the -L option.</source>
+        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the directory containing mscorlib is provided with the -L option.</target>
         <note>The following terms should not be translated: -L</note>
       </trans-unit>
     </body>

--- a/src/Java.Interop.Localization/xlf/Resources.tr.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.tr.xlf
@@ -263,6 +263,81 @@ Name, com.example.MyClass.</note>
         <target state="new">Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</target>
         <note>{0} - Kotlin method name.</note>
       </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4001">
+        <source>Unable to preload reference '{0}'.</source>
+        <target state="new">Unable to preload reference '{0}'.</target>
+        <note>{0} - assembly path</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4002">
+        <source>Please specify at least one ASSEMBLY to process.</source>
+        <target state="new">Please specify at least one ASSEMBLY to process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4003">
+        <source>Unable to create Java VM{0}{1}</source>
+        <target state="new">Unable to create Java VM{0}{1}</target>
+        <note>{0} - newline, {1} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4004">
+        <source>Unable to read profile '{0}'.{1}{2}</source>
+        <target state="new">Unable to read profile '{0}'.{1}{2}</target>
+        <note>{0} - path, {1} - newline, {2} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4005">
+        <source>Path '{0}' does not exist.</source>
+        <target state="new">Path '{0}' does not exist.</target>
+        <note>{0} - path</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4006">
+        <source>Unable to process assembly '{0}'{1}{2}{1}{3}</source>
+        <target state="new">Unable to process assembly '{0}'{1}{2}{1}{3}</target>
+        <note>{0} - assembly, {1} - newline, {2} - exception message, {3} exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8001">
+        <source>Couln't find interface {0}</source>
+        <target state="new">Couln't find interface {0}</target>
+        <note>{0} - interface name</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8002">
+        <source>Unable to read assembly '{0}' with symbols. Retrying to load it without them.</source>
+        <target state="new">Unable to read assembly '{0}' with symbols. Retrying to load it without them.</target>
+        <note>{0} - assembly</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8003">
+        <source>Type Load exception{0}{1}</source>
+        <target state="new">Type Load exception{0}{1}</target>
+        <note>{0} - newline, {1} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8004">
+        <source>Unable to find cecil's TypeDefinition of type {0}</source>
+        <target state="new">Unable to find cecil's TypeDefinition of type {0}</target>
+        <note>{0} - type</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8005">
+        <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
+        <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
+        <note>{0} - type, {1} - assembly name</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8006">
+        <source>Unable to find cecil's MethodDefinition of method {0}</source>
+        <target state="new">Unable to find cecil's MethodDefinition of method {0}</target>
+        <note>{0} - method</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8007">
+        <source>Unable to find System.Console::WriteLine method. Disabling debug injection.</source>
+        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8008">
+        <source>No type was moved =&gt; nothing to write, no new assembly created.</source>
+        <target state="new">No type was moved =&gt; nothing to write, no new assembly created.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8009">
+        <source>Method {0} was not improved. There should have been at least 2 improvements in this registration method.</source>
+        <target state="new">Method {0} was not improved. There should have been at least 2 improvements in this registration method.</target>
+        <note>{0} - method</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Java.Interop.Localization/xlf/Resources.tr.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.tr.xlf
@@ -311,7 +311,7 @@ Name, com.example.MyClass.</note>
       <trans-unit id="JniMarshalMethodGen_JM8005">
         <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
         <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
-        <note>{0} - type, {1} - assembly name</note>
+        <note>{0} - type, {1} - assembly name. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
         <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>

--- a/src/Java.Interop.Localization/xlf/Resources.tr.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.tr.xlf
@@ -271,7 +271,7 @@ Name, com.example.MyClass.</note>
       <trans-unit id="JniMarshalMethodGen_JM4002">
         <source>Please specify at least one ASSEMBLY to process.</source>
         <target state="new">Please specify at least one ASSEMBLY to process.</target>
-        <note />
+        <note>The following terms should not be translated or have any capitalization changes: ASSEMBLY. This is a special case for this particular message. In most messages, "assembly" would be translated.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4003">
         <source>Unable to create Java VM{0}{1}</source>
@@ -279,9 +279,9 @@ Name, com.example.MyClass.</note>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4004">
-        <source>Unable to read profile '{0}'.{1}{2}</source>
-        <target state="new">Unable to read profile '{0}'.{1}{2}</target>
-        <note>{0} - path, {1} - newline, {2} - exception</note>
+        <source>Unable to read profile file '{0}'.{1}{2}</source>
+        <target state="new">Unable to read profile file '{0}'.{1}{2}</target>
+        <note>{0} - path, {1} - newline, {2} - exception. In this message, the term "profile" refers to a customized list of types to process.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4005">
         <source>Path '{0}' does not exist.</source>
@@ -297,11 +297,6 @@ Name, com.example.MyClass.</note>
         <source>Couln't find interface {0}</source>
         <target state="new">Couln't find interface {0}</target>
         <note>{0} - interface name</note>
-      </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8002">
-        <source>Unable to read assembly '{0}' with symbols. Retrying to load it without them.</source>
-        <target state="new">Unable to read assembly '{0}' with symbols. Retrying to load it without them.</target>
-        <note>{0} - assembly</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
         <source>Type Load exception{0}{1}</source>

--- a/src/Java.Interop.Localization/xlf/Resources.tr.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.tr.xlf
@@ -299,29 +299,31 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</source>
-        <target state="new">Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</target>
+        <source>Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</source>
+        <target state="new">Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</target>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
-        <target state="new">Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
-        <note>{0} - type</note>
+        <source>Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <note>{0} - type
+The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8005">
         <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
         <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
-        <note>{0} - type, {1} - assembly name. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
+        <note>{0} - type, {1} - assembly name. The following terms should not be translated: -f. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
-        <target state="new">Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
-        <note>{0} - method</note>
+        <source>Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <note>{0} - method
+The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</source>
-        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
-        <note />
+        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</source>
+        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</target>
+        <note>The following terms should not be translated: -L</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Java.Interop.Localization/xlf/Resources.tr.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.tr.xlf
@@ -299,13 +299,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Type Load exception{0}{1}</source>
-        <target state="new">Type Load exception{0}{1}</target>
+        <source>Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</source>
+        <target state="new">Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</target>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find cecil's TypeDefinition of type {0}</source>
-        <target state="new">Unable to find cecil's TypeDefinition of type {0}</target>
+        <source>Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
+        <target state="new">Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
         <note>{0} - type</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8005">
@@ -314,18 +314,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - type, {1} - assembly name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find cecil's MethodDefinition of method {0}</source>
-        <target state="new">Unable to find cecil's MethodDefinition of method {0}</target>
+        <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
+        <target state="new">Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
         <note>{0} - method</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find System.Console::WriteLine method. Disabling debug injection.</source>
-        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8008">
-        <source>No type was moved =&gt; nothing to write, no new assembly created.</source>
-        <target state="new">No type was moved =&gt; nothing to write, no new assembly created.</target>
+        <source>Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</source>
+        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
         <note />
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8009">

--- a/src/Java.Interop.Localization/xlf/Resources.tr.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.tr.xlf
@@ -323,11 +323,6 @@ Name, com.example.MyClass.</note>
         <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
         <note />
       </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8009">
-        <source>Method {0} was not improved. There should have been at least 2 improvements in this registration method.</source>
-        <target state="new">Method {0} was not improved. There should have been at least 2 improvements in this registration method.</target>
-        <note>{0} - method</note>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Java.Interop.Localization/xlf/Resources.tr.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.tr.xlf
@@ -299,13 +299,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</source>
-        <target state="new">Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</target>
-        <note>{0} - newline, {1} - exception</note>
+        <source>Caught an exception while loading types. The types that cannot be loaded will not be processed. Make sure that any additional assembly references required for those types are provided using the -r option. Exception:{0}{1}</source>
+        <target state="new">Caught an exception while loading types. The types that cannot be loaded will not be processed. Make sure that any additional assembly references required for those types are provided using the -r option. Exception:{0}{1}</target>
+        <note>{0} - newline, {1} - exception. The following terms should not be translated: -r</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
-        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <source>Unable to find type '{0}'. The type will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</target>
         <note>{0} - type
 The following terms should not be translated: -L</note>
       </trans-unit>
@@ -315,14 +315,14 @@ The following terms should not be translated: -L</note>
         <note>{0} - type, {1} - assembly name. The following terms should not be translated: -f. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
-        <target state="new">Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <source>Unable to find definition of method '{0}' in assembly metadata. It will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find definition of method '{0}' in assembly metadata. It will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</target>
         <note>{0} - method
 The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</source>
-        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</target>
+        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the directory containing mscorlib is provided with the -L option.</source>
+        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the directory containing mscorlib is provided with the -L option.</target>
         <note>The following terms should not be translated: -L</note>
       </trans-unit>
     </body>

--- a/src/Java.Interop.Localization/xlf/Resources.zh-Hans.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.zh-Hans.xlf
@@ -263,6 +263,81 @@ Name, com.example.MyClass.</note>
         <target state="new">Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</target>
         <note>{0} - Kotlin method name.</note>
       </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4001">
+        <source>Unable to preload reference '{0}'.</source>
+        <target state="new">Unable to preload reference '{0}'.</target>
+        <note>{0} - assembly path</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4002">
+        <source>Please specify at least one ASSEMBLY to process.</source>
+        <target state="new">Please specify at least one ASSEMBLY to process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4003">
+        <source>Unable to create Java VM{0}{1}</source>
+        <target state="new">Unable to create Java VM{0}{1}</target>
+        <note>{0} - newline, {1} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4004">
+        <source>Unable to read profile '{0}'.{1}{2}</source>
+        <target state="new">Unable to read profile '{0}'.{1}{2}</target>
+        <note>{0} - path, {1} - newline, {2} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4005">
+        <source>Path '{0}' does not exist.</source>
+        <target state="new">Path '{0}' does not exist.</target>
+        <note>{0} - path</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4006">
+        <source>Unable to process assembly '{0}'{1}{2}{1}{3}</source>
+        <target state="new">Unable to process assembly '{0}'{1}{2}{1}{3}</target>
+        <note>{0} - assembly, {1} - newline, {2} - exception message, {3} exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8001">
+        <source>Couln't find interface {0}</source>
+        <target state="new">Couln't find interface {0}</target>
+        <note>{0} - interface name</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8002">
+        <source>Unable to read assembly '{0}' with symbols. Retrying to load it without them.</source>
+        <target state="new">Unable to read assembly '{0}' with symbols. Retrying to load it without them.</target>
+        <note>{0} - assembly</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8003">
+        <source>Type Load exception{0}{1}</source>
+        <target state="new">Type Load exception{0}{1}</target>
+        <note>{0} - newline, {1} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8004">
+        <source>Unable to find cecil's TypeDefinition of type {0}</source>
+        <target state="new">Unable to find cecil's TypeDefinition of type {0}</target>
+        <note>{0} - type</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8005">
+        <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
+        <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
+        <note>{0} - type, {1} - assembly name</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8006">
+        <source>Unable to find cecil's MethodDefinition of method {0}</source>
+        <target state="new">Unable to find cecil's MethodDefinition of method {0}</target>
+        <note>{0} - method</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8007">
+        <source>Unable to find System.Console::WriteLine method. Disabling debug injection.</source>
+        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8008">
+        <source>No type was moved =&gt; nothing to write, no new assembly created.</source>
+        <target state="new">No type was moved =&gt; nothing to write, no new assembly created.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8009">
+        <source>Method {0} was not improved. There should have been at least 2 improvements in this registration method.</source>
+        <target state="new">Method {0} was not improved. There should have been at least 2 improvements in this registration method.</target>
+        <note>{0} - method</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Java.Interop.Localization/xlf/Resources.zh-Hans.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.zh-Hans.xlf
@@ -311,7 +311,7 @@ Name, com.example.MyClass.</note>
       <trans-unit id="JniMarshalMethodGen_JM8005">
         <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
         <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
-        <note>{0} - type, {1} - assembly name</note>
+        <note>{0} - type, {1} - assembly name. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
         <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>

--- a/src/Java.Interop.Localization/xlf/Resources.zh-Hans.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.zh-Hans.xlf
@@ -271,7 +271,7 @@ Name, com.example.MyClass.</note>
       <trans-unit id="JniMarshalMethodGen_JM4002">
         <source>Please specify at least one ASSEMBLY to process.</source>
         <target state="new">Please specify at least one ASSEMBLY to process.</target>
-        <note />
+        <note>The following terms should not be translated or have any capitalization changes: ASSEMBLY. This is a special case for this particular message. In most messages, "assembly" would be translated.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4003">
         <source>Unable to create Java VM{0}{1}</source>
@@ -279,9 +279,9 @@ Name, com.example.MyClass.</note>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4004">
-        <source>Unable to read profile '{0}'.{1}{2}</source>
-        <target state="new">Unable to read profile '{0}'.{1}{2}</target>
-        <note>{0} - path, {1} - newline, {2} - exception</note>
+        <source>Unable to read profile file '{0}'.{1}{2}</source>
+        <target state="new">Unable to read profile file '{0}'.{1}{2}</target>
+        <note>{0} - path, {1} - newline, {2} - exception. In this message, the term "profile" refers to a customized list of types to process.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4005">
         <source>Path '{0}' does not exist.</source>
@@ -297,11 +297,6 @@ Name, com.example.MyClass.</note>
         <source>Couln't find interface {0}</source>
         <target state="new">Couln't find interface {0}</target>
         <note>{0} - interface name</note>
-      </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8002">
-        <source>Unable to read assembly '{0}' with symbols. Retrying to load it without them.</source>
-        <target state="new">Unable to read assembly '{0}' with symbols. Retrying to load it without them.</target>
-        <note>{0} - assembly</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
         <source>Type Load exception{0}{1}</source>

--- a/src/Java.Interop.Localization/xlf/Resources.zh-Hans.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.zh-Hans.xlf
@@ -299,29 +299,31 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</source>
-        <target state="new">Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</target>
+        <source>Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</source>
+        <target state="new">Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</target>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
-        <target state="new">Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
-        <note>{0} - type</note>
+        <source>Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <note>{0} - type
+The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8005">
         <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
         <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
-        <note>{0} - type, {1} - assembly name. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
+        <note>{0} - type, {1} - assembly name. The following terms should not be translated: -f. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
-        <target state="new">Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
-        <note>{0} - method</note>
+        <source>Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <note>{0} - method
+The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</source>
-        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
-        <note />
+        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</source>
+        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</target>
+        <note>The following terms should not be translated: -L</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Java.Interop.Localization/xlf/Resources.zh-Hans.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.zh-Hans.xlf
@@ -299,13 +299,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Type Load exception{0}{1}</source>
-        <target state="new">Type Load exception{0}{1}</target>
+        <source>Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</source>
+        <target state="new">Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</target>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find cecil's TypeDefinition of type {0}</source>
-        <target state="new">Unable to find cecil's TypeDefinition of type {0}</target>
+        <source>Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
+        <target state="new">Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
         <note>{0} - type</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8005">
@@ -314,18 +314,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - type, {1} - assembly name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find cecil's MethodDefinition of method {0}</source>
-        <target state="new">Unable to find cecil's MethodDefinition of method {0}</target>
+        <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
+        <target state="new">Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
         <note>{0} - method</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find System.Console::WriteLine method. Disabling debug injection.</source>
-        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8008">
-        <source>No type was moved =&gt; nothing to write, no new assembly created.</source>
-        <target state="new">No type was moved =&gt; nothing to write, no new assembly created.</target>
+        <source>Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</source>
+        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
         <note />
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8009">

--- a/src/Java.Interop.Localization/xlf/Resources.zh-Hans.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.zh-Hans.xlf
@@ -323,11 +323,6 @@ Name, com.example.MyClass.</note>
         <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
         <note />
       </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8009">
-        <source>Method {0} was not improved. There should have been at least 2 improvements in this registration method.</source>
-        <target state="new">Method {0} was not improved. There should have been at least 2 improvements in this registration method.</target>
-        <note>{0} - method</note>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Java.Interop.Localization/xlf/Resources.zh-Hans.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.zh-Hans.xlf
@@ -299,13 +299,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</source>
-        <target state="new">Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</target>
-        <note>{0} - newline, {1} - exception</note>
+        <source>Caught an exception while loading types. The types that cannot be loaded will not be processed. Make sure that any additional assembly references required for those types are provided using the -r option. Exception:{0}{1}</source>
+        <target state="new">Caught an exception while loading types. The types that cannot be loaded will not be processed. Make sure that any additional assembly references required for those types are provided using the -r option. Exception:{0}{1}</target>
+        <note>{0} - newline, {1} - exception. The following terms should not be translated: -r</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
-        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <source>Unable to find type '{0}'. The type will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</target>
         <note>{0} - type
 The following terms should not be translated: -L</note>
       </trans-unit>
@@ -315,14 +315,14 @@ The following terms should not be translated: -L</note>
         <note>{0} - type, {1} - assembly name. The following terms should not be translated: -f. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
-        <target state="new">Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <source>Unable to find definition of method '{0}' in assembly metadata. It will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find definition of method '{0}' in assembly metadata. It will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</target>
         <note>{0} - method
 The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</source>
-        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</target>
+        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the directory containing mscorlib is provided with the -L option.</source>
+        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the directory containing mscorlib is provided with the -L option.</target>
         <note>The following terms should not be translated: -L</note>
       </trans-unit>
     </body>

--- a/src/Java.Interop.Localization/xlf/Resources.zh-Hant.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.zh-Hant.xlf
@@ -263,6 +263,81 @@ Name, com.example.MyClass.</note>
         <target state="new">Cannot override Kotlin-generated method '{0}' because it is not a valid Java method name. This method can only be overridden from Kotlin.</target>
         <note>{0} - Kotlin method name.</note>
       </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4001">
+        <source>Unable to preload reference '{0}'.</source>
+        <target state="new">Unable to preload reference '{0}'.</target>
+        <note>{0} - assembly path</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4002">
+        <source>Please specify at least one ASSEMBLY to process.</source>
+        <target state="new">Please specify at least one ASSEMBLY to process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4003">
+        <source>Unable to create Java VM{0}{1}</source>
+        <target state="new">Unable to create Java VM{0}{1}</target>
+        <note>{0} - newline, {1} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4004">
+        <source>Unable to read profile '{0}'.{1}{2}</source>
+        <target state="new">Unable to read profile '{0}'.{1}{2}</target>
+        <note>{0} - path, {1} - newline, {2} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4005">
+        <source>Path '{0}' does not exist.</source>
+        <target state="new">Path '{0}' does not exist.</target>
+        <note>{0} - path</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM4006">
+        <source>Unable to process assembly '{0}'{1}{2}{1}{3}</source>
+        <target state="new">Unable to process assembly '{0}'{1}{2}{1}{3}</target>
+        <note>{0} - assembly, {1} - newline, {2} - exception message, {3} exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8001">
+        <source>Couln't find interface {0}</source>
+        <target state="new">Couln't find interface {0}</target>
+        <note>{0} - interface name</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8002">
+        <source>Unable to read assembly '{0}' with symbols. Retrying to load it without them.</source>
+        <target state="new">Unable to read assembly '{0}' with symbols. Retrying to load it without them.</target>
+        <note>{0} - assembly</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8003">
+        <source>Type Load exception{0}{1}</source>
+        <target state="new">Type Load exception{0}{1}</target>
+        <note>{0} - newline, {1} - exception</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8004">
+        <source>Unable to find cecil's TypeDefinition of type {0}</source>
+        <target state="new">Unable to find cecil's TypeDefinition of type {0}</target>
+        <note>{0} - type</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8005">
+        <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
+        <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
+        <note>{0} - type, {1} - assembly name</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8006">
+        <source>Unable to find cecil's MethodDefinition of method {0}</source>
+        <target state="new">Unable to find cecil's MethodDefinition of method {0}</target>
+        <note>{0} - method</note>
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8007">
+        <source>Unable to find System.Console::WriteLine method. Disabling debug injection.</source>
+        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8008">
+        <source>No type was moved =&gt; nothing to write, no new assembly created.</source>
+        <target state="new">No type was moved =&gt; nothing to write, no new assembly created.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="JniMarshalMethodGen_JM8009">
+        <source>Method {0} was not improved. There should have been at least 2 improvements in this registration method.</source>
+        <target state="new">Method {0} was not improved. There should have been at least 2 improvements in this registration method.</target>
+        <note>{0} - method</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Java.Interop.Localization/xlf/Resources.zh-Hant.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.zh-Hant.xlf
@@ -311,7 +311,7 @@ Name, com.example.MyClass.</note>
       <trans-unit id="JniMarshalMethodGen_JM8005">
         <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
         <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
-        <note>{0} - type, {1} - assembly name</note>
+        <note>{0} - type, {1} - assembly name. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
         <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>

--- a/src/Java.Interop.Localization/xlf/Resources.zh-Hant.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.zh-Hant.xlf
@@ -271,7 +271,7 @@ Name, com.example.MyClass.</note>
       <trans-unit id="JniMarshalMethodGen_JM4002">
         <source>Please specify at least one ASSEMBLY to process.</source>
         <target state="new">Please specify at least one ASSEMBLY to process.</target>
-        <note />
+        <note>The following terms should not be translated or have any capitalization changes: ASSEMBLY. This is a special case for this particular message. In most messages, "assembly" would be translated.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4003">
         <source>Unable to create Java VM{0}{1}</source>
@@ -279,9 +279,9 @@ Name, com.example.MyClass.</note>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4004">
-        <source>Unable to read profile '{0}'.{1}{2}</source>
-        <target state="new">Unable to read profile '{0}'.{1}{2}</target>
-        <note>{0} - path, {1} - newline, {2} - exception</note>
+        <source>Unable to read profile file '{0}'.{1}{2}</source>
+        <target state="new">Unable to read profile file '{0}'.{1}{2}</target>
+        <note>{0} - path, {1} - newline, {2} - exception. In this message, the term "profile" refers to a customized list of types to process.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM4005">
         <source>Path '{0}' does not exist.</source>
@@ -297,11 +297,6 @@ Name, com.example.MyClass.</note>
         <source>Couln't find interface {0}</source>
         <target state="new">Couln't find interface {0}</target>
         <note>{0} - interface name</note>
-      </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8002">
-        <source>Unable to read assembly '{0}' with symbols. Retrying to load it without them.</source>
-        <target state="new">Unable to read assembly '{0}' with symbols. Retrying to load it without them.</target>
-        <note>{0} - assembly</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
         <source>Type Load exception{0}{1}</source>

--- a/src/Java.Interop.Localization/xlf/Resources.zh-Hant.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.zh-Hant.xlf
@@ -299,29 +299,31 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</source>
-        <target state="new">Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</target>
+        <source>Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</source>
+        <target state="new">Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</target>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
-        <target state="new">Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
-        <note>{0} - type</note>
+        <source>Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <note>{0} - type
+The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8005">
         <source>Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</source>
         <target state="new">Marshal methods type '{0}' already exists. Skipped generation of marshal methods in assembly '{1}'. Use -f to force regeneration when desired.</target>
-        <note>{0} - type, {1} - assembly name. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
+        <note>{0} - type, {1} - assembly name. The following terms should not be translated: -f. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
-        <target state="new">Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
-        <note>{0} - method</note>
+        <source>Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <note>{0} - method
+The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</source>
-        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
-        <note />
+        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</source>
+        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</target>
+        <note>The following terms should not be translated: -L</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Java.Interop.Localization/xlf/Resources.zh-Hant.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.zh-Hant.xlf
@@ -299,13 +299,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Type Load exception{0}{1}</source>
-        <target state="new">Type Load exception{0}{1}</target>
+        <source>Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</source>
+        <target state="new">Catched type Load exception. Make sure all the references are available. For details check the exception: {0}{1}</target>
         <note>{0} - newline, {1} - exception</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find cecil's TypeDefinition of type {0}</source>
-        <target state="new">Unable to find cecil's TypeDefinition of type {0}</target>
+        <source>Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
+        <target state="new">Unable to find cecil's TypeDefinition of type {0}. Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
         <note>{0} - type</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8005">
@@ -314,18 +314,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - type, {1} - assembly name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find cecil's MethodDefinition of method {0}</source>
-        <target state="new">Unable to find cecil's MethodDefinition of method {0}</target>
+        <source>Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</source>
+        <target state="new">Unable to find cecil's MethodDefinition of method {0}.  Make sure the paths to all reference assemblies are passed to the tool with the -L option.</target>
         <note>{0} - method</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find System.Console::WriteLine method. Disabling debug injection.</source>
-        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8008">
-        <source>No type was moved =&gt; nothing to write, no new assembly created.</source>
-        <target state="new">No type was moved =&gt; nothing to write, no new assembly created.</target>
+        <source>Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</source>
+        <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
         <note />
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8009">

--- a/src/Java.Interop.Localization/xlf/Resources.zh-Hant.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.zh-Hant.xlf
@@ -323,11 +323,6 @@ Name, com.example.MyClass.</note>
         <target state="new">Unable to find System.Console::WriteLine method. Disabling debug injection. Make sure the paths to corlib assembly is passed to the tool with the -L option.</target>
         <note />
       </trans-unit>
-      <trans-unit id="JniMarshalMethodGen_JM8009">
-        <source>Method {0} was not improved. There should have been at least 2 improvements in this registration method.</source>
-        <target state="new">Method {0} was not improved. There should have been at least 2 improvements in this registration method.</target>
-        <note>{0} - method</note>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Java.Interop.Localization/xlf/Resources.zh-Hant.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.zh-Hant.xlf
@@ -299,13 +299,13 @@ Name, com.example.MyClass.</note>
         <note>{0} - interface name</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8003">
-        <source>Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</source>
-        <target state="new">Caught an exception while loading types. The types which cannot be loaded will not be processed. Make sure all referenced assemblies are available, use -r option. For details, check the exception:{0}{1}</target>
-        <note>{0} - newline, {1} - exception</note>
+        <source>Caught an exception while loading types. The types that cannot be loaded will not be processed. Make sure that any additional assembly references required for those types are provided using the -r option. Exception:{0}{1}</source>
+        <target state="new">Caught an exception while loading types. The types that cannot be loaded will not be processed. Make sure that any additional assembly references required for those types are provided using the -r option. Exception:{0}{1}</target>
+        <note>{0} - newline, {1} - exception. The following terms should not be translated: -r</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8004">
-        <source>Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
-        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <source>Unable to find type '{0}'. The type will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find type '{0}'. The type will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</target>
         <note>{0} - type
 The following terms should not be translated: -L</note>
       </trans-unit>
@@ -315,14 +315,14 @@ The following terms should not be translated: -L</note>
         <note>{0} - type, {1} - assembly name. The following terms should not be translated: -f. In this message, the term "marshal methods" refers to methods that allow interaction between the managed methods and Java methods, similar to the methods of the .NET System.Runtime.InteropServices.Marshal class.</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8006">
-        <source>Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</source>
-        <target state="new">Unable to find MethodDefinition of method {0}. It will not be processed. Make sure the paths to all reference assemblies are provided with the -L option.</target>
+        <source>Unable to find definition of method '{0}' in assembly metadata. It will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</source>
+        <target state="new">Unable to find definition of method '{0}' in assembly metadata. It will not be processed. Make sure the directories for all referenced assemblies are provided with the -L option.</target>
         <note>{0} - method
 The following terms should not be translated: -L</note>
       </trans-unit>
       <trans-unit id="JniMarshalMethodGen_JM8007">
-        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</source>
-        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the path to mscorlib is provided with the -L option.</target>
+        <source>Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the directory containing mscorlib is provided with the -L option.</source>
+        <target state="new">Unable to find the System.Console.WriteLine() method. Disabling debug injection. To enable debug injection, ensure the directory containing mscorlib is provided with the -L option.</target>
         <note>The following terms should not be translated: -L</note>
       </trans-unit>
     </body>

--- a/tools/jnimarshalmethod-gen/App.cs
+++ b/tools/jnimarshalmethod-gen/App.cs
@@ -189,7 +189,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 					resolver.AddToCache (ad);
 				} catch (Exception) {
 					if (Verbose)
-						Warning (Message.WarningUnableToReadWithSymbols, assembly);
+						Information ($"Unable to read assembly '{assembly}' with symbols. Retrying to load it without them.");
 
 					ad = AssemblyDefinition.ReadAssembly (assembly, readerParametersNoSymbols);
 					resolver.AddToCache (ad);
@@ -528,6 +528,8 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 		}
 
 		public static void Warning (Message message, params object[] args) => ColorMessage ($"warning JM{message.Code:X04}: {Name}: {string.Format (message.Localized, args)}", ConsoleColor.Yellow, Console.Error);
+
+		public static void Information (string message) => ColorMessage (message, ConsoleColor.Yellow, Console.Out);
 
 		static void AddToTypeMap (TypeDefinition type)
 		{

--- a/tools/jnimarshalmethod-gen/App.cs
+++ b/tools/jnimarshalmethod-gen/App.cs
@@ -129,7 +129,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 			}
 
 			if (assemblies.Count < 1)
-				ErrorAndExit (Message.ErrorAtLeastOneAssembly, 2);
+				ErrorAndExit (Message.ErrorAtLeastOneAssembly);
 
 			return assemblies;
 		}
@@ -147,7 +147,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 					typeNameRegexes.Add (new Regex (line));
 				}
 			} catch (Exception e) {
-				ErrorAndExit (Message.ErrorUnableToReadProfile, 4, typesPath, Environment.NewLine, e);
+				ErrorAndExit (Message.ErrorUnableToReadProfile, typesPath, Environment.NewLine, e);
 			}
 		}
 
@@ -172,14 +172,14 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 				try {
 					Assembly.LoadFile (Path.GetFullPath (r));
 				} catch (Exception) {
-					ErrorAndExit (Message.ErrorUnableToPreloadReference, 1, r);
+					ErrorAndExit (Message.ErrorUnableToPreloadReference, r);
 				}
 				resolver.SearchDirectories.Add (Path.GetDirectoryName (r));
 			}
 
 			foreach (var assembly in assemblies) {
 				if (!File.Exists (assembly)) {
-					ErrorAndExit (Message.ErrorPathDoesNotExist, 5, assembly);
+					ErrorAndExit (Message.ErrorPathDoesNotExist, assembly);
 				}
 
 				resolver.SearchDirectories.Add (Path.GetDirectoryName (assembly));
@@ -203,7 +203,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 					CreateMarshalMethodAssembly (assembly);
 					definedTypes.Clear ();
 				} catch (Exception e) {
-					ErrorAndExit (Message.ErrorUnableToProcessAssembly, 6, assembly, Environment.NewLine, e.Message, e);
+					ErrorAndExit (Message.ErrorUnableToProcessAssembly, assembly, Environment.NewLine, e.Message, e);
 				}
 			}
 		}
@@ -217,7 +217,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 			try {
 				builder.CreateJreVM ();
 			} catch (Exception e) {
-				ErrorAndExit (Message.ErrorUnableToCreateJavaVM, 3, Environment.NewLine, e);
+				ErrorAndExit (Message.ErrorUnableToCreateJavaVM, Environment.NewLine, e);
 			}
 		}
 
@@ -522,12 +522,12 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 
 		public static void ColorWrite (string message, ConsoleColor color) => ColorMessage (message, color, Console.Out, false);
 
-		public static void ErrorAndExit (Message message, int code, params object[] args) {
-			ColorMessage ($"Error: {Name}: {string.Format (message.Localized, args)}", ConsoleColor.Red, Console.Error);
-			Environment.Exit (code);
+		public static void ErrorAndExit (Message message, params object[] args) {
+			ColorMessage ($"error JM{message.Code:X04}: {Name}: {string.Format (message.Localized, args)}", ConsoleColor.Red, Console.Error);
+			Environment.Exit (message.Code - 0x4000);
 		}
 
-		public static void Warning (Message message, params object[] args) => ColorMessage ($"Warning: {Name}: {string.Format (message.Localized, args)}", ConsoleColor.Yellow, Console.Error);
+		public static void Warning (Message message, params object[] args) => ColorMessage ($"warning JM{message.Code:X04}: {Name}: {string.Format (message.Localized, args)}", ConsoleColor.Yellow, Console.Error);
 
 		static void AddToTypeMap (TypeDefinition type)
 		{

--- a/tools/jnimarshalmethod-gen/App.cs
+++ b/tools/jnimarshalmethod-gen/App.cs
@@ -128,10 +128,8 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 				Environment.Exit (0);
 			}
 
-			if (assemblies.Count < 1) {
-				Error ("Please specify at least one ASSEMBLY to process.");
-				Environment.Exit (2);
-			}
+			if (assemblies.Count < 1)
+				ErrorAndExit (Message.ErrorAtLeastOneAssembly, 2);
 
 			return assemblies;
 		}
@@ -149,8 +147,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 					typeNameRegexes.Add (new Regex (line));
 				}
 			} catch (Exception e) {
-				Error ($"Unable to read profile '{typesPath}'.{Environment.NewLine}{e}");
-				Environment.Exit (4);
+				ErrorAndExit (Message.ErrorUnableToReadProfile, 4, typesPath, Environment.NewLine, e);
 			}
 		}
 
@@ -175,16 +172,14 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 				try {
 					Assembly.LoadFile (Path.GetFullPath (r));
 				} catch (Exception) {
-					Error ($"Unable to preload reference '{r}'.");
-					Environment.Exit (1);
+					ErrorAndExit (Message.ErrorUnableToPreloadReference, 1, r);
 				}
 				resolver.SearchDirectories.Add (Path.GetDirectoryName (r));
 			}
 
 			foreach (var assembly in assemblies) {
 				if (!File.Exists (assembly)) {
-					Error ($"Path '{assembly}' does not exist.");
-					Environment.Exit (1);
+					ErrorAndExit (Message.ErrorPathDoesNotExist, 5, assembly);
 				}
 
 				resolver.SearchDirectories.Add (Path.GetDirectoryName (assembly));
@@ -194,7 +189,8 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 					resolver.AddToCache (ad);
 				} catch (Exception) {
 					if (Verbose)
-						Warning ($"Unable to read assembly '{assembly}' with symbols. Retrying to load it without them.");
+						Warning (Message.WarningUnableToReadWithSymbols, assembly);
+
 					ad = AssemblyDefinition.ReadAssembly (assembly, readerParametersNoSymbols);
 					resolver.AddToCache (ad);
 				}
@@ -207,8 +203,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 					CreateMarshalMethodAssembly (assembly);
 					definedTypes.Clear ();
 				} catch (Exception e) {
-					Error ($"Unable to process assembly '{assembly}'{Environment.NewLine}{e.Message}{Environment.NewLine}{e}");
-					Environment.Exit (1);
+					ErrorAndExit (Message.ErrorUnableToProcessAssembly, 6, assembly, Environment.NewLine, e.Message, e);
 				}
 			}
 		}
@@ -222,8 +217,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 			try {
 				builder.CreateJreVM ();
 			} catch (Exception e) {
-				Error ($"Unable to create Java VM{Environment.NewLine}{e}");
-				Environment.Exit (3);
+				ErrorAndExit (Message.ErrorUnableToCreateJavaVM, 3, Environment.NewLine, e);
 			}
 		}
 
@@ -317,7 +311,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 			} catch (ReflectionTypeLoadException e) {
 				types = e.Types;
 				foreach (var le in e.LoaderExceptions)
-					Warning ($"Type Load exception{Environment.NewLine}{le}");
+					Warning (Message.WarningTypeLoadException, Environment.NewLine, le);
 			}
 
 			foreach (var systemType in types) {
@@ -343,7 +337,8 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 
 				if (td == null) {
 					if (Verbose)
-						Warning ($"Unable to find cecil's TypeDefinition of type {type}");
+						Warning (Message.WarningUnableToFindTypeDefinition, type);
+
 					continue;
 				}
 				if (!td.ImplementsInterface ("Java.Interop.IJavaPeerable", cache))
@@ -351,7 +346,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 
 				var existingMarshalMethodsType = td.GetNestedType (TypeMover.NestedName);
 				if (existingMarshalMethodsType != null && !forceRegeneration) {
-					Warning ($"Marshal methods type '{existingMarshalMethodsType.GetAssemblyQualifiedName (cache)}' already exists. Skipped generation of marshal methods in assembly '{assemblyName}'. Use -f to force regeneration when desired.");
+					Warning (Message.WarningMarshalMethodsTypeAlreadyExists, existingMarshalMethodsType.GetAssemblyQualifiedName (cache), assemblyName);
 
 					return;
 				}
@@ -389,7 +384,8 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 
 						if (md == null) {
 							if (Verbose)
-								Warning ($"Unable to find cecil's MethodDefinition of method {method}");
+								Warning (Message.WarningUnableToFindMethodDefinition, method);
+
 							continue;
 						}
 
@@ -526,9 +522,12 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 
 		public static void ColorWrite (string message, ConsoleColor color) => ColorMessage (message, color, Console.Out, false);
 
-		public static void Error (string message) => ColorMessage ($"Error: {Name}: {message}", ConsoleColor.Red, Console.Error);
+		public static void ErrorAndExit (Message message, int code, params object[] args) {
+			ColorMessage ($"Error: {Name}: {string.Format (message.Localized, args)}", ConsoleColor.Red, Console.Error);
+			Environment.Exit (code);
+		}
 
-		public static void Warning (string message) => ColorMessage ($"Warning: {Name}: {message}", ConsoleColor.Yellow, Console.Error);
+		public static void Warning (Message message, params object[] args) => ColorMessage ($"Warning: {Name}: {string.Format (message.Localized, args)}", ConsoleColor.Yellow, Console.Error);
 
 		static void AddToTypeMap (TypeDefinition type)
 		{
@@ -684,7 +683,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 				var id = ad.MainModule.GetType (iface.GetCecilName ());
 
 				if (id == null) {
-					App.Warning ($"Couln't find iterface {iface.FullName}");
+					App.Warning (Message.WarningCouldntFindInterface, iface.FullName);
 					continue;
 				}
 

--- a/tools/jnimarshalmethod-gen/Message.cs
+++ b/tools/jnimarshalmethod-gen/Message.cs
@@ -28,6 +28,6 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator
 		public static Message WarningUnableToFindMethodDefinition = new Message (Resources.JniMarshalMethodGen_JM8006);
 		public static Message WarningUnableToFindSCWriteLine = new Message (Resources.JniMarshalMethodGen_JM8007);
 		public static Message WarningNoTypeWasMovedNothingToWrite = new Message (Resources.JniMarshalMethodGen_JM8008);
-		public static Message WarningMethodWasNotImproved = new Message (Resources.JniMarshalMethodGen_JM8008);
+		public static Message WarningMethodWasNotImproved = new Message (Resources.JniMarshalMethodGen_JM8009);
 	}
 }

--- a/tools/jnimarshalmethod-gen/Message.cs
+++ b/tools/jnimarshalmethod-gen/Message.cs
@@ -20,7 +20,6 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator
 		public static Message ErrorUnableToProcessAssembly = new Message (0x4006, Resources.JniMarshalMethodGen_JM4006);
 
 		public static Message WarningCouldntFindInterface = new Message (0x8001, Resources.JniMarshalMethodGen_JM8001);
-		public static Message WarningUnableToReadWithSymbols = new Message (0x8002, Resources.JniMarshalMethodGen_JM8002);
 		public static Message WarningTypeLoadException = new Message (0x8003, Resources.JniMarshalMethodGen_JM8003);
 		public static Message WarningUnableToFindTypeDefinition = new Message (0x8004, Resources.JniMarshalMethodGen_JM8004);
 		public static Message WarningMarshalMethodsTypeAlreadyExists = new Message (0x8005, Resources.JniMarshalMethodGen_JM8005);

--- a/tools/jnimarshalmethod-gen/Message.cs
+++ b/tools/jnimarshalmethod-gen/Message.cs
@@ -5,24 +5,28 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator
 	class Message
 	{
 		public string Localized { get; private set; }
+		public int Code { get; private set; }
 
-		private Message (string message) => Localized = message;
+		private Message (int code, string message) {
+			Localized = message;
+			Code = code;
+		}
 
-		public static Message ErrorUnableToPreloadReference = new Message (Resources.JniMarshalMethodGen_JM4001);
-		public static Message ErrorAtLeastOneAssembly = new Message (Resources.JniMarshalMethodGen_JM4002);
-		public static Message ErrorUnableToCreateJavaVM = new Message (Resources.JniMarshalMethodGen_JM4003);
-		public static Message ErrorUnableToReadProfile = new Message (Resources.JniMarshalMethodGen_JM4004);
-		public static Message ErrorPathDoesNotExist = new Message (Resources.JniMarshalMethodGen_JM4005);
-		public static Message ErrorUnableToProcessAssembly = new Message (Resources.JniMarshalMethodGen_JM4006);
+		public static Message ErrorUnableToPreloadReference = new Message (0x4001, Resources.JniMarshalMethodGen_JM4001);
+		public static Message ErrorAtLeastOneAssembly = new Message (0x4002, Resources.JniMarshalMethodGen_JM4002);
+		public static Message ErrorUnableToCreateJavaVM = new Message (0x4003, Resources.JniMarshalMethodGen_JM4003);
+		public static Message ErrorUnableToReadProfile = new Message (0x4004, Resources.JniMarshalMethodGen_JM4004);
+		public static Message ErrorPathDoesNotExist = new Message (0x4005, Resources.JniMarshalMethodGen_JM4005);
+		public static Message ErrorUnableToProcessAssembly = new Message (0x4006, Resources.JniMarshalMethodGen_JM4006);
 
-		public static Message WarningCouldntFindInterface = new Message (Resources.JniMarshalMethodGen_JM8001);
-		public static Message WarningUnableToReadWithSymbols = new Message (Resources.JniMarshalMethodGen_JM8002);
-		public static Message WarningTypeLoadException = new Message (Resources.JniMarshalMethodGen_JM8003);
-		public static Message WarningUnableToFindTypeDefinition = new Message (Resources.JniMarshalMethodGen_JM8004);
-		public static Message WarningMarshalMethodsTypeAlreadyExists = new Message (Resources.JniMarshalMethodGen_JM8005);
-		public static Message WarningUnableToFindMethodDefinition = new Message (Resources.JniMarshalMethodGen_JM8006);
-		public static Message WarningUnableToFindSCWriteLine = new Message (Resources.JniMarshalMethodGen_JM8007);
-		public static Message WarningNoTypeWasMovedNothingToWrite = new Message (Resources.JniMarshalMethodGen_JM8008);
-		public static Message WarningMethodWasNotImproved = new Message (Resources.JniMarshalMethodGen_JM8009);
+		public static Message WarningCouldntFindInterface = new Message (0x8001, Resources.JniMarshalMethodGen_JM8001);
+		public static Message WarningUnableToReadWithSymbols = new Message (0x8002, Resources.JniMarshalMethodGen_JM8002);
+		public static Message WarningTypeLoadException = new Message (0x8003, Resources.JniMarshalMethodGen_JM8003);
+		public static Message WarningUnableToFindTypeDefinition = new Message (0x8004, Resources.JniMarshalMethodGen_JM8004);
+		public static Message WarningMarshalMethodsTypeAlreadyExists = new Message (0x8005, Resources.JniMarshalMethodGen_JM8005);
+		public static Message WarningUnableToFindMethodDefinition = new Message (0x8006, Resources.JniMarshalMethodGen_JM8006);
+		public static Message WarningUnableToFindSCWriteLine = new Message (0x8007, Resources.JniMarshalMethodGen_JM8007);
+		public static Message WarningNoTypeWasMovedNothingToWrite = new Message (0x8008, Resources.JniMarshalMethodGen_JM8008);
+		public static Message WarningMethodWasNotImproved = new Message (0x8009, Resources.JniMarshalMethodGen_JM8009);
 	}
 }

--- a/tools/jnimarshalmethod-gen/Message.cs
+++ b/tools/jnimarshalmethod-gen/Message.cs
@@ -25,7 +25,5 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator
 		public static Message WarningMarshalMethodsTypeAlreadyExists = new Message (0x8005, Resources.JniMarshalMethodGen_JM8005);
 		public static Message WarningUnableToFindMethodDefinition = new Message (0x8006, Resources.JniMarshalMethodGen_JM8006);
 		public static Message WarningUnableToFindSCWriteLine = new Message (0x8007, Resources.JniMarshalMethodGen_JM8007);
-		public static Message WarningNoTypeWasMovedNothingToWrite = new Message (0x8008, Resources.JniMarshalMethodGen_JM8008);
-		public static Message WarningMethodWasNotImproved = new Message (0x8009, Resources.JniMarshalMethodGen_JM8009);
 	}
 }

--- a/tools/jnimarshalmethod-gen/Message.cs
+++ b/tools/jnimarshalmethod-gen/Message.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Java.Interop.Localization;
 
 namespace Xamarin.Android.Tools.JniMarshalMethodGenerator

--- a/tools/jnimarshalmethod-gen/Message.cs
+++ b/tools/jnimarshalmethod-gen/Message.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Java.Interop.Localization;
+
+namespace Xamarin.Android.Tools.JniMarshalMethodGenerator
+{
+	class Message
+	{
+		public string Localized { get; private set; }
+
+		private Message (string message) => Localized = message;
+
+		public static Message ErrorUnableToPreloadReference = new Message (Resources.JniMarshalMethodGen_JM4001);
+		public static Message ErrorAtLeastOneAssembly = new Message (Resources.JniMarshalMethodGen_JM4002);
+		public static Message ErrorUnableToCreateJavaVM = new Message (Resources.JniMarshalMethodGen_JM4003);
+		public static Message ErrorUnableToReadProfile = new Message (Resources.JniMarshalMethodGen_JM4004);
+		public static Message ErrorPathDoesNotExist = new Message (Resources.JniMarshalMethodGen_JM4005);
+		public static Message ErrorUnableToProcessAssembly = new Message (Resources.JniMarshalMethodGen_JM4006);
+
+		public static Message WarningCouldntFindInterface = new Message (Resources.JniMarshalMethodGen_JM8001);
+		public static Message WarningUnableToReadWithSymbols = new Message (Resources.JniMarshalMethodGen_JM8002);
+		public static Message WarningTypeLoadException = new Message (Resources.JniMarshalMethodGen_JM8003);
+		public static Message WarningUnableToFindTypeDefinition = new Message (Resources.JniMarshalMethodGen_JM8004);
+		public static Message WarningMarshalMethodsTypeAlreadyExists = new Message (Resources.JniMarshalMethodGen_JM8005);
+		public static Message WarningUnableToFindMethodDefinition = new Message (Resources.JniMarshalMethodGen_JM8006);
+		public static Message WarningUnableToFindSCWriteLine = new Message (Resources.JniMarshalMethodGen_JM8007);
+		public static Message WarningNoTypeWasMovedNothingToWrite = new Message (Resources.JniMarshalMethodGen_JM8008);
+		public static Message WarningMethodWasNotImproved = new Message (Resources.JniMarshalMethodGen_JM8008);
+	}
+}

--- a/tools/jnimarshalmethod-gen/TypeMover.cs
+++ b/tools/jnimarshalmethod-gen/TypeMover.cs
@@ -49,7 +49,8 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator
 			}
 
 			if (movedTypesCount <= 0) {
-				App.Warning (Message.WarningNoTypeWasMovedNothingToWrite);
+				if (App.Verbose)
+					App.Information ("No type was moved => nothing to write, no new assembly created.");
 				return;
 			}
 
@@ -504,7 +505,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator
 
 
 			if (isRegisterMethod && improvements < 2)
-				App.Warning (Message.WarningMethodWasNotImproved, md);
+				App.Information ($"Method {md} was not improved. There should have been at least 2 performance improvements in this registration method.");
 
 			if (src.Body.HasExceptionHandlers)
 				foreach (var eh in src.Body.ExceptionHandlers)

--- a/tools/jnimarshalmethod-gen/TypeMover.cs
+++ b/tools/jnimarshalmethod-gen/TypeMover.cs
@@ -30,7 +30,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator
 			if (App.Debug) {
 				consoleWriteLine = GetSingleParameterMethod (resolver, Destination.MainModule, "mscorlib", "System.Console", "WriteLine", "System.String");
 				if (consoleWriteLine == null) {
-					App.Warning ("Unable to find System.Console::WriteLine method. Disabling debug injection");
+					App.Warning (Message.WarningUnableToFindSCWriteLine);
 					App.Debug = false;
 				}
 			}
@@ -49,7 +49,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator
 			}
 
 			if (movedTypesCount <= 0) {
-				App.Warning ("No type was moved => nothing to write, no new assembly created.");
+				App.Warning (Message.WarningNoTypeWasMovedNothingToWrite);
 				return;
 			}
 
@@ -504,7 +504,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator
 
 
 			if (isRegisterMethod && improvements < 2)
-				App.Warning ($"Method {md} was not improved. There should have been at least 2 improvements in this registration method.");
+				App.Warning (Message.WarningMethodWasNotImproved, md);
 
 			if (src.Body.HasExceptionHandlers)
 				foreach (var eh in src.Body.ExceptionHandlers)

--- a/tools/jnimarshalmethod-gen/Xamarin.Android.Tools.JniMarshalMethodGenerator.csproj
+++ b/tools/jnimarshalmethod-gen/Xamarin.Android.Tools.JniMarshalMethodGenerator.csproj
@@ -28,6 +28,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Java.Interop.Export\Java.Interop.Export.csproj" />
+    <ProjectReference Include="..\..\src\Java.Interop.Localization\Java.Interop.Localization.csproj" />
     <ProjectReference Include="..\..\src\Java.Interop\Java.Interop.csproj" />
     <ProjectReference Include="..\..\src\Java.Runtime.Environment\Java.Runtime.Environment.csproj" />
     <ProjectReference Include="..\..\src\Java.Interop.Tools.Cecil\Java.Interop.Tools.Cecil.csproj" />


### PR DESCRIPTION
and warnings messages. Uses the same `Java.Interop.Localization` assembly
as other JI tools use for localizable text.

Change some of the warnings into informational output and also extend
some of the warnings with more information how to possibly avoid
the warning.