### PR TITLE
Refactor Crc64 type

### DIFF
--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/Crc64.Table.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/Crc64.Table.cs
@@ -1,8 +1,8 @@
 namespace Java.Interop.Tools.JavaCallableWrappers
 {
-	partial class Crc64
+	partial class Crc64Helper
 	{
-		static readonly ulong[,] Table = {
+		static readonly ulong[,] table = {
 			{
 				0x0000000000000000, 0x7ad870c830358979, 0xf5b0e190606b12f2, 0x8f689158505e9b8b,
 				0xc038e5739841b68f, 0xbae095bba8743ff6, 0x358804e3f82aa47d, 0x4f50742bc81f2d04,

--- a/src/Java.Interop.Tools.TypeNameMappings/Java.Interop.Tools.TypeNameMappings/JavaNativeTypeManager.cs
+++ b/src/Java.Interop.Tools.TypeNameMappings/Java.Interop.Tools.TypeNameMappings/JavaNativeTypeManager.cs
@@ -205,8 +205,7 @@ namespace Java.Interop.Tools.TypeNameMappings
 			case PackageNamingPolicy.LowercaseWithAssemblyName:
 				return "assembly_" + (assemblyName.Replace ('.', '_') + "." + type.Namespace).ToLowerInvariant ();
 			case PackageNamingPolicy.LowercaseCrc64:
-				using (var crc = new Crc64 ())
-					return CRC_PREFIX + ToHash (type.Namespace + ":" + assemblyName, crc);
+				return CRC_PREFIX + ToCrc64 (type.Namespace + ":" + assemblyName);
 			default:
 					throw new NotSupportedException ($"PackageNamingPolicy.{PackageNamingPolicy} is no longer supported.");
 			}
@@ -574,8 +573,7 @@ namespace Java.Interop.Tools.TypeNameMappings
 			case PackageNamingPolicy.LowercaseWithAssemblyName:
 				return "assembly_" + (type.GetPartialAssemblyName (cache).Replace ('.', '_') + "." + type.Namespace).ToLowerInvariant ();
 			case PackageNamingPolicy.LowercaseCrc64:
-				using (var crc = new Crc64 ())
-					return CRC_PREFIX + ToHash (type.Namespace + ":" + type.GetPartialAssemblyName (cache), crc);
+				return CRC_PREFIX + ToCrc64 (type.Namespace + ":" + type.GetPartialAssemblyName (cache));
 			default:
 					throw new NotSupportedException ($"PackageNamingPolicy.{PackageNamingPolicy} is no longer supported.");
 			}
@@ -644,10 +642,10 @@ namespace Java.Interop.Tools.TypeNameMappings
 		}
 #endif  // HAVE_CECIL
 
-		static string ToHash (string value, HashAlgorithm algorithm)
+		static string ToCrc64 (string value)
 		{
 			var data = Encoding.UTF8.GetBytes (value);
-			var hash = algorithm.ComputeHash (data);
+			var hash = Crc64Helper.Compute (data);
 			var buf  = new StringBuilder (hash.Length * 2);
 			foreach (var b in hash)
 				buf.AppendFormat ("{0:x2}", b);


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/5451

Split the code to static helper class, which can be used from
`Java.Interop.Tools.TypeNameMappings.JavaNativeTypeManager.GetPackageName`.

This way the linker can strip the whole
`System.Security.Cryptography.Primitives` assembly out of simple XA
apps.

The `Crc64` is still needed in XA, so we still keep it based
on `System.Security.Cryptography.HashAlgorithm`.