### PR TITLE
[ci] Make VC++ toolchain optional

### DIFF
--- a/build-tools/scripts/NativeToolchain.targets
+++ b/build-tools/scripts/NativeToolchain.targets
@@ -1,14 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
+  <PropertyGroup Condition=" $([MSBuild]::IsOSPlatform ('windows')) And '$(VSINSTALLROOT)' != '' ">
+    <_VcvarsallPath>$(VSINSTALLROOT)\VC\Auxiliary\Build\vcvarsall.bat</_VcvarsallPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" $([MSBuild]::IsOSPlatform ('windows')) And Exists ('$(_VcvarsallPath)') ">
+    <NativeToolchainSupported>True</NativeToolchainSupported>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" !$([MSBuild]::IsOSPlatform ('windows')) ">
+    <NativeToolchainSupported>True</NativeToolchainSupported>
+  </PropertyGroup>
+
   <Target Name="GetNativeBuildCommands">
-    <ItemGroup Condition=" '$(VSINSTALLROOT)' != '' And Exists('$(VSINSTALLROOT)') ">
-      <_Vcvarsall
-          Include="$(VSINSTALLROOT)\VC\Auxiliary\Build\vcvarsall.bat"
-      />
-    </ItemGroup>
-    <PropertyGroup Condition=" '@(_Vcvarsall->Count())' != '0' ">
-      <_Vcvarsall>%(_Vcvarsall.Identity)</_Vcvarsall>
-      <PrepareNativeToolchain>call "$(_Vcvarsall)" </PrepareNativeToolchain>
+    <PropertyGroup Condition=" Exists ('$(_VcvarsallPath)') ">
+      <PrepareNativeToolchain>call "$(_VcvarsallPath)" </PrepareNativeToolchain>
     </PropertyGroup>
     <PropertyGroup>
       <CmakeGenerator Condition=" $([MSBuild]::IsOSPlatform ('windows')) ">-G "NMake Makefiles"</CmakeGenerator>

--- a/src/java-interop/Directory.Build.targets
+++ b/src/java-interop/Directory.Build.targets
@@ -23,7 +23,7 @@
     <_JavaInteropNativeLib Include="CMakeLists.txt" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(NativeToolchainSupported)' == 'True' ">
     <None Include="@(_JavaInteropNativeLib->'$(OutputPath)%(Dir)$(_JavaInteropLibName)')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>%(Dir)$(_JavaInteropLibName)</Link>
@@ -60,6 +60,7 @@
   </Target>
 
   <Target Name="_BuildLibs"
+      Condition=" '$(NativeToolchainSupported)' == 'True' "
       DependsOnTargets="GetNativeBuildCommands;_BuildJni_c;_GetCmakeOptions"
       BeforeTargets="Build"
       Inputs="@(_JavaInteropNativeLib);$(MSBuildThisFileFullPath);java-interop.csproj;@(ClInclude);@(ClCompile)"

--- a/tests/NativeTiming/Directory.Build.targets
+++ b/tests/NativeTiming/Directory.Build.targets
@@ -23,7 +23,7 @@
     <_NativeTimingLib Include="CMakeLists.txt" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(NativeToolchainSupported)' == 'True' ">
     <None Include="@(_NativeTimingLib->'$(OutputPath)%(Dir)$(_NativeTimingLibName)')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>%(Dir)$(_NativeTimingLibName)</Link>
@@ -40,6 +40,7 @@
   </ItemGroup>
 
   <Target Name="_BuildLibs"
+      Condition=" '$(NativeToolchainSupported)' == 'True' "
       BeforeTargets="Build"
       DependsOnTargets="GetNativeBuildCommands"
       Inputs="@(_NativeTimingLib);$(MSBuildThisFileFullPath);NativeTiming.csproj;@(ClInclude);@(ClCompile)"


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/5757

Turns Out™ that the xamarin-android Windows CI machine *doesn't* have
Visual C++ installed, and thus *can't* build `src/java-interop` with
the changes in 3824b974.  (Rephrased: 3824b974 broke the Windows
build for xamarin-android!)

Update `NativeToolchain.targets`, `src/java-interop`, and
`tests/NativeTiming` so that native files are *optional* when building
on Windows.  This should allow xamarin-android CI to work.