### PR TITLE
[generator] Revert change to use auto-properties in EventArgs classes.

### DIFF
--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteDuplicateInterfaceEventArgs.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteDuplicateInterfaceEventArgs.txt
@@ -123,24 +123,37 @@ internal partial class AnimatorListenerInvoker : global::Java.Lang.Object, Anima
 
 // event args for java.code.AnimatorListener.OnAnimationEnd
 public partial class AnimationEndEventArgs : global::System.EventArgs {
+	bool handled;
+
+	public bool Handled {
+		get { return handled; }
+		set { handled = value; }
+	}
+
 	public AnimationEndEventArgs (bool handled, int param1)
 	{
-		this.Handled = handled;
-		this.Param1 = param1;
+		this.handled = handled;
+		this.param1 = param1;
+	}
+
+	int param1;
+
+	public int Param1 {
+		get { return param1; }
 	}
 
 	public AnimationEndEventArgs (bool handled, int param1, int param2)
 	{
-		this.Handled = handled;
-		this.Param1 = param1;
-		this.Param2 = param2;
+		this.handled = handled;
+		this.param1 = param1;
+		this.param2 = param2;
 	}
 
-	public bool Handled { get; set; }
+	int param2;
 
-	public int Param1 { get; private set; }
-
-	public int Param2 { get; private set; }
+	public int Param2 {
+		get { return param2; }
+	}
 
 }
 

--- a/tests/generator-Tests/expected.ji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
+++ b/tests/generator-Tests/expected.ji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
@@ -123,22 +123,42 @@ namespace Com.Google.Android.Exoplayer.Drm {
 	public partial class ExoMediaDrmOnEventEventArgs : global::System.EventArgs {
 		public ExoMediaDrmOnEventEventArgs (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm p0, byte[] p1, int p2, int p3, byte[] p4)
 		{
-			this.P0 = p0;
-			this.P1 = p1;
-			this.P2 = p2;
-			this.P3 = p3;
-			this.P4 = p4;
+			this.p0 = p0;
+			this.p1 = p1;
+			this.p2 = p2;
+			this.p3 = p3;
+			this.p4 = p4;
 		}
 
-		public global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm P0 { get; private set; }
+		global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm p0;
 
-		public byte[] P1 { get; private set; }
+		public global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm P0 {
+			get { return p0; }
+		}
 
-		public int P2 { get; private set; }
+		byte[] p1;
 
-		public int P3 { get; private set; }
+		public byte[] P1 {
+			get { return p1; }
+		}
 
-		public byte[] P4 { get; private set; }
+		int p2;
+
+		public int P2 {
+			get { return p2; }
+		}
+
+		int p3;
+
+		public int P3 {
+			get { return p3; }
+		}
+
+		byte[] p4;
+
+		public byte[] P4 {
+			get { return p4; }
+		}
 
 	}
 


### PR DESCRIPTION
In https://github.com/xamarin/java.interop/pull/726, properties in generated EventArgs classes were changed from regular properties to use auto-properties:

From:
```
int param1;
public int Param1 {
    get { return param1; }
}
```

To:
```
public int Param1 { get; }
```

However this is technically a breaking change, since users could have hand written code that references the backing field.  Although the usage is likely rare, we have decided to revert the auto-property change for compatibility reasons.