### PR TITLE
[generator] Fix NRE from return type not getting set for abstract methods with generics.

### DIFF
--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
@@ -1286,15 +1286,13 @@ namespace generatortests
 			  </package>
 
 			  <package name='com.example' jni-name='com/example'>
-			    <interface abstract='true' deprecated='not deprecated' final='false' name='FlowIterator' static='false' visibility='public' jni-signature='Lcom/mob/tools/java8/FlowIterator;'>
+			    <interface abstract='true' deprecated='not deprecated' final='false' name='FlowIterator' static='false' visibility='public' jni-signature='Lcom/example/FlowIterator;'
 			      <typeParameters>
 			        <typeParameter name='R' classBound='java.lang.Object' jni-classBound='Ljava/lang/Object;'></typeParameter>
 			      </typeParameters>
-			      <method abstract='true' deprecated='not deprecated' final='false' name='next' jni-signature='(I)R' bridge='false' native='false' return='R' jni-return='TR;' static='false' synchronized='false' synthetic='false' visibility='public'>
-			        <parameter name='count' type='int' jni-type='I'></parameter>
-			      </method>
+			      <method abstract='true' deprecated='not deprecated' final='false' name='next' jni-signature='()Ljava/lang/Object;' bridge='false' native='false' return='R' jni-return='TR;' static='false' synchronized='false' synthetic='false' visibility='public' />
 			    </interface>
-			    <class abstract='true' deprecated='not deprecated' extends='java.lang.Object' extends-generic-aware='java.lang.Object' jni-extends='Ljava/lang/Object;' final='false' name='RangeIterator' static='true' visibility='public' jni-signature='Lcom/example/RangeIterator;'>
+			    <class abstract='true' deprecated='not deprecated' extends='java.lang.Object' extends-generic-aware='java.lang.Object' jni-extends='Ljava/lang/Object;' final='false' name='FlowIterator.RangeIterator' static='true' visibility='public' jni-signature='Lcom/example/FlowIterator$RangeIterator;'>
 			      <implements name='com.example.FlowIterator' name-generic-aware='com.example.FlowIterator&lt;T&gt;' jni-type='Lcom/example/FlowIterator&lt;TT;&gt;;'></implements>
 			      <typeParameters>
 			        <typeParameter name='T' interfaceBounds='java.lang.Comparable&lt;T&gt;' jni-interfaceBounds='Ljava/lang/Comparable&lt;TT;&gt;;'>
@@ -1303,14 +1301,12 @@ namespace generatortests
 			          </genericConstraints>
 			        </typeParameter>
 			      </typeParameters>
-			      <method abstract='false' deprecated='not deprecated' final='false' name='next' jni-signature='(I)Ljava/lang/Comparable;' bridge='false' native='false' return='T' jni-return='TT;' static='false' synchronized='false' synthetic='false' visibility='public'>
-			        <parameter name='count' type='int' jni-type='I'></parameter>
-			      </method>
+			      <method abstract='false' deprecated='not deprecated' final='false' name='next' jni-signature='()Ljava/lang/Comparable;' bridge='false' native='false' return='T' jni-return='TT;' static='false' synchronized='false' synthetic='false' visibility='public' />
 			    </class>
 			  </package>
 			</api>");
 
-			var iface = gens.OfType<ClassGen> ().Single (c => c.Name == "RangeIterator");
+			var iface = gens.OfType<ClassGen> ().Single (c => c.Name == "FlowIterator.RangeIterator");
 			var method = iface.Methods.Single ();
 
 			var bmad = new BoundMethodAbstractDeclaration (iface, method, options, null);
@@ -1318,7 +1314,7 @@ namespace generatortests
 
 			bmad.Write (source_writer);
 
-			var expected = @"Java.Lang.Object Com.Example.RangeIterator.Next (int count)
+			var expected = @"Java.Lang.Object Com.Example.RangeIterator.Next ()
 					{
 					  throw new NotImplementedException ();
 					}";

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
@@ -1306,15 +1306,16 @@ namespace generatortests
 			  </package>
 			</api>");
 
