### PR TITLE
[generator] Fix localization error.

### DIFF
--- a/tools/generator/CodeGeneratorContext.cs
+++ b/tools/generator/CodeGeneratorContext.cs
@@ -16,5 +16,6 @@ namespace MonoDroid.Generation
 		string ContextMethodString => ContextMethod != null ? "in method " + ContextMethod.Name + " " : null;
 		string ContextTypeString => ContextType != null ? "in managed type " + ContextType.FullName : null;
 		public string ContextString => ContextFieldString + ContextMethodString + ContextTypeString;
+		public string ContextTypeMember => (ContextType != null ? $"{ContextType.FullName}." : string.Empty) + ContextMethod?.Name ?? ContextField?.Name;
 	}
 }

--- a/tools/generator/CodeGeneratorContext.cs
+++ b/tools/generator/CodeGeneratorContext.cs
@@ -16,6 +16,17 @@ namespace MonoDroid.Generation
 		string ContextMethodString => ContextMethod != null ? "in method " + ContextMethod.Name + " " : null;
 		string ContextTypeString => ContextType != null ? "in managed type " + ContextType.FullName : null;
 		public string ContextString => ContextFieldString + ContextMethodString + ContextTypeString;
-		public string ContextTypeMember => (ContextType != null ? $"{ContextType.FullName}." : string.Empty) + ContextMethod?.Name ?? ContextField?.Name;
+
+		public string GetContextTypeMember ()
+		{
+			var output = ContextType?.FullName ?? string.Empty;
+
+			if (ContextMethod != null) {
+				output += $"{ContextMethod.Name} ({string.Join (", ", ContextMethod?.Parameters.Select (p => p.RawType).ToArray ())})";
+				return output;
+			}
+
+			return output + ContextField?.Name;
+		}
 	}
 }

