### PR TITLE
[generator] Fix invalid code generated for EventArgs classes with parameter arrays.

### DIFF
--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteInterfaceEventArgsWithParamArray.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteInterfaceEventArgsWithParamArray.txt
@@ -1,0 +1,14 @@
+// event args for com.xamarin.android.MyListener.onDoSomething
+public partial class MyEventArgs : global::System.EventArgs {
+
+	public MyEventArgs (params Java.Lang.Object[] args)
+	{
+		this.args = args;
+	}
+
+	Java.Lang.Object[] args;
+	public Java.Lang.Object[] Args {
+		get { return args; }
+	}
+}
+

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteInterfaceEventArgsWithParamArray.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteInterfaceEventArgsWithParamArray.txt
@@ -1,0 +1,14 @@
+// event args for com.xamarin.android.MyListener.onDoSomething
+public partial class MyEventArgs : global::System.EventArgs {
+
+	public MyEventArgs (params Java.Lang.Object[]? args)
+	{
+		this.args = args;
+	}
+
+	Java.Lang.Object[]? args;
+	public Java.Lang.Object[]? Args {
+		get { return args; }
+	}
+}
+

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
@@ -1041,6 +1041,32 @@ namespace generatortests
 		}
 
 		[Test]
+		public void WriteInterfaceEventArgsWithParamArray ()
+		{
+			var xml = @"<api>
+			  <package name='java.lang' jni-name='java/lang'>
+			    <class abstract='false' deprecated='not deprecated' final='false' name='Object' static='false' visibility='public' jni-signature='Ljava/lang/Object;' />
+			  </package>
+			  <package name='com.xamarin.android' jni-name='com/xamarin/android'>
+			    <interface abstract='true' deprecated='not deprecated' final='false' name='MyListener' static='true' visibility='public' jni-signature='Lcom/xamarin/android/MyListener;'>
+			      <method abstract='true' deprecated='deprecated' final='false' name='onDoSomething' jni-signature='([Ljava/lang/Object;)V' bridge='false' native='false' return='void' jni-return='V' static='false' synchronized='false' synthetic='false' visibility='public'>
+			        <parameter name='args' type='java.lang.Object...' jni-type='[Ljava/lang/Object;'></parameter>
+			      </method>
+			    </interface>
+			  </package>
+			</api>";
+
+			var gens = ParseApiDefinition (xml);
+			var iface = gens.Single (g => g.Name == "IMyListener");
+
+			generator.Context.ContextTypes.Push (iface);
+			generator.WriteInterfaceEventArgs (iface as InterfaceGen, iface.Methods [0], string.Empty);
+			generator.Context.ContextTypes.Pop ();
+
+			Assert.AreEqual (GetExpected (nameof (WriteInterfaceEventArgsWithParamArray)), writer.ToString ().NormalizeLineEndings ());
+		}
+
+		[Test]
 		public void WriteInterfaceEventHandler ()
 		{
 			var iface = SupportTypeBuilder.CreateInterface ("java.code.IMyInterface", options);

--- a/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/CodeGenerator.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/CodeGenerator.cs
@@ -598,10 +598,14 @@ namespace MonoDroid.Generation
 						if (p.IsSender)
 							continue;
 						writer.WriteLine ();
-						//var safeTypeName = p.Type.StartsWith ("params ", StringComparison.Ordinal) ? p.Type.Substring ("params ".Length) : p.Type;
-						writer.WriteLine ("{0}\t{1} {2};", indent, opt.GetTypeReferenceName (p), opt.GetSafeIdentifier (p.Name));
+
+						// Remove "params" from things like "global::Java.Lang.Object[]"
+						var type_reference_name = opt.GetTypeReferenceName (p);
+						type_reference_name = type_reference_name.StartsWith ("params ", StringComparison.Ordinal) ? type_reference_name.Substring ("params ".Length) : type_reference_name;
+
+						writer.WriteLine ("{0}\t{1} {2};", indent, type_reference_name, opt.GetSafeIdentifier (p.Name));
 						// AbsListView.IMultiChoiceModeListener.onItemCheckedStateChanged() hit this strict name check, at parameter "@checked".
-						writer.WriteLine ("{0}\tpublic {1} {2} {{", indent, opt.GetTypeReferenceName (p), p.PropertyName);
+						writer.WriteLine ("{0}\tpublic {1} {2} {{", indent, type_reference_name, p.PropertyName);
 						writer.WriteLine ("{0}\t\tget {{ return {1}; }}", indent, opt.GetSafeIdentifier (p.Name));
 						writer.WriteLine ("{0}\t}}", indent);
 					}


### PR DESCRIPTION
Fixes: #817

If we are creating an `EventArgs` class for a method that has a parameter array like this:

```
public interface SomeListener {
    void onSomeNotification (Object... args);
}
```

We are generating the following invalid C# code:

```
public partial class SomeEventArgs : global::System.EventArgs {
    params global::Java.Lang.Object[] args;

    public params global::Java.Lang.Object[] Args {
        get { return args; }
    }
}
```

This commit removes the extraneous `params` output.