-			var iface = gens.OfType<ClassGen> ().Single (c => c.Name == "FlowIterator.RangeIterator");
-			var method = iface.Methods.Single ();
+			var declIface = gens.OfType<InterfaceGen> ().Single (c => c.Name == "IFlowIterator");
+			var declClass = declIface.NestedTypes.OfType<ClassGen> ().Single (c => c.Name == "FlowIteratorRangeIterator");
+			var method = declClass.Methods.Single ();
 
-			var bmad = new BoundMethodAbstractDeclaration (iface, method, options, null);
+			var bmad = new BoundMethodAbstractDeclaration (declClass, method, options, null);
 			var source_writer = new CodeWriter (writer);
 
 			bmad.Write (source_writer);
 
-			var expected = @"Java.Lang.Object Com.Example.RangeIterator.Next ()
+			var expected = @"Java.Lang.Object Com.Example.FlowIteratorRangeIterator.Next ()
 					{
 					  throw new NotImplementedException ();
 					}";

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
@@ -1286,7 +1286,7 @@ namespace generatortests
 			  </package>
 
 			  <package name='com.example' jni-name='com/example'>
-			    <interface abstract='true' deprecated='not deprecated' final='false' name='FlowIterator' static='false' visibility='public' jni-signature='Lcom/example/FlowIterator;'
+			    <interface abstract='true' deprecated='not deprecated' final='false' name='FlowIterator' static='false' visibility='public' jni-signature='Lcom/example/FlowIterator;'>
 			      <typeParameters>
 			        <typeParameter name='R' classBound='java.lang.Object' jni-classBound='Ljava/lang/Object;'></typeParameter>
 			      </typeParameters>

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using generator.SourceWriters;
 using MonoDroid.Generation;
 using NUnit.Framework;
 using Xamarin.Android.Binder;
+using Xamarin.SourceWriter;
 
 namespace generatortests
 {
@@ -1270,6 +1272,59 @@ namespace generatortests
 			var result = writer.ToString ().NormalizeLineEndings ();
 			Assert.True (result.Contains ("internal static new IntPtr class_ref".NormalizeLineEndings ()));
 			Assert.False (result.Contains ("internal static IntPtr class_ref".NormalizeLineEndings ()));
+		}
+
+		[Test]
+		public void WriteBoundMethodAbstractDeclarationWithGenericReturn ()
+		{
+			// Fix a case where the ReturnType of a class method implementing a generic interface method
+			// that has a generic parameter type return (like T) wasn't getting set, resulting in a NRE.
+			var gens = ParseApiDefinition (@"<api>
+			  <package name='java.lang' jni-name='java/lang'>
+			    <class abstract='false' deprecated='not deprecated' final='false' name='Object' static='false' visibility='public' jni-signature='Ljava/lang/Object;' />
+			    <interface abstract='false' deprecated='not deprecated' final='false' name='Comparable' static='false' visibility='public' jni-signature='Ljava/lang/Double;' />
+			  </package>
+
+			  <package name='com.example' jni-name='com/example'>
+			    <interface abstract='true' deprecated='not deprecated' final='false' name='FlowIterator' static='false' visibility='public' jni-signature='Lcom/mob/tools/java8/FlowIterator;'>
+			      <typeParameters>
+			        <typeParameter name='R' classBound='java.lang.Object' jni-classBound='Ljava/lang/Object;'></typeParameter>
+			      </typeParameters>
+			      <method abstract='true' deprecated='not deprecated' final='false' name='next' jni-signature='(I)R' bridge='false' native='false' return='R' jni-return='TR;' static='false' synchronized='false' synthetic='false' visibility='public'>
+			        <parameter name='count' type='int' jni-type='I'></parameter>
+			      </method>
+			    </interface>
+			    <class abstract='true' deprecated='not deprecated' extends='java.lang.Object' extends-generic-aware='java.lang.Object' jni-extends='Ljava/lang/Object;' final='false' name='RangeIterator' static='true' visibility='public' jni-signature='Lcom/example/RangeIterator;'>
+			      <implements name='com.example.FlowIterator' name-generic-aware='com.example.FlowIterator&lt;T&gt;' jni-type='Lcom/example/FlowIterator&lt;TT;&gt;;'></implements>
+			      <typeParameters>
+			        <typeParameter name='T' interfaceBounds='java.lang.Comparable&lt;T&gt;' jni-interfaceBounds='Ljava/lang/Comparable&lt;TT;&gt;;'>
+			          <genericConstraints>
+			            <genericConstraint type='java.lang.Comparable&lt;T&gt;'></genericConstraint>
+			          </genericConstraints>
+			        </typeParameter>
+			      </typeParameters>
+			      <method abstract='false' deprecated='not deprecated' final='false' name='next' jni-signature='(I)Ljava/lang/Comparable;' bridge='false' native='false' return='T' jni-return='TT;' static='false' synchronized='false' synthetic='false' visibility='public'>
+			        <parameter name='count' type='int' jni-type='I'></parameter>
+			      </method>
+			    </class>
+			  </package>
+			</api>");
+
+			var iface = gens.OfType<ClassGen> ().Single (c => c.Name == "RangeIterator");
+			var method = iface.Methods.Single ();
+
+			var bmad = new BoundMethodAbstractDeclaration (iface, method, options, null);
+			var source_writer = new CodeWriter (writer);
+
+			bmad.Write (source_writer);
+
+			var expected = @"Java.Lang.Object Com.Example.RangeIterator.Next (int count)
+					{
+					  throw new NotImplementedException ();
+					}";
+
+			// Ignore nullable operator so this test works on all generators  ;)
+			Assert.AreEqual (expected.NormalizeLineEndings (), writer.ToString ().NormalizeLineEndings ().Replace ("?", ""));
 		}
 	}
 }

