### PR TITLE
[generator] Provide line/col numbers for api.xml warnings.

### DIFF
--- a/tests/generator-Tests/Unit-Tests/XmlApiImporterTests.cs
+++ b/tests/generator-Tests/Unit-Tests/XmlApiImporterTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Xml.Linq;
 using MonoDroid.Generation;
 using NUnit.Framework;
@@ -225,6 +226,23 @@ namespace generatortests
 			var p = XmlApiImporter.CreateParameter (xml.Root);
 
 			Assert.True (p.NotNull);
+		}
+
+		[Test]
+		public void PreserveSourceLineInfo ()
+		{
+			var xml = XDocument.Parse ("<package name=\"com.example.test\" jni-name=\"com/example/test\">\n<class name=\"test\">\n<method name=\"add-h-_1V8i\" final=\"false\" />\n</class>\n</package>", LoadOptions.SetBaseUri | LoadOptions.SetLineInfo);
+			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), new CodeGenerationOptions { ApiXmlFile = "obj/Debug/api.xml" });
+
+			Assert.AreEqual (2, klass.LineNumber);
+			Assert.AreEqual (2, klass.LinePosition);
+			Assert.AreEqual ("obj/Debug/api.xml", klass.SourceFile);
+
+			var method = klass.Methods.Single ();
+
+			Assert.AreEqual (3, method.LineNumber);
+			Assert.AreEqual (2, method.LinePosition);
+			Assert.AreEqual ("obj/Debug/api.xml", method.SourceFile);
 		}
 	}
 }

--- a/tools/generator/CodeGenerationOptions.cs
+++ b/tools/generator/CodeGenerationOptions.cs
@@ -48,6 +48,7 @@ namespace MonoDroid.Generation
 		readonly SortedSet<string> jni_marshal_delegates = new SortedSet<string> ();
 		readonly object jni_marshal_delegates_lock = new object ();
 
+		public string ApiXmlFile { get; set; }
 		public bool UseGlobal { get; set; }
 		public bool IgnoreNonPublicType { get; set; }
 		public string AssemblyName { get; set; }

