### PR TITLE
[build] Fix for MSBuild 16.8.

### DIFF
--- a/src/Java.Interop/Directory.Build.targets
+++ b/src/Java.Interop/Directory.Build.targets
@@ -16,14 +16,11 @@
       Inputs="$(_JNIEnvGenPath)"
       Outputs="Java.Interop/JniEnvironment.g.cs;$(IntermediateOutputPath)jni.c">
     <MakeDir Directories="$(IntermediateOutputPath)" />
-    <PropertyGroup>
-      <_AddCompile Condition=" !Exists('Java.Interop/JniEnvironment.g.cs') ">True</_AddCompile>
-    </PropertyGroup>
     <Exec
         Command="$(_RunJNIEnvGen) Java.Interop/JniEnvironment.g.cs $(IntermediateOutputPath)jni.c"
     />
     <ItemGroup>
-      <Compile Include="Java.Interop/JniEnvironment.g.cs" Condition=" '$(_AddCompile)' == 'True' " />
+      <Compile Include="$([System.IO.Path]::Combine('Java.Interop','JniEnvironment.g.cs'))" KeepDuplicates="false" />
     </ItemGroup>
   </Target>
   <Target Name="BuildInteropJar"


### PR DESCRIPTION
We have some "clever" code that attempts to determine if it needs to add `Java.Interop/JniEnvironment.g.cs` to our compile items, since it may already be there because of file globs, if this isn't a clean run.  However this code no longer seems to work under MSBuild 16.8.  `$(_AddCompile)` remains `False` and thus the file isn't getting added to the compile on first run.

Instead we're going to use `KeepDuplicates='false'` to do the de-duping for us.

The wrinkle is that this file is added as `Java.Interop/JniEnvironment.g.cs` or `Java.Interop\JniEnvironment.g.cs` depending on OS, so we need to use `Path.Combine` to ensure our added file matches the copy from the glob, so the de-dupe will work.

Without any de-duping, the build produces a `CS2002: Source file 'JniEnvironment.g.cs' specified multiple times` warning.