### PR TITLE
Use locking instead of ConcurrentDictionary

### DIFF
--- a/src/Java.Interop/Java.Interop/JniRuntime.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.cs
@@ -420,7 +420,7 @@ namespace Java.Interop
 		{
 			lock (TrackedInstances) {
 				foreach (var k in TrackedInstances.Keys.ToList ()) {
-					if (TrackedInstances.TryGetValue (k, out var d) {
+					if (TrackedInstances.TryGetValue (k, out var d)) {
 						TrackedInstances.Remove (k);
 						d.Dispose ();
 					}

--- a/src/Java.Interop/Java.Interop/JniRuntime.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.cs
@@ -418,16 +418,14 @@ namespace Java.Interop
 
 		void ClearTrackedReferences ()
 		{
+			List<IDisposable> values;
 			lock (TrackedInstances) {
-				foreach (var k in TrackedInstances.Keys.ToList ()) {
-					if (TrackedInstances.TryGetValue (k, out var d)) {
-						TrackedInstances.Remove (k);
-						d.Dispose ();
-					}
-				}
-
+				values = new List<IDisposable> (TrackedInstances.Values);
 				TrackedInstances.Clear ();
 			}
+
+			foreach (var d in values)
+				d.Dispose ();
 		}
 
 		public virtual bool ExceptionShouldTransitionToJni (Exception e)

--- a/src/Java.Interop/Java.Interop/JniRuntime.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.cs
@@ -1,7 +1,6 @@
 #nullable enable
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -168,7 +167,7 @@ namespace Java.Interop
 			current = newCurrent;
 		}
 
-		ConcurrentDictionary<IntPtr, IDisposable>       TrackedInstances    = new ConcurrentDictionary<IntPtr, IDisposable> ();
+		Dictionary<IntPtr, IDisposable>                 TrackedInstances    = new Dictionary<IntPtr, IDisposable> ();
 
 		JavaVMInterface                                 Invoker;
 		bool                                            DestroyRuntimeOnDispose;
@@ -403,21 +402,32 @@ namespace Java.Interop
 
 		internal void Track (JniType value)
 		{
-			TrackedInstances.TryAdd (value.PeerReference.Handle, value);
+			lock (TrackedInstances) {
+				if (!TrackedInstances.ContainsKey (value.PeerReference.Handle))
+					TrackedInstances [value.PeerReference.Handle] = value;
+			}
 		}
 
 		internal void UnTrack (IntPtr key)
 		{
-			TrackedInstances.TryRemove (key, out var _);
+			lock (TrackedInstances) {
+				if (TrackedInstances.ContainsKey (key))
+					TrackedInstances.Remove (key);
+			}
 		}
 
 		void ClearTrackedReferences ()
 		{
-			foreach (var k in TrackedInstances.Keys.ToList ()) {
-				if (TrackedInstances.TryRemove (k, out var d))
-					d.Dispose ();
+			lock (TrackedInstances) {
+				foreach (var k in TrackedInstances.Keys.ToList ()) {
+					if (TrackedInstances.TryGetValue (k, out var d) {
+						TrackedInstances.Remove (k);
+						d.Dispose ();
+					}
+				}
+
+				TrackedInstances.Clear ();
 			}
-			TrackedInstances.Clear ();
 		}
 
 		public virtual bool ExceptionShouldTransitionToJni (Exception e)


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/5455

This is motivated by reducing the XA's HelloWorld apk size. It results
in dropping `System.Collections.Concurrent.dll` from linked assemblies
set and saving another 1.32% of assemblies size.

apk size comparison - XA's BuildReleaseArm64False/net6 test:

    Size difference in bytes ([*1] apk1 only, [*2] apk2 only):
      +          22 assemblies/Java.Interop.dll
      -         316 assemblies/System.Private.CoreLib.dll
      -         702 assemblies/System.Linq.dll
      -       8,471 assemblies/System.Collections.Concurrent.dll *1
    Summary:
      -       9,467 Assemblies -1.32% (of 719,277)
      -      15,872 Uncompressed assemblies -1.06% (of 1,491,456) 