### PR TITLE
[class-parse] Support AndroidX's NonNull annotation.

### DIFF
--- a/src/Xamarin.Android.Tools.Bytecode/XmlClassDeclarationBuilder.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/XmlClassDeclarationBuilder.cs
@@ -464,6 +464,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 			// https://stackoverflow.com/questions/4963300/which-notnull-java-annotation-should-i-use
 			switch (annotation.Type) {
 				case "Landroid/annotation/NonNull;":
+				case "Landroidx/annotation/NonNull;":
 				case "Landroidx/annotation/RecentlyNonNull;":
 				case "Ljavax/validation/constraints/NotNull;":
 				case "Ledu/umd/cs/findbugs/annotations/NonNull;":


### PR DESCRIPTION
There is yet another `@NonNull` annotation: `androidx.annotation.NonNull` that we need to recognize to help create NRT assemblies:

https://developer.android.com/reference/androidx/annotation/NonNull