### PR TITLE
[build] target net6.0 instead of netcoreapp3.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -50,7 +50,7 @@
     <XamarinAndroidToolsDirectory   Condition=" '$(XamarinAndroidToolsDirectory)' == '' ">$(MSBuildThisFileDirectory)external\xamarin-android-tools</XamarinAndroidToolsDirectory>
   </PropertyGroup>
   <PropertyGroup>
-    <DotNetToolPath Condition=" '$(DotNetToolPath)' == '' ">dotnet</DotNetToolPath>
+    <DotnetToolPath Condition=" '$(DotnetToolPath)' == '' ">dotnet</DotnetToolPath>
     <CmakePath Condition=" '$(CmakePath)' == '' ">cmake</CmakePath>
     <GradleHome Condition=" '$(GradleHome)' == '' ">$(MSBuildThisFileDirectory)build-tools\gradle</GradleHome>
     <GradleWPath Condition=" '$(GradleWPath)' == '' ">$(GradleHome)\gradlew</GradleWPath>
@@ -68,7 +68,7 @@
     <Runtime Condition="'$(OS)' != 'Windows_NT'">mono</Runtime>
     <_JNIEnvGenPath Condition=" '$(JIBuildingForNetCoreApp)' == 'True' ">$(BuildToolOutputFullPath)jnienv-gen.dll</_JNIEnvGenPath>
     <_JNIEnvGenPath Condition=" '$(JIBuildingForNetCoreApp)' != 'True' ">$(BuildToolOutputFullPath)jnienv-gen.exe</_JNIEnvGenPath>
-    <_RunJNIEnvGen Condition=" '$(JIBuildingForNetCoreApp)' == 'True' ">$(DotNetToolPath) "$(_JNIEnvGenPath)"</_RunJNIEnvGen>
+    <_RunJNIEnvGen Condition=" '$(JIBuildingForNetCoreApp)' == 'True' ">$(DotnetToolPath) "$(_JNIEnvGenPath)"</_RunJNIEnvGen>
     <_RunJNIEnvGen Condition=" '$(JIBuildingForNetCoreApp)' != 'True' ">$(Runtime) "$(_JNIEnvGenPath)"</_RunJNIEnvGen>
   </PropertyGroup>
   

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,7 +27,7 @@
     <AppendTargetFrameworkToOutputPath Condition=" '$(AppendTargetFrameworkToOutputPath)' == '' ">False</AppendTargetFrameworkToOutputPath>
     <BaseIntermediateOutputPath Condition=" '$(BaseIntermediateOutputPath)' == '' ">obj\</BaseIntermediateOutputPath>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' != '' And $(TargetFramework.StartsWith ('netcoreapp')) ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <JIBuildingForNetCoreApp>True</JIBuildingForNetCoreApp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(JIBuildingForNetCoreApp)' == 'True' ">
@@ -50,6 +50,7 @@
     <XamarinAndroidToolsDirectory   Condition=" '$(XamarinAndroidToolsDirectory)' == '' ">$(MSBuildThisFileDirectory)external\xamarin-android-tools</XamarinAndroidToolsDirectory>
   </PropertyGroup>
   <PropertyGroup>
+    <DotNetToolPath Condition=" '$(DotNetToolPath)' == '' ">dotnet</DotNetToolPath>
     <CmakePath Condition=" '$(CmakePath)' == '' ">cmake</CmakePath>
     <GradleHome Condition=" '$(GradleHome)' == '' ">$(MSBuildThisFileDirectory)build-tools\gradle</GradleHome>
     <GradleWPath Condition=" '$(GradleWPath)' == '' ">$(GradleHome)\gradlew</GradleWPath>
@@ -67,7 +68,7 @@
     <Runtime Condition="'$(OS)' != 'Windows_NT'">mono</Runtime>
     <_JNIEnvGenPath Condition=" '$(JIBuildingForNetCoreApp)' == 'True' ">$(BuildToolOutputFullPath)jnienv-gen.dll</_JNIEnvGenPath>
     <_JNIEnvGenPath Condition=" '$(JIBuildingForNetCoreApp)' != 'True' ">$(BuildToolOutputFullPath)jnienv-gen.exe</_JNIEnvGenPath>
-    <_RunJNIEnvGen Condition=" '$(JIBuildingForNetCoreApp)' == 'True' ">dotnet "$(_JNIEnvGenPath)"</_RunJNIEnvGen>
+    <_RunJNIEnvGen Condition=" '$(JIBuildingForNetCoreApp)' == 'True' ">$(DotNetToolPath) "$(_JNIEnvGenPath)"</_RunJNIEnvGen>
     <_RunJNIEnvGen Condition=" '$(JIBuildingForNetCoreApp)' != 'True' ">$(Runtime) "$(_JNIEnvGenPath)"</_RunJNIEnvGen>
   </PropertyGroup>
   

