### PR TITLE
[build] build reference assembly for Java.Interop.dll

### DIFF
--- a/src/Java.Interop/Java.Interop-MonoAndroid.csproj
+++ b/src/Java.Interop/Java.Interop-MonoAndroid.csproj
@@ -15,6 +15,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
     <LangVersion>8.0</LangVersion>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
   <Import Project="..\..\Directory.Build.props" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/Java.Interop/Java.Interop.csproj
+++ b/src/Java.Interop/Java.Interop.csproj
@@ -14,6 +14,7 @@
     <JNIEnvGenPath>$(BuildToolOutputFullPath)</JNIEnvGenPath>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DefineConstants>DEBUG;$(DefineConstants)</DefineConstants>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/5119

The `Microsoft.Android.Ref` package for .NET 6 needs to contain
reference assemblies for each assembly we ship.

`Java.Interop.dll` is one of these, so we need to set
`$(ProduceReferenceAssembly)` to generate a reference assembly
automatically.

Size difference:

    Length Name
    ------ ----
    227328 Java.Interop.dll
     94208 ref/Java.Interop.dll