### PR TITLE
[AzDO] Switch default branch from master to main.

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -1,13 +1,13 @@
 # Java.Interop Pipelines
 
 trigger:
-  - master
+  - main
   - d16-*
 
 pr:
   branches:
     include:
-    - master
+    - main
     - d16-*
   paths:
     exclude:


### PR DESCRIPTION
Update `azure-pipelines.yaml` to look for the `main` branch instead of the `master` branch, in preparation for renaming the default branch.