--- a/build-tools/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks/JdkInfo.cs
+++ b/build-tools/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks/JdkInfo.cs
@@ -21,7 +21,7 @@ namespace Java.Interop.BootstrapTasks
 
 		public  string  MaximumJdkVersion     { get; set; }
 
-		public  string  DotNetToolPath        { get; set; }
+		public  string  DotnetToolPath        { get; set; }
 
 		static  Regex   VersionExtractor  = new Regex (@"(?<version>[\d]+(\.\d+)+)", RegexOptions.Compiled);
 
@@ -97,7 +97,7 @@ namespace Java.Interop.BootstrapTasks
 
 		void WritePropertyFile (string javaPath, string jarPath, string javacPath, string jdkJvmPath, string rtJarPath, IEnumerable<string> includes)
 		{
-			var dotnet = string.IsNullOrEmpty (DotNetToolPath) ? "dotnet" : DotNetToolPath;
+			var dotnet = string.IsNullOrEmpty (DotnetToolPath) ? "dotnet" : DotnetToolPath;
 			var msbuild = XNamespace.Get ("http://schemas.microsoft.com/developer/msbuild/2003");
 			var project = new XElement (msbuild + "Project",
 				new XElement (msbuild + "Choose",
@@ -115,7 +115,7 @@ namespace Java.Interop.BootstrapTasks
 						javacPath),
 					new XElement (msbuild + "JarPath", new XAttribute ("Condition", " '$(JarPath)' == '' "),
 						jarPath),
-					new XElement (msbuild + "DotNetToolPath", new XAttribute ("Condition", " '$(DotNetToolPath)' == '' "),
+					new XElement (msbuild + "DotnetToolPath", new XAttribute ("Condition", " '$(DotnetToolPath)' == '' "),
 						dotnet),
 					CreateJreRtJarPath (msbuild, rtJarPath)));
 			project.Save (PropertyFile.ItemSpec);

--- a/build-tools/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks/JdkInfo.cs
+++ b/build-tools/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks/JdkInfo.cs
@@ -21,6 +21,8 @@ namespace Java.Interop.BootstrapTasks
 
 		public  string  MaximumJdkVersion     { get; set; }
 
+		public  string  DotNetToolPath        { get; set; }
+
 		static  Regex   VersionExtractor  = new Regex (@"(?<version>[\d]+(\.\d+)+)", RegexOptions.Compiled);
 
 		[Required]
@@ -95,6 +97,7 @@ namespace Java.Interop.BootstrapTasks
 
 		void WritePropertyFile (string javaPath, string jarPath, string javacPath, string jdkJvmPath, string rtJarPath, IEnumerable<string> includes)
 		{
+			var dotnet = string.IsNullOrEmpty (DotNetToolPath) ? "dotnet" : DotNetToolPath;
 			var msbuild = XNamespace.Get ("http://schemas.microsoft.com/developer/msbuild/2003");
 			var project = new XElement (msbuild + "Project",
 				new XElement (msbuild + "Choose",
@@ -112,6 +115,8 @@ namespace Java.Interop.BootstrapTasks
 						javacPath),
 					new XElement (msbuild + "JarPath", new XAttribute ("Condition", " '$(JarPath)' == '' "),
 						jarPath),
+					new XElement (msbuild + "DotNetToolPath", new XAttribute ("Condition", " '$(DotNetToolPath)' == '' "),
+						dotnet),
 					CreateJreRtJarPath (msbuild, rtJarPath)));
 			project.Save (PropertyFile.ItemSpec);
 		}

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -19,10 +19,10 @@ variables:
   RunningOnCI: true
   Build.Configuration: Release
   MaxJdkVersion: 8
-  DotNetCoreVersion: 5.0.103
+  DotNetCoreVersion: 6.0.x
   HostedMacImage: macOS-10.15
   HostedWinVS2019: Hosted Windows 2019 with VS2019
-  NetCoreTargetFrameworkPathSuffix: -netcoreapp3.1
+  NetCoreTargetFrameworkPathSuffix: -net6.0
   VSInstallRoot: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
 
 jobs:
@@ -38,15 +38,13 @@ jobs:
 
   - template: templates\install-dependencies.yaml
 
