### PR TITLE
[generator] Use GC.KeepAlive for reference type method parameters.

### DIFF
--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteKotlinUnsignedArrayTypeMethodsClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteKotlinUnsignedArrayTypeMethodsClass.txt
@@ -27,6 +27,7 @@ public partial class MyClass {
 				JNIEnv.CopyArray (native_value, value);
 				JNIEnv.DeleteLocalRef (native_value);
 			}
+			global::System.GC.KeepAlive (value);
 		}
 	}
 
@@ -46,6 +47,7 @@ public partial class MyClass {
 				JNIEnv.CopyArray (native_value, value);
 				JNIEnv.DeleteLocalRef (native_value);
 			}
+			global::System.GC.KeepAlive (value);
 		}
 	}
 
@@ -65,6 +67,7 @@ public partial class MyClass {
 				JNIEnv.CopyArray (native_value, value);
 				JNIEnv.DeleteLocalRef (native_value);
 			}
+			global::System.GC.KeepAlive (value);
 		}
 	}
 
@@ -84,6 +87,7 @@ public partial class MyClass {
 				JNIEnv.CopyArray (native_value, value);
 				JNIEnv.DeleteLocalRef (native_value);
 			}
+			global::System.GC.KeepAlive (value);
 		}
 	}
 

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteKotlinUnsignedArrayTypePropertiesClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteKotlinUnsignedArrayTypePropertiesClass.txt
@@ -36,6 +36,7 @@ public partial class MyClass {
 					JNIEnv.CopyArray (native_value, value);
 					JNIEnv.DeleteLocalRef (native_value);
 				}
+				global::System.GC.KeepAlive (value);
 			}
 		}
 	}
@@ -65,6 +66,7 @@ public partial class MyClass {
 					JNIEnv.CopyArray (native_value, value);
 					JNIEnv.DeleteLocalRef (native_value);
 				}
+				global::System.GC.KeepAlive (value);
 			}
 		}
 	}
@@ -94,6 +96,7 @@ public partial class MyClass {
 					JNIEnv.CopyArray (native_value, value);
 					JNIEnv.DeleteLocalRef (native_value);
 				}
+				global::System.GC.KeepAlive (value);
 			}
 		}
 	}
@@ -123,6 +126,7 @@ public partial class MyClass {
 					JNIEnv.CopyArray (native_value, value);
 					JNIEnv.DeleteLocalRef (native_value);
 				}
+				global::System.GC.KeepAlive (value);
 			}
 		}
 	}

--- a/tests/generator-Tests/expected.ji/Adapters/Xamarin.Test.AbsSpinner.cs
+++ b/tests/generator-Tests/expected.ji/Adapters/Xamarin.Test.AbsSpinner.cs
@@ -89,6 +89,7 @@ namespace Xamarin.Test {
 					__args [0] = new JniArgumentValue ((value == null) ? IntPtr.Zero : ((global::Java.Lang.Object) value).Handle);
 					_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, __args);
 				} finally {
+					global::System.GC.KeepAlive (value);
 				}
 			}
 		}
@@ -137,6 +138,7 @@ namespace Xamarin.Test {
 					_members.InstanceMethods.InvokeAbstractVoidMethod (__id, this, __args);
 				} finally {
 					JNIEnv.DeleteLocalRef (native_value);
+					global::System.GC.KeepAlive (value);
 				}
 			}
 		}

--- a/tests/generator-Tests/expected.ji/Adapters/Xamarin.Test.AdapterView.cs
+++ b/tests/generator-Tests/expected.ji/Adapters/Xamarin.Test.AdapterView.cs
@@ -124,6 +124,7 @@ namespace Xamarin.Test {
 					_members.InstanceMethods.InvokeAbstractVoidMethod (__id, this, __args);
 				} finally {
 					JNIEnv.DeleteLocalRef (native_value);
+					global::System.GC.KeepAlive (value);
 				}
 			}
 		}

--- a/tests/generator-Tests/expected.ji/Core_Jar2Xml/Android.Text.SpannableString.cs
+++ b/tests/generator-Tests/expected.ji/Core_Jar2Xml/Android.Text.SpannableString.cs
@@ -54,6 +54,7 @@ namespace Android.Text {
 				_members.InstanceMethods.FinishCreateInstance (__id, this, __args);
 			} finally {
 				JNIEnv.DeleteLocalRef (native_source);
+				global::System.GC.KeepAlive (source);
 			}
 		}
 
