### PR TITLE
[.JavaSource, .ApiXmlAdjuster] Use Nullable Reference Types

### DIFF
--- a/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource.csproj
+++ b/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource.csproj
@@ -2,6 +2,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <DefineConstants>INTERNAL_NULLABLE_ATTRIBUTES</DefineConstants>
     <ProjectGuid>{5C0B3562-8DA0-4726-9762-75B9709ED6B7}</ProjectGuid>
     <AssemblyTitle>Java.Interop.Tools.JavaSource</AssemblyTitle>
     <Company>Microsoft Corporation</Company>
@@ -11,6 +14,9 @@
   <PropertyGroup>
     <OutputPath>$(ToolOutputFullPath)</OutputPath>
   </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\utils\NullableAttributes.cs" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Irony" Version="1.1.0" />
   </ItemGroup>

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApi.RelationAnalysisModel.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApi.RelationAnalysisModel.cs
@@ -7,47 +7,48 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 	
 	public partial class JavaClass
 	{
-		public JavaTypeReference ResolvedExtends { get; set; }
+		public  JavaTypeReference?      ResolvedExtends             { get; set; }
 	}
 	
 	public partial class JavaImplements
 	{
-		public JavaTypeReference ResolvedName { get; set; }
+		public  JavaTypeReference?      ResolvedName                { get; set; }
 	}
 	
 	public partial class JavaField
 	{
-		public JavaTypeReference ResolvedType { get; set; }
+		public  JavaTypeReference?      ResolvedType                { get; set; }
 	}
 	
 	public partial class JavaMethod
 	{
-		public JavaTypeReference ResolvedReturnType { get; set; }
+		public  JavaTypeReference?      ResolvedReturnType          { get; set; }
 	}
 	
 	public partial class JavaParameter
 	{
-		public JavaTypeReference ResolvedType { get; set; }
+		public  JavaTypeReference?      ResolvedType                { get; set; }
 	}
 	
 	public partial class JavaGenericConstraint
 	{
-		public JavaTypeReference ResolvedType { get; set; }
+		public  JavaTypeReference?      ResolvedType                { get; set; }
 	}
 	
 	// GenericInheritanceMapper extensibility
 	
 	public partial class JavaClass
 	{
-		public IDictionary<JavaTypeReference,JavaTypeReference> GenericInheritanceMapping { get; set; }
+		public IDictionary<JavaTypeReference,JavaTypeReference>?
+		                                GenericInheritanceMapping   { get; set; }
 	}
 	
 	// OverrideMarker extensibility
 	
 	public partial class JavaMethod
 	{
-		public JavaMethodReference BaseMethod { get; set; }
-		public IList<JavaInterface> ImplementedInterfaces { get; set; } 
+		public  JavaMethodReference?    BaseMethod                  { get; set; }
+		public  IList<JavaInterface>?   ImplementedInterfaces       { get; set; }
 	}
 	
 	public partial class JavaMethodReference
@@ -57,12 +58,12 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			this.Method = candidate;
 		}
 
-		public JavaMethod Method { get; set; }
+		public  JavaMethod?             Method                      { get; set; }
 	}
 	
 	public partial class JavaParameter
 	{
-		public string InstantiatedGenericArgumentName { get; set; }
+		public  string?                 InstantiatedGenericArgumentName { get; set; }
 	}
 }
 

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApi.XmlModel.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApi.XmlModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Xml;
 
@@ -12,25 +13,25 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			Packages = new List<JavaPackage> ();
 		}
 
