### PR TITLE
[generator] Disable [SupportedOSPlatform] until we can build with .NET 5/6.

### DIFF
--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
@@ -236,18 +236,20 @@ namespace generatortests
 	{
 		protected override CodeGenerationTarget Target => CodeGenerationTarget.XAJavaInterop1;
 
-		[Test]
-		public void SupportedOSPlatform ()
-		{
-			var klass = SupportTypeBuilder.CreateClass ("java.code.MyClass", options);
-			klass.ApiAvailableSince = 30;
 
-			generator.Context.ContextTypes.Push (klass);
-			generator.WriteType (klass, string.Empty, new GenerationInfo ("", "", "MyAssembly"));
-			generator.Context.ContextTypes.Pop ();
+		// Disabled until we can properly build .NET 5/6 assemblies in our XA tree.
+		//[Test]
+		//public void SupportedOSPlatform ()
+		//{
+		//	var klass = SupportTypeBuilder.CreateClass ("java.code.MyClass", options);
+		//	klass.ApiAvailableSince = 30;
 
-			StringAssert.Contains ("[global::System.Runtime.Versioning.SupportedOSPlatformAttribute (\"android30.0\")]", builder.ToString (), "Should contain SupportedOSPlatform!");
-		}
+		//	generator.Context.ContextTypes.Push (klass);
+		//	generator.WriteType (klass, string.Empty, new GenerationInfo ("", "", "MyAssembly"));
+		//	generator.Context.ContextTypes.Pop ();
+
+		//	StringAssert.Contains ("[global::System.Runtime.Versioning.SupportedOSPlatformAttribute (\"android30.0\")]", builder.ToString (), "Should contain SupportedOSPlatform!");
+		//}
 	}
 
 	[TestFixture]

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/NamespaceMapping.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/NamespaceMapping.cs
@@ -32,20 +32,21 @@ namespace MonoDroid.Generation
 				foreach (var jni in opt.GetJniMarshalDelegates ())
 					sw.WriteLine ($"delegate {FromJniType (jni[jni.Length - 1])} {jni} (IntPtr jnienv, IntPtr klass{GetDelegateParameters (jni)});");
 
+				// Disabled until we can properly build .NET 5/6 assemblies in our XA tree.
 				// [SupportedOSPlatform] only exists in .NET 5.0+, so we need to generate a
 				// dummy one so earlier frameworks can compile.
-				if (opt.CodeGenerationTarget == Xamarin.Android.Binder.CodeGenerationTarget.XAJavaInterop1) {
-					sw.WriteLine ("#if !NET");
-					sw.WriteLine ("namespace System.Runtime.Versioning {");
-					sw.WriteLine ("    [System.Diagnostics.Conditional(\"NEVER\")]");
-					sw.WriteLine ("    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Event | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]");
-					sw.WriteLine ("    internal sealed class SupportedOSPlatformAttribute : Attribute {");
-					sw.WriteLine ("        public SupportedOSPlatformAttribute (string platformName) { }");
-					sw.WriteLine ("    }");
-					sw.WriteLine ("}");
-					sw.WriteLine ("#endif");
-					sw.WriteLine ("");
-				}
+				//if (opt.CodeGenerationTarget == Xamarin.Android.Binder.CodeGenerationTarget.XAJavaInterop1) {
+				//	sw.WriteLine ("#if !NET");
+				//	sw.WriteLine ("namespace System.Runtime.Versioning {");
+				//	sw.WriteLine ("    [System.Diagnostics.Conditional(\"NEVER\")]");
+				//	sw.WriteLine ("    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Event | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]");
+				//	sw.WriteLine ("    internal sealed class SupportedOSPlatformAttribute : Attribute {");
+				//	sw.WriteLine ("        public SupportedOSPlatformAttribute (string platformName) { }");
+				//	sw.WriteLine ("    }");
+				//	sw.WriteLine ("}");
+				//	sw.WriteLine ("#endif");
+				//	sw.WriteLine ("");
+				//}
 			}
 		}
 

--- a/tools/generator/SourceWriters/Attributes/SupportedOSPlatformAttr.cs
+++ b/tools/generator/SourceWriters/Attributes/SupportedOSPlatformAttr.cs
@@ -15,7 +15,8 @@ namespace generator.SourceWriters
 
 		public override void WriteAttribute (CodeWriter writer)
 		{
-			writer.WriteLine ($"[global::System.Runtime.Versioning.SupportedOSPlatformAttribute (\"android{Version}.0\")]");
+			// Disabled until we can properly build .NET 5/6 assemblies in our XA tree.
+			//writer.WriteLine ($"[global::System.Runtime.Versioning.SupportedOSPlatformAttribute (\"android{Version}.0\")]");
 		}
 	}
 }


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/5497

We cannot currently build `net5.0` or `net6.0` assemblies in our XA tree and instead do some workaround that involves compiling with `netcoreapp3.1` but referencing 5.0 BCL.  This creates a conflict between the local `[SupportedOSPlatform]` we create in `netcoreapp3.1` `Mono.Android.dll`, and the real one in the 5.0 BCL.

```
error CS0433: The type 'SupportedOSPlatformAttribute' exists in both 'Mono.Android, Version=0.0.0.0, 
Culture=neutral, PublicKeyToken=84e04ff9cfb79065' and 'System.Runtime, Version=5.0.0.0, Culture=neutral, 
PublicKeyToken=b03f5f7f11d50a3a' [/Users/runner/work/1/s/tests/Mono.Android-Tests/Java.Interop-Tests/
Java.Interop-Tests.NET.csproj] [/Users/runner/work/1/s/tests/Mono.Android-Tests/Runtime-Microsoft.Android.Sdk
/Mono.Android.NET-Tests.csproj]
```

We will disable generating these attributes until we can build `Mono.Android.dll` with `NET`, in which case it will not contain the local attribute.