### PR TITLE
[generator] Output correct formatting for binding warnings.

### DIFF
--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorContextTests.cs
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorContextTests.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Linq;
+using MonoDroid.Generation;
+using NUnit.Framework;
+
+namespace generatortests
+{
+	[TestFixture]
+	public class CodeGeneratorContextTests
+	{
+		[Test]
+		public void GetContextTypeMember ()
+		{
+			var klass = new TestClass ("Object", "java.code.MyClass");
+
+			klass.AddMethod (SupportTypeBuilder.CreateMethod (klass, "Echo", new CodeGenerationOptions (), "uint", false, false, new Parameter ("value", "uint", "uint", false)));
+			klass.AddField (new TestField ("string", "Foo"));
+
+			var context = new CodeGeneratorContext ();
+			context.ContextTypes.Push (klass);
+
+			Assert.AreEqual ("java.code.MyClass", context.GetContextTypeMember ());
+
+			context.ContextMethod = klass.Methods.Single ();
+
+			Assert.AreEqual ("java.code.MyClass.Echo (uint)", context.GetContextTypeMember ());
+
+			context.ContextMethod = null;
+			context.ContextField = klass.Fields.Single ();
+
+			Assert.AreEqual ("java.code.MyClass.Foo", context.GetContextTypeMember ());
+
+			context.ContextMethod = klass.Methods.Single ();
+			context.ContextField = null;
+			context.ContextTypes.Clear ();
+
+			Assert.AreEqual ("Echo (uint)", context.GetContextTypeMember ());
+		}
+	}
+}

--- a/tools/generator/CodeGeneratorContext.cs
+++ b/tools/generator/CodeGeneratorContext.cs
@@ -19,14 +19,19 @@ namespace MonoDroid.Generation
 
 		public string GetContextTypeMember ()
 		{
-			var output = ContextType?.FullName ?? string.Empty;
+			var parts = new List<string> ();
 
-			if (ContextMethod != null) {
-				output += $"{ContextMethod.Name} ({string.Join (", ", ContextMethod?.Parameters.Select (p => p.InternalType).ToArray ())})";
-				return output;
-			}
+			// Type name
+			if (!string.IsNullOrEmpty (ContextType?.FullName))
+				parts.Add (ContextType?.FullName);
 
-			return output + ContextField?.Name;
+			// Member name
+			if (ContextMethod != null)
+				parts.Add ($"{ContextMethod.Name} ({string.Join (", ", ContextMethod?.Parameters.Select (p => p.InternalType).ToArray ())})");
+			else if (ContextField != null)
+				parts.Add (ContextField.Name);
+
+			return string.Join (".", parts);
 		}
 	}
 }


### PR DESCRIPTION
In https://github.com/xamarin/java.interop/commit/d664e90ecf0ed1a08a61acc7708215e678255e95 we refactored some output regarding binding warning messages in order to better support localization.  Unfortunately this refactoring left out a period between some type and member names:

```
warning BG8700: Unknown return type 'Android.App.Admin.AppOpsManagerMode' for member 'Android.App.AppOpsManagerUnsafeCheckOp (java.lang.String, int, java.lang.String)'. 
```

`Android.App.AppOpsManagerUnsafeCheckOp` should be `Android.App.AppOpsManager.UnsafeCheckOp` instead.