### PR TITLE
[generator] Ignore types without names.

### DIFF
--- a/tests/generator-Tests/Unit-Tests/XmlApiImporterTests.cs
+++ b/tests/generator-Tests/Unit-Tests/XmlApiImporterTests.cs
@@ -266,5 +266,41 @@ namespace generatortests
 			Assert.AreEqual (0, klass.Fields.Count);
 			Assert.AreEqual (0, klass.Methods.Count);
 		}
+
+		[Test]
+		public void IgnoreTypesWithInvalidNames ()
+		{
+			var xml = XDocument.Parse (@"
+				<api>
+					<package name='com.example.test' jni-name='com/example/test'>
+						<class name='' visibility='public' />
+						<class name='Document.' visibility='public' />
+						<interface name='' visibility='public' />
+						<interface name='Document.' visibility='public' />
+					</package>
+				</api>");
+
+			var gens = XmlApiImporter.Parse (xml, opt);
+
+			// None of these should be parsed because they have invalid names
+			Assert.AreEqual (0, gens.Count);
+		}
+
+		[Test]
+		public void IgnoreUserObfuscatedTypes ()
+		{
+			var xml = XDocument.Parse (@"
+				<api>
+					<package name='com.example.test' jni-name='com/example/test'>
+						<class name='MyClass' visibility='public' obfuscated='true' />
+						<interface name='MyInterface' visibility='public' obfuscated='true' />
+					</package>
+				</api>");
+
+			var gens = XmlApiImporter.Parse (xml, opt);
+
+			// None of these should be parsed because the user has said they are obfuscated
+			Assert.AreEqual (0, gens.Count);
+		}
 	}
 }

--- a/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
@@ -61,14 +61,12 @@ namespace MonoDroid.Generation
 
 				switch (elem.Name.LocalName) {
 					case "class":
-						if (elem.XGetAttribute ("obfuscated") == "true")
-							continue;
-						gen = CreateClass (ns, elem, options);
+						if (ShouldBind (elem))
+							gen = CreateClass (ns, elem, options);
 						break;
 					case "interface":
-						if (elem.XGetAttribute ("obfuscated") == "true")
-							continue;
-						gen = CreateInterface (ns, elem, options);
+						if (ShouldBind (elem))
+							gen = CreateInterface (ns, elem, options);
 						break;
 					default:
 						Report.LogCodedWarning (0, Report.WarningUnexpectedPackageChildNode, elem.Name.ToString ());
@@ -521,6 +519,21 @@ namespace MonoDroid.Generation
 				model.LineNumber = info.LineNumber;
 				model.LinePosition = info.LinePosition;
 			}
+		}
+
+		static bool ShouldBind (XElement elem)
+		{
+			// Don't bind things the user has said are "obfuscated"
+			if (elem.XGetAttribute ("obfuscated") == "true")
+				return false;
+
+			var java_name = elem.XGetAttribute ("name");
+
+			// Ignore types that do not have a name (nested classes would end in a period like "Document.")
+			if (!java_name.HasValue () || java_name.EndsWith (".", StringComparison.Ordinal))
+				return false;
+
+			return true;
 		}
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/xamarin/java.interop/issues/835

Somehow Google has compiled `firebase-firestore.aar` to contain a class with a dollar sign in its name:
```
    <class
      abstract="false"
      deprecated="not deprecated"
      jni-extends="Ljava/lang/Object;"
      extends="java.lang.Object"
      extends-generic-aware="java.lang.Object"
      final="false"
      name="Document."
      jni-signature="Lcom/google/firebase/firestore/model/Document$;"
      source-file-name="Document.java"
      static="false"
      visibility="public" />
```

This causes an `IndexOutOfRangeException` for `generator` when it tries to parse `Document.` into a parent class name and nested class name.

```
  Unhandled Exception: (TaskId:666)
  System.IndexOutOfRangeException: Index was outside the bounds of the array. (TaskId:666)

    at MonoDroid.Generation.XmlApiImporter.CreateGenBaseSupport (System.Xml.Linq.XElement pkg, System.Xml.Linq.XElement elem, System.Boolean isInterface) [0x0021c] in <fc31e3500e9a44b181504040e11d2f7d>:0  (TaskId:666)
    at MonoDroid.Generation.XmlApiImporter.CreateClass (System.Xml.Linq.XElement pkg, System.Xml.Linq.XElement elem, 
    at MonoDroid.Generation.Parser.ParsePackage (System.Xml.Linq.XElement ns, System.Predicate`1[T] p) [0x00087] in 
    at MonoDroid.Generation.Parser.ParsePackage (System.Xml.Linq.XElement ns) [0x00000] in 
    at MonoDroid.Generation.Parser.Parse (System.Xml.Linq.XDocument doc, System.Collections.Generic.IEnumerable`1[T] fixups, 
    at MonoDroid.Generation.Parser.Parse (System.String filename, System.Collections.Generic.IEnumerable`1[T] fixups, 
    at Xamarin.Android.Binder.CodeGenerator.Run (Xamarin.Android.Binder.CodeGeneratorOptions options, 
    at Xamarin.Android.Binder.CodeGenerator.Run (Xamarin.Android.Binder.CodeGeneratorOptions options) [0x0001b] in 
    at Xamarin.Android.Binder.CodeGenerator.Main (System.String[] args) [0x0000c] in <fc31e3500e9a44b181504040e11d2f7d>:0  
```

We cannot reproduce *how* to do this, so we're currently assuming this is some sort of bytecode manipulation.  As such, we are going to have `generator` ignore types with an empty name and types that end in a period, which would indicate a nested type with an empty name.