### PR TITLE
Bump to xamarin/xamarin-android-tools/main@d92fc3e3

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -108,10 +108,10 @@ jobs:
 
   - template: templates\install-dependencies.yaml
     
-  - script: make prepare CONFIGURATION=$(Build.Configuration)
+  - script: make prepare CONFIGURATION=$(Build.Configuration) JI_MAX_JDK=11
     displayName: make prepare
     
-  - script: make all CONFIGURATION=$(Build.Configuration)
+  - script: make all CONFIGURATION=$(Build.Configuration) JI_MAX_JDK=11
     displayName: make all
     
   - script: |

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -18,6 +18,7 @@ pr:
 variables:
   RunningOnCI: true
   Build.Configuration: Release
+  MaxJdkVersion: 8
   DotNetCoreVersion: 5.0.103
   HostedMacImage: macOS-10.15
   HostedWinVS2019: Hosted Windows 2019 with VS2019
@@ -108,15 +109,15 @@ jobs:
 
   - template: templates\install-dependencies.yaml
     
-  - script: make prepare CONFIGURATION=$(Build.Configuration) JI_MAX_JDK=11
+  - script: make prepare CONFIGURATION=$(Build.Configuration) JI_MAX_JDK=$(MaxJdkVersion)
     displayName: make prepare
     
-  - script: make all CONFIGURATION=$(Build.Configuration) JI_MAX_JDK=11
+  - script: make all CONFIGURATION=$(Build.Configuration) JI_MAX_JDK=$(MaxJdkVersion)
     displayName: make all
     
   - script: |
       r=0
-      make run-all-tests CONFIGURATION=$(Build.Configuration) || r=$?
+      make run-all-tests CONFIGURATION=$(Build.Configuration) JI_MAX_JDK=$(MaxJdkVersion) || r=$?
       jar cf xatb.jar -C tests/Xamarin.Android.Tools.Bytecode-Tests/obj/*/classes .
       zip -r bin.zip bin
       exit $r
@@ -158,7 +159,7 @@ jobs:
 
   - template: templates\install-dependencies.yaml
     
-  - script: make prepare-core CONFIGURATION=$(Build.Configuration)
+  - script: make prepare-core CONFIGURATION=$(Build.Configuration) JI_MAX_JDK=$(MaxJdkVersion)
     displayName: make prepare-core
       
   - template: templates\core-build.yaml

--- a/build-tools/automation/templates/core-build.yaml
+++ b/build-tools/automation/templates/core-build.yaml
@@ -6,7 +6,7 @@ steps:
   displayName: Prepare Solution
   inputs:
     projects: Java.Interop.sln
-    arguments: '-c $(Build.Configuration) -target:Prepare'
+    arguments: '-c $(Build.Configuration) -target:Prepare -p:MaxJdkVersion=$(MaxJdkVersion)'
 
 - task: DotNetCoreCLI@2
   displayName: Build Solution

--- a/build-tools/scripts/Prepare.targets
+++ b/build-tools/scripts/Prepare.targets
@@ -7,10 +7,14 @@
   <Target Name="Prepare">
     <Exec Command="git submodule update --init --recursive" WorkingDirectory="$(_TopDir)" />
     <MSBuild Projects="$(MSBuildThisFileDirectory)..\..\build-tools\Java.Interop.BootstrapTasks\Java.Interop.BootstrapTasks.csproj" />
+    <PropertyGroup>
+      <_MaxJdk>$(MaxJdkVersion)</_MaxJdk>
+      <_MaxJdk Condition=" '$(_MaxJdk)' == '' ">$(JI_MAX_JDK)</_MaxJdk>
+    </PropertyGroup>
     <JdkInfo
         JdksRoot="$(ProgramFiles)\Java"
         MakeFragmentFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\JdkInfo.mk"
-        MaximumJdkVersion="$(JI_MAX_MDK)"
+        MaximumJdkVersion="$(_MaxJdk)"
         PropertyFile="$(_TopDir)\bin\Build$(Configuration)\JdkInfo.props">
       <Output TaskParameter="JavaHomePath" PropertyName="_JavaSdkDirectory" />
     </JdkInfo>


### PR DESCRIPTION
Context: https://developercommunity.visualstudio.com/t/illegal-character-exception-in-xamarinandroid-afte/1363149

Changes: https://github.com/xamarin/xamarin-android-tools/compare/554d45a166a02da0ca1d0d9ca895eaa650fb648a...d92fc3e3a27e8240551baa813b15d6bf006a5620

  * xamarin/xamarin-android-tools@d92fc3e: [Xamarin.Android.Tools.AndroidSdk] Probe for AdoptOpenJDK Locations (#115)
  * xamarin/xamarin-android-tools@dca30d9: [Xamarin.Android.Tools.AndroidSdk] Probe for Zulu JDK (#114)
  * xamarin/xamarin-android-tools@237642c: [Xamarin.Android.Tools.AndroidSdk] Probe for Microsoft OpenJDK dirs (#113)
  * xamarin/xamarin-android-tools@e618e00: [Xamarin.Android.Tools.AndroidSdk] Fix quotes in %PATH% or %PATHEXT% (#112)