### PR TITLE
[ApiXmlAdjuster] Use different data model structures for better performance

### DIFF
--- a/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/JavaStubParser.cs
+++ b/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/JavaStubParser.cs
@@ -318,7 +318,7 @@ namespace Java.Interop.Tools.JavaSource {
 				var pkg = new JavaPackage (null) { Name = (string) node.ChildNodes [0].AstNode };
 
 				foreach (var t in (IEnumerable<JavaType>) node.ChildNodes [2].AstNode)
-					pkg.AddType (t.Name!, t);
+					pkg.AddType (t);
 
 				node.AstNode = pkg;
 			};
@@ -648,7 +648,7 @@ namespace Java.Interop.Tools.JavaSource {
 			package.ClearTypes ();
 
 			foreach (var t in results)
-				package.AddType (t.Name!, t);
+				package.AddType (t);
 
 			void Flatten (List<JavaType> list, JavaType t)
 			{

--- a/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/JavaStubParser.cs
+++ b/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/JavaStubParser.cs
@@ -315,7 +315,12 @@ namespace Java.Interop.Tools.JavaSource {
 			identifier.AstConfig.NodeCreator = (ctx, node) => node.AstNode = node.Token.ValueString;
 			compile_unit.AstConfig.NodeCreator = (ctx, node) => {
 				ProcessChildren (ctx, node);
-				node.AstNode = new JavaPackage (null) { Name = (string)node.ChildNodes [0].AstNode, Types = ((IEnumerable<JavaType>)node.ChildNodes [2].AstNode).ToList () };
+				var pkg = new JavaPackage (null) { Name = (string) node.ChildNodes [0].AstNode };
+
+				foreach (var t in (IEnumerable<JavaType>) node.ChildNodes [2].AstNode)
+					pkg.AddType (t.Name!, t);
+
+				node.AstNode = pkg;
 			};
 			opt_package_decl.AstConfig.NodeCreator = SelectSingleChild;
 			package_decl.AstConfig.NodeCreator = SelectChildValueAt (1);
@@ -637,9 +642,13 @@ namespace Java.Interop.Tools.JavaSource {
 		void FlattenNestedTypes (JavaPackage package)
 		{
 			var results = new List<JavaType> ();
-			foreach (var t in package.Types)
+			foreach (var t in package.AllTypes)
 				Flatten (results, t);
-			package.Types = results.ToList ();
+
+			package.ClearTypes ();
+
+			foreach (var t in results)
+				package.AddType (t.Name!, t);
 
 			void Flatten (List<JavaType> list, JavaType t)
 			{

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApi.XmlModel.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApi.XmlModel.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 	{
 		public JavaApi ()
 		{
-			Packages = new Dictionary<string, JavaPackage> (StringComparer.OrdinalIgnoreCase);
+			Packages = new Dictionary<string, JavaPackage> ();
 		}
 
 		public  string?                 ExtendedApiSource   { get; set; }
@@ -22,7 +22,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 
 	public partial class JavaPackage
 	{
-		private Dictionary<string, List<JavaType>> types = new Dictionary<string, List<JavaType>> (StringComparer.OrdinalIgnoreCase);
+		private Dictionary<string, List<JavaType>> types = new Dictionary<string, List<JavaType>> ();
 
 		public JavaPackage (JavaApi? parent)
 		{

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiDefectFinderExtensions.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiDefectFinderExtensions.cs
@@ -7,7 +7,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 	{
 		public static void FindDefects (this JavaApi api)
 		{
-			foreach (var type in api.Packages.SelectMany (p => p.Types).Where (t => !t.IsReferenceOnly))
+			foreach (var type in api.AllPackages.SelectMany (p => p.AllTypes).Where (t => !t.IsReferenceOnly))
 				type.FindDefects ();
 		}
 		

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiGenericInheritanceMapperExtensions.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiGenericInheritanceMapperExtensions.cs
@@ -8,7 +8,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 	{
 		public static void CreateGenericInheritanceMapping (this JavaApi api)
 		{
-			foreach (var kls in api.Packages.SelectMany (p => p.Types).OfType<JavaClass> ())
+			foreach (var kls in api.AllPackages.SelectMany (p => p.AllTypes).OfType<JavaClass> ())
 				kls.PrepareGenericInheritanceMapping ();
 		}
 		

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiNonBindableStripper.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiNonBindableStripper.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		public static void StripNonBindables (this JavaApi api)
 		{
 			var invalids = new List<JavaMember> ();
-			foreach (var member in api.Packages.SelectMany (p => p.Types)
+			foreach (var member in api.AllPackages.SelectMany (p => p.AllTypes)
 			         .SelectMany (t => t.Members).Where (m => m.Name != null && m.Name.Contains ('$')))
 				invalids.Add (member);
 			foreach (var invalid in invalids)

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiOverrideMarkerExtensions.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiOverrideMarkerExtensions.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 
 		public static void MarkOverrides (this JavaApi api, HashSet<JavaClass> doneList)
 		{
-			foreach (var kls in api.Packages.SelectMany (p => p.Types).OfType<JavaClass> ())
+			foreach (var kls in api.AllPackages.SelectMany (p => p.AllTypes).OfType<JavaClass> ())
 				kls.MarkOverrides (doneList);
 		}
 		

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiTypeResolverExtensions.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiTypeResolverExtensions.cs
@@ -87,7 +87,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 					catch (JavaTypeResolutionException ex) {
 						Log.LogError ("Error while processing type '{0}': {1}", t, ex.Message);
 						errors = true;
-						t.Parent?.RemoveType (t.Name!, t);
+						t.Parent?.RemoveType (t);
 					}
 				foreach (var t in api.AllPackages.SelectMany (p => p.AllTypes).OfType<JavaInterface> ().ToArray ())
 					try {
@@ -95,7 +95,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 					} catch (JavaTypeResolutionException ex) {
 						Log.LogError ("Error while processing type '{0}': {1}", t, ex.Message);
 						errors = true;
-						t.Parent?.RemoveType (t.Name!, t);
+						t.Parent?.RemoveType (t);
 					}
 				if (!errors)
 					break;

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiTypeResolverExtensions.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiTypeResolverExtensions.cs
@@ -39,13 +39,31 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		
 		public static JavaType FindNonGenericType (this JavaApi api, string? name)
 		{
-			var ret = FindPackages (api, name ?? "")
-				.SelectMany (p => p.Types)
-				.FirstOrDefault (t => name == (t.Parent?.Name != null ? t.Parent.Name + "." : "") + t.Name);
-			if (ret == null)
-				ret = ManagedType.DummyManagedPackages
-				                 .SelectMany (p => p.Types)
-				                 .FirstOrDefault (t => t.FullName == name);
+			// Given a type name like 'android.graphics.BitmapFactory.Options'
+			// We're going to search for:
+			// - Pkg: android.graphics.BitmapFactory  Type: Options
+			// - Pkg: android.graphics                Type: BitmapFactory.Options
+			// - Pkg: android                         Type: graphics.BitmapFactory.Options
+			// etc.  We will short-circuit as soon as we find a match
+			var index = name?.LastIndexOf ('.') ?? -1;
+
+			while (index > 0) {
+				var ns = name!.Substring (0, index);
+				var type_name = name.Substring (index + 1);
+
+				if (api.Packages.TryGetValue (ns, out var pkg)) {
+					if (pkg.Types.TryGetValue (type_name, out var type))
+						return type.First ();
+				}
+
+				index = name.LastIndexOf ('.', index - 1);
+			}
+
+			// See if it's purely a C# type
+			var ret = ManagedType.DummyManagedPackages
+				.SelectMany (p => p.AllTypes)
+				.FirstOrDefault (t => t.FullName == name);
+
 			if (ret == null) {
 				// We moved this type to "mono.android.app.IntentService" which makes this
 				// type resolution fail if a user tries to reference it in Java.
@@ -58,43 +76,26 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			return ret;
 		}
 
-		static IEnumerable<JavaPackage> FindPackages (JavaApi api, string name)
-		{
-			// Given a type name like "java.lang.Object", return packages that could
-			// possibly contain the type so we don't search all packages, ie:
-			// - java.lang
-			// - java
-			var package_names = new List<string> ();
-			int index;
-
-			while ((index = name.LastIndexOf ('.')) >= 0) {
-				name = name.Substring (0, index);
-				package_names.Add (name);
-			}
-
-			return api.Packages.Where (p => package_names.Contains (p.Name, StringComparer.Ordinal)).ToList ();
-		}
-
 		public static void Resolve (this JavaApi api)
 		{
 			while (true) {
 				bool errors = false;
-				foreach (var t in api.Packages.SelectMany (p => p.Types).OfType<JavaClass> ().ToArray ())
+				foreach (var t in api.AllPackages.SelectMany (p => p.AllTypes).OfType<JavaClass> ().ToArray ())
 					try {
 						t.Resolve ();
 					}
 					catch (JavaTypeResolutionException ex) {
 						Log.LogError ("Error while processing type '{0}': {1}", t, ex.Message);
 						errors = true;
-						t.Parent?.Types.Remove (t);
+						t.Parent?.RemoveType (t.Name!, t);
 					}
-				foreach (var t in api.Packages.SelectMany (p => p.Types).OfType<JavaInterface> ().ToArray ())
+				foreach (var t in api.AllPackages.SelectMany (p => p.AllTypes).OfType<JavaInterface> ().ToArray ())
 					try {
 						t.Resolve ();
 					} catch (JavaTypeResolutionException ex) {
 						Log.LogError ("Error while processing type '{0}': {1}", t, ex.Message);
 						errors = true;
-						t.Parent?.Types.Remove (t);
+						t.Parent?.RemoveType (t.Name!, t);
 					}
 				if (!errors)
 					break;

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiXmlGeneratorExtensions.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiXmlGeneratorExtensions.cs
@@ -24,15 +24,15 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 			if (api.Platform != null)
 				writer.WriteAttributeString ("platform", api.Platform);
 
-			foreach (var pkg in api.Packages) {
-				if (!pkg.Types.Any (t => !t.IsReferenceOnly))
+			foreach (var pkg in api.AllPackages) {
+				if (!pkg.AllTypes.Any (t => !t.IsReferenceOnly))
 					continue;
 				writer.WriteStartElement ("package");
 				writer.WriteAttributeString ("name", pkg.Name);
 				if (!string.IsNullOrEmpty (pkg.JniName)) {
 					writer.WriteAttributeString ("jni-name", pkg.JniName);
 				}
-				foreach (var type in pkg.Types) {
+				foreach (var type in pkg.AllTypes) {
 					if (type.IsReferenceOnly)
 						continue; // skip reference only types
 					if (type is JavaClass)

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiXmlLoaderExtensions.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiXmlLoaderExtensions.cs
@@ -70,11 +70,11 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 					if (reader.LocalName == "class") {
 						var kls = new JavaClass (package) { IsReferenceOnly = isReferenceOnly };
 						kls.Load (reader);
-						package.AddType (kls.Name!, kls);
+						package.AddType (kls);
 					} else if (reader.LocalName == "interface") {
 						var iface = new JavaInterface (package) { IsReferenceOnly = isReferenceOnly };
 						iface.Load (reader);
-						package.AddType (iface.Name!, iface);
+						package.AddType (iface);
 					} else
 						throw XmlUtil.UnexpectedElementOrContent ("package", reader, "class", "interface");
 				} while (true);

--- a/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiXmlLoaderExtensions.cs
+++ b/src/Xamarin.Android.Tools.ApiXmlAdjuster/JavaApiXmlLoaderExtensions.cs
@@ -32,11 +32,14 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 						break; // </api>
 					if (reader.NodeType != XmlNodeType.Element || reader.LocalName != "package")
 						throw XmlUtil.UnexpectedElementOrContent ("api", reader, "package");
-					var pkg = api.Packages.FirstOrDefault (p => p.Name == reader.GetAttribute ("name"));
-					if (pkg == null) {
+
+					var name = reader.GetAttribute ("name");
+
+					if (!api.Packages.TryGetValue (name, out var pkg)) {
 						pkg = new JavaPackage (api);
-						api.Packages.Add (pkg);
+						api.Packages.Add (name, pkg);
 					}
+
 					pkg.Load (reader, isReferenceOnly);
 				} while (true);
 	
@@ -67,11 +70,11 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 					if (reader.LocalName == "class") {
 						var kls = new JavaClass (package) { IsReferenceOnly = isReferenceOnly };
 						kls.Load (reader);
-						package.Types.Add (kls);
+						package.AddType (kls.Name!, kls);
 					} else if (reader.LocalName == "interface") {
 						var iface = new JavaInterface (package) { IsReferenceOnly = isReferenceOnly };
 						iface.Load (reader);
-						package.Types.Add (iface);
+						package.AddType (iface.Name!, iface);
 					} else
 						throw XmlUtil.UnexpectedElementOrContent ("package", reader, "class", "interface");
 				} while (true);

--- a/tests/Java.Interop.Tools.JavaSource-Tests/JavaStubParserTests.cs
+++ b/tests/Java.Interop.Tools.JavaSource-Tests/JavaStubParserTests.cs
@@ -35,7 +35,7 @@ class Example {
 			Assert.AreEqual (null, package.Name);
 			Assert.AreEqual (1, package.Types.Count);
 
-			var Example_Type = package.Types [0];
+			var Example_Type = package.AllTypes.First ();
 			Assert.AreEqual ("Example", Example_Type.FullName);
 
 			Assert.AreEqual (1, Example_Type.Members.Count);

--- a/tests/Xamarin.Android.Tools.ApiXmlAdjuster-Tests/JavaApiTest.cs
+++ b/tests/Xamarin.Android.Tools.ApiXmlAdjuster-Tests/JavaApiTest.cs
@@ -19,9 +19,9 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster.Tests
 		[Test]
 		public void TestToString ()
 		{
-			var pkg = api.Packages.First (p => p.Name == "android.database");
+			var pkg = api.AllPackages.First (p => p.Name == "android.database");
 			Assert.AreEqual ("[Package] android.database", pkg.ToString ());
-			var kls = pkg.Types.First (t => t.FullName == "android.database.ContentObservable");
+			var kls = pkg.AllTypes.First (t => t.FullName == "android.database.ContentObservable");
 			Assert.AreEqual ("[Class] android.database.ContentObservable", kls.ToString ());
 		}
 

--- a/tests/Xamarin.Android.Tools.ApiXmlAdjuster-Tests/OverrideMarkerTest.cs
+++ b/tests/Xamarin.Android.Tools.ApiXmlAdjuster-Tests/OverrideMarkerTest.cs
@@ -53,7 +53,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster.Tests
 			xapi.Resolve ();
 			xapi.CreateGenericInheritanceMapping ();
 			xapi.MarkOverrides ();
-			var t = xapi.Packages.First (_ => _.Name == "XXX").Types.First (_ => _.Name == "SherlockExpandableListActivity");
+			var t = xapi.AllPackages.First (_ => _.Name == "XXX").AllTypes.First (_ => _.Name == "SherlockExpandableListActivity");
 			var m = t.Members.OfType<JavaMethod> ().First (_ => _.Name == "addContentView");
 			Assert.IsNotNull (m.BaseMethod, "base method not found");
 		}
@@ -88,7 +88,7 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster.Tests
 			xapi = new JavaApi ();
 			using (var xr = XmlReader.Create (new StringReader (sw.ToString ())))
 				xapi.Load (xr, true);
-			var t = xapi.Packages.First (_ => _.Name == "XXX").Types.First (_ => _.Name == "GenericConstructors");
+			var t = xapi.AllPackages.First (_ => _.Name == "XXX").AllTypes.First (_ => _.Name == "GenericConstructors");
 			var m = t.Members.OfType<JavaConstructor> ().FirstOrDefault ();
 			Assert.IsNotNull (m.TypeParameters, "constructor not found");
 		}

--- a/tests/Xamarin.Android.Tools.ApiXmlAdjuster-Tests/TypeResolverTest.cs
+++ b/tests/Xamarin.Android.Tools.ApiXmlAdjuster-Tests/TypeResolverTest.cs
@@ -76,20 +76,20 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster.Tests
 			var api = JavaApiTestHelper.GetLoadedApi ();
 
 			// Create "mono.android.app" package
-			var mono_android_app = new JavaPackage (api) { Name = "mono.android.app", JniName = "mono/android/app", Types = new List<JavaType> () };
-			api.Packages.Add (mono_android_app);
+			var mono_android_app = new JavaPackage (api) { Name = "mono.android.app", JniName = "mono/android/app" };
+			api.Packages.Add (mono_android_app.Name, mono_android_app);
 
 			// Remove "android.app.IntentService" type
-			var android_app = api.Packages.Single (p => p.Name == "android.app");
-			var intent_service = android_app.Types.Single (t => t.Name == "IntentService");
-			android_app.Types.Remove (intent_service);
+			var android_app = api.AllPackages.Single (p => p.Name == "android.app");
+			var intent_service = android_app.AllTypes.Single (t => t.Name == "IntentService");
+			android_app.RemoveType (intent_service.Name, intent_service);
 
 			// Create new "mono.android.app.IntentService" type
 			var new_intent_service = new JavaClass (mono_android_app) {
 				Name = intent_service.Name,
 			};
 
-			mono_android_app.Types.Add (new_intent_service);
+			mono_android_app.AddType (new_intent_service.Name, new_intent_service);
 
 			api.Resolve ();
 

--- a/tests/Xamarin.Android.Tools.ApiXmlAdjuster-Tests/TypeResolverTest.cs
+++ b/tests/Xamarin.Android.Tools.ApiXmlAdjuster-Tests/TypeResolverTest.cs
@@ -82,14 +82,14 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster.Tests
 			// Remove "android.app.IntentService" type
 			var android_app = api.AllPackages.Single (p => p.Name == "android.app");
 			var intent_service = android_app.AllTypes.Single (t => t.Name == "IntentService");
-			android_app.RemoveType (intent_service.Name, intent_service);
+			android_app.RemoveType (intent_service);
 
 			// Create new "mono.android.app.IntentService" type
 			var new_intent_service = new JavaClass (mono_android_app) {
 				Name = intent_service.Name,
 			};
 
-			mono_android_app.AddType (new_intent_service.Name, new_intent_service);
+			mono_android_app.AddType (new_intent_service);
 
 			api.Resolve ();
 

--- a/tools/generator/Extensions/JavaApiDllLoaderExtensions.cs
+++ b/tools/generator/Extensions/JavaApiDllLoaderExtensions.cs
@@ -21,12 +21,12 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 					var iface = new JavaInterface (pkg);
 					iface.Load (iface_gen);
 
-					pkg.AddType (iface.Name, iface);
+					pkg.AddType (iface);
 				} else if (gen is ClassGen class_gen) {
 					var kls = new JavaClass (pkg);
 					kls.Load (opt, class_gen);
 
-					pkg.AddType (kls.Name, kls);
+					pkg.AddType (kls);
 				}
 				else
 					throw new InvalidOperationException ();

--- a/tools/generator/Extensions/JavaApiDllLoaderExtensions.cs
+++ b/tools/generator/Extensions/JavaApiDllLoaderExtensions.cs
@@ -12,19 +12,21 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 		{
 			JavaPackage pkg = null;
 			foreach (var gen in gens.Where (_ => _.IsAcw)) {
-				pkg = api.Packages.FirstOrDefault (_ => _.Name == gen.PackageName);
-				if (pkg == null) {
+				if (!api.Packages.TryGetValue (gen.PackageName, out pkg)) {
 					pkg = new JavaPackage (api) { Name = gen.PackageName };
-					api.Packages.Add (pkg);
+					api.Packages.Add (pkg.Name, pkg);
 				}
-				if (gen is InterfaceGen) {
+
+				if (gen is InterfaceGen iface_gen) {
 					var iface = new JavaInterface (pkg);
-					pkg.Types.Add (iface);
-					iface.Load ((InterfaceGen) gen);
-				} else if (gen is ClassGen c) {
+					iface.Load (iface_gen);
+
+					pkg.AddType (iface.Name, iface);
+				} else if (gen is ClassGen class_gen) {
 					var kls = new JavaClass (pkg);
-					pkg.Types.Add (kls);
-					kls.Load (opt, c);
+					kls.Load (opt, class_gen);
+
+					pkg.AddType (kls.Name, kls);
 				}
 				else
 					throw new InvalidOperationException ();

--- a/tools/param-name-importer/DroidDocImporter.cs
+++ b/tools/param-name-importer/DroidDocImporter.cs
@@ -97,15 +97,15 @@ namespace Xamarin.Android.ApiTools.DroidDocImporter
 				bool isClass = apiSignatureTokens.Contains ("class");
 				options.DiagnosticWriter.WriteLine (apiSignatureTokens);
 
-				var javaPackage = api.Packages.FirstOrDefault (p => p.Name == packageName);
+				var javaPackage = api.AllPackages.FirstOrDefault (p => p.Name == packageName);
 				if (javaPackage == null) {
 					javaPackage = new JavaPackage (api) { Name = packageName };
-					api.Packages.Add (javaPackage);
+					api.Packages.Add (packageName, javaPackage);
 				}
 
 				var javaType = isClass ? (JavaType)new JavaClass (javaPackage) : new JavaInterface (javaPackage);
 				javaType.Name = apiSignatureTokens.Substring (apiSignatureTokens.LastIndexOf (' ') + 1);
-				javaPackage.Types.Add (javaType);
+				javaPackage.AddType (javaType.Name, javaType);
 
 				string sectionType = null;
 				var sep = new string [] { ", " };
@@ -166,9 +166,6 @@ namespace Xamarin.Android.ApiTools.DroidDocImporter
 					.OrderBy (m => m.Name + "(" + string.Join (",", m.Parameters.Select (p => p.Type)) + ")")
 					.ToArray ();
 			}
-			foreach (var pkg in api.Packages)
-				pkg.Types = pkg.Types.OrderBy (t => t.Name).ToArray ();
-			api.Packages = api.Packages.OrderBy (p => p.Name).ToArray ();
 
 			if (options.OutputTextFile != null)
 				api.WriteParameterNamesText (options.OutputTextFile);

--- a/tools/param-name-importer/DroidDocImporter.cs
+++ b/tools/param-name-importer/DroidDocImporter.cs
@@ -105,7 +105,7 @@ namespace Xamarin.Android.ApiTools.DroidDocImporter
 
 				var javaType = isClass ? (JavaType)new JavaClass (javaPackage) : new JavaInterface (javaPackage);
 				javaType.Name = apiSignatureTokens.Substring (apiSignatureTokens.LastIndexOf (' ') + 1);
-				javaPackage.AddType (javaType.Name, javaType);
+				javaPackage.AddType (javaType);
 
 				string sectionType = null;
 				var sep = new string [] { ", " };

--- a/tools/param-name-importer/JavaApiParameterNamesExporter.cs
+++ b/tools/param-name-importer/JavaApiParameterNamesExporter.cs
@@ -31,11 +31,11 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 				}
 			};
 
-			foreach (var package in api.Packages) {
+			foreach (var package in api.AllPackages.OrderBy (p => p.Name)) {
 				writer.WriteStartElement ("package");
 				writer.WriteAttributeString ("name", package.Name);
 
-				foreach (var type in package.Types) {
+				foreach (var type in package.AllTypes.OrderBy (t => t.Name)) {
 					if (!type.Members.OfType<JavaMethodBase> ().Any (m => m.Parameters.Any ()))
 						continue; // we care only about types that has any methods that have parameters.
 					
@@ -115,12 +115,12 @@ namespace Xamarin.Android.Tools.ApiXmlAdjuster
 					writer.Write ($"{indent}<{string.Join (",", tps.TypeParameters.Select (p => p.Name))}>");
 			};
 
-			foreach (var package in api.Packages) {
+			foreach (var package in api.AllPackages.OrderBy (p => p.Name)) {
 				writer.WriteLine ();
 				writer.WriteLine ($"package {package.Name}");
 				writer.WriteLine (";---------------------------------------");
 
-				foreach (var type in package.Types) {
+				foreach (var type in package.AllTypes.OrderBy (t => t.Name)) {
 					if (!type.Members.OfType<JavaMethodBase> ().Any (m => m.Parameters.Any ()))
 						continue; // we care only about types that has any methods that have parameters.
 					writer.Write (type is JavaClass ? "  class " : "  interface ");

--- a/tools/param-name-importer/JavaStubSourceImporter.cs
+++ b/tools/param-name-importer/JavaStubSourceImporter.cs
@@ -82,7 +82,7 @@ namespace Xamarin.Android.ApiTools.JavaStubImporter
 				pkg = parsedPackage;
 			} else
 				foreach (var t in parsedPackage.AllTypes)
-					pkg.AddType (t.Name, t);
+					pkg.AddType (t);
 
 			return true;
 		}

--- a/tools/param-name-importer/JavaStubSourceImporter.cs
+++ b/tools/param-name-importer/JavaStubSourceImporter.cs
@@ -28,8 +28,8 @@ namespace Xamarin.Android.ApiTools.JavaStubImporter
 						break;
 				}
 			}
-			foreach (var pkg in api.Packages) {
-				foreach (var t in pkg.Types) {
+			foreach (var pkg in api.AllPackages) {
+				foreach (var t in pkg.AllTypes.OrderBy (t => t.Name)) {
 					// Our API definitions don't contain non-public members, so remove those (but it does contain non-public types).
 					t.Members = t.Members.Where (m => m != null && m.Visibility != "").ToList ();
 					// Constructor "type" is the full name of the class.
@@ -56,9 +56,7 @@ namespace Xamarin.Android.ApiTools.JavaStubImporter
 						.OrderBy (m => m.Name + "(" + string.Join (",", m.Parameters.Select (p => p.Type)) + ")")
 						.ToArray ();
 				}
-				pkg.Types = pkg.Types.OrderBy (t => t.Name).ToArray ();
 			}
-			api.Packages = api.Packages.OrderBy (p => p.Name).ToArray ();
 
 			if (options.OutputTextFile != null)
 				api.WriteParameterNamesText (options.OutputTextFile);
@@ -78,14 +76,14 @@ namespace Xamarin.Android.ApiTools.JavaStubImporter
 			if (parsedPackage == null) {
 				return false;
 			}
-			var pkg = api.Packages.FirstOrDefault (p => p.Name == parsedPackage.Name);
+			var pkg = api.AllPackages.FirstOrDefault (p => p.Name == parsedPackage.Name);
 			if (pkg == null) {
-				api.Packages.Add (parsedPackage);
+				api.AllPackages.Add (parsedPackage);
 				pkg = parsedPackage;
 			} else
-				foreach (var t in parsedPackage.Types)
-					pkg.Types.Add (t);
-			pkg.Types = pkg.Types.OrderBy (t => t.Name).ToList ();
+				foreach (var t in parsedPackage.AllTypes)
+					pkg.AddType (t.Name, t);
+
 			return true;
 		}
 	}


### PR DESCRIPTION
Today, our ApiXmlAdjuster process builds an in-memory model of every Java type we know about, and then queries this model many times in order to ensure we can resolve every needed Java type to build a binding.  The data structure of this model is:
```
public class JavaApi
{
  public List<JavaPackage> Packages { get; }
}

public class JavaPackage
{
  public List<JavaType> Types { get; }
}
```

Then it is queried using LINQ like this:
```
// Bad
var type = api.Packages.SelectMany (p => p.Types).FirstOrDefault (t => t.Name == type_name);

// Less bad
var type = api.Packages.FirstOrDefault (p => p.Name == pkg_name)?.Types.FirstOrDefault (t => t.Name == type_name);
```

In the random GPS package I used for testing, `JavaApi` contained 310 packages and a total of 5941 types.  Repeatedly looping through them looking for the correct type takes a considerable amount of time.

Instead, we can use a `Dictionary` to store packages and types keyed by name to significantly speed up type resolution:
```
public class JavaApi
{
  public Dictionary<string, JavaPackage> Packages { get; }
}

public class JavaPackage
{
  public Dictionary<string, List<JavaType>> Types { get; }
}
```

For the GPS project, this reduced time taken considerably:
| Version | Time |
| -- | -- |
| master | 9.3s |
| This PR | 1.4s |

The only "interesting" detail is that we can have multiple types with the same *Java* name, such as `MyInterface` and `MyInterfaceConsts`.  Thus we need to use `Dictionary<string, List<JavaType>>` to ensure we collect them all.

For good measure I ran a XA build with this to ensure `Mono.Android` `ApiCompat` didn't find any issues: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4282925.