### PR TITLE
[Xamarin.Android.Tools.Bytecode] Relax _ApiXml check

### DIFF
--- a/src/Xamarin.Android.Tools.Bytecode/JavaDocumentScraper.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/JavaDocumentScraper.cs
@@ -328,7 +328,7 @@ namespace Xamarin.Android.Tools.Bytecode
 					int len = reader.ReadBlock (buf, 0, buf.Length);
 					rawXML = new string (buf, 0, len).Trim ();
 				}
-				if (rawXML.Contains ("<api>") && rawXML.Contains ("<package"))
+				if (rawXML.Contains ("<api") && rawXML.Contains ("<package"))
 					kind = JavaDocletType._ApiXml;
 				else if (rawXML.StartsWith ("package", StringComparison.Ordinal) ||
 						rawXML.StartsWith (";", StringComparison.Ordinal)) {


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/issues/767
Context: https://github.com/xamarin/xamarin-android/blob/a7413a2389886082c3d3422c50a7e6cc84f43d8f/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Bindings.ClassParse.targets#L23

Commit 69e1b80a added `java-source-utils.jar`, which can parse Java
source code to extract parameter names, storing them into a
"`class-parse`-like XML file".

A benefit to a "`class-parse`-like XML file" is that it should be
possible to use this same file with `class-parse --docspath`,
overriding parameter names present in Java bytecode (which typically
*isn't* present, as `javac -parameters` is rarely used).

Unfortunately, this doesn't work: if you attempt to use
`java-source-utils.jar` output w/ `class-parse --docspath`, it fails:

	System.Exception: Directory 'example.xml' does not exist
	  at Xamarin.Android.Tools.Bytecode.AndroidDocScraper..ctor (System.String dir, System.String patternHead, System.String resetPatternHead, System.String parameterPairSplitter, System.Boolean continuousParamLines, System.String openMethod, System.String paramSep, System.String closeMethod, System.String postCloseMethodParens) [0x00093] in <e7fad12ab9c24ce08dac8732f18e1d85>:0
	  at Xamarin.Android.Tools.Bytecode.AndroidDocScraper..ctor (System.String dir, System.String patternHead, System.String resetPatternHead, System.String parameterPairSplitter, System.Boolean continuousParamLines) [0x00000] in <e7fad12ab9c24ce08dac8732f18e1d85>:0
	  at Xamarin.Android.Tools.Bytecode.DroidDocScraper..ctor (System.String dir) [0x00000] in <e7fad12ab9c24ce08dac8732f18e1d85>:0
	  at Xamarin.Android.Tools.Bytecode.ClassPath.CreateDocScraper (System.String src) [0x00037] in <e7fad12ab9c24ce08dac8732f18e1d85>:0

The problem is that we shouldn't be creating a `DroidDocScraper`
for `java-source-utils.jar` output, it should be creating a
`ApiXmlDocScraper`!

We're creating the wrong `*Scraper` type because
`JavaMethodParameterNameProvider.GetDocletType()` doesn't detect
`java-source-utils.jar` output as being `JavaDocletType._ApiXml`;
instead, it treats it as the default of `JavaDocletType.DroidDoc`.

`JavaMethodParameterNameProvider.GetDocletType()` doesn't detect
`java-source-utils.jar` output as being `JavaDocletType._ApiXml`,
because it requires that the XML contain:

	<api>

while `java-source-utils.jar` instead emits:

	<api api-source="java-source-utils">

Relax `JavaMethodParameterNameProvider.GetDocletType()` to instead
check for `<api`.  This allows `class-parse` to use
`java-source-utils.jar` output for parameter names.