### PR TITLE
[java-source-utils] Use mavenCentral, not jcenter

### DIFF
--- a/tools/java-source-utils/build.gradle
+++ b/tools/java-source-utils/build.gradle
@@ -23,9 +23,9 @@ java {
 }
 
 repositories {
-    // Use jcenter for resolving dependencies.
+    // Use maven central for resolving dependencies.
     // You can declare any Maven/Ivy/file repository here.
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
Context: https://blog.gradle.org/jcenter-shutdown
Context: https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

JCenter is shutting down.  It is no longer browsable as of May 1,
and artifacts hosted on JCenter will not be accessible as of
February 1, 2022.

Stop using JCenter, and instead use [Maven Central][0].

[0]: https://search.maven.org/