### PR TITLE
[build] Suppress NuGet warnings

### DIFF
--- a/src/Java.Interop/Java.Interop.csproj
+++ b/src/Java.Interop/Java.Interop.csproj
@@ -51,7 +51,7 @@
     <None Include="Documentation\Java.Interop\JniManagedPeerStates.xml" />
     <None Include="Documentation\Java.Interop\JniEnvironment.References.xml" />
     <ProjectReference Include="..\..\build-tools\jnienv-gen\jnienv-gen.csproj"
-        ReferenceOutputAssembly="false"
+        ReferenceOutputAssembly="false" NoWarn="NU1702"
     />
   </ItemGroup>
   <ItemGroup>

--- a/src/Java.Interop/Java.Interop.csproj
+++ b/src/Java.Interop/Java.Interop.csproj
@@ -15,6 +15,7 @@
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+    <MSBuildWarningsAsMessages>NU1702</MSBuildWarningsAsMessages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DefineConstants>DEBUG;$(DefineConstants)</DefineConstants>

--- a/src/Java.Interop/Java.Interop.csproj
+++ b/src/Java.Interop/Java.Interop.csproj
@@ -52,7 +52,7 @@
     <None Include="Documentation\Java.Interop\JniManagedPeerStates.xml" />
     <None Include="Documentation\Java.Interop\JniEnvironment.References.xml" />
     <ProjectReference Include="..\..\build-tools\jnienv-gen\jnienv-gen.csproj"
-        ReferenceOutputAssembly="false" NoWarn="NU1702"
+        ReferenceOutputAssembly="false"
     />
   </ItemGroup>
   <ItemGroup>

--- a/tools/logcat-parse/logcat-parse.csproj
+++ b/tools/logcat-parse/logcat-parse.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Mono.Options" Version="5.3.0.1" />
     <PackageReference Include="Mono.Terminal" Version="5.4.0" />
-    <PackageReference Include="Mono.CSharp" Version="4.0.0.143" />
+    <PackageReference Include="Mono.CSharp" Version="4.0.0.143" NoWarn="NU1701" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Suppress some NuGet warnings:

**logcat-parse.csproj**
```
Warning NU1701: Package 'Mono.CSharp 4.0.0.143' was restored using '.NETFramework,Version=v4.6.1, 
.NETFramework,Version=v4.6.2, .NETFramework,Version=v4.7, .NETFramework,Version=v4.7.1, 
.NETFramework,Version=v4.7.2, .NETFramework,Version=v4.8' instead of the project target framework 
'.NETCoreApp,Version=v3.1'. This package may not be fully compatible with your project.
```

**Java.Interop.csproj**
```
Warning NU1702: ProjectReference 'D:\a\1\s\build-tools\jnienv-gen\jnienv-gen.csproj' was resolved using 
'.NETFramework,Version=v4.7.2' instead of the project target framework '.NETStandard,Version=v2.0'. 
This project may not be fully compatible with your project.
```