### PR TITLE
Bump to mono/LineEditor/v5.4.1@3fa0c2eb (#740)

### DIFF
--- a/tools/logcat-parse/Directory.Build.targets
+++ b/tools/logcat-parse/Directory.Build.targets
@@ -1,0 +1,13 @@
+<Project>
+
+  <Target Name="_CopyDebugSymbols"
+      Condition=" '$(TargetFramework)' != '' "
+      AfterTargets="Build">
+    <Copy
+        SourceFiles="$(PkgMono_Terminal)\lib\netstandard2.0\LineEditor.pdb"
+        DestinationFolder="$(OutputPath)"
+        SkipUnchangedFiles="True"
+    />
+  </Target>
+
+</Project>

--- a/tools/logcat-parse/logcat-parse.csproj
+++ b/tools/logcat-parse/logcat-parse.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Mono.Options" Version="5.3.0.1" />
-    <PackageReference Include="Mono.Terminal" Version="5.4.0" />
+    <PackageReference Include="Mono.Terminal" Version="5.4.1" GeneratePathProperty="True" />
     <PackageReference Include="Mono.CSharp" Version="4.0.0.143" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1230070

Changes: https://github.com/mono/LineEditor/compare/5a7e3e24730e5392e2c37eddea3f0833bab5d18f...3fa0c2eb46b79b958a028b063d295a304cdb4842

  * mono/LineEditor@3fa0c2e: Fix NuGet publishing errors (#9)
  * mono/LineEditor@06a4ddf: Bump `$(PackageVersion)` to 5.4.1.
  * mono/LineEditor@bce1b7f: Enable .pdb files for Release config & add AzDO build script (#8)
  * mono/LineEditor@4831e1a: Merge pull request #6 from terrajobst/code-of-conduct
  * mono/LineEditor@5b4a4aa: Link Code of Conduct
  * mono/LineEditor@410ca3d: Merge pull request #2 from VEIT-Electronics/master
  * mono/LineEditor@3d802e7: Merge pull request #1 from VEIT-Electronics/bugfix/ENG-232-line-editor-completions
  * mono/LineEditor@0d43552: fix: text overriding was only platform specific (check platform)

The most important piece is mono/LineEditor@bce1b7f, which will allow
us to redistribute `LineEditor.pdb` in the Xamarin.Android installers.

Add a post-`Build` target to `logcat-parse/Directory.Build.targets`
which copies `LineEditor.pdb` into `$(OutputPath)`.  This will allow
the Xamarin.Android installer to include `LineEditor.pdb` into the
installer packages.