### PR TITLE
[CI] Enable native tests for Mac - .NET Core.

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -160,5 +160,7 @@ jobs:
   - template: templates\core-build.yaml
       
   - template: templates\core-tests.yaml
+    parameters:
+      runNativeTests: true
 
   - template: templates\fail-on-issue.yaml

--- a/build-tools/automation/templates/core-tests.yaml
+++ b/build-tools/automation/templates/core-tests.yaml
@@ -1,5 +1,6 @@
 parameters:
   condition: succeeded()
+  runNativeTests: false
 
 steps:
 - task: DotNetCoreCLI@2
@@ -58,24 +59,26 @@ steps:
     arguments: bin/Test$(Build.Configuration)/Xamarin.SourceWriter-Tests.dll
   continueOnError: true
 
-# Running native Java.Interop tests are not yet supported on .NET Core
-#- task: DotNetCoreCLI@2
-#  displayName: 'Tests: Java.Interop'
-#  inputs:
-#    command: test
-#    arguments: bin/Test$(Build.Configuration)/Java.Interop-Tests.dll
-#  continueOnError: true
+- task: DotNetCoreCLI@2
+  displayName: 'Tests: Java.Interop'
+  condition: eq('${{ parameters.runNativeTests }}', 'true')
+  inputs:
+    command: test
+    arguments: bin/Test$(Build.Configuration)/Java.Interop-Tests.dll
+  continueOnError: true
 
-#- task: DotNetCoreCLI@2
-#  displayName: 'Tests: Java.Interop.Dynamic'
-#  inputs:
-#    command: test
-#    arguments: bin/Test$(Build.Configuration)/Java.Interop.Dynamic-Tests.dll
-#  continueOnError: true
+- task: DotNetCoreCLI@2
+  displayName: 'Tests: Java.Interop.Dynamic'
+  condition: eq('${{ parameters.runNativeTests }}', 'true')
+  inputs:
+    command: test
+    arguments: bin/Test$(Build.Configuration)/Java.Interop.Dynamic-Tests.dll
+  continueOnError: true
 
-#- task: DotNetCoreCLI@2
-#  displayName: 'Tests: Java.Interop.Export'
-#  inputs:
-#    command: test
-#    arguments: bin/Test$(Build.Configuration)/Java.Interop.Export-Tests.dll
-#  continueOnError: true
+- task: DotNetCoreCLI@2
+  displayName: 'Tests: Java.Interop.Export'
+  condition: eq('${{ parameters.runNativeTests }}', 'true')
+  inputs:
+    command: test
+    arguments: bin/Test$(Build.Configuration)/Java.Interop.Export-Tests.dll
+  continueOnError: true


### PR DESCRIPTION
We originally did not enable native tests on our Mac .NET Core build lane because they didn't work.  However with recent improvements (https://github.com/xamarin/java.interop/pull/801) they now succeed, so we should enable them to ensure they do not break.