--- a/tools/generator/CodeGenerator.cs
+++ b/tools/generator/CodeGenerator.cs
@@ -60,6 +60,7 @@ namespace Xamarin.Android.Binder
 			string api_xml_adjuster_output = options.ApiXmlAdjusterOutput;
 			var apiSource           = "";
 			var opt                 = new CodeGenerationOptions () {
+				ApiXmlFile            = options.ApiDescriptionFile,
 				CodeGenerationTarget  = options.CodeGenerationTarget,
 				UseGlobal             = options.GlobalTypeNames,
 				IgnoreNonPublicType   = true,

--- a/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/CodeGenerator.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/CodeGenerator.cs
@@ -393,11 +393,11 @@ namespace MonoDroid.Generation
 			bool needsProperty = false;
 			foreach (Field f in fields) {
 				if (gen.ContainsName (f.Name)) {
-					Report.LogCodedWarning (0, SourceWriterExtensions.GetFieldCollisionMessage (gen, f), gen.FullName, f.Name, gen.JavaName);
+					Report.LogCodedWarning (0, SourceWriterExtensions.GetFieldCollisionMessage (gen, f), f, gen.FullName, f.Name, gen.JavaName);
 					continue;
 				}
 				if (seen != null && seen.Contains (f.Name)) {
-					Report.LogCodedWarning (0, Report.WarningDuplicateField, gen.FullName, f.Name, gen.JavaName);
+					Report.LogCodedWarning (0, Report.WarningDuplicateField, f, gen.FullName, f.Name, gen.JavaName);
 					continue;
 				}
 				if (f.Validate (opt, gen.TypeParameters, Context)) {
@@ -935,11 +935,11 @@ namespace MonoDroid.Generation
 			foreach (var method in eventMethods) {
 				string name = method.CalculateEventName (target.ContainsName);
 				if (String.IsNullOrEmpty (name)) {
-					Report.LogCodedWarning (0, Report.WarningEmptyEventName, @interface.FullName, method.Name);
+					Report.LogCodedWarning (0, Report.WarningEmptyEventName, method, @interface.FullName, method.Name);
 					continue;
 				}
 				if (opt.GetSafeIdentifier (name) != name) {
-					Report.LogCodedWarning (0, Report.WarningInvalidEventName, @interface.FullName, method.Name);
+					Report.LogCodedWarning (0, Report.WarningInvalidEventName, method, @interface.FullName, method.Name);
 					continue;
 				}
 				var prop = target.Properties.FirstOrDefault (p => p.Setter == method);
@@ -996,7 +996,7 @@ namespace MonoDroid.Generation
 				full_delegate_name += "Handler";
 			if (m.RetVal.IsVoid || m.IsEventHandlerWithHandledProperty) {
 				if (opt.GetSafeIdentifier (name) != name) {
-					Report.LogCodedWarning (0, Report.WarningInvalidEventName2, @interface.FullName, name);
+					Report.LogCodedWarning (0, Report.WarningInvalidEventName2, m, @interface.FullName, name);
 					return;
 				} else {
 					var mt = target.Methods.Where (method => string.Compare (method.Name, connector_fmt, StringComparison.OrdinalIgnoreCase) == 0 && method.IsListenerConnector).FirstOrDefault ();
@@ -1005,7 +1005,7 @@ namespace MonoDroid.Generation
 				}
 			} else {
 				if (opt.GetSafeIdentifier (name) != name) {
-					Report.LogCodedWarning (0, Report.WarningInvalidEventPropertyName, @interface.FullName, name);
+					Report.LogCodedWarning (0, Report.WarningInvalidEventPropertyName, m, @interface.FullName, name);
 					return;
 				}
 				writer.WriteLine ("{0}WeakReference{2} weak_implementor_{1};", indent, name, opt.NullableOperator);

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ClassGen.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ClassGen.cs
@@ -294,13 +294,13 @@ namespace MonoDroid.Generation
 
 			base_symbol = IsAnnotation ? opt.SymbolTable.Lookup ("java.lang.Object") : BaseType != null ? opt.SymbolTable.Lookup (BaseType) : null;
 			if (base_symbol == null && FullName != "Java.Lang.Object" && FullName != "System.Object") {
-				Report.LogCodedWarning (0, Report.WarningUnknownBaseType, FullName, BaseType);
+				Report.LogCodedWarning (0, Report.WarningUnknownBaseType, this, FullName, BaseType);
 				IsValid = false;
 				return false;
 			}
 
 			if ((base_symbol != null && !base_symbol.Validate (opt, TypeParameters, context)) || !base.OnValidate (opt, type_params, context)) {
-				Report.LogCodedWarning (0, Report.WarningInvalidBaseType, FullName, BaseType);
+				Report.LogCodedWarning (0, Report.WarningInvalidBaseType, this, FullName, BaseType);
 				IsValid = false;
 				return false;
 			}

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Field.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Field.cs
@@ -4,7 +4,7 @@ using MonoDroid.Utils;
 
 namespace MonoDroid.Generation
 {
-	public class Field : ApiVersionsSupport.IApiAvailability
+	public class Field : ApiVersionsSupport.IApiAvailability, ISourceLineInfo
 	{
 		public string Annotation { get; set; }
 		public int ApiAvailableSince { get; set; }
@@ -25,6 +25,10 @@ namespace MonoDroid.Generation
 		public string Value { get; set; }
 		public string Visibility { get; set; }
 
+		public int LineNumber { get; set; } = -1;
+		public int LinePosition { get; set; } = -1;
+		public string SourceFile { get; set; }
+
 		internal string GetMethodPrefix => TypeNameUtilities.GetCallPrefix (Symbol);
 
 		internal string ID => JavaName + "_jfieldId";
@@ -38,7 +42,7 @@ namespace MonoDroid.Generation
 			Symbol = opt.SymbolTable.Lookup (TypeName, type_params);
 
 			if (Symbol == null || !Symbol.Validate (opt, type_params, context)) {
-				Report.LogCodedWarning (0, Report.WarningUnexpectedFieldType, TypeName, context.GetContextTypeMember ());
+				Report.LogCodedWarning (0, Report.WarningUnexpectedFieldType, this, TypeName, context.GetContextTypeMember ());
 				return false;
 			}
 

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
@@ -6,7 +6,7 @@ using MonoDroid.Generation.Utilities;
 
 namespace MonoDroid.Generation
 {
-	public abstract class GenBase : IGeneratable, ApiVersionsSupport.IApiAvailability
+	public abstract class GenBase : IGeneratable, ApiVersionsSupport.IApiAvailability, ISourceLineInfo
 	{
 		bool enum_updated;
 		bool property_filled;
@@ -32,6 +32,10 @@ namespace MonoDroid.Generation
 		public List<Property> Properties { get; } = new List<Property> ();
 		public string DefaultValue { get; set; }
 		public bool HasVirtualMethods { get; set; }
+
+		public int LineNumber { get; set; } = -1;
+		public int LinePosition { get; set; } = -1;
+		public string SourceFile { get; set; }
 
 		public string ReturnCast => string.Empty;
 
@@ -662,9 +666,9 @@ namespace MonoDroid.Generation
 					Interfaces.Add (isym);
 				else {
 					if (isym == null)
-						Report.LogCodedWarning (0, Report.WarningBaseInterfaceNotFound, FullName, iface_name);
+						Report.LogCodedWarning (0, Report.WarningBaseInterfaceNotFound, this, FullName, iface_name);
 					else
-						Report.LogCodedWarning (0, Report.WarningBaseInterfaceInvalid, FullName, iface_name);
+						Report.LogCodedWarning (0, Report.WarningBaseInterfaceInvalid, this, FullName, iface_name);
 					iface_validation_failed = true;
 				}
 			}

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ISourceLineInfo.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ISourceLineInfo.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MonoDroid.Generation
+{
+	public interface ISourceLineInfo
+	{
+		int LineNumber { get; set; }
+		int LinePosition { get; set; }
+		string SourceFile { get; set; }
+	}
+}

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/InterfaceGen.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/InterfaceGen.cs
@@ -204,9 +204,9 @@ namespace MonoDroid.Generation
 
 			if (!base.OnValidate (opt, type_params, context) || iface_validation_failed || MethodValidationFailed) {
 				if (iface_validation_failed)
-					Report.LogCodedWarning (0, Report.WarningInvalidDueToInterfaces, FullName);
+					Report.LogCodedWarning (0, Report.WarningInvalidDueToInterfaces, this, FullName);
 				else if (MethodValidationFailed)
-					Report.LogCodedWarning (0, Report.WarningInvalidDueToMethods, FullName);
+					Report.LogCodedWarning (0, Report.WarningInvalidDueToMethods, this, FullName);
 				foreach (GenBase nest in NestedTypes)
 					nest.Invalidate ();
 				IsValid = false;

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/MethodBase.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/MethodBase.cs
@@ -5,7 +5,7 @@ using MonoDroid.Generation.Utilities;
 
 namespace MonoDroid.Generation
 {
-	public abstract class MethodBase : ApiVersionsSupport.IApiAvailability
+	public abstract class MethodBase : ApiVersionsSupport.IApiAvailability, ISourceLineInfo
 	{
 		protected MethodBase (GenBase declaringType)
 		{
@@ -23,6 +23,10 @@ namespace MonoDroid.Generation
 		public string Name { get; set; }
 		public ParameterList Parameters { get; } = new ParameterList ();
 		public string Visibility { get; set; }
+
+		public int LineNumber { get; set; } = -1;
+		public int LinePosition { get; set; } = -1;
+		public string SourceFile { get; set; }
 
 		public string [] AutoDetectEnumifiedOverrideParameters (AncestorDescendantCache cache)
 		{

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Parameter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Parameter.cs
@@ -10,13 +10,17 @@ using Xamarin.Android.Tools;
 
 namespace MonoDroid.Generation {
 
-	public class Parameter {
-
+	public class Parameter : ISourceLineInfo
+	{
 		bool is_sender;
 		string name;
 		string type, managed_type, rawtype;
 		ISymbol sym;
 		bool is_enumified;
+
+		public int LineNumber { get; set; } = -1;
+		public int LinePosition { get; set; } = -1;
+		public string SourceFile { get; set; }
 
 		internal Parameter (string name, string type, string managedType, bool isEnumified, string rawtype = null, bool notNull = false)
 		{
@@ -262,11 +266,11 @@ namespace MonoDroid.Generation {
 		{
 			sym = opt.SymbolTable.Lookup (type, type_params);
 			if (sym == null) {
-				Report.LogCodedWarning (0, Report.WarningUnknownParameterType, type, context.GetContextTypeMember ());
+				Report.LogCodedWarning (0, Report.WarningUnknownParameterType, this, type, context.GetContextTypeMember ());
 				return false;
 			}
 			if (!sym.Validate (opt, type_params, context)) {
-				Report.LogCodedWarning (0, Report.WarningInvalidParameterType, type, context.GetContextTypeMember ());
+				Report.LogCodedWarning (0, Report.WarningInvalidParameterType, this, type, context.GetContextTypeMember ());
 				return false;
 			}
 			return true;

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ReturnValue.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ReturnValue.cs
@@ -14,12 +14,14 @@ namespace MonoDroid.Generation {
 		string managed_type;
 		string raw_type;
 		bool is_enumified;
+		Method owner;
 
 		public ReturnValue (Method owner, string java_type, string managed_type, bool isEnumified, bool notNull)
 		{
 			this.raw_type = this.java_type = java_type;
 			this.managed_type = managed_type;
 			this.is_enumified = isEnumified;
+			this.owner = owner;
 			NotNull = notNull;
 		}
 
@@ -121,11 +123,11 @@ namespace MonoDroid.Generation {
 		{
 			sym = (IsEnumified ? opt.SymbolTable.Lookup (managed_type, type_params) : null) ?? opt.SymbolTable.Lookup (java_type, type_params);
 			if (sym == null) {
-				Report.LogCodedWarning (0, Report.WarningUnknownReturnType, java_type, context.GetContextTypeMember ());
+				Report.LogCodedWarning (0, Report.WarningUnknownReturnType, owner, java_type, context.GetContextTypeMember ());
 				return false;
 			}
 			if (!sym.Validate (opt, type_params, context)) {
-				Report.LogCodedWarning (0, Report.WarningInvalidReturnType, java_type, context.GetContextTypeMember ());
+				Report.LogCodedWarning (0, Report.WarningInvalidReturnType, owner, java_type, context.GetContextTypeMember ());
 				return false;
 			}
 			return true;

--- a/tools/generator/SourceWriters/Extensions/SourceWriterExtensions.cs
+++ b/tools/generator/SourceWriters/Extensions/SourceWriterExtensions.cs
@@ -24,12 +24,12 @@ namespace generator.SourceWriters
 
 			foreach (var f in fields) {
 				if (gen.ContainsName (f.Name)) {
-					Report.LogCodedWarning (0, GetFieldCollisionMessage (gen, f), gen.FullName, f.Name, gen.JavaName);
+					Report.LogCodedWarning (0, GetFieldCollisionMessage (gen, f), f, gen.FullName, f.Name, gen.JavaName);
 					continue;
 				}
 
 				if (seen != null && seen.Contains (f.Name)) {
-					Report.LogCodedWarning (0, Report.WarningDuplicateField, gen.FullName, f.Name, gen.JavaName);
+					Report.LogCodedWarning (0, Report.WarningDuplicateField, f, gen.FullName, f.Name, gen.JavaName);
 					continue;
 				}
 
@@ -66,12 +66,12 @@ namespace generator.SourceWriters
 				var name = method.CalculateEventName (target.ContainsName);
 
 				if (string.IsNullOrEmpty (name)) {
-					Report.LogCodedWarning (0, Report.WarningEmptyEventName, iface.FullName, method.Name);
+					Report.LogCodedWarning (0, Report.WarningEmptyEventName, method, iface.FullName, method.Name);
 					continue;
 				}
 
 				if (opt.GetSafeIdentifier (name) != name) {
-					Report.LogCodedWarning (0, Report.WarningInvalidEventName, iface.FullName, method.Name);
+					Report.LogCodedWarning (0, Report.WarningInvalidEventName, method, iface.FullName, method.Name);
 					continue;
 				}
 
@@ -150,7 +150,7 @@ namespace generator.SourceWriters
 
 			if (method.RetVal.IsVoid || method.IsEventHandlerWithHandledProperty) {
 				if (opt.GetSafeIdentifier (name) != name) {
-					Report.LogCodedWarning (0, Report.WarningInvalidEventName2, iface.FullName, name);
+					Report.LogCodedWarning (0, Report.WarningInvalidEventName2, method, iface.FullName, name);
 					return;
 				} else {
 					var mt = target.Methods.Where (method => string.Compare (method.Name, connector_fmt, StringComparison.OrdinalIgnoreCase) == 0 && method.IsListenerConnector).FirstOrDefault ();
@@ -160,7 +160,7 @@ namespace generator.SourceWriters
 				}
 			} else {
 				if (opt.GetSafeIdentifier (name) != name) {
-					Report.LogCodedWarning (0, Report.WarningInvalidEventPropertyName, iface.FullName, name);
+					Report.LogCodedWarning (0, Report.WarningInvalidEventPropertyName, method, iface.FullName, name);
 					return;
 				}
 

--- a/tools/generator/SourceWriters/InterfaceMemberAlternativeClass.cs
+++ b/tools/generator/SourceWriters/InterfaceMemberAlternativeClass.cs
@@ -101,12 +101,12 @@ namespace generator.SourceWriters
 
 			foreach (var f in fields) {
 				if (iface.ContainsName (f.Name)) {
-					Report.LogCodedWarning (0, SourceWriterExtensions.GetFieldCollisionMessage (iface, f), iface.FullName, f.Name, iface.JavaName);
+					Report.LogCodedWarning (0, SourceWriterExtensions.GetFieldCollisionMessage (iface, f), f, iface.FullName, f.Name, iface.JavaName);
 					continue;
 				}
 
 				if (seen.Contains (f.Name)) {
-					Report.LogCodedWarning (0, Report.WarningDuplicateField, iface.FullName, f.Name, iface.JavaName);
+					Report.LogCodedWarning (0, Report.WarningDuplicateField, f, iface.FullName, f.Name, iface.JavaName);
 					continue;
 				}
 

--- a/tools/generator/Utilities/Report.cs
+++ b/tools/generator/Utilities/Report.cs
@@ -91,6 +91,9 @@ namespace MonoDroid.Generation
 		public static void LogCodedWarning (int verbosity, LocalizedMessage message, params string [] args)
 			=> LogCodedWarning (verbosity, message, null, null, -1, -1, args);
 
+		public static void LogCodedWarning (int verbosity, LocalizedMessage message, ISourceLineInfo sourceInfo, params string [] args)
+			=> LogCodedWarning (verbosity, message, null, sourceInfo.SourceFile, sourceInfo.LineNumber, sourceInfo.LinePosition, args);
+
 		public static void LogCodedWarning (int verbosity, LocalizedMessage message, Exception innerException, params string [] args)
 			=> LogCodedWarning (verbosity, message, innerException, null, -1, -1, args);
 

--- a/tools/generator/generator.slnf
+++ b/tools/generator/generator.slnf
@@ -7,6 +7,7 @@
       "src\\Java.Interop.Tools.Cecil\\Java.Interop.Tools.Cecil.csproj",
       "src\\Java.Interop.Tools.JavaCallableWrappers\\Java.Interop.Tools.JavaCallableWrappers.csproj",
       "src\\Java.Interop.Tools.Diagnostics\\Java.Interop.Tools.Diagnostics.csproj",
+      "src\\Java.Interop.Tools.Generator\\Java.Interop.Tools.Generator.csproj",
       "src\\Xamarin.Android.Tools.AnnotationSupport\\Xamarin.Android.Tools.AnnotationSupport.csproj",
       "src\\Xamarin.Android.Tools.ApiXmlAdjuster\\Xamarin.Android.Tools.ApiXmlAdjuster.csproj",
       "src\\Xamarin.Android.Tools.Bytecode\\Xamarin.Android.Tools.Bytecode.csproj",


### PR DESCRIPTION
Today, when you get a warning while trying to bind an `api.xml` file, no source information is provided:
```
BINDINGSGENERATOR : warning BG8700: Unknown return type 'com.blah.a.a.a.a' for member 
'Com.Blah.Foo.Sdk.LoggerGetUserLogger ()'. [C:\code\temp\Blah\Blah.csproj]
```

We can make the user experience a tiny bit nicer by adding the file name and line/col information in standard MSBuild format.  This allows users to double click the error in VS and be taken directly to the correct location in the `api.xml` file:
```
BINDINGSGENERATOR : obj\Debug\api.xml(1684, 8) warning BG8700: Unknown return type 'com.blah.a.a.a.a' 
for member 'Com.Blah.Foo.Sdk.LoggerGetUserLogger ()'. [C:\code\temp\Blah\Blah.csproj]
```
