### PR TITLE
Conditionally call ManagedPeer.Init()

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,10 +23,6 @@
       Project="$(_OutputPath)MonoInfo.props"
       Condition="Exists('$(_OutputPath)MonoInfo.props')"
   />
-  <Import
-      Project="$(_OutputPath)XamarinAndroid.props"
-      Condition="Exists('$(_OutputPath)XamarinAndroid.props')"
-  />
   <PropertyGroup>
     <AppendTargetFrameworkToOutputPath Condition=" '$(AppendTargetFrameworkToOutputPath)' == '' ">False</AppendTargetFrameworkToOutputPath>
     <BaseIntermediateOutputPath Condition=" '$(BaseIntermediateOutputPath)' == '' ">obj\</BaseIntermediateOutputPath>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,6 +23,10 @@
       Project="$(_OutputPath)MonoInfo.props"
       Condition="Exists('$(_OutputPath)MonoInfo.props')"
   />
+  <Import
+      Project="$(_OutputPath)XamarinAndroid.props"
+      Condition="Exists('$(_OutputPath)XamarinAndroid.props')"
+  />
   <PropertyGroup>
     <AppendTargetFrameworkToOutputPath Condition=" '$(AppendTargetFrameworkToOutputPath)' == '' ">False</AppendTargetFrameworkToOutputPath>
     <BaseIntermediateOutputPath Condition=" '$(BaseIntermediateOutputPath)' == '' ">obj\</BaseIntermediateOutputPath>

--- a/src/Java.Interop/Java.Interop-MonoAndroid.csproj
+++ b/src/Java.Interop/Java.Interop-MonoAndroid.csproj
@@ -23,7 +23,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;INTEROP;FEATURE_JNIENVIRONMENT_JI_PINVOKES;FEATURE_JNIOBJECTREFERENCE_INTPTRS;INTERNAL_NULLABLE_ATTRIBUTES</DefineConstants>
+    <DefineConstants>DEBUG;INTEROP;FEATURE_JNIENVIRONMENT_JI_PINVOKES;FEATURE_JNIOBJECTREFERENCE_INTPTRS;INTERNAL_NULLABLE_ATTRIBUTES;$(JavaInteropDefineConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -39,7 +39,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-    <DefineConstants>INTEROP;FEATURE_JNIENVIRONMENT_JI_PINVOKES;FEATURE_JNIOBJECTREFERENCE_INTPTRS;INTERNAL_NULLABLE_ATTRIBUTES</DefineConstants>
+    <DefineConstants>INTEROP;FEATURE_JNIENVIRONMENT_JI_PINVOKES;FEATURE_JNIOBJECTREFERENCE_INTPTRS;INTERNAL_NULLABLE_ATTRIBUTES;$(JavaInteropDefineConstants)</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
     <DocumentationFile>..\..\bin\Release\Java.Interop.xml</DocumentationFile>

--- a/src/Java.Interop/Java.Interop-MonoAndroid.csproj
+++ b/src/Java.Interop/Java.Interop-MonoAndroid.csproj
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <XAConfigPath>..\..\bin\Build$(Configuration)\XAConfig.props</XAConfigPath>
+  </PropertyGroup>
+  <Import Condition="Exists ('$(XAConfigPath)')" Project="$(XAConfigPath)" />
+  <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>8.0.30703</ProductVersion>

--- a/src/Java.Interop/Java.Interop-MonoAndroid.csproj
+++ b/src/Java.Interop/Java.Interop-MonoAndroid.csproj
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <XAConfigPath>..\..\bin\Build$(Configuration)\XAConfig.props</XAConfigPath>
-  </PropertyGroup>
-  <Import Condition="Exists ('$(XAConfigPath)')" Project="$(XAConfigPath)" />
-  <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>8.0.30703</ProductVersion>
@@ -22,6 +18,10 @@
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
   <Import Project="..\..\Directory.Build.props" />
+  <PropertyGroup>
+    <XAConfigPath>..\..\bin\Build$(Configuration)\XAConfig.props</XAConfigPath>
+  </PropertyGroup>
+  <Import Condition="Exists ('$(XAConfigPath)')" Project="$(XAConfigPath)" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>

--- a/src/Java.Interop/Java.Interop.csproj
+++ b/src/Java.Interop/Java.Interop.csproj
@@ -5,7 +5,7 @@
     <NoWarn>1591</NoWarn>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
-    <DefineConstants>INTEROP;FEATURE_JNIENVIRONMENT_JI_PINVOKES;FEATURE_JNIOBJECTREFERENCE_INTPTRS;INTERNAL_NULLABLE_ATTRIBUTES</DefineConstants>
+    <DefineConstants>INTEROP;FEATURE_JNIENVIRONMENT_JI_PINVOKES;FEATURE_JNIOBJECTREFERENCE_INTPTRS;INTERNAL_NULLABLE_ATTRIBUTES;$(JavaInteropDefineConstants)</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(Configuration)\$(TargetFramework.ToLowerInvariant())\</IntermediateOutputPath>

--- a/src/Java.Interop/Java.Interop.csproj
+++ b/src/Java.Interop/Java.Interop.csproj
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <XAConfigPath>..\..\bin\Build$(Configuration)\XAConfig.props</XAConfigPath>
+  </PropertyGroup>
+  <Import Condition="Exists ('$(XAConfigPath)')" Project="$(XAConfigPath)" />
+  <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <NoWarn>1591</NoWarn>
     <SignAssembly>true</SignAssembly>

--- a/src/Java.Interop/Java.Interop/JniEnvironment.Errors.cs
+++ b/src/Java.Interop/Java.Interop/JniEnvironment.Errors.cs
@@ -30,7 +30,6 @@ namespace Java.Interop {
 					throw new InvalidOperationException (string.Format ("Could not raise an exception; JNIEnv::ThrowNew() returned {0}.", r));
 			}
 
-#if !XA_INTEGRATION
 			public static void Throw (Exception e)
 			{
 				if (e == null)
@@ -41,7 +40,6 @@ namespace Java.Interop {
 				}
 				Throw (je.PeerReference);
 			}
-#endif  // !XA_INTEGRATION
 		}
 	}
 }

