### PR TITLE
[build] use $(RollForward) Major for console apps

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,6 +37,7 @@
     <TestOutputFullPath>$(MSBuildThisFileDirectory)bin\Test$(Configuration)-$(TargetFramework.ToLowerInvariant())\</TestOutputFullPath>
     <UtilityOutputFullPath Condition=" '$(UtilityOutputFullPathCoreApps)' != '' ">$(UtilityOutputFullPathCoreApps)</UtilityOutputFullPath>
     <UtilityOutputFullPath Condition=" '$(UtilityOutputFullPathCoreApps)' == '' ">$(ToolOutputFullPath)</UtilityOutputFullPath>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(JIBuildingForNetCoreApp)' != 'True' ">
     <IntermediateOutputPath>$(BaseIntermediateOutputPath)\$(Configuration)</IntermediateOutputPath>


### PR DESCRIPTION
Context: https://natemcmaster.com/blog/2019/01/09/netcore-primitives-3/
Context: https://github.com/dotnet/designs/blob/main/accepted/2019/runtime-binding.md#rollforward

I've seen an error on a CI machine that *only* has .NET 5 & 6
installed:

    Task "BindingsGenerator"
    ...
    It was not possible to find any compatible framework version
    The framework 'Microsoft.NETCore.App', version '3.1.0' was not found.
    - The following frameworks were found:
        5.0.1 at [/usr/local/share/dotnet/shared/Microsoft.NETCore.App]
        6.0.0-alpha.1.20560.10 at [/usr/local/share/dotnet/shared/Microsoft.NETCore.App]
    You can resolve the problem by installing the specified framework and/or SDK.
    - https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=3.1.0&arch=x64&rid=osx.10.15-x64
    Xamarin.Android.Bindings.ClassParse.targets(35,5): error MSB6006: "dotnet" exited with code 150.

By default, a .NET Core app will only "roll forward" to a patch
release, since `generator.csproj` targets `netcoreapp3.1` it would
only successfully run on .NET Core 3.1.x.

To change this behavior you can modify `generator.runtimeconfig.json`:

    {
      "runtimeOptions": {
        "tfm": "netcoreapp3.1",
        "rollForward": "Major",
        "framework": {
        "name": "Microsoft.NETCore.App",
        "version": "3.1.0"
        }
      }
    }

`Major` appears to be what we want to enable it to pick a newer dotnet
runtime/sdk. This would allow a .NET Core 3.x to be used or some newer
version if no .NET Core 3.x is found:

> `RollForward` can have the following values:
> * `LatestPatch` -- Roll forward to the highest patch version. This
>   disables minor version roll forward.
> * `Minor` -- Roll forward to the lowest higher minor version, if
>   requested minor version is missing. If the requested minor version
>   is present, then the `LatestPatch` policy is used.
> * `Major` -- Roll forward to lowest higher major version, and lowest
>   minor version, if requested major version is missing. If the
>   requested major version is present, then the `Minor` policy is
>   used.

We can also use the `$(RollForward)` MSBuild property as an
alternative to creating the `*.runtimeconfig.json` file.

I think it's likely best to just use this value across the board, as
there isn't a reason we *wouldn't* want `generator` or the other
command-line tools to run on newer .NET versions.