### PR TITLE
Fix compiler warnings.

### DIFF
--- a/src/Java.Interop.Localization/Java.Interop.Localization.csproj
+++ b/src/Java.Interop.Localization/Java.Interop.Localization.csproj
@@ -5,6 +5,7 @@
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <DefineConstants>INTERNAL_NULLABLE_ATTRIBUTES</DefineConstants>
+    <NeutralLanguage>en</NeutralLanguage>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Java.Interop/Java.Interop/JavaArray.cs
+++ b/src/Java.Interop/Java.Interop/JavaArray.cs
@@ -30,7 +30,10 @@ namespace Java.Interop
 
 		[MaybeNull]
 		public abstract T this [int index] {
+			// I think this will be fixable in .NET5+ with support for "T?"
+#pragma warning disable CS8766 // Nullability of reference types in return type doesn't match implicitly implemented member (possibly because of nullability attributes).
 			get;
+#pragma warning restore CS8766
 			set;
 		}
 

--- a/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
+++ b/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
@@ -180,7 +180,7 @@ namespace Java.Interop
 						var method  = m.Marshaler.Method;
 						Debug.WriteLine ($"JNIEnv::RegisterNatives() given a generic delegate type.  .NET Core doesn't like this.");
 						Debug.WriteLine ($"  Java: {m.Name}{m.Signature}");
-						Debug.WriteLine ($"  Marshaler Type={m.Marshaler.GetType ().FullName} Method={method.DeclaringType.FullName}.{method.Name}");
+						Debug.WriteLine ($"  Marshaler Type={m.Marshaler.GetType ().FullName} Method={method.DeclaringType!.FullName}.{method.Name}");
 					}
 				}
 #endif  // DEBUG && NETCOREAPP

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniMarshalMemberBuilder.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniMarshalMemberBuilder.cs
@@ -87,7 +87,7 @@ namespace Java.Interop {
 			{
 				if (value == null)
 					throw new ArgumentNullException (nameof (value));
-				return CreateMarshalToManagedExpression (value.GetMethodInfo ()).Compile ();
+				return CreateMarshalToManagedExpression (value.GetMethodInfo ()!).Compile ();
 			}
 
 			public  abstract    LambdaExpression                            CreateMarshalToManagedExpression (MethodInfo method);

--- a/src/Java.Interop/Java.Interop/JniType.cs
+++ b/src/Java.Interop/Java.Interop/JniType.cs
@@ -14,7 +14,7 @@ namespace Java.Interop {
 
 	public sealed class JniType : IDisposable {
 
-		[return: NotNullIfNotNull ("name")]
+		[return: NotNullIfNotNull ("classFileData")]
 		public static unsafe JniType? DefineClass (string name, JniObjectReference loader, byte[] classFileData)
 		{
 			if (classFileData == null)

--- a/src/Java.Runtime.Environment/Java.Runtime.Environment.csproj
+++ b/src/Java.Runtime.Environment/Java.Runtime.Environment.csproj
@@ -7,6 +7,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
+    <MSBuildWarningsAsMessages>NU1702</MSBuildWarningsAsMessages>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Fix some NRT warnings that have crept in.

---

Also add `<NeutralLanguage>en</NeutralLanguage>` to fix:
```
Warning CA1824: Mark assemblies with NeutralResourcesLanguageAttribute
```

Basically this says that the "neutral" language this assembly contains is also the English translations, so we don't need to spend time probing for satellite resource assemblies when the English language is requested.

---
Also add `<MSBuildWarningsAsMessages>NU1702</MSBuildWarningsAsMessages>` to suppress:

```
Warning NU1702: ProjectReference 'D:\a\1\s\src\java-interop\java-interop.csproj' was resolved using 
'.NETFramework,Version=v4.7.2' instead of the project target framework '.NETStandard,Version=v2.0'. 
This project may not be fully compatible with your project.
```