### PR TITLE
[One .NET] specify AssemblyMetadataAttribute for IsTrimmable

### DIFF
--- a/src/Java.Interop/Properties/AssemblyInfo.cs
+++ b/src/Java.Interop/Properties/AssemblyInfo.cs
@@ -13,6 +13,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct ("")]
 [assembly: AssemblyTrademark ("Microsoft Corporation")]
 [assembly: AssemblyVersion ("0.1.0.0")]
+[assembly: AssemblyMetadata ("IsTrimmable", "True")]
 
 [assembly: InternalsVisibleTo (
 	"Java.Interop.GenericMarshaler, PublicKey=" +


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/5638
Context: https://github.com/xamarin/xamarin-android/pull/5879

Going forward in .NET 6, we shouldn't use the `%(IsTrimmable)`
metadata anymore, but use the following C# attribute in each assembly
instead:

    [assembly: AssemblyMetadata ("IsTrimmable", "True")]

Similar changes on the iOS side here:

https://github.com/xamarin/xamarin-macios/commit/289053b1e3bdf3b8c3cc3839384811f6018bba48

This adds `AssemblyMetadataAttribute` for `Java.Interop.dll`.