### PR TITLE
[C++] Get rid of compiler warnings

### DIFF
--- a/src/java-interop/java-interop-gc-bridge-mono.cc
+++ b/src/java-interop/java-interop-gc-bridge-mono.cc
@@ -256,7 +256,8 @@ java_interop_gc_bridge_new (JavaVM *jvm)
 	}
 #endif  /* defined (XAMARIN_ANDROID_DYLIB_MONO) */
 
-	JavaInteropGCBridge bridge = {0};
+	JavaInteropGCBridge bridge;
+	memset (&bridge, 0, sizeof(bridge));
 
 	bridge.jvm  = jvm;
 
@@ -896,7 +897,7 @@ take_weak_global_ref_jni (JavaInteropGCBridge *bridge, JNIEnv *env, MonoObject *
 }
 
 static jmethodID
-get_add_reference_method (JavaInteropGCBridge *bridge, JNIEnv *env, jobject obj, MonoClass *mclass)
+get_add_reference_method (JavaInteropGCBridge *bridge, JNIEnv *env, jobject obj, [[maybe_unused]] MonoClass *mclass)
 {
 	if (!obj)
 		return NULL;
@@ -1280,7 +1281,8 @@ java_interop_gc_bridge_register_hooks (JavaInteropGCBridge *bridge, int weak_ref
 
 	const char *message = NULL;
 
-	MonoGCBridgeCallbacks   bridge_cbs = {0};
+	MonoGCBridgeCallbacks   bridge_cbs;
+	memset (&bridge_cbs, 0, sizeof(bridge_cbs));
 
 	switch (weak_ref_kind) {
 	case JAVA_INTEROP_GC_BRIDGE_USE_WEAK_REFERENCE_KIND_JAVA:

--- a/src/java-interop/java-interop-gc-bridge-mono.cc
+++ b/src/java-interop/java-interop-gc-bridge-mono.cc
@@ -257,7 +257,7 @@ java_interop_gc_bridge_new (JavaVM *jvm)
 #endif  /* defined (XAMARIN_ANDROID_DYLIB_MONO) */
 
 	JavaInteropGCBridge bridge;
-	memset (&bridge, 0, sizeof(bridge));
+	memset (&bridge, 0, sizeof (bridge));
 
 	bridge.jvm  = jvm;
 
@@ -1282,7 +1282,7 @@ java_interop_gc_bridge_register_hooks (JavaInteropGCBridge *bridge, int weak_ref
 	const char *message = NULL;
 
 	MonoGCBridgeCallbacks   bridge_cbs;
-	memset (&bridge_cbs, 0, sizeof(bridge_cbs));
+	memset (&bridge_cbs, 0, sizeof (bridge_cbs));
 
 	switch (weak_ref_kind) {
 	case JAVA_INTEROP_GC_BRIDGE_USE_WEAK_REFERENCE_KIND_JAVA:

--- a/src/java-interop/java-interop-util.cc
+++ b/src/java-interop/java-interop-util.cc
@@ -10,6 +10,8 @@ utf16_to_utf8 (const wchar_t *widestr)
 	char *mbstr = static_cast<char*> (calloc (required_size, sizeof (char)));
 	int converted_size = WideCharToMultiByte (CP_UTF8, 0, widestr, -1, mbstr, required_size, NULL, NULL);
 
+	// Hush a compiler warning about unused variable in RELEASE
+	(void)converted_size;
 	assert (converted_size == required_size);
 
 	return mbstr;
@@ -22,6 +24,8 @@ utf8_to_utf16 (const char *mbstr)
 	wchar_t *widestr = static_cast<wchar_t*> (calloc (required_chars, sizeof (wchar_t)));
 	int converted_chars = MultiByteToWideChar (CP_UTF8, 0, mbstr, -1, widestr, required_chars);
 
+	// Hush a compiler warning about unused variable in RELEASE
+	(void)converted_chars;
 	assert (converted_chars == required_chars);
 
 	return widestr;


### PR DESCRIPTION
When Java.Interop is built with GCC (e.g. on Linux or with MinGW), the
flags Xamarin.Android passes to the compiler cause a handful of warnings
to be shown regarding incomplete field assignment when initializing
structure instances:

    java-interop-gc-bridge-mono.cc:259:33: warning: missing initializer for member ‘JavaInteropGCBridge::BridgeProcessing_type’ [-Wmissing-field-initializers]
      259 |  JavaInteropGCBridge bridge = {0};
          |                                 ^
    java-interop-gc-bridge-mono.cc:259:33: warning: missing initializer for member ‘JavaInteropGCBridge::BridgeProcessing_field’ [-Wmissing-field-initializers]
    java-interop-gc-bridge-mono.cc:259:33: warning: missing initializer for member ‘JavaInteropGCBridge::BridgeProcessing_vtables_count’ [-Wmissing-field-initializers]
    java-interop-gc-bridge-mono.cc:259:33: warning: missing initializer for member ‘JavaInteropGCBridge::BridgeProcessing_vtables_length’ [-Wmissing-field-initializers]
    java-interop-gc-bridge-mono.cc:259:33: warning: missing initializer for member ‘JavaInteropGCBridge::BridgeProcessing_domains’ [-Wmissing-field-initializers]
    java-interop-gc-bridge-mono.cc:259:33: warning: missing initializer for member ‘JavaInteropGCBridge::BridgeProcessing_vtables’ [-Wmissing-field-initializers]
    java-interop-gc-bridge-mono.cc:259:33: warning: missing initializer for member ‘JavaInteropGCBridge::num_bridge_types’ [-Wmissing-field-initializers]
    java-interop-gc-bridge-mono.cc:259:33: warning: missing initializer for member ‘JavaInteropGCBridge::mono_java_gc_bridge_info’ [-Wmissing-field-initializers]
    java-interop-gc-bridge-mono.cc:259:33: warning: missing initializer for member ‘JavaInteropGCBridge::gc_disabled’ [-Wmissing-field-initializers]
    java-interop-gc-bridge-mono.cc:259:33: warning: missing initializer for member ‘JavaInteropGCBridge::gc_gref_count’ [-Wmissing-field-initializers]
    java-interop-gc-bridge-mono.cc:259:33: warning: missing initializer for member ‘JavaInteropGCBridge::gc_weak_gref_count’ [-Wmissing-field-initializers]
    java-interop-gc-bridge-mono.cc:259:33: warning: missing initializer for member ‘JavaInteropGCBridge::Runtime_instance’ [-Wmissing-field-initializers]
    java-interop-gc-bridge-mono.cc:259:33: warning: missing initializer for member ‘JavaInteropGCBridge::Runtime_gc’ [-Wmissing-field-initializers]
    java-interop-gc-bridge-mono.cc:259:33: warning: missing initializer for member ‘JavaInteropGCBridge::WeakReference_class’ [-Wmissing-field-initializers]
    java-interop-gc-bridge-mono.cc:259:33: warning: missing initializer for member ‘JavaInteropGCBridge::WeakReference_init’ [-Wmissing-field-initializers]
    java-interop-gc-bridge-mono.cc:259:33: warning: missing initializer for member ‘JavaInteropGCBridge::WeakReference_get’ [-Wmissing-field-initializers]
    java-interop-gc-bridge-mono.cc:259:33: warning: missing initializer for member ‘JavaInteropGCBridge::GCUserPeerable_class’ [-Wmissing-field-initializers]
    java-interop-gc-bridge-mono.cc:259:33: warning: missing initializer for member ‘JavaInteropGCBridge::GCUserPeerable_add’ [-Wmissing-field-initializers]
    java-interop-gc-bridge-mono.cc:259:33: warning: missing initializer for member ‘JavaInteropGCBridge::GCUserPeerable_clear’ [-Wmissing-field-initializers]
    java-interop-gc-bridge-mono.cc:259:33: warning: missing initializer for member ‘JavaInteropGCBridge::gref_log’ [-Wmissing-field-initializers]
    java-interop-gc-bridge-mono.cc:259:33: warning: missing initializer for member ‘JavaInteropGCBridge::lref_log’ [-Wmissing-field-initializers]
    java-interop-gc-bridge-mono.cc:259:33: warning: missing initializer for member ‘JavaInteropGCBridge::gref_path’ [-Wmissing-field-initializers]
    java-interop-gc-bridge-mono.cc:259:33: warning: missing initializer for member ‘JavaInteropGCBridge::lref_path’ [-Wmissing-field-initializers]
    java-interop-gc-bridge-mono.cc:259:33: warning: missing initializer for member ‘JavaInteropGCBridge::gref_log_level’ [-Wmissing-field-initializers]
    java-interop-gc-bridge-mono.cc:259:33: warning: missing initializer for member ‘JavaInteropGCBridge::lref_log_level’ [-Wmissing-field-initializers]
    java-interop-gc-bridge-mono.cc:259:33: warning: missing initializer for member ‘JavaInteropGCBridge::gref_cleanup’ [-Wmissing-field-initializers]
    java-interop-gc-bridge-mono.cc:259:33: warning: missing initializer for member ‘JavaInteropGCBridge::lref_cleanup’ [-Wmissing-field-initializers]
    java-interop-gc-bridge-mono.cc: In function ‘_jmethodID* get_add_reference_method(JavaInteropGCBridge*, JNIEnv*, jobject, MonoClass*)’:
    java-interop-gc-bridge-mono.cc:1283:41: warning: missing initializer for member ‘MonoGCBridgeCallbacks::bridge_class_kind’ [-Wmissing-field-initializers]
     1283 |  MonoGCBridgeCallbacks   bridge_cbs = {0};
          |                                         ^
    java-interop-gc-bridge-mono.cc:1283:41: warning: missing initializer for member ‘MonoGCBridgeCallbacks::is_bridge_object’ [-Wmissing-field-initializers]
    java-interop-gc-bridge-mono.cc:1283:41: warning: missing initializer for member ‘MonoGCBridgeCallbacks::cross_references’ [-Wmissing-field-initializers]

Instead of initializing every field, simply use `memset` to initialize
the structure memory to `0`.

Another warning fixed by this commit is one regarding unused function
parameters:

    java-interop-gc-bridge-mono.cc:899:93: warning: unused parameter ‘mclass’ [-Wunused-parameter]
      899 | get_add_reference_method (JavaInteropGCBridge *bridge, JNIEnv *env, jobject obj, MonoClass *mclass)
          |                                                                                  ~~~~~~~~~~~^~~~~~

Yet another fixed warning relates to MinGW `RELEASE` builds only:

    java-interop-util.cc: In function ‘char* utf16_to_utf8(const wchar_t*)’:
    java-interop/java-interop-util.cc:11:6: warning: unused variable ‘converted_size’ [-Wunused-variable]
       11 |  int converted_size = WideCharToMultiByte (CP_UTF8, 0, widestr, -1, mbstr, required_size, NULL, NULL);
          |      ^~~~~~~~~~~~~~
    java-interop/java-interop-util.cc: In function ‘wchar_t* utf8_to_utf16(const char*)’:
    java-interop/java-interop-util.cc:23:6: warning: unused variable ‘converted_chars’ [-Wunused-variable]
       23 |  int converted_chars = MultiByteToWideChar (CP_UTF8, 0, mbstr, -1, widestr, required_chars);
          |      ^~~~~~~~~~~~~~~

These warnings are shown because the `assert` macro used in the above
functions is not compiled in `RELEASE` build which leaves the variables
mentioned above indeed unused.