### PR TITLE
[class-parse, generator] Allow users to expose Kotlin internal types/members with metadata.

### DIFF
--- a/src/Xamarin.Android.Tools.Bytecode/ClassFile.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/ClassFile.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/src/Xamarin.Android.Tools.Bytecode/Methods.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/Methods.cs
@@ -352,6 +352,9 @@ namespace Xamarin.Android.Tools.Bytecode {
 		Abstract        = 0x0400,
 		Strict          = 0x0800,
 		Synthetic       = 0x1000,
+
+		// This is not a real Java MethodAccessFlags, it is used to denote Kotlin "internal" access.
+		Internal        = 0x10000000,
 	}
 
 	[Flags]

--- a/src/Xamarin.Android.Tools.Bytecode/XmlClassDeclarationBuilder.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/XmlClassDeclarationBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -28,9 +28,6 @@ namespace Xamarin.Android.Tools.Bytecode {
 
 		public XElement ToXElement ()
 		{
-			var visibility = GetClassVisibility (this.classFile.AccessFlags);
-			if (visibility == "private")
-				return null;
 			return new XElement (GetElementName (),
 					new XAttribute ("abstract",                 (classFile.AccessFlags & ClassAccessFlags.Abstract) != 0),
 					new XAttribute ("deprecated",               GetDeprecatedValue (classFile.Attributes)),
@@ -319,7 +316,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 		IEnumerable<XElement> GetConstructors ()
 		{
 			return classFile.Methods.Where (m => m.Name == "<init>" 
-					&& (GetMethodVisibility(m.AccessFlags) == "public" || GetMethodVisibility(m.AccessFlags) == "protected"))
+					&& (GetMethodVisibility(m.AccessFlags) == "public" || GetMethodVisibility(m.AccessFlags) == "protected" || GetMethodVisibility (m.AccessFlags) == "kotlin-internal"))
 				.OrderBy (m => m.Name + m.Descriptor, StringComparer.OrdinalIgnoreCase)
 				.Select (c => GetMethod ("constructor", GetThisClassName (), c, null));
 		}
@@ -374,6 +371,8 @@ namespace Xamarin.Android.Tools.Bytecode {
 
 		static string GetVisibility (MethodAccessFlags accessFlags)
 		{
+			if (accessFlags.HasFlag (MethodAccessFlags.Internal))
+				return "kotlin-internal";
 			if ((accessFlags & MethodAccessFlags.Public) != 0)
 				return "public";
 			if ((accessFlags & MethodAccessFlags.Protected) != 0)
@@ -605,6 +604,8 @@ namespace Xamarin.Android.Tools.Bytecode {
 
 		static string GetMethodVisibility (MethodAccessFlags accessFlags)
 		{
+			if (accessFlags.HasFlag (MethodAccessFlags.Internal))
+				return "kotlin-internal";
 			if ((accessFlags & MethodAccessFlags.Public) != 0)
 				return "public";
 			if ((accessFlags & MethodAccessFlags.Protected) != 0)
@@ -628,7 +629,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 		IEnumerable<XElement> GetMethods ()
 		{
 			return classFile.Methods.Where (m => !m.Name.StartsWith ("<", StringComparison.OrdinalIgnoreCase)
-						&& (GetMethodVisibility(m.AccessFlags) == "public" || GetMethodVisibility(m.AccessFlags) == "protected"))
+						&& (GetMethodVisibility(m.AccessFlags) == "public" || GetMethodVisibility(m.AccessFlags) == "protected" || GetMethodVisibility (m.AccessFlags) == "kotlin-internal"))
 				.OrderBy (m => m.Name + m.Descriptor, StringComparer.OrdinalIgnoreCase)
 				.Select (m => GetMethod ("method", m.Name, m,
 					returns: m.ReturnType.TypeSignature));

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/KotlinFixupsTests.cs
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/KotlinFixupsTests.cs
@@ -24,6 +24,9 @@ namespace Xamarin.Android.Tools.BytecodeTests
 
 			Assert.False (klass.AccessFlags.HasFlag (ClassAccessFlags.Public));
 			Assert.False (inner_class.InnerClassAccessFlags.HasFlag (ClassAccessFlags.Public));
+
+			var output = new XmlClassDeclarationBuilder (klass).ToXElement ().ToString ();
+			Assert.True (output.Contains ("visibility=\"private\""));
 		}
 
 		[Test]
@@ -58,6 +61,9 @@ namespace Xamarin.Android.Tools.BytecodeTests
 			KotlinFixups.Fixup (new [] { klass });
 
 			Assert.False (ctor.AccessFlags.HasFlag (MethodAccessFlags.Public));
+
+			var output = new XmlClassDeclarationBuilder (klass).ToXElement ().ToString ();
+			Assert.True (output.Contains ("visibility=\"kotlin-internal\""));
 		}
 
 		[Test]
@@ -124,6 +130,9 @@ namespace Xamarin.Android.Tools.BytecodeTests
 			KotlinFixups.Fixup (new [] { klass });
 
 			Assert.False (method.AccessFlags.HasFlag (MethodAccessFlags.Public));
+
+			var output = new XmlClassDeclarationBuilder (klass).ToXElement ().ToString ();
+			Assert.True (output.Contains ("visibility=\"kotlin-internal\""));
 		}
 
 		[Test]
@@ -154,6 +163,9 @@ namespace Xamarin.Android.Tools.BytecodeTests
 
 			Assert.False (getter.AccessFlags.HasFlag (MethodAccessFlags.Public));
 			Assert.False (setter.AccessFlags.HasFlag (MethodAccessFlags.Public));
+
+			var output = new XmlClassDeclarationBuilder (klass).ToXElement ().ToString ();
+			Assert.True (output.Contains ("visibility=\"kotlin-internal\""));
 		}
 
 		[Test]

--- a/tests/generator-Tests/Unit-Tests/XmlApiImporterTests.cs
+++ b/tests/generator-Tests/Unit-Tests/XmlApiImporterTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
 using MonoDroid.Generation;
@@ -243,6 +244,27 @@ namespace generatortests
 			Assert.AreEqual (3, method.LineNumber);
 			Assert.AreEqual (2, method.LinePosition);
 			Assert.AreEqual ("obj/Debug/api.xml", method.SourceFile);
+		}
+
+		[Test]
+		public void IgnoreKotlinInternalMembers ()
+		{
+			var xml = XDocument.Parse (@"
+				<api>
+					<package name='com.example.test' jni-name='com/example/test'>
+						<class name='Test' visibility='public'>
+							<constructor name='Test' visibility='kotlin-internal' />
+							<method name='DoStuff' visibility='kotlin-internal' />
+							<field name='MyField' visibility='kotlin-internal' />
+						</class>
+					</package>
+				</api>");
+
+			var gens = new Parser (opt).Parse (xml, new List<string> (), "0", 0);
+			var klass = gens.Single ();
+
+			Assert.AreEqual (0, klass.Fields.Count);
+			Assert.AreEqual (0, klass.Methods.Count);
 		}
 	}
 }