-  - task: NuGetToolInstaller@0
+  - task: MSBuild@1
+    displayName: MSBuild Java.Interop.sln /t:Restore
     inputs:
-      versionSpec: 5.x
+      solution: Java.Interop.sln
+      configuration: $(Build.Configuration)
+      msbuildArguments: /t:Restore /p:RestoreConfigFile=$(System.DefaultWorkingDirectory)\external\xamarin-android-tools\NuGet.config
 
-  - task: NuGetCommand@2
-    inputs:
-      command: custom
-      arguments: restore external\xamarin-android-tools\Xamarin.Android.Tools.sln -ConfigFile external\xamarin-android-tools\NuGet.config
-      
   - task: MSBuild@1
     displayName: MSBuild Java.Interop.sln /t:Prepare
     inputs:
@@ -108,7 +106,12 @@ jobs:
     submodules: recursive
 
   - template: templates\install-dependencies.yaml
-    
+
+  - script: >
+      dotnet tool install --global boots &&
+      boots --preview Mono
+    displayName: Install Mono
+
   - script: make prepare CONFIGURATION=$(Build.Configuration) JI_MAX_JDK=$(MaxJdkVersion)
     displayName: make prepare
     

--- a/build-tools/automation/templates/install-dependencies.yaml
+++ b/build-tools/automation/templates/install-dependencies.yaml
@@ -6,3 +6,4 @@ steps:
   displayName: Use .NET Core $(DotNetCoreVersion)
   inputs:
     version: $(DotNetCoreVersion)
+    includePreviewVersions: true

--- a/build-tools/jnienv-gen/jnienv-gen.csproj
+++ b/build-tools/jnienv-gen/jnienv-gen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(Configuration)\$(TargetFramework.ToLowerInvariant())\</IntermediateOutputPath>
   </PropertyGroup>

--- a/build-tools/scripts/Prepare.targets
+++ b/build-tools/scripts/Prepare.targets
@@ -15,6 +15,7 @@
         JdksRoot="$(ProgramFiles)\Java"
         MakeFragmentFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\JdkInfo.mk"
         MaximumJdkVersion="$(_MaxJdk)"
+        DotNetToolPath="$(DotNetToolPath)"
         PropertyFile="$(_TopDir)\bin\Build$(Configuration)\JdkInfo.props">
       <Output TaskParameter="JavaHomePath" PropertyName="_JavaSdkDirectory" />
     </JdkInfo>

--- a/build-tools/scripts/Prepare.targets
+++ b/build-tools/scripts/Prepare.targets
@@ -15,7 +15,7 @@
         JdksRoot="$(ProgramFiles)\Java"
         MakeFragmentFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\JdkInfo.mk"
         MaximumJdkVersion="$(_MaxJdk)"
-        DotNetToolPath="$(DotNetToolPath)"
+        DotnetToolPath="$(DotnetToolPath)"
         PropertyFile="$(_TopDir)\bin\Build$(Configuration)\JdkInfo.props">
       <Output TaskParameter="JavaHomePath" PropertyName="_JavaSdkDirectory" />
     </JdkInfo>

--- a/build-tools/scripts/jdk.mk
+++ b/build-tools/scripts/jdk.mk
@@ -45,5 +45,5 @@ endif # $(OS)=Linux
 $(_INCLUDE_MK) $(_INCLUDE_PROPS): bin/Build$(CONFIGURATION)/Java.Interop.BootstrapTasks.dll
 	$(MSBUILD) $(MSBUILD_FLAGS) build-tools/scripts/jdk.targets /t:GetPreferredJdkRoot \
 		/p:JdksRoot="$(_JDKS_ROOT)" \
-		/p:DotNetToolPath="$(DOTNET_TOOL_PATH)" \
+		/p:DotnetToolPath="$(DOTNET_TOOL_PATH)" \
 		$(if $(JI_MAX_JDK),"/p:MaximumJdkVersion=$(JI_MAX_JDK)")

--- a/build-tools/scripts/jdk.mk
+++ b/build-tools/scripts/jdk.mk
@@ -45,4 +45,5 @@ endif # $(OS)=Linux
 $(_INCLUDE_MK) $(_INCLUDE_PROPS): bin/Build$(CONFIGURATION)/Java.Interop.BootstrapTasks.dll
 	$(MSBUILD) $(MSBUILD_FLAGS) build-tools/scripts/jdk.targets /t:GetPreferredJdkRoot \
 		/p:JdksRoot="$(_JDKS_ROOT)" \
