### PR TITLE
[ApiXmlAdjuster] Fix for finding "mono.app.android.IntentService".

### DIFF
--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiTypeResolverExtensions.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiTypeResolverExtensions.cs
@@ -44,8 +44,15 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 				ret = ManagedType.DummyManagedPackages
 				                 .SelectMany (p => p.Types)
 				                 .FirstOrDefault (t => t.FullName == name);
-			if (ret == null)
+			if (ret == null) {
+				// We moved this type to "mono.android.app.IntentService" which makes this
+				// type resolution fail if a user tries to reference it in Java.
+				if (name == "android.app.IntentService")
+					return FindNonGenericType (api, "mono.android.app.IntentService");
+
 				throw new JavaTypeResolutionException (string.Format ("Type '{0}' was not found.", name));
+			}
+
 			return ret;
 		}
 

--- a/tests/Xamarin.Android.Tools.ApiXmlAdjuster-Tests/JavaApiTestHelper.cs
+++ b/tests/Xamarin.Android.Tools.ApiXmlAdjuster-Tests/JavaApiTestHelper.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster.Tests
 				"..",
 				"..");
 
-		static  readonly    string  ApiPath = Path.Combine (
+		public static readonly string ApiPath = Path.Combine (
 				TopDir,
 				"tests",
 				"Xamarin.Android.Tools.ApiXmlAdjuster-Tests",


### PR DESCRIPTION
Fixes: #717 

A long time ago, we moved our managed binding of `android.app.IntentService` to `mono.android.app.IntentService`.  When a user switches from `jar2xml` to `class-parse` and tries to reference this type it cannot be found because type resolution is now done in C# rather than Java.

We likely can't move the type back due to backwards compatibility issues, so we modify our type resolver to specially case this type and know where it moved to.