### PR TITLE
[jnimarshalmethod-gen] Avoid creating AppDomains

### DIFF
--- a/tools/jnimarshalmethod-gen/App.cs
+++ b/tools/jnimarshalmethod-gen/App.cs
@@ -39,16 +39,12 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 
 		public static int Main (string [] args)
 		{
-			var domain = AppDomain.CreateDomain ("workspace");
-			var app = (App)domain.CreateInstanceAndUnwrap (typeof (App).Assembly.FullName, typeof (App).FullName);
-
+			var app = new App ();
 			app.AddMonoPathToResolverSearchDirectories ();
 
 			var assemblies = app.ProcessArguments (args);
 			app.ProcessAssemblies (assemblies);
 			var filesToDelete = app.FilesToDelete;
-
-			AppDomain.Unload (domain);
 
 			foreach (var path in filesToDelete)
 				File.Delete (path);
@@ -282,8 +278,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 
 		void CreateMarshalMethodAssembly (string path)
 		{
-			var assembly        = Assembly.LoadFile (Path.GetFullPath (path));
-
+			var assembly        = Assembly.Load (File.ReadAllBytes (Path.GetFullPath (path)));
 			var baseName        = Path.GetFileNameWithoutExtension (path);
 			var assemblyName    = new AssemblyName (baseName + "-JniMarshalMethods");
 			var fileName        = assemblyName.Name + ".dll";


### PR DESCRIPTION
This is part of making the tool to work on Windows and later also with
NET5. The created `AppDomain` was used to isolate processed assembly,
so that we can unload it and overwrite it with generated changes.

That didn't work on Windows even with .NET framework, which has
the `AppDomain`s API. In NET5 the creation of AppDomains is not even
part of the API.

So instead of using the created `AppDomain`s, we preload the assembly
in memory and load it from there.