--- a/src/Java.Interop/Java.Interop/JniEnvironment.References.cs
+++ b/src/Java.Interop/Java.Interop/JniEnvironment.References.cs
@@ -59,12 +59,10 @@ namespace Java.Interop
 				throw new InvalidOperationException (string.Format ("Could not push a frame; JNIEnv::PushLocalFrame() returned {0}.", r));
 			}
 
-#if !XA_INTEGRATION
 			public static int GetIdentityHashCode (JniObjectReference value)
 			{
 				return JniSystem.IdentityHashCode (value);
 			}
-#endif  // !XA_INTEGRATION
 
 			public static IntPtr NewReturnToJniRef (IJavaPeerable value)
 			{

--- a/src/Java.Interop/Java.Interop/JniEnvironment.Strings.cs
+++ b/src/Java.Interop/Java.Interop/JniEnvironment.Strings.cs
@@ -17,7 +17,6 @@ namespace Java.Interop
 					return NewString (s, value.Length);
 			}
 
-#if !XA_INTEGRATION
 			public static string? ToString (IntPtr reference)
 			{
 				return ToString (new JniObjectReference (reference));
@@ -28,7 +27,6 @@ namespace Java.Interop
 				Debug.Assert (targetType == typeof (string), "Expected targetType==typeof(string); was: " + targetType);
 				return ToString (ref reference, transfer);
 			}
-#endif  // !XA_INTEGRATION
 
 			public static unsafe string? ToString (JniObjectReference value)
 			{

--- a/src/Java.Interop/Java.Interop/JniObjectReferenceOptions.cs
+++ b/src/Java.Interop/Java.Interop/JniObjectReferenceOptions.cs
@@ -19,12 +19,9 @@ namespace Java.Interop
 		const       JniObjectReferenceOptions   DisposeSource       = (JniObjectReferenceOptions) (1 << 1);
 	}
 
-#if !XA_INTEGRATION
 	partial class JniRuntime {
 		partial class JniValueManager {
 			const   JniObjectReferenceOptions   DoNotRegisterTarget = (JniObjectReferenceOptions) (1 << 2);
 		}
 	}
-#endif  // !XA_INTEGRATION
 }
-

--- a/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods.cs
+++ b/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods.cs
@@ -111,7 +111,6 @@ namespace Java.Interop
 			return r;
 		}
 
-#if !XA_INTEGRATION
 		internal JniObjectReference AllocObject (Type declaringType)
 		{
 			var r   = GetConstructorsForType (declaringType)
@@ -120,7 +119,6 @@ namespace Java.Interop
 			r.Flags = JniObjectReferenceFlags.Alloc;
 			return r;
 		}
