### PR TITLE
[jcw-gen] Do not register static methods on an interface.

### DIFF
--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
@@ -153,7 +153,8 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 						return d;
 					})
 					.Where (d => GetRegisterAttributes (d).Any ())
-					.SelectMany (d => d.Methods)) {
+					.SelectMany (d => d.Methods)
+					.Where (m => !m.IsStatic)) {
 				AddMethod (imethod, imethod);
 			}
 

--- a/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGeneratorTests.cs
+++ b/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGeneratorTests.cs
@@ -189,6 +189,7 @@ public class ExportsMembers
 		__md_methods = 
 			""n_GetInstance:()Lcrc64197ae30a36756915/ExportsMembers;:__export__\n"" +
 			""n_GetValue:()Ljava/lang/String;:__export__\n"" +
+			""n_staticMethodNotMangled:()V:__export__\n"" +
 			""n_methodNamesNotMangled:()V:__export__\n"" +
 			""n_CompletelyDifferentName:(Ljava/lang/String;I)Ljava/lang/String;:__export__\n"" +
 			""n_methodThatThrows:()V:__export__\n"" +
@@ -216,6 +217,14 @@ public class ExportsMembers
 	}
 
 	private native java.lang.String n_GetValue ();
+
+
+	public static void staticMethodNotMangled ()
+	{
+		n_staticMethodNotMangled ();
+	}
+
+	private static native void n_staticMethodNotMangled ();
 
 
 	public void methodNamesNotMangled ()

--- a/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/SupportDeclarations.cs
+++ b/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/SupportDeclarations.cs
@@ -275,6 +275,11 @@ namespace Xamarin.Android.ToolsTests {
 		}
 
 		[Export]
+		public static void staticMethodNotMangled ()
+		{
+		}
+
+		[Export]
 		public void methodNamesNotMangled ()
 		{
 		}


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/5251

When an Java interface contains a `static` method in API-30+, we use C# 8.0's new support for these methods to place them directly on the interface.  When a C# class implements the interface, the Java Callable Wrapper we generate will register every method on the interface during startup.  However, static methods are not `virtual` and cannot be overridden, so they do not have a connector and do not need to be registered.

This results in a case where the register command fails because no connector is specified (nothing after the final colon).

```
__md_methods = "n_comparing:(Ljava/util/function/Function;)Ljava/util/Comparator;:\n" +
...
```

To fix this, when adding methods from implemented interfaces we need to skip `static` interface members.

A test was added in https://github.com/xamarin/xamarin-android/pull/5262.

- Failure without this change: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4201499&view=ms.vss-test-web.build-test-results-tab.
- Success with this change: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4201951&view=results
