### PR TITLE
[param-name-importer] Fix crash trying to modify a Dictionary.Values collection directly

### DIFF
--- a/tools/param-name-importer/JavaStubSourceImporter.cs
+++ b/tools/param-name-importer/JavaStubSourceImporter.cs
@@ -78,7 +78,7 @@ namespace Xamarin.Android.ApiTools.JavaStubImporter
 			}
 			var pkg = api.AllPackages.FirstOrDefault (p => p.Name == parsedPackage.Name);
 			if (pkg == null) {
-				api.AllPackages.Add (parsedPackage);
+				api.Packages.Add (parsedPackage.Name, parsedPackage);
 				pkg = parsedPackage;
 			} else
 				foreach (var t in parsedPackage.AllTypes)


### PR DESCRIPTION
In https://github.com/xamarin/java.interop/pull/756, we switched from using `List<JavaPackage>` to `Dictionary<string, JavaPackage>` for better performance.  To minimize the diffs needed with existing code, we created an accessor for the `Dictionary.Values`:

```
public IDictionary<string, JavaPackage>Packages { get; }
public ICollection<JavaPackage> AllPackages => Packages.Values;
```

However if you attempt to modify this collection directly, you get an exception.  

```
System.NotSupportedException: Mutating a value collection derived from a dictionary is not allowed.
   at System.ThrowHelper.ThrowNotSupportedException(ExceptionResource resource)
   at Xamarin.Android.ApiTools.JavaStubImporter.JavaStubSourceImporter.ParseJava(String javaSourceText) in C:\code\xamarin-android-backport\external\Java.Interop\tools\param-name-importer\JavaStubSourceImporter.cs:line 81
   at Xamarin.Android.ApiTools.JavaStubImporter.JavaStubSourceImporter.Import(ImporterOptions options) in C:\code\xamarin-android-backport\external\Java.Interop\tools\param-name-importer\JavaStubSourceImporter.cs:line 27
   at Xamarin.Android.ApiTools.Driver.Main(String[] args) in C:\code\xamarin-android-backport\external\Java.Interop\tools\param-name-importer\Program.cs:line 22
```

Thus we need to update this code that adds to the collection to use the dictionary properly.

Also verified that this is the only code that attempts to write to `AllPackages`.