--- a/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
@@ -37,13 +37,16 @@ namespace MonoDroid.Generation
 						klass.AddImplementedInterface (iname);
 						break;
 					case "method":
-						klass.AddMethod (CreateMethod (klass, child, options));
+						if (child.XGetAttribute ("visibility") != "kotlin-internal")
+							klass.AddMethod (CreateMethod (klass, child, options));
 						break;
 					case "constructor":
-						klass.Ctors.Add (CreateCtor (klass, child, options));
+						if (child.XGetAttribute ("visibility") != "kotlin-internal")
+							klass.Ctors.Add (CreateCtor (klass, child, options));
 						break;
 					case "field":
-						klass.AddField (CreateField (klass, child, options));
+						if (child.XGetAttribute ("visibility") != "kotlin-internal")
+							klass.AddField (CreateField (klass, child, options));
 						break;
 					case "typeParameters":
 						break; // handled at GenBaseSupport
@@ -230,10 +233,12 @@ namespace MonoDroid.Generation
 						iface.AddImplementedInterface (iname);
 						break;
 					case "method":
-						iface.AddMethod (CreateMethod (iface, child, options));
+						if (child.XGetAttribute ("visibility") != "kotlin-internal")
+							iface.AddMethod (CreateMethod (iface, child, options));
 						break;
 					case "field":
-						iface.AddField (CreateField (iface, child, options));
+						if (child.XGetAttribute ("visibility") != "kotlin-internal")
+							iface.AddField (CreateField (iface, child, options));
 						break;
 					case "typeParameters":
 						break; // handled at GenBaseSupport


### PR DESCRIPTION
Fixes #790.

Modify `class-parse` to emit Kotlin `internal` types/members so that users can use `metadata` to change them to `public` if they wish, giving them the same access they would have if consumed from Java.  If `visibility` is not changed to `public` by the user, `generator` will ignore importing these types/members, resulting in the same bindings as today.

Format is the same as existing metadata visibility fixup:
```
<attr path="/api/package[@name='com.example']/class[@name='MyClass']" name="visibility">public</attr>
```

`class-parse` now emits all `private` **_types_** as `visibility="private"` because the existing `generator` behavior will ignore any `private` types, which is what we want.  Kotlin `internal` types were already being changed to `private`, so they fall into this category.

`class-parse` now emits Kotlin `internal` **_members_** as `visibility="kotlin-internal"` because the existing `generator` behavior is that members marked as `internal` or `private` are actually bound as `internal/private` members. Whether this was ever intentional is debatable, but it is a behavior that user code in the wild relies on that we do not wish to break.

There are a couple of issues with simply allowing members to be bound as `internal/private`:
- Though the linker would remove them, it is not very desirable to bloat our assemblies and build times with something that isn't intended to be used. 
- In testing, there is at least 1 `generator` [bug](https://github.com/xamarin/java.interop/issues/811) where attempting to bind a `private` member results in invalid C# code. This casts doubt that this was ever "supported", and thus there could be an unknown number of other bugs users would begin hitting if we started emitting a bunch of `private` members.