--- a/tools/generator/SourceWriters/BoundMethodAbstractDeclaration.cs
+++ b/tools/generator/SourceWriters/BoundMethodAbstractDeclaration.cs
@@ -19,6 +19,9 @@ namespace generator.SourceWriters
 			this.method = method;
 			this.opt = opt;
 
+			ReturnType = new TypeReferenceWriter (opt.GetTypeReferenceName (method.RetVal));
+			this.AddMethodParameters (method.Parameters, opt);
+
 			if (method.RetVal.IsGeneric && gen != null) {
 				Name = method.Name;
 				ExplicitInterfaceImplementation = opt.GetOutputName (gen.FullName);
@@ -35,7 +38,6 @@ namespace generator.SourceWriters
 			IsAbstract = true;
 			IsShadow = impl.RequiresNew (method.Name, method);
 			SetVisibility (method.Visibility);
-			ReturnType = new TypeReferenceWriter (opt.GetTypeReferenceName (method.RetVal));
 
 			NewFirst = true;
 
@@ -51,7 +53,6 @@ namespace generator.SourceWriters
 			Attributes.Add (new RegisterAttr (method.JavaName, method.JniSignature, method.ConnectorName, additionalProperties: method.AdditionalAttributeString ()));
 
 			SourceWriterExtensions.AddMethodCustomAttributes (Attributes, method);
-			this.AddMethodParameters (method.Parameters, opt);
 		}
 
 		public override void Write (CodeWriter writer)


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/5921

For the following generic-laden Java:
```
public interface MyInterface<R> {
  R Next (int count);
}

public abstract class MyClass<T> implements MyInterface<T> {
  public T Next (int count);
}
```

We need to generate an explicit method declaration:
```
Java.Lang.Object Com.Example.IMyInterface.Next (int count)
{
  throw new NotImplementedException ();
}
```

However when we did the `generator` refactor this code code path was not tested, and the code short-circuits, bypassing setting the `ReturnType` and `Parameters` collection.

Attempting to generate the method results in an NRE:
```
ReturnType.WriteTypeReference (writer);

   at Xamarin.SourceWriter.MethodWriter.WriteReturnType(CodeWriter writer) in C:\code\xamarin-android-backport\external\Java.Interop\src\Xamarin.SourceWriter\Models\MethodWriter.cs:line 154
```

This commit ensures the `ReturnType` and `Parameters` collection is set before the method returns.

Pre-refactor code: https://github.com/xamarin/java.interop/blob/main/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/CodeGenerator.cs#L1175-L1181