### PR TITLE
Bump to xamarin/xamarin-android-tools/main@63510cfc; packageSources

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -6,6 +6,8 @@
 -->
 <configuration>
   <packageSources>
+    <clear />
+    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" protocolVersion="3" />
     <!-- For XliffTasks -->
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" protocolVersion="3" />
   </packageSources>

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -16,8 +16,10 @@ pr:
 
 # Global variables
 variables:
+  RunningOnCI: true
+  Build.Configuration: Release
   DotNetCoreVersion: 3.1.300
-  HostedMac: Hosted Mac Internal
+  HostedMacImage: macOS-10.15
   HostedWinVS2019: Hosted Windows 2019 with VS2019
 
 jobs:
@@ -91,7 +93,8 @@ jobs:
     
 - job: mac_build
   displayName: Mac - Mono
-  pool: $(HostedMac)
+  pool:
+    vmImage: $(HostedMacImage)
   timeoutInMinutes: 20
   workspace:
     clean: all
@@ -140,7 +143,8 @@ jobs:
     
 - job: mac_dotnet_build
   displayName: Mac - .NET Core
-  pool: $(HostedMac)
+  pool:
+    vmImage: $(HostedMacImage)
   timeoutInMinutes: 20
   workspace:
     clean: all

--- a/build-tools/automation/templates/install-dependencies.yaml
+++ b/build-tools/automation/templates/install-dependencies.yaml
@@ -6,9 +6,3 @@ steps:
   displayName: Use .NET Core $(DotNetCoreVersion)
   inputs:
     version: $(DotNetCoreVersion)
-  
-- script: |
-    dotnet tool install --global boots  
-    boots --stable Mono
-  displayName: Install Mono-Stable
-  condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))


### PR DESCRIPTION
Context: https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610
Context: https://azure.microsoft.com/en-us/resources/3-ways-to-mitigate-risk-using-private-package-feeds/
Context: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/12676/ncident-help-for-Substitution-attack-risk-from-multiple-package-feeds

Changes: https://github.com/xamarin/xamarin-android-tools/compare/26d65d95943b18bb9575d75c8c60ce36180a0db9...63510cfc6cc30da0d2ee6290ff3c225d60f8c2ad

  * xamarin/xamarin-android-tools@63510cf: [ci] Update packageSources in NuGet.config (#105)
  * xamarin/xamarin-android-tools@83ed0a4: Bump ta xamarin/LibZipSharp/1.0.22@9f563dd1 (#104)
  * xamarin/xamarin-android-tools@8ea78a4: Add Microsoft.Android.Build.BaseTasks project (#101)
  * xamarin/xamarin-android-tools@b2d9fdf: [NDK] Locate and select only compatible NDK versions (#103)
  * xamarin/xamarin-android-tools@5ff1702: [tests] Use dotnet test to run AndroidSdk-Tests (#102)
  * xamarin/xamarin-android-tools@ad80a42: [ci] Use the new "main" default branch (#100)

There is a Package Substitution Attack inherent in NuGet, whereby
if multiple package sources provide packages with the same name,
it is *indeterminate* which package source will provide the package.

For example, consider the [`XliffTasks` package][0], currently
provided from the [`dotnet-eng`][1] feed, and *not* present in the
NuGet.org feed.  If a "hostile attacker" submits an `XliffTasks`
package to NuGet.org, then we don't know, and cannot control, whether
the build will use the "hostile" `XliffTasks` package from NuGet.org
or the "desired" package from `dotnet-eng`.

There are two ways to prevent this attack:

 1. Use `//packageSources/clear` and have *only one*
    `//packageSources/add` entry in `NuGet.config`

 2. Use `//packageSources/clear` and *fully trust* every
    `//packageSources/add` entry in `NuGet.config`.
    `NuGet.org` *cannot* be a trusted source, nor can any feed
    location which allows "anyone" to add new packages, nor can
    a feed which itself contains [upstream sources][2].

As the `XliffTasks` package is *not* in `NuGet.org`, option (1)
isn't an option.  Go with option (2), using the existing
`dotnet-eng` source and the new *trusted* [`dotnet-public`][3]
package source.

[0]: https://github.com/dotnet/xliff-tasks
[1]: https://dev.azure.com/dnceng/public/_packaging?_a=feed&feed=dotnet-eng
[2]: https://docs.microsoft.com/en-us/azure/devops/artifacts/concepts/upstream-sources?view=azure-devops
[3]: https://dev.azure.com/dnceng/public/_packaging?_a=feed&feed=dotnet-public