### PR TITLE
[generator] Ensure DIM from Cecil imported references get correctly marked.

### DIFF
--- a/tools/generator/Java.Interop.Tools.Generator.Importers/CecilApiImporter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Importers/CecilApiImporter.cs
@@ -191,7 +191,7 @@ namespace MonoDroid.Generation
 				IsAbstract = m.IsAbstract,
 				IsAcw = reg_attr != null,
 				IsFinal = m.IsFinal,
-				IsInterfaceDefaultMethod = GetJavaDefaultInterfaceMethodAttribute (m.CustomAttributes) != null,
+				IsInterfaceDefaultMethod = IsDefaultInterfaceMethod (declaringType, m),
 				IsReturnEnumified = GetGeneratedEnumAttribute (m.MethodReturnType.CustomAttributes) != null,
 				IsStatic = m.IsStatic,
 				IsVirtual = m.IsVirtual,
@@ -248,5 +248,16 @@ namespace MonoDroid.Generation
 
 		static CustomAttribute GetRegisterAttribute (Collection<CustomAttribute> attributes) =>
 			attributes.FirstOrDefault (a => a.AttributeType.FullNameCorrected () == "Android.Runtime.RegisterAttribute");
+
+		static bool IsDefaultInterfaceMethod (GenBase declaringType, MethodDefinition method)
+		{
+			if (!(declaringType is InterfaceGen))
+				return false;
+
+			if (GetJavaDefaultInterfaceMethodAttribute (method.CustomAttributes) != null)
+				return true;
+
+			return !method.IsAbstract && !method.IsStatic;
+		}
 	}
 }


### PR DESCRIPTION
Context: https://github.com/xamarin/AndroidX/pull/235

Given the following API:
```
public interface IMyInterface {
  void DoSomething () => throw new Exception ();
}

public abstract class MyClass : IMyInterface { }
```

We need to ensure that `Method.IsInterfaceDefaultMethod` gets set for `DoSomething` so that our `BoundClass.AddInterfaceAbstractMembers` logic knows it does not need to create an `abstract MyClass.DoSomething ()`.  

This works correctly if the interface is in the assembly we are binding (because it uses `XmlApiImporter`).  However if the interface is in a reference assembly it uses `CecilApiImporter`.  Our Cecil importer only marks the DIM if it has `[JavaInterfaceDefaultMethodAttribute]` which we don't appear to ever emit.

So if the interface is in a reference assembly (like `Mono.Android`), the following gets generated...
```
public abstract class MyClass : IMyInterface {
  public abstract void DoSomething ();
}
```

...which causes most bindings that inherit `MyClass` to fail since they don't think they need to implement the DIM.

This commit marks the interface method as `default` if it is neither `abstract` nor `static`.

## Testing

Unfortunately we cannot easily write a unit test for this, as we test Cecil importing by compiling types into the test library ([source](https://github.com/xamarin/java.interop/blob/master/tests/generator-Tests/Unit-Tests/ManagedTests.cs)), and the test library is still `net472` to support running on Mono, which does not support DIM.

I ran this against the library in the Context and it fixed that case.