### PR TITLE
Update jcw-gen to work with interfaces in typemaps

### DIFF
--- a/tools/jcw-gen/App.cs
+++ b/tools/jcw-gen/App.cs
@@ -83,6 +83,10 @@ namespace Java.Interop.Tools
 
 		static void GenerateJavaCallableWrapper (TypeDefinition type, string outputPath, TypeDefinitionCache cache)
 		{
+			if (type.IsInterface) {
+				return;
+			}
+
 			var generator = new JavaCallableWrapperGenerator (type, log: Console.WriteLine, cache) {
 			};
 			generator.Generate (outputPath);


### PR DESCRIPTION
Context: ebd7d76161ac60ce7ad3bfee87789f08a333ae78

ebd7d761 introduced support for interfaces in typemaps, but it failed
to update the `jcw-gen` utility to ignore them when generating Java
Code Wrappers.  This, in turn, made Xamarin.Android fail to build.

Fix the issue by ignoring interfaces in `jcw-gen`