-		public string ExtendedApiSource { get; set; }
-		public string Platform { get; set; }
-		public IList<JavaPackage> Packages { get; set; }
+		public  string?                 ExtendedApiSource   { get; set; }
+		public  string?                 Platform            { get; set; }
+		public  IList<JavaPackage>      Packages            { get; set; }
 	}
 
 	public partial class JavaPackage
 	{
-		public JavaPackage (JavaApi parent)
+		public JavaPackage (JavaApi? parent)
 		{
 			Parent = parent;
 			
 			Types = new List<JavaType> ();
 		}
 		
-		public JavaApi Parent { get; private set; }
+		public  JavaApi?                Parent              { get; private set; }
 
-		public string Name { get; set; }
-		public string JniName { get; set; }
-		public IList<JavaType> Types { get; set; }
+		public  string?                 Name                { get; set; }
+		public  string?                 JniName             { get; set; }
+		public  IList<JavaType>         Types               { get; set; }
 		
 		// Content of this value is not stable.
 		public override string ToString ()
@@ -41,7 +42,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 
 	public abstract partial class JavaType
 	{
-		protected JavaType (JavaPackage parent)
+		protected JavaType (JavaPackage? parent)
 		{
 			Parent = parent;
 			
@@ -49,22 +50,22 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			Members = new List<JavaMember> ();
 		}
 
-		public JavaPackage Parent { get; private set; }
+		public  JavaPackage?            Parent                  { get; private set; }
 
-		public bool IsReferenceOnly { get; set; }
+		public  bool                    IsReferenceOnly         { get; set; }
 
-		public bool Abstract { get; set; }
-		public string Deprecated { get; set; }
-		public bool Final { get; set; }
-		public string Name { get; set; }
-		public bool Static { get; set; }
-		public string Visibility { get; set; }
+		public  bool                    Abstract                { get; set; }
+		public  string?                 Deprecated              { get; set; }
+		public  bool                    Final                   { get; set; }
+		public  string?                 Name                    { get; set; }
+		public  bool                    Static                  { get; set; }
+		public  string?                 Visibility              { get; set; }
 
-		public string ExtendedJniSignature { get; set; }
+		public  string?                 ExtendedJniSignature    { get; set; }
 
-		public IList<JavaImplements> Implements { get; set; }
-		public JavaTypeParameters TypeParameters { get; set; }
-		public IList<JavaMember> Members { get; set; }
+		public  IList<JavaImplements>   Implements              { get; set; }
+		public  JavaTypeParameters?     TypeParameters          { get; set; }
+		public  IList<JavaMember>       Members                 { get; set; }
 
 		public string FullName {
 			get { return Parent?.Name + ((Parent?.Name?.Length ?? 0) > 0 ? "." : string.Empty) + Name; }
@@ -74,13 +75,14 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		public string ToStringHelper ()
 		{
 			// FIXME: add type attributes.
-			return Parent.Name + "." + Name;
+			return (Parent?.Name == null ? "" : Parent.Name + ".") +
+				(Name ?? "");
 		}
 	}
 
 	public partial class JavaInterface : JavaType
 	{
-		public JavaInterface (JavaPackage parent)
+		public JavaInterface (JavaPackage? parent)
 			: base (parent)
 		{
 		}
@@ -94,14 +96,14 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 
 	public partial class JavaClass : JavaType
 	{
-		public JavaClass (JavaPackage parent)
+		public JavaClass (JavaPackage? parent)
 			: base (parent)
 		{
 		}
 		
-		public string Extends { get; set; }
-		public string ExtendsGeneric { get; set; }
-		public string ExtendedJniExtends { get; set; }
+		public  string?                 Extends             { get; set; }
+		public  string?                 ExtendsGeneric      { get; set; }
+		public  string?                 ExtendedJniExtends  { get; set; }
 
 		// Content of this value is not stable.
 		public override string ToString ()
@@ -147,42 +149,42 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 
 	public partial class JavaImplements
 	{
-		public string Name { get; set; }
-		public string NameGeneric { get; set; }
-		
-		public string ExtendedJniType { get; set; }
+		public  string?                 Name                { get; set; }
+		public  string?                 NameGeneric         { get; set; }
+
+		public  string?                 ExtendedJniType     { get; set; }
 	}
 
 	public partial class JavaMember
 	{
-		protected JavaMember (JavaType parent)
+		protected JavaMember (JavaType? parent)
 		{
 			Parent = parent;
 		}
 		
-		public JavaType Parent { get; private set; }
-		
-		public string Deprecated { get; set; }
-		public bool Final { get; set; }
-		public string Name { get; set; }
-		public bool Static { get; set; }
-		public string Visibility { get; set; }
-		public string ExtendedJniSignature { get; set; }
+		public  JavaType?               Parent                  { get; private set; }
+
+		public  string?                 Deprecated              { get; set; }
+		public  bool                    Final                   { get; set; }
+		public  string?                 Name                    { get; set; }
+		public  bool                    Static                  { get; set; }
+		public  string?                 Visibility              { get; set; }
+		public  string?                 ExtendedJniSignature    { get; set; }
 	}
 
 	public partial class JavaField : JavaMember
 	{
-		public JavaField (JavaType parent)
+		public JavaField (JavaType? parent)
 			: base (parent)
 		{
 		}
 
-		public bool NotNull { get; set; }
-		public bool Transient { get; set; }
-		public string Type { get; set; }
-		public string TypeGeneric { get; set; }
-		public string Value { get; set; }
-		public bool Volatile { get; set; }
+		public  bool                    NotNull                 { get; set; }
+		public  bool                    Transient               { get; set; }
+		public  string?                 Type                    { get; set; }
+		public  string?                 TypeGeneric             { get; set; }
+		public  string?                 Value                   { get; set; }
+		public  bool                    Volatile                { get; set; }
 		
 		// Content of this value is not stable.
 		public override string ToString ()
@@ -193,23 +195,29 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 
 	public partial class JavaMethodBase : JavaMember
 	{
-		protected JavaMethodBase (JavaType parent)
+		protected JavaMethodBase (JavaType? parent)
 			: base (parent)
 		{
 			Parameters = new List<JavaParameter> ();
-			Exceptions = new List<JavaException> ();
 		}
 
-		public IList<JavaParameter> Parameters { get; set; }
-		public IList<JavaException> Exceptions { get; set; }
-		public JavaTypeParameters TypeParameters { get; set; }
+		IList<JavaException>? exceptions;
+
+		public  IList<JavaParameter>    Parameters          { get; set; }
+		public  JavaTypeParameters?     TypeParameters      { get; set; }
 		
-		public bool ExtendedBridge { get; set; }
-		public string ExtendedJniReturn { get; set; }
-		public bool ExtendedSynthetic { get; set; }
+		public  bool                    ExtendedBridge      { get; set; }
+		public  string?                 ExtendedJniReturn   { get; set; }
+		public  bool                    ExtendedSynthetic   { get; set; }
+
+		[NotNull]
+		public  IList<JavaException>?   Exceptions          {
+			get => exceptions ?? (exceptions = new List<JavaException>());
+			set => exceptions = value;
+		}
 
 		// Content of this value is not stable.
-		public string ToStringHelper (string returnType, string name, JavaTypeParameters typeParameters)
+		public string ToStringHelper (string? returnType, string? name, JavaTypeParameters? typeParameters)
 		{
 			return string.Format ("{0}{1}{2}{3}{4}{5}({6})",
 				returnType,
@@ -224,33 +232,33 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 
 	public partial class JavaConstructor : JavaMethodBase
 	{
-		public JavaConstructor (JavaType parent)
+		public JavaConstructor (JavaType? parent)
 			: base (parent)
 		{
 		}
 		
 		// it was required in the original API XML, but removed in class-parsed...
-		public string Type { get; set; }
+		public  string?                 Type                { get; set; }
 		
 		// Content of this value is not stable.
 		public override string ToString ()
 		{
-			return "[Constructor] " + ToStringHelper (null, Parent.Name, null);
+			return "[Constructor] " + ToStringHelper (null, Parent?.Name, null);
 		}
 	}
 
 	public partial class JavaMethod : JavaMethodBase
 	{
-		public JavaMethod (JavaType parent)
+		public JavaMethod (JavaType? parent)
 			: base (parent)
 		{
 		}
 		
-		public bool Abstract { get; set; }
-		public bool Native { get; set; }
-		public string Return { get; set; }
-		public bool ReturnNotNull { get; set; }
-		public bool Synchronized { get; set; }
+		public  bool                    Abstract            { get; set; }
+		public  bool                    Native              { get; set; }
+		public  string?                 Return              { get; set; }
+		public  bool                    ReturnNotNull       { get; set; }
+		public  bool                    Synchronized        { get; set; }
 
 		// Content of this value is not stable.
 		public override string ToString ()
@@ -261,16 +269,16 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 
 	public partial class JavaParameter
 	{
-		public JavaParameter (JavaMethodBase parent)
+		public JavaParameter (JavaMethodBase? parent)
 		{
 			Parent = parent;
 		}
 
-		public JavaMethodBase Parent { get; private set; }
-		public string Name { get; set; }
-		public string Type { get; set; }
-		public string JniType { get; set; }
-		public bool NotNull { get; set; }
+		public  JavaMethodBase?         Parent              { get; private set; }
+		public  string?                 Name                { get; set; }
+		public  string?                 Type                { get; set; }
+		public  string?                 JniType             { get; set; }
+		public  bool                    NotNull             { get; set; }
 
 		// Content of this value is not stable.
 		public override string ToString ()
@@ -281,9 +289,9 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 
 	public partial class JavaException
 	{
-		public string Name { get; set; }
-		public string Type { get; set; }
-		public string TypeGenericAware { get; set; }
+		public  string?                 Name                { get; set; }
+		public  string?                 Type                { get; set; }
+		public  string?                 TypeGenericAware    { get; set; }
 	}
 
 	public partial class JavaTypeParameters
@@ -294,39 +302,39 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			TypeParameters = new List<JavaTypeParameter> ();
 		}
 		
-		public JavaTypeParameters (JavaMethodBase parent)
+		public JavaTypeParameters (JavaMethodBase? parent)
 		{
 			ParentMethod = parent;
 			TypeParameters = new List<JavaTypeParameter> ();
 		}
 		
-		public JavaType ParentType { get; set; }
-		public JavaMethodBase ParentMethod { get; set; }
+		public  JavaType?                   ParentType      { get; set; }
+		public  JavaMethodBase?             ParentMethod    { get; set; }
 		
-		public IList<JavaTypeParameter> TypeParameters { get; set; }
+		public  IList<JavaTypeParameter>    TypeParameters  { get; set; }
 	}
 
 	public partial class JavaTypeParameter
 	{
-		public JavaTypeParameter (JavaTypeParameters parent)
+		public JavaTypeParameter (JavaTypeParameters? parent)
 		{
 			Parent = parent;
 		}
 		
-		public JavaTypeParameters Parent { get; set; }
+		public  JavaTypeParameters?     Parent                      { get; set; }
 		
-		public string Name { get; set; }
+		public  string?                 Name                        { get; set; }
+
+		public  string?                 ExtendedJniClassBound       { get; set; }
+		public  string?                 ExtendedClassBound          { get; set; }
+		public  string?                 ExtendedInterfaceBounds     { get; set; }
+		public  string?                 ExtendedJniInterfaceBounds  { get; set; }
 		
-		public string ExtendedJniClassBound { get; set; }
-		public string ExtendedClassBound { get; set; }
-		public string ExtendedInterfaceBounds { get; set; }
-		public string ExtendedJniInterfaceBounds { get; set; }
-		
-		public JavaGenericConstraints GenericConstraints { get; set; }
+		public  JavaGenericConstraints? GenericConstraints          { get; set; }
 		
 		public override string ToString ()
 		{
-			return Name;
+			return Name ?? "";
 		}
 	}
 
@@ -337,9 +345,15 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			GenericConstraints = new List<JavaGenericConstraint> ();
 		}
 		
-		public string BoundsType { get; set; } // extends / super
+		public  string?                         BoundsType          { get; set; } // extends / super
 		
-		public IList<JavaGenericConstraint> GenericConstraints { get; set; }
+		IList<JavaGenericConstraint>?   genericConstraints;
+
+		[NotNull]
+		public  IList<JavaGenericConstraint>?   GenericConstraints  {
+			get => genericConstraints ?? (genericConstraints = new List<JavaGenericConstraint> ());
+			set => genericConstraints = value;
+		}
 		
 		public override string ToString ()
 		{
@@ -352,11 +366,11 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 	
 	public partial class JavaGenericConstraint
 	{
-		public string Type { get; set; }
+		public  string?                         Type                { get; set; }
 		
 		public override string ToString ()
 		{
-			return Type;
+			return Type ?? "";
 		}
 	}
 }

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiDefectFinderExtensions.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiDefectFinderExtensions.cs
@@ -21,7 +21,8 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		{
 			int dummy;
 			foreach (var p in methodBase.Parameters) {
-				if (p.Name.StartsWith ("p", StringComparison.Ordinal) && int.TryParse (p.Name.Substring (1), out dummy)) {
+				if ((p.Name?.StartsWith ("p", StringComparison.Ordinal) ?? false) &&
+						int.TryParse (p.Name.Substring (1), out dummy)) {
 					Log.LogWarning ("Warning: {0} in {1} has 'unnamed' parameters", methodBase.Parent, methodBase);
 					break; // reporting once is enough.
 				}

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiFixVisibilityExtensions.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiFixVisibilityExtensions.cs
@@ -5,33 +5,33 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 {
 	public static class JavaApiFixVisibilityExtensions
 	{
-		public static string GetVisibleTypeName (this JavaParameter parameter)
+		public static string? GetVisibleTypeName (this JavaParameter parameter)
 		{
 			var r = GetVisibleNonSpecialType (parameter);
 			return r != null ? r.ToString () : parameter.Type;
 		}
 
-		public static string GetVisibleReturnTypeName (this JavaMethod method)
+		public static string? GetVisibleReturnTypeName (this JavaMethod method)
 		{
 			var r = GetVisibleNonSpecialReturnType (method);
 			return r != null ? r.ToString () : method.Return;
 		}
 
-		public static JavaTypeReference GetVisibleNonSpecialType (this JavaParameter parameter)
+		public static JavaTypeReference? GetVisibleNonSpecialType (this JavaParameter parameter)
 		{
 			return GetVisibleNonSpecialType (parameter.Parent, parameter.ResolvedType);
 		}
 
-		public static JavaTypeReference GetVisibleNonSpecialReturnType (this JavaMethod method)
+		public static JavaTypeReference? GetVisibleNonSpecialReturnType (this JavaMethod method)
 		{
 			return GetVisibleNonSpecialType (method, method.ResolvedReturnType);
 		}
 
-		static JavaTypeReference GetVisibleNonSpecialType (this JavaMethodBase method, JavaTypeReference r)
+		static JavaTypeReference? GetVisibleNonSpecialType (this JavaMethodBase? method, JavaTypeReference? r)
 		{
 			if (r == null || r.SpecialName != null || r.ReferencedTypeParameter != null || r.ArrayPart != null)
 				return null;
-			var requiredVisibility = method.Visibility == "public" && method.Parent.Visibility == "public" ? "public" : method.Visibility;
+			var requiredVisibility = method?.Visibility == "public" && method.Parent?.Visibility == "public" ? "public" : method?.Visibility;
 			for (var t = r; t != null; t = (t.ReferencedType as JavaClass)?.ResolvedExtends) {
 				if (t.ReferencedType == null)
 					break;
@@ -41,7 +41,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			return null;
 		}
 
-		static bool IsAcceptableVisibility (string required, string actual)
+		static bool IsAcceptableVisibility (string? required, string? actual)
 		{
 			if (required == "public")
 				return actual == "public";

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiGeneralExtensions.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiGeneralExtensions.cs
@@ -8,12 +8,12 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 	{
 		public static JavaApi GetApi (this JavaType type)
 		{
-			return type.Parent.Parent;
+			return type.Parent?.Parent ?? throw new InvalidOperationException ("`JavaApi` via JavaType.Parent.Parent not set!");
 		}
 		
 		public static JavaApi GetApi (this JavaMember member)
 		{
-			return member.Parent.Parent.Parent;
+			return member.Parent?.Parent?.Parent ?? throw new InvalidOperationException ("`JavaApi` via JavaMethod.Parent.Parent.Parent not set!");;
 		}
 	}
 	

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiGenericInheritanceMapperExtensions.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiGenericInheritanceMapperExtensions.cs
@@ -26,16 +26,16 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 				// begin processing from the base class.
 				bt.PrepareGenericInheritanceMapping ();
 				
-				if (cls.ResolvedExtends.TypeParameters == null)
+				if (cls.ResolvedExtends?.TypeParameters == null)
 					cls.GenericInheritanceMapping = empty;
-				else if (cls.ResolvedExtends.ReferencedType.TypeParameters == null) {
+				else if (cls.ResolvedExtends?.ReferencedType?.TypeParameters == null) {
 					// FIXME: I guess this should not happen. But this still happens.
 					Log.LogWarning ("Warning: '{0}' is referenced as base type of '{1}' and expected to have generic type parameters, but it does not.", cls.ExtendsGeneric, cls.FullName);
 					cls.GenericInheritanceMapping = empty;
 				} else {
 					if (cls.ResolvedExtends.ReferencedType.TypeParameters.TypeParameters.Count != cls.ResolvedExtends.TypeParameters.Count)
 						throw new Exception (string.Format ("On {0}.{1}, referenced generic arguments count do not match the base type parameters definition",
-							cls.Parent.Name, cls.Name));
+							cls.Parent?.Name, cls.Name));
 					var dic = empty;
 					foreach (var kvp in cls.ResolvedExtends.ReferencedType.TypeParameters.TypeParameters.Zip (
 						 cls.ResolvedExtends.TypeParameters,

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiNonBindableStripper.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiNonBindableStripper.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			         .SelectMany (t => t.Members).Where (m => m.Name != null && m.Name.Contains ('$')))
 				invalids.Add (member);
 			foreach (var invalid in invalids)
-				invalid.Parent.Members.Remove (invalid);
+				invalid.Parent?.Members.Remove (invalid);
 		}
 	}
 }

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiOverrideMarkerExtensions.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiOverrideMarkerExtensions.cs
@@ -34,7 +34,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		
 		static void MarkBaseMethod (this JavaClass cls, JavaMethod method)
 		{
-			JavaClass k = cls;
+			JavaClass? k = cls;
 			while (true) {
 				k = k.ResolvedExtends != null ? k.ResolvedExtends.ReferencedType as JavaClass : null;
 				if (k == null)
@@ -44,14 +44,14 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 				var candidates = k.Members.OfType<JavaMethod> ().Where (_ => _.Name == method.Name);
 				// Then we find exact parameter type matches.
 				// No need to check returns. We only care about Java.
-				var candidate = candidates.FirstOrDefault (c => method.IsImplementing (c, cls.GenericInheritanceMapping));
+				var candidate = candidates.FirstOrDefault (c => method.IsImplementing (c, cls.GenericInheritanceMapping ?? throw new InvalidOperationException ($"missing {nameof(cls.GenericInheritanceMapping)}!")));
 				if (candidate != null) {
 					method.BaseMethod = new JavaMethodReference (candidate);
 					
 					for (int i = 0; i < candidate.Parameters.Count; i++)
-						if (candidate.Parameters [i].ResolvedType.ReferencedTypeParameter != null &&
-						    method.Parameters [i].ResolvedType.ReferencedTypeParameter == null)
-							method.Parameters [i].InstantiatedGenericArgumentName = candidate.Parameters [i].ResolvedType.ReferencedTypeParameter.Name;
+						if (candidate.Parameters [i].ResolvedType?.ReferencedTypeParameter != null &&
+							    method.Parameters [i].ResolvedType?.ReferencedTypeParameter == null)
+							method.Parameters [i].InstantiatedGenericArgumentName = candidate.Parameters [i].ResolvedType?.ReferencedTypeParameter?.Name;
 					break;
 				}
 			}

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaTypeName.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaTypeName.cs
@@ -131,14 +131,14 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			}
 		}
 
-		public JavaTypeName GenericParent { get; set; }
-		public string DottedName { get; set; }
-		public string BoundsType { get; set; } // " extends " / " super "
-		public IList<JavaTypeName> GenericConstraints { get; private set; }
-		public IList<JavaTypeName> GenericArguments { get; private set; }
-		public string ArrayPart { get; set; }
+		public  JavaTypeName?           GenericParent       { get; set; }
+		public  string?                 DottedName          { get; set; }
+		public  string?                 BoundsType          { get; set; } // " extends " / " super "
+		public  IList<JavaTypeName>?    GenericConstraints  { get; private set; }
+		public  IList<JavaTypeName>?    GenericArguments    { get; private set; }
+		public  string?                 ArrayPart           { get; set; }
 
-		public string FullNameNonGeneric {
+		public string? FullNameNonGeneric {
 			get {
 				if (GenericParent != null)
 					return GenericParent.FullNameNonGeneric + "." + DottedName;

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaTypeReference.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaTypeReference.cs
@@ -21,7 +21,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		public static readonly JavaTypeReference ULong;
 		public static readonly JavaTypeReference UByte;
 
-		internal static JavaTypeReference GetSpecialType (string name)
+		internal static JavaTypeReference? GetSpecialType (string? name)
 		{
 			switch (name) {
 			case "void": return Void;
@@ -60,12 +60,12 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			UByte = new JavaTypeReference ("ubyte");
 		}
 
-		JavaTypeReference (string specialName)
+		JavaTypeReference (string? specialName)
 		{
 			SpecialName = specialName;
 		}
 		
-		public JavaTypeReference (string constraintLabel, IEnumerable<JavaTypeReference> wildcardConstraints, string arrayPart)
+		public JavaTypeReference (string? constraintLabel, IEnumerable<JavaTypeReference>? wildcardConstraints, string? arrayPart)
 		{
 			SpecialName = GenericWildcard.SpecialName;
 			ArrayPart = arrayPart;
@@ -73,7 +73,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			WildcardConstraints = wildcardConstraints != null && wildcardConstraints.Any () ? wildcardConstraints.ToList () : null;
 		}
 
-		public JavaTypeReference (JavaTypeReference referencedType, string arrayPart, string wildcardBoundsType, IEnumerable<JavaTypeReference> wildcardConstraints)
+		public JavaTypeReference (JavaTypeReference referencedType, string? arrayPart, string? wildcardBoundsType, IEnumerable<JavaTypeReference>? wildcardConstraints)
 		{
 			if (referencedType == null)
 				throw new ArgumentNullException ("referencedType");
@@ -86,7 +86,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			ArrayPart = arrayPart;
 		}
 		
-		public JavaTypeReference (JavaTypeParameter referencedTypeParameter, string arrayPart)
+		public JavaTypeReference (JavaTypeParameter referencedTypeParameter, string? arrayPart)
 		{
 			if (referencedTypeParameter == null)
 				throw new ArgumentNullException ("referencedTypeParameter");
@@ -94,7 +94,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			ArrayPart = arrayPart;
 		}
 		
-		public JavaTypeReference (JavaType referencedType, IList<JavaTypeReference> typeParameters, string arrayPart)
+		public JavaTypeReference (JavaType referencedType, IList<JavaTypeReference>? typeParameters, string? arrayPart)
 		{
 			if (referencedType == null)
 				throw new ArgumentNullException ("referencedType");
@@ -103,15 +103,15 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			ArrayPart = arrayPart;
 		}
 		
-		public string SpecialName { get; private set; }
+		public  string?                     SpecialName             { get; private set; }
 
-		public string WildcardBoundsType { get; private set; }
-		public IList<JavaTypeReference> WildcardConstraints { get; private set; }
+		public  string?                     WildcardBoundsType      { get; private set; }
+		public  IList<JavaTypeReference>?   WildcardConstraints     { get; private set; }
 
-		public JavaType ReferencedType { get; private set; }
-		public JavaTypeParameter ReferencedTypeParameter { get; private set; }
-		public IList<JavaTypeReference> TypeParameters { get; private set; }
-		public string ArrayPart { get; private set; }
+		public  JavaType?                   ReferencedType          { get; private set; }
+		public  JavaTypeParameter?          ReferencedTypeParameter { get; private set; }
+		public  IList<JavaTypeReference>?   TypeParameters          { get; private set; }
+		public  string?                     ArrayPart               { get; private set; }
 		
 		public override string ToString ()
 		{
@@ -123,9 +123,9 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 				return ReferencedTypeParameter.ToString () + ArrayPart;
 			else
 				return string.Format ("{0}{1}{2}{3}{4}",
-					ReferencedType.Parent.Name,
-					string.IsNullOrEmpty (ReferencedType.Parent.Name) ? string.Empty : ".",
-					ReferencedType.Name,
+					ReferencedType?.Parent?.Name,
+					string.IsNullOrEmpty (ReferencedType?.Parent?.Name) ? string.Empty : ".",
+					ReferencedType?.Name,
 					TypeParameters == null ? null : '<' + string.Join (", ", TypeParameters.Select (_ => _.ToString ())) + '>',
 					ArrayPart);
 		}
@@ -135,12 +135,12 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			// it's skipping TypeParameters because it's too annoying...
 			if (SpecialName != null)
 				return SpecialName.GetHashCode ();
-			return  (ReferencedType != null ? ReferencedType.Name.GetHashCode () : 0) << 15 +
-				(ReferencedTypeParameter != null ? ReferencedTypeParameter.Name.GetHashCode () : 0) << 7 +
+			return  (ReferencedType != null ? ReferencedType.Name?.GetHashCode () ?? 0 : 0) << 15 +
+				(ReferencedTypeParameter != null ? ReferencedTypeParameter.Name?.GetHashCode () ?? 0 : 0) << 7 +
 				(ArrayPart != null ? ArrayPart.GetHashCode () : 0);
 		}
 		
-		public override bool Equals (object obj)
+		public override bool Equals (object? obj)
 		{
 			return AreEqual (this, obj as JavaTypeReference);
 		}
@@ -149,7 +149,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		// Note that it is to compare them as a type reference, not as its object entity.
 		// So, for example, if one has a TypeParameter with T with some contraint and
 		// the other has a TypeParameter with T somehow without it, they are still "same".
-		public static bool AreEqual (JavaTypeReference tr1, JavaTypeReference tr2)
+		public static bool AreEqual (JavaTypeReference tr1, JavaTypeReference? tr2)
 		{
 			if (tr1 == null)
 				return tr2 == null;

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaTypeResolutionUtil.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaTypeResolutionUtil.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Xamarin.Android.Tools.ApiXmlAdjuster
@@ -7,6 +8,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 	public static class JavaTypeResolutionUtil
 	{
 
+		[return: MaybeNull]
 		static V Get<K,V> (this IDictionary<K,V> dic, K key)
 		{
 			V v;
@@ -43,28 +45,28 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			// but rather like "this method is an override, but it should be still generated in the resulting XML".
 			// For example, this results in that java.util.EnumMap#put() is NOT an override of
 			// java.util.AbstractMap#put(), it is an override, not just that it is still generated in the XML.
-			if (bp.ResolvedType.ReferencedTypeParameter != null && dp.ResolvedType.ReferencedTypeParameter != null &&
+			if (bp.ResolvedType?.ReferencedTypeParameter != null && dp.ResolvedType?.ReferencedTypeParameter != null &&
 			    bp.ResolvedType.ReferencedTypeParameter.ToString () != dp.ResolvedType.ReferencedTypeParameter.ToString ())
 				return false;
 			if (bp.Type == dp.Type)
 				return true;
 
-			if (bp.ResolvedType.ArrayPart != bp.ResolvedType.ArrayPart)
+			if (bp.ResolvedType?.ArrayPart != bp.ResolvedType?.ArrayPart)
 				return false;
 			
 			// if base is type with generic type parameters and derived is without any generic args, that's OK.
 			// java.lang.Class should match java.lang.Class<T>.
-			if (bp.ResolvedType.ReferencedType != null && dp.ResolvedType.ReferencedType != null &&
-			    bp.ResolvedType.ReferencedType.FullName == dp.ResolvedType.ReferencedType.FullName &&
-			    dp.ResolvedType.TypeParameters == null)
+			if (bp.ResolvedType?.ReferencedType != null && dp.ResolvedType?.ReferencedType != null &&
+			    bp.ResolvedType?.ReferencedType.FullName == dp.ResolvedType?.ReferencedType.FullName &&
+			    dp.ResolvedType?.TypeParameters == null)
 				return true;
 				
 			// generic instantiation check.
-			var baseGTP = bp.ResolvedType.ReferencedTypeParameter;
+			var baseGTP = bp.ResolvedType?.ReferencedTypeParameter;
 			if (baseGTP != null) {
-				if (baseGTP.Parent.ParentMethod != null && baseGTP.IsConformantType (dp.ResolvedType))
+				if (baseGTP.Parent?.ParentMethod != null && baseGTP.IsConformantType (dp.ResolvedType))
 					return true;
-				var k = genericInstantiation.Keys.FirstOrDefault (tr => bp.ResolvedType.Equals (tr));
+				var k = genericInstantiation.Keys.FirstOrDefault (tr => bp.ResolvedType?.Equals (tr) ?? false);
 				if (k == null)
 					// the specified generic type parameter is not part of
 					// the mappings e.g. non-instantiated ones.
@@ -80,13 +82,13 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			return false;
 		}
 		
-		static bool IsConformantType (this JavaTypeParameter typeParameter, JavaTypeReference examinedType)
+		static bool IsConformantType (this JavaTypeParameter typeParameter, JavaTypeReference? examinedType)
 		{
 			if (typeParameter.GenericConstraints == null)
 				return true;
 			// FIXME: implement correct generic constraint conformance check.
 			Log.LogDebug ("NOTICE: generic constraint conformance check is not implemented, so the type might be actually compatible. Type parameter: {0}{1}, examined type: {2}",
-			                               typeParameter.Name, typeParameter.Parent.ParentMethod?.Name ?? typeParameter.Parent.ParentType?.Name, examinedType);
+					typeParameter.Name, typeParameter.Parent?.ParentMethod?.Name ?? typeParameter.Parent?.ParentType?.Name, examinedType);
 			return false;
 		}
 	}

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/Log.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/Log.cs
@@ -15,11 +15,11 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 
 		static Action<string> write_default = s => (DefaultWriter ?? Console.Out).WriteLine (s);
 
-		static Action<string> e, w, d;
+		static Action<string>? e, w, d;
 
-		public static TextWriter DefaultWriter { get; set; }
+		public  static  TextWriter?     DefaultWriter   { get; set; }
 
-		public static LoggingLevel Verbosity { get; set; } = LoggingLevel.Error;
+		public  static  LoggingLevel    Verbosity       { get; set; } = LoggingLevel.Error;
 
 		public static Action<string> LogErrorAction {
 			get { return e ?? write_default; }
@@ -34,19 +34,19 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			set { d = value; }
 		}
 
-		public static void LogError (string format, params object [] args)
+		public static void LogError (string format, params object?[] args)
 		{
 			if ((int) Verbosity >= (int) LoggingLevel.Error)
 				LogErrorAction (args.Length > 0 ? string.Format (format, args) : format);
 		}
 
-		public static void LogWarning (string format, params object [] args)
+		public static void LogWarning (string format, params object?[] args)
 		{
 			if ((int)Verbosity >= (int)LoggingLevel.Warning)
 				LogWarningAction (args.Length > 0 ? string.Format (format, args) : format);
 		}
 
-		public static void LogDebug (string format, params object [] args)
+		public static void LogDebug (string format, params object?[] args)
 		{
 			if ((int)Verbosity >= (int)LoggingLevel.Debug)
 				LogDebugAction (args.Length > 0 ? string.Format (format, args) : format);

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/Xamarin.Android.Tools.ApiXmlAdjuster.csproj
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/Xamarin.Android.Tools.ApiXmlAdjuster.csproj
@@ -2,10 +2,17 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <DefineConstants>INTERNAL_NULLABLE_ATTRIBUTES</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup>
     <OutputPath>$(TestOutputFullPath)</OutputPath>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\utils\NullableAttributes.cs" />
+  </ItemGroup>
 
 </Project>

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/XmlUtil.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/XmlUtil.cs
@@ -11,10 +11,10 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		static string GetLocation (XmlReader reader)
 		{
 			var li = reader as IXmlLineInfo;
-			return string.Format ("{0} ({1},{2})", string.IsNullOrEmpty (reader.BaseURI) ? null : new Uri (reader.BaseURI).LocalPath, li.LineNumber, li.LinePosition);
+			return string.Format ("{0} ({1},{2})", string.IsNullOrEmpty (reader.BaseURI) ? null : new Uri (reader.BaseURI).LocalPath, li?.LineNumber ?? 0, li?.LinePosition ?? 0);
 		}
 		
-		public static Exception UnexpectedElementOrContent (string elementName, XmlReader reader, params string [] expected)
+		public static Exception UnexpectedElementOrContent (string? elementName, XmlReader reader, params string?[] expected)
 		{
 			return new Exception (string.Format ("{0}: Unexpected element or content in '{1}': node is {2}, name is '{3}'. Expected elements are: {4}",
 				GetLocation (reader), elementName ?? "(top level)", reader.NodeType, reader.LocalName, string.Join (", ", expected)));


### PR DESCRIPTION
Update `Java.Interop.Tools.JavaSource.dll` and
`Xamarin.Android.Tools.ApiXmlAdjuster.dll` so that C# 8
[Nullable Reference Types][0] are used.

[0]: https://docs.microsoft.com/dotnet/csharp/nullable-references