### PR TITLE
[jnimarshalmethod-gen] Fix registration on Windows

### DIFF
--- a/tools/jnimarshalmethod-gen/App.cs
+++ b/tools/jnimarshalmethod-gen/App.cs
@@ -489,8 +489,12 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 
 		static void AddRegisterNativeMembers (TypeBuilder dt, ParameterExpression targetType, List<Expression> registrationElements)
 		{
-			var args    = Expression.Parameter (typeof (JniNativeMethodRegistrationArguments),   "args");
+			if (Verbose) {
+				Console.Write ("Adding registration method for ");
+				ColorWriteLine ($"{dt.FullName}", ConsoleColor.Green);
+			}
 
+			var args    = Expression.Parameter (typeof (JniNativeMethodRegistrationArguments),   "args");
 			var body = Expression.Block (
 					new[]{targetType},
 					Expression.Assign (targetType, Expression.Call (Type_GetType, Expression.Constant (dt.FullName))),
@@ -500,6 +504,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 
 			var rb = dt.DefineMethod ("__RegisterNativeMembers",
 					System.Reflection.MethodAttributes.Public | System.Reflection.MethodAttributes.Static);
+			rb.SetParameters (typeof (JniNativeMethodRegistrationArguments));
 			rb.SetCustomAttribute (new CustomAttributeBuilder (typeof (JniAddNativeMethodRegistrationAttribute).GetConstructor (Type.EmptyTypes), new object[0]));
 #if _DUMP_REGISTER_NATIVE_MEMBERS
 			Console.WriteLine ($"## Dumping contents of `{dt.FullName}::__RegisterNativeMembers`: ");


### PR DESCRIPTION
Set parameters to registration method builder, to get rid of exception
we are getting on Windows. Looks like the S.L.E code still differs
between Windows and Mac.

Also report adding registration methods in verbose mode, similar as we
do with marshal methods.

The `ArgumentOutOfRangeException` mentined above:

    error JM4006: jnimarshalmethod-gen: Unable to process assembly '.\bin\TestDebug\Java.Interop.Export-Tests.dll'
    Specified argument was out of the range of valid values.
    Parameter name: The specified parameter index is not in range.
    System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.
    Parameter name: The specified parameter index is not in range.
       at System.Reflection.Emit.MethodBuilder.DefineParameter(Int32 position, ParameterAttributes attributes, String strParamName)
       at System.Linq.Expressions.Compiler.LambdaCompiler..ctor(AnalyzedTree tree, LambdaExpression lambda, MethodBuilder method)
       at System.Linq.Expressions.Compiler.LambdaCompiler.Compile(LambdaExpression lambda, MethodBuilder method, DebugInfoGenerator debugInfoGenerator)
       at Xamarin.Android.Tools.JniMarshalMethodGenerator.App.AddRegisterNativeMembers(TypeBuilder dt, ParameterExpression targetType, List`1 registrationElements) in C:\Users\rodo\git\java.interop\tools\jnimarshalmethod-gen\App.cs:line 564
       at Xamarin.Android.Tools.JniMarshalMethodGenerator.App.CreateMarshalMethodAssembly(String path) in C:\Users\rodo\git\java.interop\tools\jnimarshalmethod-gen\App.cs:line 426
       at Xamarin.Android.Tools.JniMarshalMethodGenerator.App.ProcessAssemblies(List`1 assemblies) in C:\Users\rodo\git\java.interop\tools\jnimarshalmethod-gen\App.cs:line 201