+		/p:DotNetToolPath="$(DOTNET_TOOL_PATH)" \
 		$(if $(JI_MAX_JDK),"/p:MaximumJdkVersion=$(JI_MAX_JDK)")

--- a/build-tools/scripts/jdk.targets
+++ b/build-tools/scripts/jdk.targets
@@ -6,6 +6,7 @@
         JdksRoot="$(JdksRoot)"
         MakeFragmentFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\JdkInfo.mk"
         MaximumJdkVersion="$(MaximumJdkVersion)"
+        DotNetToolPath="$(DotNetToolPath)"
         PropertyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\JdkInfo.props">
       <Output TaskParameter="JavaHomePath" PropertyName="_JavaHome"/>
     </JdkInfo>

--- a/build-tools/scripts/jdk.targets
+++ b/build-tools/scripts/jdk.targets
@@ -6,7 +6,7 @@
         JdksRoot="$(JdksRoot)"
         MakeFragmentFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\JdkInfo.mk"
         MaximumJdkVersion="$(MaximumJdkVersion)"
-        DotNetToolPath="$(DotNetToolPath)"
+        DotnetToolPath="$(DotnetToolPath)"
         PropertyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\JdkInfo.props">
       <Output TaskParameter="JavaHomePath" PropertyName="_JavaHome"/>
     </JdkInfo>

