### PR TITLE
Use `const` instead of `static readonly`

### DIFF
--- a/src/Java.Interop/Java.Interop/JniNativeMethodRegistrationArguments.cs
+++ b/src/Java.Interop/Java.Interop/JniNativeMethodRegistrationArguments.cs
@@ -7,7 +7,7 @@ namespace Java.Interop
 {
 	public struct JniNativeMethodRegistrationArguments
 	{
-		static readonly string invalidStateMessage = $"{nameof(JniNativeMethodRegistrationArguments)} state is invalid. Please use constructor with parameters.";
+		const string invalidStateMessage = $"{nameof(JniNativeMethodRegistrationArguments)} state is invalid. Please use constructor with parameters.";
 
 		public ICollection<JniNativeMethodRegistration> Registrations {
 			get { return _registrations ?? throw new InvalidOperationException (invalidStateMessage); }

--- a/src/Java.Interop/Java.Interop/JniNativeMethodRegistrationArguments.cs
+++ b/src/Java.Interop/Java.Interop/JniNativeMethodRegistrationArguments.cs
@@ -7,7 +7,7 @@ namespace Java.Interop
 {
 	public struct JniNativeMethodRegistrationArguments
 	{
-		const string invalidStateMessage = $"{nameof(JniNativeMethodRegistrationArguments)} state is invalid. Please use constructor with parameters.";
+		const string invalidStateMessage = nameof(JniNativeMethodRegistrationArguments) + " state is invalid. Please use constructor with parameters.";
 
 		public ICollection<JniNativeMethodRegistration> Registrations {
 			get { return _registrations ?? throw new InvalidOperationException (invalidStateMessage); }


### PR DESCRIPTION
To fix this error and improve performance a bit:

    error CA1802: Field 'invalidStateMessage' is declared as 'readonly' but is initialized with a constant value. Mark this field as 'const' instead.

Context: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1802