@@ -74,6 +75,7 @@ namespace Android.Text {
 				_members.InstanceMethods.FinishCreateInstance (__id, this, __args);
 			} finally {
 				JNIEnv.DeleteLocalRef (native_source);
+				global::System.GC.KeepAlive (source);
 			}
 		}
 
@@ -106,6 +108,7 @@ namespace Android.Text {
 				var __rm = _members.InstanceMethods.InvokeVirtualInt32Method (__id, this, __args);
 				return (global::Android.Text.SpanTypes) __rm;
 			} finally {
+				global::System.GC.KeepAlive (what);
 			}
 		}
 

--- a/tests/generator-Tests/expected.ji/Core_Jar2Xml/Android.Text.SpannableStringInternal.cs
+++ b/tests/generator-Tests/expected.ji/Core_Jar2Xml/Android.Text.SpannableStringInternal.cs
@@ -66,6 +66,7 @@ namespace Android.Text {
 				var __rm = _members.InstanceMethods.InvokeVirtualInt32Method (__id, this, __args);
 				return (global::Android.Text.SpanTypes) __rm;
 			} finally {
+				global::System.GC.KeepAlive (p0);
 			}
 		}
 

--- a/tests/generator-Tests/expected.ji/Core_Jar2Xml/Android.Views.View.cs
+++ b/tests/generator-Tests/expected.ji/Core_Jar2Xml/Android.Views.View.cs
@@ -181,6 +181,7 @@ namespace Android.Views {
 				__args [0] = new JniArgumentValue ((l == null) ? IntPtr.Zero : ((global::Java.Lang.Object) l).Handle);
 				_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, __args);
 			} finally {
+				global::System.GC.KeepAlive (l);
 			}
 		}
 
@@ -211,6 +212,7 @@ namespace Android.Views {
 				__args [0] = new JniArgumentValue ((l == null) ? IntPtr.Zero : ((global::Java.Lang.Object) l).Handle);
 				_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, __args);
 			} finally {
+				global::System.GC.KeepAlive (l);
 			}
 		}
 
@@ -243,6 +245,7 @@ namespace Android.Views {
 				_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, __args);
 			} finally {
 				JNIEnv.DeleteLocalRef (native_views);
+				global::System.GC.KeepAlive (views);
 			}
 		}
 

--- a/tests/generator-Tests/expected.ji/GenericArguments/Com.Google.Android.Exoplayer.Drm.FrameworkMediaDrm.cs
+++ b/tests/generator-Tests/expected.ji/GenericArguments/Com.Google.Android.Exoplayer.Drm.FrameworkMediaDrm.cs
@@ -63,6 +63,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 				__args [0] = new JniArgumentValue ((p0 == null) ? IntPtr.Zero : ((global::Java.Lang.Object) p0).Handle);
 				_members.InstanceMethods.InvokeAbstractVoidMethod (__id, this, __args);
 			} finally {
+				global::System.GC.KeepAlive (p0);
 			}
 		}
 

--- a/tests/generator-Tests/expected.ji/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
+++ b/tests/generator-Tests/expected.ji/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
@@ -202,6 +202,7 @@ namespace Xamarin.Test {
 					SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
 					_members.InstanceMethods.FinishCreateInstance (__id, this, __args);
 				} finally {
+					global::System.GC.KeepAlive (__self);
 				}
 			}
 

--- a/tests/generator-Tests/expected.ji/NormalMethods/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/NormalMethods/Xamarin.Test.SomeObject.cs
@@ -52,6 +52,7 @@ namespace Xamarin.Test {
 				SetHandle (__r.Handle, JniHandleOwnership.TransferLocalRef);
 				_members.InstanceMethods.FinishCreateInstance (__id, this, __args);
 			} finally {
+				global::System.GC.KeepAlive (c);
 			}
 		}
 
@@ -114,6 +115,8 @@ namespace Xamarin.Test {
 				var __rm = _members.InstanceMethods.InvokeVirtualInt32Method (__id, this, __args);
 				return __rm;
 			} finally {
+				global::System.GC.KeepAlive (o);
+				global::System.GC.KeepAlive (t);
 			}
 		}
 
@@ -260,6 +263,7 @@ namespace Xamarin.Test {
 				_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, __args);
 			} finally {
 				JNIEnv.DeleteLocalRef (native_astring);
+				global::System.GC.KeepAlive (anObject);
 			}
 		}
 
@@ -323,6 +327,7 @@ namespace Xamarin.Test {
 				_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, __args);
 			} finally {
 				JNIEnv.DeleteLocalRef (native_p0);
+				global::System.GC.KeepAlive (p0);
 			}
 		}
 

