### PR TITLE
[build] fix env vars causing gradle build error

### DIFF
--- a/tools/java-source-utils/Directory.Build.targets
+++ b/tools/java-source-utils/Directory.Build.targets
@@ -11,6 +11,7 @@
         Command="&quot;$(GradleWPath)&quot; -d $(GradleArgs) -PjavaSourceVer=$(JavacSourceVersion) -PjavaTargetVer=$(JavacTargetVersion) jar"
         EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);APP_HOME=$(GradleHome)"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
+        IgnoreStandardErrorWarningFormat="true"
     />
     <Copy
         SourceFiles="build\libs\java-source-utils.jar"
@@ -72,7 +73,7 @@
     />
   </Target>
 
-  <Target Name="_CleanJava" DependsOnTargets="Clean">
+  <Target Name="_CleanJava" BeforeTargets="Clean">
     <Delete Files="$(OutputPath)java-source-utils.jar" />
     <Exec
         Command="&quot;$(GradleWPath)&quot; clean $(GradleArgs)"


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/5044#issuecomment-683131462
Context: https://docs.microsoft.com/visualstudio/msbuild/exec-task

An env var can break the build such as running the following powershell:

    > $env:FOO="`nFoo.cs(123,1) error: oh dear!"

A `\n` new line in the string is required to hit an issue.

This results in a confusing build error:

    (_BuildJava target) ->
        EXEC : Foo.cs(123,1) error : oh dear!

`gradlew -d` emits every environment variable, and if there is a line
that looks like an MSBuild error it will emit the error. We can set
`IgnoreStandardErrorWarningFormat="true"` to disable this behavior.

This could commonly happen on CI systems, if a commit message contains
an error message.

In the case of Azure DevOps, `%BUILD_SOURCEVERSIONMESSAGE%` will
contain the full commit message.

I also fixed the `_CleanJava` target that was not running at all.
`java-source-utils.csproj` now properly cleans now.