### PR TITLE
[generator] Fix NRE when interfaces appear to implement classes.

### DIFF
--- a/tools/generator/SourceWriters/BoundInterface.cs
+++ b/tools/generator/SourceWriters/BoundInterface.cs
@@ -137,7 +137,11 @@ namespace generator.SourceWriters
 			foreach (var isym in iface.Interfaces) {
 				var igen = (isym is GenericSymbol ? (isym as GenericSymbol).Gen : isym) as InterfaceGen;
 
-				if (igen.IsConstSugar (opt) || igen.RawVisibility != "public")
+				// igen *should not* be null here because we *should* only be inheriting interfaces, but
+				// in the case of constants on that interface we create a C# *class* that is registered for the
+				// Java *interface*. Thus when we do type resolution, we are actually pointed to the
+				// Foo abstract class instead of the IFoo interface.
+				if (igen is null || igen.IsConstSugar (opt) || igen.RawVisibility != "public")
 					continue;
 
 				Implements.Add (opt.GetOutputName (isym.FullName));


### PR DESCRIPTION
Fixes #797.

In #780 we made a change to only apply the ConstSugar logic to `Mono.Android.dll`. However there are of course other libraries written by Google that use the same pattern, namely AndroidX.  I still think removing ConstSugar is the correct move for libraries other than `Mono.Android` because it causes more problems than it solves.  (Also ConstSugar is irrelevant in the DIM world we want to move the ecosystem to.)

However, there is an issue when other libraries try to create interfaces that inherit `Mono.Android`'s `Android.Provider.BaseColumns`.

Mono.Android contains:
```
[Register ("android.provider.BaseColumns")] public abstract class BaseColumns
[Register ("android.provider.BaseColumns")] public interface IBaseColumns
```

When we build our Java -> C# typemap, we only support a single map per key, and it just happens that `abstract class BaseColumns` wins.  Thus when we look for the Symbol that matches `implements android.provider.BaseColumns` we end up with a `class` instead of a `type`.  We then cast that as an `InterfaceGen` which is `null` and hit an NRE.

There are probably some deep, risky changes that *should* happen that would fix this, like supporting multiple entries in our typemap, or not emitting `[Register]` on our synthetic classes we create to allow access to Java interface constants.

But for today the easiest fix is to bail if we hit this case.  The bindings will still be fine since these interfaces are not meant to be implemented, just used to provide access to constants.