--- a/tests/generator-Tests/expected.ji/NormalProperties/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/NormalProperties/Xamarin.Test.SomeObject.cs
@@ -230,6 +230,7 @@ namespace Xamarin.Test {
 					__args [0] = new JniArgumentValue ((value == null) ? IntPtr.Zero : ((global::Java.Lang.Object) value).Handle);
 					_members.InstanceMethods.InvokeAbstractVoidMethod (__id, this, __args);
 				} finally {
+					global::System.GC.KeepAlive (value);
 				}
 			}
 		}

--- a/tests/generator-Tests/expected.ji/ParameterXPath/Xamarin.Test.A.cs
+++ b/tests/generator-Tests/expected.ji/ParameterXPath/Xamarin.Test.A.cs
@@ -66,6 +66,7 @@ namespace Xamarin.Test {
 				_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, __args);
 			} finally {
 				JNIEnv.DeleteLocalRef (native_adapter);
+				global::System.GC.KeepAlive (adapter);
 			}
 		}
 
@@ -98,6 +99,7 @@ namespace Xamarin.Test {
 				_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, __args);
 			} finally {
 				JNIEnv.DeleteLocalRef (native_p0);
+				global::System.GC.KeepAlive (p0);
 			}
 		}
 

--- a/tests/generator-Tests/expected.ji/StaticProperties/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/StaticProperties/Xamarin.Test.SomeObject.cs
@@ -108,6 +108,7 @@ namespace Xamarin.Test {
 				__args [0] = new JniArgumentValue ((newvalue == null) ? IntPtr.Zero : ((global::Java.Lang.Object) newvalue).Handle);
 				_members.StaticMethods.InvokeVoidMethod (__id, __args);
 			} finally {
+				global::System.GC.KeepAlive (newvalue);
 			}
 		}
 

--- a/tests/generator-Tests/expected.ji/Streams/Java.IO.FilterOutputStream.cs
+++ b/tests/generator-Tests/expected.ji/Streams/Java.IO.FilterOutputStream.cs
@@ -54,6 +54,7 @@ namespace Java.IO {
 				_members.InstanceMethods.FinishCreateInstance (__id, this, __args);
 			} finally {
 				JNIEnv.DeleteLocalRef (native__out);
+				global::System.GC.KeepAlive (@out);
 			}
 		}
 

--- a/tests/generator-Tests/expected.ji/Streams/Java.IO.InputStream.cs
+++ b/tests/generator-Tests/expected.ji/Streams/Java.IO.InputStream.cs
@@ -221,6 +221,7 @@ namespace Java.IO {
 					JNIEnv.CopyArray (native_buffer, buffer);
 					JNIEnv.DeleteLocalRef (native_buffer);
 				}
+				global::System.GC.KeepAlive (buffer);
 			}
 		}
 
@@ -262,6 +263,7 @@ namespace Java.IO {
 					JNIEnv.CopyArray (native_buffer, buffer);
 					JNIEnv.DeleteLocalRef (native_buffer);
 				}
+				global::System.GC.KeepAlive (buffer);
 			}
 		}
 

--- a/tests/generator-Tests/expected.ji/Streams/Java.IO.OutputStream.cs
+++ b/tests/generator-Tests/expected.ji/Streams/Java.IO.OutputStream.cs
@@ -141,6 +141,7 @@ namespace Java.IO {
 					JNIEnv.CopyArray (native_buffer, buffer);
 					JNIEnv.DeleteLocalRef (native_buffer);
 				}
+				global::System.GC.KeepAlive (buffer);
 			}
 		}
 
@@ -180,6 +181,7 @@ namespace Java.IO {
 					JNIEnv.CopyArray (native_buffer, buffer);
 					JNIEnv.DeleteLocalRef (native_buffer);
 				}
+				global::System.GC.KeepAlive (buffer);
 			}
 		}
 

--- a/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericImplementation.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericImplementation.cs
@@ -87,6 +87,7 @@ namespace Test.ME {
 					JNIEnv.CopyArray (native_value, value);
 					JNIEnv.DeleteLocalRef (native_value);
 				}
+				global::System.GC.KeepAlive (value);
 			}
 		}
 

--- a/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericObjectPropertyImplementation.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericObjectPropertyImplementation.cs
@@ -106,6 +106,7 @@ namespace Test.ME {
 					__args [0] = new JniArgumentValue ((value == null) ? IntPtr.Zero : ((global::Java.Lang.Object) value).Handle);
 					_members.InstanceMethods.InvokeVirtualVoidMethod (__id, this, __args);
 				} finally {
+					global::System.GC.KeepAlive (value);
 				}
 			}
 		}