--- a/tools/generator/CodeGeneratorContext.cs
+++ b/tools/generator/CodeGeneratorContext.cs
@@ -22,7 +22,7 @@ namespace MonoDroid.Generation
 			var output = ContextType?.FullName ?? string.Empty;
 
 			if (ContextMethod != null) {
-				output += $"{ContextMethod.Name} ({string.Join (", ", ContextMethod?.Parameters.Select (p => p.RawType).ToArray ())})";
+				output += $"{ContextMethod.Name} ({string.Join (", ", ContextMethod?.Parameters.Select (p => p.InternalType).ToArray ())})";
 				return output;
 			}
 

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Field.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Field.cs
@@ -38,7 +38,7 @@ namespace MonoDroid.Generation
 			Symbol = opt.SymbolTable.Lookup (TypeName, type_params);
 
 			if (Symbol == null || !Symbol.Validate (opt, type_params, context)) {
-				Report.LogCodedWarning (0, Report.WarningUnexpectedFieldType, TypeName, context.ContextTypeMember);
+				Report.LogCodedWarning (0, Report.WarningUnexpectedFieldType, TypeName, context.GetContextTypeMember ());
 				return false;
 			}
 

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Field.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Field.cs
@@ -38,7 +38,7 @@ namespace MonoDroid.Generation
 			Symbol = opt.SymbolTable.Lookup (TypeName, type_params);
 
 			if (Symbol == null || !Symbol.Validate (opt, type_params, context)) {
-				Report.LogCodedWarning (0, Report.WarningUnexpectedFieldType, TypeName, context.ContextString);
+				Report.LogCodedWarning (0, Report.WarningUnexpectedFieldType, TypeName, context.ContextTypeMember);
 				return false;
 			}
 

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenericParameterDefinition.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenericParameterDefinition.cs
@@ -38,7 +38,7 @@ namespace MonoDroid.Generation
 			foreach (var c in ConstraintExpressions) {
 				var sym = opt.SymbolTable.Lookup (c, type_params);
 				if (sym == null) {
-					Report.LogCodedWarning (0, Report.WarningUnknownGenericConstraint, c, context.ContextTypeMember);
+					Report.LogCodedWarning (0, Report.WarningUnknownGenericConstraint, c, context.GetContextTypeMember ());
 					validated = true;
 					return false;
 				}

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenericParameterDefinition.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenericParameterDefinition.cs
@@ -38,7 +38,7 @@ namespace MonoDroid.Generation
 			foreach (var c in ConstraintExpressions) {
 				var sym = opt.SymbolTable.Lookup (c, type_params);
 				if (sym == null) {
-					Report.LogCodedWarning (0, Report.WarningUnknownGenericConstraint, c, context.ContextString);
+					Report.LogCodedWarning (0, Report.WarningUnknownGenericConstraint, c, context.ContextTypeMember);
 					validated = true;
 					return false;
 				}

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Parameter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Parameter.cs
@@ -224,6 +224,8 @@ namespace MonoDroid.Generation {
 			get { return managed_type ?? sym.FullName; }
 		}
 
+		public string RawType => type;
+
 		public string Annotation { get; internal set; }
 
 		public void SetGeneratedEnumType (string enumType)
@@ -260,11 +262,11 @@ namespace MonoDroid.Generation {
 		{
 			sym = opt.SymbolTable.Lookup (type, type_params);
 			if (sym == null) {
-				Report.LogCodedWarning (0, Report.WarningUnknownParameterType, type, context.ContextTypeMember);
+				Report.LogCodedWarning (0, Report.WarningUnknownParameterType, type, context.GetContextTypeMember ());
 				return false;
 			}
 			if (!sym.Validate (opt, type_params, context)) {
-				Report.LogCodedWarning (0, Report.WarningInvalidParameterType, type, context.ContextTypeMember);
+				Report.LogCodedWarning (0, Report.WarningInvalidParameterType, type, context.GetContextTypeMember ());
 				return false;
 			}
 			return true;

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Parameter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Parameter.cs
@@ -260,11 +260,11 @@ namespace MonoDroid.Generation {
 		{
 			sym = opt.SymbolTable.Lookup (type, type_params);
 			if (sym == null) {
-				Report.LogCodedWarning (0, Report.WarningUnknownParameterType, type, context.ContextString);
+				Report.LogCodedWarning (0, Report.WarningUnknownParameterType, type, context.ContextTypeMember);
 				return false;
 			}
 			if (!sym.Validate (opt, type_params, context)) {
-				Report.LogCodedWarning (0, Report.WarningInvalidParameterType, type, context.ContextString);
+				Report.LogCodedWarning (0, Report.WarningInvalidParameterType, type, context.ContextTypeMember);
 				return false;
 			}
 			return true;

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Parameter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Parameter.cs
@@ -224,7 +224,7 @@ namespace MonoDroid.Generation {
 			get { return managed_type ?? sym.FullName; }
 		}
 
-		public string RawType => type;
+		public string InternalType => managed_type ?? sym?.FullName ?? type;
 
 		public string Annotation { get; internal set; }
 

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ReturnValue.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ReturnValue.cs
@@ -121,11 +121,11 @@ namespace MonoDroid.Generation {
 		{
 			sym = (IsEnumified ? opt.SymbolTable.Lookup (managed_type, type_params) : null) ?? opt.SymbolTable.Lookup (java_type, type_params);
 			if (sym == null) {
-				Report.LogCodedWarning (0, Report.WarningUnknownReturnType, java_type, context.ContextString);
+				Report.LogCodedWarning (0, Report.WarningUnknownReturnType, java_type, context.ContextTypeMember);
 				return false;
 			}
 			if (!sym.Validate (opt, type_params, context)) {
-				Report.LogCodedWarning (0, Report.WarningInvalidReturnType, java_type, context.ContextString);
+				Report.LogCodedWarning (0, Report.WarningInvalidReturnType, java_type, context.ContextTypeMember);
 				return false;
 			}
 			return true;

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ReturnValue.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ReturnValue.cs
@@ -121,11 +121,11 @@ namespace MonoDroid.Generation {
 		{
 			sym = (IsEnumified ? opt.SymbolTable.Lookup (managed_type, type_params) : null) ?? opt.SymbolTable.Lookup (java_type, type_params);
 			if (sym == null) {
-				Report.LogCodedWarning (0, Report.WarningUnknownReturnType, java_type, context.ContextTypeMember);
+				Report.LogCodedWarning (0, Report.WarningUnknownReturnType, java_type, context.GetContextTypeMember ());
 				return false;
 			}
 			if (!sym.Validate (opt, type_params, context)) {
-				Report.LogCodedWarning (0, Report.WarningInvalidReturnType, java_type, context.ContextTypeMember);
+				Report.LogCodedWarning (0, Report.WarningInvalidReturnType, java_type, context.GetContextTypeMember ());
 				return false;
 			}
 			return true;


### PR DESCRIPTION
In #689 we made `generator` localizable.  One of the changes was this pattern:

```
- Report.Warning (0, Report.WarningReturnValue + 0, "Unknown return type {0} {1}.", java_type, context.ContextString);
+ Report.LogCodedWarning (0, Report.WarningUnknownReturnType, java_type, context.ContextString);

where:
Report.WarningUnexpectedFieldType = "Unknown return type '{0}' for member '{1}'."
```

However `context.ContextString` generates a hard to localize string like:
```
in method CreateFromXml in managed type Android.Content.Res.ColorStateList
```

resulting in warnings like this:
```
warning BG8800: Unknown return type 'System.Xml.XmlReader' for member 'in method CreateFromXml in managed type Android.Content.Res.ColorStateList'.
```

Instead, create a `context.ContextTypeMember` method that formats the member as just a type signature, which fits the localized message:
```
warning BG8800: Unknown return type 'System.Xml.XmlReader' for member 'Android.Content.Res.ColorStateList.CreateFromXml'.
```