### PR TITLE
[generator] Handle multiple @return javadoc values

### DIFF
--- a/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/SourceJavadocToXmldocGrammar.BlockTagsBnfTerms.cs
+++ b/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/SourceJavadocToXmldocGrammar.BlockTagsBnfTerms.cs
@@ -121,13 +121,10 @@ namespace Java.Interop.Tools.JavaSource {
 							AstNodeToXmlContent (parseNode.ChildNodes [1]));
 						FinishParse (context, parseNode).Returns.Add (r);
 						parseNode.AstNode = r;
-
 					} else {
 						var r = jdi.Returns.First () as XElement;
 						if (r != null) {
 							r.Add (" ", AstNodeToXmlContent (parseNode.ChildNodes [1]));
-							FinishParse (context, parseNode).Returns.Clear ();
-							FinishParse (context, parseNode).Returns.Add (r);
 							parseNode.AstNode = r;
 						}
 					}

--- a/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/SourceJavadocToXmldocGrammar.BlockTagsBnfTerms.cs
+++ b/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/SourceJavadocToXmldocGrammar.BlockTagsBnfTerms.cs
@@ -114,10 +114,23 @@ namespace Java.Interop.Tools.JavaSource {
 					if (!grammar.ShouldImport (ImportJavadoc.ReturnTag)) {
 						return;
 					}
-					var r = new XElement ("returns",
+					// When encountering multiple @return keys in a line, append subsequent @return key content to the original <returns> element.
+					var jdi = FinishParse (context, parseNode);
+					if (jdi.Returns.Count == 0) {
+						var r = new XElement ("returns",
 							AstNodeToXmlContent (parseNode.ChildNodes [1]));
-					FinishParse (context, parseNode).Returns.Add (r);
-					parseNode.AstNode   = r;
+						FinishParse (context, parseNode).Returns.Add (r);
+						parseNode.AstNode = r;
+
+					} else {
+						var r = jdi.Returns.First () as XElement;
+						if (r != null) {
+							r.Add (" ", AstNodeToXmlContent (parseNode.ChildNodes [1]));
+							FinishParse (context, parseNode).Returns.Clear ();
+							FinishParse (context, parseNode).Returns.Add (r);
+							parseNode.AstNode = r;
+						}
+					}
 				};
 
 				SeeDeclaration.Rule = "@see" + BlockValues;

--- a/tests/Java.Interop.Tools.JavaSource-Tests/SourceJavadocToXmldocParserTests.cs
+++ b/tests/Java.Interop.Tools.JavaSource-Tests/SourceJavadocToXmldocParserTests.cs
@@ -17,21 +17,19 @@ namespace Java.Interop.Tools.JavaSource.Tests
 	[TestFixture]
 	public class SourceJavadocToXmldocParserTests : SourceJavadocToXmldocGrammarFixture {
 
-		[Test]
-		public void TryParse ()
+		[Test, TestCaseSource (nameof (TryParse_Success))]
+		public void TryParse (ParseResult parseResult)
 		{
-			foreach (var values in TryParse_Success) {
-				ParseTree parseTree;
-				var p = new SourceJavadocToXmldocParser (XmldocStyle.Full);
-				var n = p.TryParse (values.Javadoc, null, out parseTree);
-				Assert.IsFalse (parseTree.HasErrors (), DumpMessages (parseTree, p));
-				Assert.AreEqual (values.FullXml, GetMemberXml (n), $"while parsing input: ```{values.Javadoc}```");
+			ParseTree parseTree;
+			var p = new SourceJavadocToXmldocParser (XmldocStyle.Full);
+			var n = p.TryParse (parseResult.Javadoc, null, out parseTree);
+			Assert.IsFalse (parseTree.HasErrors (), DumpMessages (parseTree, p));
+			Assert.AreEqual (parseResult.FullXml, GetMemberXml (n), $"while parsing input: ```{parseResult.Javadoc}```");
 
-				p = new SourceJavadocToXmldocParser (XmldocStyle.IntelliSense);
-				n = p.TryParse (values.Javadoc, null, out parseTree);
-				Assert.IsFalse (parseTree.HasErrors (), DumpMessages (parseTree, p));
-				Assert.AreEqual (values.IntelliSenseXml, GetMemberXml (n), $"while parsing input: ```{values.Javadoc}```");
-			}
+			p = new SourceJavadocToXmldocParser (XmldocStyle.IntelliSense);
+			n = p.TryParse (parseResult.Javadoc, null, out parseTree);
+			Assert.IsFalse (parseTree.HasErrors (), DumpMessages (parseTree, p));
+			Assert.AreEqual (parseResult.IntelliSenseXml, GetMemberXml (n), $"while parsing input: ```{parseResult.Javadoc}```");
 		}
 
 		static string GetMemberXml (IEnumerable<XNode> members)
@@ -40,7 +38,7 @@ namespace Java.Interop.Tools.JavaSource.Tests
 			return e.ToString ();
 		}
 
-		static readonly ParseResult[] TryParse_Success = new ParseResult[]{
+		public static readonly ParseResult[] TryParse_Success = new ParseResult[]{
 			new ParseResult {
 				Javadoc = "Summary.\n\nP2.\n\n<p>Hello!</p>",
 				FullXml = @"<member>
@@ -78,6 +76,17 @@ namespace Java.Interop.Tools.JavaSource.Tests
   <returns>
     <c>true</c> if something
  or other; otherwise <c>false</c>.</returns>
+</member>",
+			},
+			new ParseResult {
+				Javadoc = "@return {@code true} if something else @return {@code false}.",
+				FullXml = @"<member>
+  <returns>
+    <c>true</c> if something else <c>false</c>.</returns>
+</member>",
+				IntelliSenseXml = @"<member>
+  <returns>
+    <c>true</c> if something else <c>false</c>.</returns>
 </member>",
 			},
 			new ParseResult {
@@ -166,7 +175,7 @@ more description here.</para>
 			},
 		};
 
-		class ParseResult {
+		public class ParseResult {
 			public  string  Javadoc;
 			public  string  FullXml;
 			public  string  IntelliSenseXml;


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/5485

In an attempt to generate updated documentation for API 30 I've noticed
a minor issue in generator.  When a `<javadoc>` element contains
multiple @return values, we will generate multiple `<returns>` elements
in our C# documentation.  This results in invalid C# documentation with
partially missing return information, and the second `<returns>` element
value is not displayed in IDE intellisense.  This also causes an issue
when the xml is processed by `mdoc`.  These extra return lines will
continue to be appended to the `mdoc` output every time the tool is ran
against the invalid `Mono.Android.xml`.