--- a/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericStringImplementation.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericStringImplementation.cs
@@ -87,6 +87,7 @@ namespace Test.ME {
 					JNIEnv.CopyArray (native_value, value);
 					JNIEnv.DeleteLocalRef (native_value);
 				}
+				global::System.GC.KeepAlive (value);
 			}
 		}
 

--- a/tests/generator-Tests/expected.ji/TestInterface/Test.ME.TestInterfaceImplementation.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Test.ME.TestInterfaceImplementation.cs
@@ -188,6 +188,7 @@ namespace Test.ME {
 				var __rm = _members.InstanceMethods.InvokeAbstractInt32Method (__id, this, __args);
 				return __rm;
 			} finally {
+				global::System.GC.KeepAlive (tag);
 			}
 		}
 
@@ -203,6 +204,7 @@ namespace Test.ME {
 				_members.InstanceMethods.InvokeAbstractVoidMethod (__id, this, __args);
 			} finally {
 				JNIEnv.DeleteLocalRef (native_value);
+				global::System.GC.KeepAlive (value);
 			}
 		}
 
@@ -219,6 +221,7 @@ namespace Test.ME {
 				return global::Java.Lang.Object.GetObject<Java.Lang.ICharSequence> (__rm.Handle, JniHandleOwnership.TransferLocalRef);
 			} finally {
 				JNIEnv.DeleteLocalRef (native_value);
+				global::System.GC.KeepAlive (value);
 			}
 		}
 

--- a/tests/generator-Tests/expected.ji/java.lang.Enum/Java.Lang.Enum.cs
+++ b/tests/generator-Tests/expected.ji/java.lang.Enum/Java.Lang.Enum.cs
@@ -50,6 +50,7 @@ namespace Java.Lang {
 				return __rm;
 			} finally {
 				JNIEnv.DeleteLocalRef (native_o);
+				global::System.GC.KeepAlive (o);
 			}
 		}
 

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Parameter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Parameter.cs
@@ -276,6 +276,32 @@ namespace MonoDroid.Generation {
 			return true;
 		}
 
+		public bool ShouldGenerateKeepAlive ()
+		{
+			if (Symbol.IsEnum)
+				return false;
+
+			return Type switch {
+				"bool" => false,
+				"sbyte" => false,
+				"char" => false,
+				"double" => false,
+				"float" => false,
+				"int" => false,
+				"long" => false,
+				"short" => false,
+				"uint" => false,
+				"ushort" => false,
+				"ulong" => false,
+				"byte" => false,
+				"ubyte" => false,       // Not a C# type, but we will see it from Kotlin unsigned types support
+				"string" => false,
+				"java.lang.String" => false,
+				"Android.Graphics.Color" => false,
+				_ => true
+			};
+		}
+
 		public ISymbol Symbol => sym;
 	}
 }

--- a/tools/generator/SourceWriters/BoundConstructor.cs
+++ b/tools/generator/SourceWriters/BoundConstructor.cs
@@ -76,6 +76,10 @@ namespace generator.SourceWriters
 			var call_cleanup = constructor.Parameters.GetCallCleanup (opt);
 			foreach (string cleanup in call_cleanup)
 				writer.WriteLine (cleanup);
+
+			foreach (var p in constructor.Parameters.Where (para => para.ShouldGenerateKeepAlive ()))
+				writer.WriteLine ($"global::System.GC.KeepAlive ({opt.GetSafeIdentifier (p.Name)});");
+
 			writer.Unindent ();
 
 			writer.WriteLine ("}");

--- a/tools/generator/SourceWriters/Extensions/SourceWriterExtensions.cs
+++ b/tools/generator/SourceWriters/Extensions/SourceWriterExtensions.cs
@@ -264,6 +264,9 @@ namespace generator.SourceWriters
 			foreach (string cleanup in method.Parameters.GetCallCleanup (opt))
 				body.Add ("\t" + cleanup);
 
+			foreach (var p in method.Parameters.Where (para => para.ShouldGenerateKeepAlive ()))
+				body.Add ($"\tglobal::System.GC.KeepAlive ({opt.GetSafeIdentifier (p.Name)});");
+
 			body.Add ("}");
 		}
 


### PR DESCRIPTION
Fixes: #719

Under certain circumstances, it is possible for a method parameter to get GC collected before native code is finished using it.  Add an appropriate `GC.KeepAlive (param)` to ensure the object stays alive until we are done with it.  As an optimization, this is only needed for reference types.