-#endif  // !XA_INTEGRATION
 
 		internal unsafe JniObjectReference NewObject (string constructorSignature, Type declaringType, JniArgumentValue* parameters)
 		{

--- a/src/Java.Interop/Java.Interop/JniPeerMembers.cs
+++ b/src/Java.Interop/Java.Interop/JniPeerMembers.cs
@@ -24,14 +24,12 @@ namespace Java.Interop {
 			if (!typeof (IJavaPeerable).IsAssignableFrom (managedPeerType))
 				throw new ArgumentException ("'managedPeerType' must implement the IJavaPeerable interface.", nameof (managedPeerType));
 
-#if !XA_INTEGRATION
 			Debug.Assert (
 					JniEnvironment.Runtime.TypeManager.GetTypeSignature (managedPeerType).SimpleReference == jniPeerTypeName,
 					string.Format ("ManagedPeerType <=> JniTypeName Mismatch! javaVM.GetJniTypeInfoForType(typeof({0})).JniTypeName=\"{1}\" != \"{2}\"",
 						managedPeerType.FullName,
 						JniEnvironment.Runtime.TypeManager.GetTypeSignature (managedPeerType).SimpleReference,
 						jniPeerTypeName));
-#endif  // !XA_INTEGRATION
 
 			ManagedPeerType = managedPeerType;
 		}
@@ -47,14 +45,12 @@ namespace Java.Interop {
 				if (!typeof (IJavaPeerable).IsAssignableFrom (managedPeerType))
 					throw new ArgumentException ("'managedPeerType' must implement the IJavaPeerable interface.", nameof (managedPeerType));
 
-#if !XA_INTEGRATION
 				Debug.Assert (
 					JniEnvironment.Runtime.TypeManager.GetTypeSignature (managedPeerType).SimpleReference == jniPeerTypeName,
 					string.Format ("ManagedPeerType <=> JniTypeName Mismatch! javaVM.GetJniTypeInfoForType(typeof({0})).JniTypeName=\"{1}\" != \"{2}\"",
 						managedPeerType.FullName,
 						JniEnvironment.Runtime.TypeManager.GetTypeSignature (managedPeerType).SimpleReference,
 						jniPeerTypeName));
-#endif  // !XA_INTEGRATION
 			}
 
 			JniPeerTypeName = jniPeerTypeName;

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
@@ -201,7 +201,7 @@ namespace Java.Interop {
 						yield return type;
 						continue;
 					}
-#if !XA_INTEGRATION
+
 					if (typeSignature.ArrayRank > 0) {
 						var rank        = typeSignature.ArrayRank;
 						var arrayType   = type;
@@ -214,7 +214,7 @@ namespace Java.Interop {
 						}
 						yield return arrayType;
 					}
-#endif  // !XA_INTEGRATION
+
 					if (typeSignature.ArrayRank > 0) {
 						var rank        = typeSignature.ArrayRank;
 						var arrayType   = type;

--- a/src/Java.Interop/Java.Interop/JniRuntime.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.cs
@@ -248,9 +248,9 @@ namespace Java.Interop
 				}
 			}
 
-#if !XA_INTEGRATION
+#if !XA_JI_EXCLUDE
 			ManagedPeer.Init ();
-#endif  // !XA_INTEGRATION
+#endif
 		}
 
 		T SetRuntime<T> (T value)

--- a/src/Java.Interop/Java.Interop/JniRuntime.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.cs
@@ -250,7 +250,7 @@ namespace Java.Interop
 
 #if !XA_JI_EXCLUDE
 			ManagedPeer.Init ();
-#endif
+#endif  // !XA_JI_EXCLUDE
 		}
 
 		T SetRuntime<T> (T value)

--- a/src/Java.Interop/Java.Interop/JniRuntime.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.cs
@@ -325,11 +325,9 @@ namespace Java.Interop
 				JniObjectReference.Dispose (ref ClassLoader);
 
 				ClearTrackedReferences ();
-#if !XA_INTEGRATION
 				ValueManager.Dispose ();
 				marshalMemberBuilder?.Dispose ();
 				TypeManager.Dispose ();
-#endif  // !XA_INTEGRATION
 				ObjectReferenceManager.Dispose ();
 
 				var environments = JniEnvironment.Info.Values;
@@ -389,11 +387,7 @@ namespace Java.Interop
 
 		public virtual Exception? GetExceptionForThrowable (ref JniObjectReference reference, JniObjectReferenceOptions options)
 		{
-#if XA_INTEGRATION
-			throw new NotSupportedException ("Do not know h ow to convert a JniObjectReference to a System.Exception!");
-#else   // !XA_INTEGRATION
 			return ValueManager.GetValue<Exception> (ref reference, options);
-#endif  // !̣XA_INTEGRATION
 		}
 
 		public int GlobalReferenceCount {
@@ -436,13 +430,7 @@ namespace Java.Interop
 
 		public virtual void RaisePendingException (Exception pendingException)
 		{
-#if XA_INTEGRATION
-			if (pendingException == null)
-				throw new ArgumentNullException (nameof (pendingException));
-			throw new NotSupportedException ("Do not know how to marshal System.Exception instances.");
-#else   // !XA_INTEGRATION
 			JniEnvironment.Exceptions.Throw (pendingException);
-#endif  // !XA_INTEGRATION
 		}
 	}
 }

--- a/src/Java.Interop/Java.Interop/JniType.cs
+++ b/src/Java.Interop/Java.Interop/JniType.cs
@@ -67,12 +67,7 @@ namespace Java.Interop {
 			return $"JniType(Name='{Name}' PeerReference={PeerReference})";
 		}
 
-#if XA_INTEGRATION
-		internal
-#else   // !XA_INTEGRATION
-		public
-#endif  // !XA_INTEGRATION
-		void RegisterWithRuntime ()
+		public void RegisterWithRuntime ()
 		{
 			AssertValid ();
 


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/5400
Context: https://github.com/xamarin/xamarin-android/pull/5444

Driven by `XA_JI_EXCLUDE`, which will be defined
in `XAConfig.props` in `$(JavaInteropDefineConstants)`, when
building for XA. The file is generated by XA's `xaprep`
in `bin/Build$(Configuration)`.

Also clean old `XA_INTEGRATION` #if's, they are not used anymore.
