### PR TITLE
[global.json] Update Microsoft.Build.NoTargets to 2.0.1.

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+    "msbuild-sdks": {
+        "Microsoft.Build.NoTargets": "2.0.1"
+    }
+}

--- a/src/java-interop/java-interop.csproj
+++ b/src/java-interop/java-interop.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Build.NoTargets/1.0.110">
+<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <OutputPath>$(ToolOutputFullPath)</OutputPath>

--- a/tools/java-source-utils/java-source-utils.csproj
+++ b/tools/java-source-utils/java-source-utils.csproj
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.Build.NoTargets/1.0.110">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <TargetFrameworks>net472</TargetFrameworks>


### PR DESCRIPTION
Java.Interop is using `Microsoft.Build.NoTargets` version `1.0.110`, while Xamarin.Android uses `2.0.1`.  This causes some build warnings when building XA:
```
/Users/builder/azdo/_work/1/s/xamarin-android/external/Java.Interop/tools/java-source-utils/java-source-utils.csproj :
warning MSB4240: Multiple versions of the same SDK "Microsoft.Build.NoTargets" cannot be specified. 
The previously resolved SDK version "2.0.1" from location "/Users/builder/azdo/_work/1/s/xamarin-android/src/
java-runtime/java-runtime.csproj" will be used and the version "1.0.110" will be ignored.
```

Fix this by moving the version number from the individual csproj's and into a `global.json` with a version matching XA's `global.json`.