### PR TITLE
[invocation-overhead] Fix CS0436 warnings

### DIFF
--- a/tests/invocation-overhead/invocation-overhead.cs
+++ b/tests/invocation-overhead/invocation-overhead.cs
@@ -10,7 +10,52 @@ using JIIntPtrEnv   = Java.Interop.JIIntPtrs.JniEnvironment;
 using PinvokeEnv    = Java.Interop.JIPinvokes.JniEnvironment;
 using XAIntPtrEnv   = Java.Interop.XAIntPtrs.JniEnvironment;
 
+public class XFieldInfo
+{
+	public IntPtr ID;
+	public bool   IsStatic;
+	public bool IsValid {get {return ID != IntPtr.Zero;}}
+	public XFieldInfo (string name, string signature, IntPtr id, bool isStatic)
+	{
+		ID = id;
+		IsStatic = isStatic;
+	}
+	public override string ToString ()
+	{
+		return string.Format ("{0}(0x{1})", GetType ().FullName, ID.ToString ("x"));
+	}
+}
+
+public class XMethodInfo
+{
+	public IntPtr ID;
+	public bool   IsStatic;
+	public bool IsValid {get {return ID != IntPtr.Zero;}}
+	public XMethodInfo (string name, string signature, IntPtr id, bool isStatic)
+	{
+		ID = id;
+		IsStatic = isStatic;
+	}
+	public override string ToString ()
+	{
+		return string.Format ("{0}(0x{1})", GetType ().FullName, ID.ToString ("x"));
+	}
+}
+
+
 namespace Java.Interop.SafeHandles {
+	public class JniFieldInfo : XFieldInfo {
+		public JniFieldInfo (string name, string signature, IntPtr id, bool isStatic)
+			: base (name, signature, id, isStatic)
+		{
+		}
+	}
+	public class JniMethodInfo : XMethodInfo {
+		public JniMethodInfo (string name, string signature, IntPtr id, bool isStatic)
+			: base (name, signature, id, isStatic)
+		{
+		}
+	}
 	public struct JniObjectReference
 	{
 		public  JniReferenceSafeHandle      SafeHandle  {get; private set;}
@@ -195,6 +240,18 @@ namespace Java.Interop.SafeHandles {
 }
 
 namespace Java.Interop.JIIntPtrs {
+	public class JniFieldInfo : XFieldInfo {
+		public JniFieldInfo (string name, string signature, IntPtr id, bool isStatic)
+			: base (name, signature, id, isStatic)
+		{
+		}
+	}
+	public class JniMethodInfo : XMethodInfo {
+		public JniMethodInfo (string name, string signature, IntPtr id, bool isStatic)
+			: base (name, signature, id, isStatic)
+		{
+		}
+	}
 	public struct JniObjectReference
 	{
 		public  IntPtr                      Handle  {get; private set;}
@@ -236,6 +293,18 @@ namespace Java.Interop.JIIntPtrs {
 }
 
 namespace Java.Interop.JIPinvokes {
+	public class JniFieldInfo : XFieldInfo {
+		public JniFieldInfo (string name, string signature, IntPtr id, bool isStatic)
+			: base (name, signature, id, isStatic)
+		{
+		}
+	}
+	public class JniMethodInfo : XMethodInfo {
+		public JniMethodInfo (string name, string signature, IntPtr id, bool isStatic)
+			: base (name, signature, id, isStatic)
+		{
+		}
+	}
 	public struct JniObjectReference
 	{
 		public  IntPtr                      Handle  {get; private set;}
@@ -282,6 +351,18 @@ namespace Java.Interop.JIPinvokes {
 	}
 }
 namespace Java.Interop.XAIntPtrs {
+	public class JniFieldInfo : XFieldInfo {
+		public JniFieldInfo (string name, string signature, IntPtr id, bool isStatic)
+			: base (name, signature, id, isStatic)
+		{
+		}
+	}
+	public class JniMethodInfo : XMethodInfo {
+		public JniMethodInfo (string name, string signature, IntPtr id, bool isStatic)
+			: base (name, signature, id, isStatic)
+		{
+		}
+	}
 	public struct JniObjectReference
 	{
 		public  IntPtr                      Handle  {get; private set;}
@@ -317,51 +398,6 @@ namespace Java.Interop.XAIntPtrs {
 			LogCreateLocalRef (h);
 			XAIntPtrEnv.References.DeleteLocalRef (h);
 			return new Exception ("yada yada yada");
-		}
-	}
-}
-
-namespace Java.Interop {
-	public sealed class JniFieldInfo
-	{
-		public IntPtr ID;
-		public bool   IsStatic;
-		public bool IsValid {get {return ID != IntPtr.Zero;}}
-
-		public JniFieldInfo (IntPtr id, bool isStatic)
-		{
-			ID = id;
-			IsStatic = isStatic;
-		}
-		public JniFieldInfo (string name, string signature, IntPtr id, bool isStatic)
-		{
-			ID = id;
-			IsStatic = isStatic;
-		}
-
-		public override string ToString ()
-		{
-			return string.Format ("{0}(0x{1})", GetType ().FullName, ID.ToString ("x"));
-		}
-	}
-	public class JniMethodInfo
-	{
-		public IntPtr ID;
-		public bool   IsStatic;
-		public bool IsValid {get {return ID != IntPtr.Zero;}}
-		public JniMethodInfo (IntPtr id, bool isStatic)
-		{
-			ID = id;
-			IsStatic = isStatic;
-		}
-		public JniMethodInfo (string name, string signature, IntPtr id, bool isStatic)
-		{
-			ID = id;
-			IsStatic = isStatic;
-		}
-		public override string ToString ()
-		{
-			return string.Format ("{0}(0x{1})", GetType ().FullName, ID.ToString ("x"));
 		}
 	}
 }


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4466540&view=logs&j=f31c9f97-4411-58e7-49ac-fc73f645e6b6&t=cbeb8522-7b64-5cc0-7bee-eff0e164a409

Commit 2a299eb1 accidentally introduced ~650 warnings to the build:

	tests\invocation-overhead\jni.cs(5756,24): Warning CS0436:
	The type 'JniFieldInfo' in 'D:\a\1\s\tests\invocation-overhead\invocation-overhead.cs' conflicts with the
	imported type 'JniFieldInfo' in 'Java.Interop, Version=0.1.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065'.
	Using the type defined in 'D:\a\1\s\tests\invocation-overhead\invocation-overhead.cs'.

This was because commit 2a299eb1 added a declaration for `JniFieldInfo`
and `JniMethodInfo` in the `Java.Interop` namespace within
`invocation-overhead.cs`.

Fix the warnings by moving the `JniFieldInfo` and `JniMethodInfo`
declarations into the "per-handle-type" sub-namespaces.