--- a/global.json
+++ b/global.json
@@ -1,4 +1,7 @@
 {
+    "sdk": {
+        "allowPrerelease": true
+    },
     "msbuild-sdks": {
         "Microsoft.Build.NoTargets": "2.0.1"
     }

--- a/src/Java.Interop.Export/Java.Interop.Export.csproj
+++ b/src/Java.Interop.Export/Java.Interop.Export.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <ProjectGuid>{B501D075-6183-4E1D-92C9-F7B5002475B1}</ProjectGuid>
     <SignAssembly>true</SignAssembly>

--- a/src/Java.Interop.GenericMarshaler/Java.Interop.GenericMarshaler.csproj
+++ b/src/Java.Interop.GenericMarshaler/Java.Interop.GenericMarshaler.csproj
@@ -24,6 +24,8 @@
     <ProjectReference Include="..\Java.Interop\Java.Interop.csproj">
       <Project>{94BD81F7-B06F-4295-9636-F8A3B6BDC762}</Project>
       <Name>Java.Interop</Name>
+      <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
+      <AdditionalProperties>TargetFramework=netstandard2.0</AdditionalProperties>
     </ProjectReference>
   </ItemGroup>
 </Project>

--- a/src/Java.Interop/Java.Interop.csproj
+++ b/src/Java.Interop/Java.Interop.csproj
@@ -4,8 +4,19 @@
     <XAConfigPath>..\..\bin\Build$(Configuration)\XAConfig.props</XAConfigPath>
   </PropertyGroup>
   <Import Condition="Exists ('$(XAConfigPath)')" Project="$(XAConfigPath)" />
+  <!--
+    NOTE: in xamarin-android, this project gets built by xabuild in Xamarin.Android-Tests.sln
+    Exclude net6.0, because xabuild cannot build net5.0 or higher
+  -->
+  <PropertyGroup Condition=" '$(XABuild)' == 'true' ">
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <_JniEnvSkipGetTargetFrameworkProperties>true</_JniEnvSkipGetTargetFrameworkProperties>
+    <_JniEnvAdditionalProperties>TargetFramework=net472</_JniEnvAdditionalProperties>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(XABuild)' != 'true' ">
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+  </PropertyGroup>
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <NoWarn>1591</NoWarn>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
@@ -57,6 +68,8 @@
     <None Include="Documentation\Java.Interop\JniEnvironment.References.xml" />
     <ProjectReference Include="..\..\build-tools\jnienv-gen\jnienv-gen.csproj"
         ReferenceOutputAssembly="false"
+        SkipGetTargetFrameworkProperties="$(_JniEnvSkipGetTargetFrameworkProperties)"
+        AdditionalProperties="$(_JniEnvAdditionalProperties)"
     />
   </ItemGroup>
   <ItemGroup>

--- a/src/java-interop/java-interop.csproj
+++ b/src/java-interop/java-interop.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <OutputPath>$(ToolOutputFullPath)</OutputPath>
     <JNIEnvGenPath>$(BuildToolOutputFullPath)</JNIEnvGenPath>
     <OutputName>java-interop</OutputName>

--- a/tests/Java.Interop-PerformanceTests/Java.Interop-PerformanceTests.csproj
+++ b/tests/Java.Interop-PerformanceTests/Java.Interop-PerformanceTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/tests/Java.Interop-Tests/Java.Interop-Tests.csproj
+++ b/tests/Java.Interop-Tests/Java.Interop-Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
@@ -10,7 +10,7 @@
     <OutputPath>$(TestOutputFullPath)</OutputPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <DefineConstants>$(DefineConstants);NO_MARSHAL_MEMBER_BUILDER_SUPPORT;NO_GC_BRIDGE_SUPPORT</DefineConstants>
   </PropertyGroup>
 
@@ -37,7 +37,7 @@
     <ProjectReference Include="..\TestJVM\TestJVM.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.1' ">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net6.0' ">
     <ProjectReference Include="..\..\src\Java.Interop.Export\Java.Interop.Export.csproj" />
   </ItemGroup>
 

--- a/tests/TestJVM/TestJVM.csproj
+++ b/tests/TestJVM/TestJVM.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/invocation-overhead/Directory.Build.targets
+++ b/tests/invocation-overhead/Directory.Build.targets
@@ -29,7 +29,7 @@
         Targets="_Run_net472"
     />
     <MSBuild Projects="$(MSBuildThisFileDirectory)invocation-overhead.csproj"
-        Properties="TargetFramework=netcoreapp3.1"
+        Properties="TargetFramework=net6.0"
         Targets="_Run_netcoreapp"
     />
   </Target>

--- a/tests/invocation-overhead/invocation-overhead.csproj
+++ b/tests/invocation-overhead/invocation-overhead.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <AppendTargetFrameworkToOutputPath>True</AppendTargetFrameworkToOutputPath>
     <DefineConstants>FEATURE_JNIENVIRONMENT_JI_INTPTRS;FEATURE_JNIENVIRONMENT_JI_PINVOKES;FEATURE_JNIENVIRONMENT_SAFEHANDLES;FEATURE_JNIENVIRONMENT_XA_INTPTRS </DefineConstants>

--- a/tools/class-parse/class-parse.csproj
+++ b/tools/class-parse/class-parse.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/tools/generator/generator.csproj
+++ b/tools/generator/generator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <DefineConstants>$(DefineConstants);GENERATOR;HAVE_CECIL;JCW_ONLY_TYPE_NAMES</DefineConstants>
     <LangVersion>8.0</LangVersion>

--- a/tools/jcw-gen/jcw-gen.csproj
+++ b/tools/jcw-gen/jcw-gen.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/tools/logcat-parse/logcat-parse.csproj
+++ b/tools/logcat-parse/logcat-parse.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/tools/param-name-importer/param-name-importer.csproj
+++ b/tools/param-name-importer/param-name-importer.csproj
@@ -12,7 +12,7 @@
     <Reference Include="System.IO.Compression" Condition="$(TargetFramework.StartsWith('net4'))" />
   </ItemGroup>
   <ItemGroup>
-    <!-- This package erroneously contains /net6.0/SgmlReader.exe and /net6.0/SgmlReaderDll.dll.
+    <!-- This package erroneously contains /netcoreapp3.1/SgmlReader.exe and /netcoreapp3.1/SgmlReaderDll.dll.
          We are going to use a package reference to download the nuget, and a regular reference to actually
          reference the correct assembly. -->
     <PackageReference Include="Microsoft.Xml.SgmlReader" Version="1.8.16" ExcludeAssets="Compile" GeneratePathProperty="true" />

--- a/tools/param-name-importer/param-name-importer.csproj
+++ b/tools/param-name-importer/param-name-importer.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup>
@@ -12,7 +12,7 @@
     <Reference Include="System.IO.Compression" Condition="$(TargetFramework.StartsWith('net4'))" />
   </ItemGroup>
   <ItemGroup>
-    <!-- This package erroneously contains /netcoreapp3.1/SgmlReader.exe and /netcoreapp3.1/SgmlReaderDll.dll.
+    <!-- This package erroneously contains /net6.0/SgmlReader.exe and /net6.0/SgmlReaderDll.dll.
          We are going to use a package reference to download the nuget, and a regular reference to actually
          reference the correct assembly. -->
     <PackageReference Include="Microsoft.Xml.SgmlReader" Version="1.8.16" ExcludeAssets="Compile" GeneratePathProperty="true" />


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/5891
Context: https://github.com/xamarin/xamarin-android/commit/e59f6493fedd789cbd3157d369104516cfffd3f0

xamarin-android should imminently be building libraries targeting `net6.0` instead of `netcoreapp3.1`.

We should be able to do this now, because Mono 6.12.0.137 supports building both .NET 5.0 and .NET 6.0.