### PR TITLE
[generator] Only apply ConstSugar to Mono.Android.dll.

### DIFF
--- a/tests/generator-Tests/Unit-Tests/InterfaceConstantsTests.cs
+++ b/tests/generator-Tests/Unit-Tests/InterfaceConstantsTests.cs
@@ -50,7 +50,7 @@ namespace generatortests
 		{
 			// Need a JLO class "FromXml" to trigger ConstSugar logic. (ie: this is "building" Mono.Android.dll)
 			var klass = new TestClass ("java.lang.Object", "java.lang.Object") {
-				FromXml = true
+				FromXml = true,
 			};
 
 			options.SymbolTable.AddType (klass);

--- a/tests/generator-Tests/Unit-Tests/InterfaceConstantsTests.cs
+++ b/tests/generator-Tests/Unit-Tests/InterfaceConstantsTests.cs
@@ -48,6 +48,13 @@ namespace generatortests
 		[Test]
 		public void WriteConstSugarInterfaceFields ()
 		{
+			// Need a JLO class "FromXml" to trigger ConstSugar logic. (ie: this is "building" Mono.Android.dll)
+			var klass = new TestClass ("java.lang.Object", "java.lang.Object") {
+				FromXml = true
+			};
+
+			options.SymbolTable.AddType (klass);
+
 			// This is an interface that only has fields (IsConstSugar)
 			// We treat   a little differenly because they don't need to interop with Java
 			var iface = SupportTypeBuilder.CreateEmptyInterface ("java.code.IMyInterface");

--- a/tools/generator/CodeGenerationOptions.cs
+++ b/tools/generator/CodeGenerationOptions.cs
@@ -59,8 +59,10 @@ namespace MonoDroid.Generation
 		public bool SupportNestedInterfaceTypes { get; set; }
 		public bool SupportNullableReferenceTypes { get; set; }
 		public bool UseShallowReferencedTypes { get; set; }
+		public bool RemoveConstSugar => BuildingCoreAssembly;
 
 		bool? buildingCoreAssembly;
+		// Basically this means "Are we building Mono.Android.dll?"
 		public bool BuildingCoreAssembly {
 			get {
 				return buildingCoreAssembly ?? (buildingCoreAssembly = (SymbolTable.Lookup ("java.lang.Object") is ClassGen gen && gen.FromXml)).Value;

--- a/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/CodeGenerator.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/CodeGenerator.cs
@@ -55,7 +55,7 @@ namespace MonoDroid.Generation
 			foreach (ISymbol isym in @class.Interfaces) {
 				GenericSymbol gs = isym as GenericSymbol;
 				InterfaceGen gen = (gs == null ? isym : gs.Gen) as InterfaceGen;
-				if (gen != null && (gen.IsConstSugar || gen.RawVisibility != "public"))
+				if (gen != null && (gen.IsConstSugar (opt) || gen.RawVisibility != "public"))
 					continue;
 				if (sb.Length > 0)
 					sb.Append (", ");
@@ -465,13 +465,13 @@ namespace MonoDroid.Generation
 
 			// If this interface is just fields and we can't generate any of them
 			// then we don't need to write the interface
-			if (@interface.IsConstSugar && @interface.GetGeneratableFields (opt).Count () == 0)
+			if (@interface.IsConstSugar (opt) && @interface.GetGeneratableFields (opt).Count () == 0)
 				return;
 
 			WriteInterfaceDeclaration (@interface, indent, gen_info);
 
 			// If this interface is just constant fields we don't need to write all the invoker bits
-			if (@interface.IsConstSugar)
+			if (@interface.IsConstSugar (opt))
 				return;
 
 			if (!@interface.AssemblyQualifiedName.Contains ('/'))
@@ -514,7 +514,7 @@ namespace MonoDroid.Generation
 			StringBuilder sb = new StringBuilder ();
 			foreach (ISymbol isym in @interface.Interfaces) {
 				InterfaceGen igen = (isym is GenericSymbol ? (isym as GenericSymbol).Gen : isym) as InterfaceGen;
-				if (igen.IsConstSugar || igen.RawVisibility != "public")
+				if (igen.IsConstSugar (opt) || igen.RawVisibility != "public")
 					continue;
 				if (sb.Length > 0)
 					sb.Append (", ");
@@ -526,7 +526,7 @@ namespace MonoDroid.Generation
 			if (@interface.IsDeprecated)
 				writer.WriteLine ("{0}[ObsoleteAttribute (@\"{1}\")]", indent, @interface.DeprecatedComment);
 
-			if (!@interface.IsConstSugar) {
+			if (!@interface.IsConstSugar (opt)) {
 				var signature = string.IsNullOrWhiteSpace (@interface.Namespace)
 					? @interface.FullName.Replace ('.', '/')
 					: @interface.Namespace + "." + @interface.FullName.Substring (@interface.Namespace.Length + 1).Replace ('.', '/');
@@ -537,7 +537,7 @@ namespace MonoDroid.Generation
 			if (@interface.TypeParameters != null && @interface.TypeParameters.Any ())
 				writer.WriteLine ("{0}{1}", indent, @interface.TypeParameters.ToGeneratedAttributeString ());
 			writer.WriteLine ("{0}{1} partial interface {2}{3} {{", indent, @interface.Visibility, @interface.Name,
-				@interface.IsConstSugar ? string.Empty : @interface.Interfaces.Count == 0 || sb.Length == 0 ? " : " + GetAllInterfaceImplements () : " : " + sb.ToString ());
+				@interface.IsConstSugar (opt) ? string.Empty : @interface.Interfaces.Count == 0 || sb.Length == 0 ? " : " + GetAllInterfaceImplements () : " : " + sb.ToString ());
 
 			if (opt.SupportDefaultInterfaceMethods && (@interface.HasDefaultMethods || @interface.HasStaticMethods))
 				WriteClassHandle (@interface, indent + "\t", @interface.Name);

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/InterfaceGen.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/InterfaceGen.cs
@@ -158,22 +158,24 @@ namespace MonoDroid.Generation
 
 		public bool HasStaticMethods => GetAllMethods ().Any (m => m.IsStatic);
 
-		public bool IsConstSugar {
-			get {
-				if (Methods.Count > 0 || Properties.Count > 0)
+		public bool IsConstSugar (CodeGenerationOptions options)
+		{
+			if (!options.RemoveConstSugar)
+				return false;
+
+			if (Methods.Count > 0 || Properties.Count > 0)
+				return false;
+
+			foreach (InterfaceGen impl in GetAllDerivedInterfaces ())
+				if (!impl.IsConstSugar (options))
 					return false;
 
-				foreach (InterfaceGen impl in GetAllDerivedInterfaces ())
-					if (!impl.IsConstSugar)
-						return false;
+			// Need to keep Java.IO.ISerializable as a "marker interface"; want to
+			// hide android.provider.ContactsContract.DataColumnsWithJoins
+			if (Fields.Count == 0 && Interfaces.Count == 0)
+				return false;
 
-				// Need to keep Java.IO.ISerializable as a "marker interface"; want to
-				// hide android.provider.ContactsContract.DataColumnsWithJoins
-				if (Fields.Count == 0 && Interfaces.Count == 0)
-					return false;
-
-				return true;
-			}
+			return true;
 		}
 
 		// If there is a property it cannot generate valid implementor, so reject this at least so far.

--- a/tools/generator/SourceWriters/BoundClass.cs
+++ b/tools/generator/SourceWriters/BoundClass.cs
@@ -143,7 +143,7 @@ namespace generator.SourceWriters
 		void AddImplementedInterfaces (ClassGen klass)
 		{
 			foreach (var isym in klass.Interfaces) {
-				if ((!(isym is GenericSymbol gs) ? isym : gs.Gen) is InterfaceGen gen && (gen.IsConstSugar || gen.RawVisibility != "public"))
+				if ((!(isym is GenericSymbol gs) ? isym : gs.Gen) is InterfaceGen gen && (gen.IsConstSugar (opt) || gen.RawVisibility != "public"))
 					continue;
 
 				Implements.Add (opt.GetOutputName (isym.FullName));

--- a/tools/generator/SourceWriters/BoundInterface.cs
+++ b/tools/generator/SourceWriters/BoundInterface.cs
@@ -26,7 +26,7 @@ namespace generator.SourceWriters
 			// If this interface is just fields and we can't generate any of them
 			// then we don't need to write the interface.  We still keep this type
 			// because it may have nested types or need an InterfaceMemberAlternativeClass.
-			if (iface.IsConstSugar && iface.GetGeneratableFields (opt).Count () == 0) {
+			if (iface.IsConstSugar (opt) && iface.GetGeneratableFields (opt).Count () == 0) {
 				dont_generate = true;
 				return;
 			}
@@ -43,7 +43,7 @@ namespace generator.SourceWriters
 			if (iface.IsDeprecated)
 				Attributes.Add (new ObsoleteAttr (iface.DeprecatedComment) { WriteAttributeSuffix = true, WriteEmptyString = true });
 
-			if (!iface.IsConstSugar) {
+			if (!iface.IsConstSugar (opt)) {
 				var signature = string.IsNullOrWhiteSpace (iface.Namespace)
 					? iface.FullName.Replace ('.', '/')
 					: iface.Namespace + "." + iface.FullName.Substring (iface.Namespace.Length + 1).Replace ('.', '/');
@@ -63,7 +63,7 @@ namespace generator.SourceWriters
 			AddNestedTypes (iface, opt, context, genInfo);
 
 			// If this interface is just constant fields we don't need to add all the invoker bits
-			if (iface.IsConstSugar)
+			if (iface.IsConstSugar (opt))
 				return;
 
 			if (!iface.AssemblyQualifiedName.Contains ('/')) {
@@ -137,13 +137,13 @@ namespace generator.SourceWriters
 			foreach (var isym in iface.Interfaces) {
 				var igen = (isym is GenericSymbol ? (isym as GenericSymbol).Gen : isym) as InterfaceGen;
 
-				if (igen.IsConstSugar || igen.RawVisibility != "public")
+				if (igen.IsConstSugar (opt) || igen.RawVisibility != "public")
 					continue;
 
 				Implements.Add (opt.GetOutputName (isym.FullName));
 			}
 
-			if (Implements.Count == 0 && !iface.IsConstSugar)
+			if (Implements.Count == 0 && !iface.IsConstSugar (opt))
 				Implements.AddRange (new [] { "IJavaObject", "IJavaPeerable" });
 		}
 


### PR DESCRIPTION
Fixes #752 

The Android API has an "interesting" pattern where they have an interface with some static constants, and then they inherit that interface in other types to inherit those constants.

Example: https://developer.android.com/reference/android/provider/BaseColumns

```
public interface BaseColumns {
  public static final String _COUNT = "_count";
  public static final String _ID = "_id";
}
```
This interface is inherited by ~115 other types, including other interfaces that only have static constant fields, like [CalendarContract.CalendarSyncColumns ](https://developer.android.com/reference/android/provider/CalendarContract.CalendarSyncColumns?hl=en).  This made a very messy API when we bound it due the constants being copied into our alternative `IBaseColumnsConsts` and `ICalendarSyncColumnsConsts` classes.  Therefore we decided to call this pattern "ConstSugar" and we wrote code to remove these interfaces that did not provide value in the managed API.

However this logic is applied to all binding libraries, and there can exist marker interfaces that meet the same criteria as ConstSugar, and they get silently removed from binding libraries.

```
public interface CanSerialize {
  public static final int VERSION = 1;
}

public interface CanJsonSerialize : CanSerialize {
}
```

In this example we would not bind `CanJsonSerialize`.  Worse, an interface can go from not being considered ConstSugar to triggering ConstSugar simply by *additions* to an API.  If `CanSerialize` originally had no fields, both interfaces would be generated.  Once `VERSION` is added, `CanJsonSerialize` is considered ConstSugar and will get removed.

Since this logic is very specific to `Mono.Android`, we're going to use `CodeGenerationOptions.BuildingCoreAssembly` to determine if we're building `Mono.Android.dll`, and only run ConstSugar logic if true.  This will prevent the logic from running on user binding projects and causing unexplained missing API for users.