### PR TITLE
[ci] Don't kick off CI for documentation only changes.

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -5,8 +5,14 @@ trigger:
   - d16-*
 
 pr:
-  - master
-  - d16-*
+  branches:
+    include:
+    - master
+    - d16-*
+  paths:
+    exclude:
+    - README.md
+    - Documentation/*
 
 # Global variables
 variables:


### PR DESCRIPTION
Use the "paths" feature of CI triggers to prevent running CI for PRs that only contain "Documentation" changes.

https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#paths

I wasn't able to verify that this works.  It's possible that it needs to already be on the default branch in order to take effect.  It shouldn't hurt to merge it and then test.