### PR TITLE
[generator] Ensure "global::" is prepended to generic return casts.

### DIFF
--- a/tests/generator-Tests/expected.ji/Adapters/Xamarin.Test.AbsSpinner.cs
+++ b/tests/generator-Tests/expected.ji/Adapters/Xamarin.Test.AbsSpinner.cs
@@ -123,7 +123,7 @@ namespace Xamarin.Test {
 				const string __id = "getAdapter.()Lxamarin/test/Adapter;";
 				try {
 					var __rm = _members.InstanceMethods.InvokeAbstractObjectMethod (__id, this, null);
-					return (Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+					return (global::Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (__rm.Handle, JniHandleOwnership.TransferLocalRef);
 				} finally {
 				}
 			}

--- a/tests/generator-Tests/expected.ji/Adapters/Xamarin.Test.AdapterView.cs
+++ b/tests/generator-Tests/expected.ji/Adapters/Xamarin.Test.AdapterView.cs
@@ -109,7 +109,7 @@ namespace Xamarin.Test {
 				const string __id = "getAdapter.()Lxamarin/test/Adapter;";
 				try {
 					var __rm = _members.InstanceMethods.InvokeAbstractObjectMethod (__id, this, null);
-					return (Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+					return (global::Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (__rm.Handle, JniHandleOwnership.TransferLocalRef);
 				} finally {
 				}
 			}

--- a/tests/generator-Tests/expected.ji/NormalMethods/Xamarin.Test.A.cs
+++ b/tests/generator-Tests/expected.ji/NormalMethods/Xamarin.Test.A.cs
@@ -65,7 +65,7 @@ namespace Xamarin.Test {
 					JniArgumentValue* __args = stackalloc JniArgumentValue [1];
 					__args [0] = new JniArgumentValue (index);
 					var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, __args);
-					return (Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+					return (global::Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (__rm.Handle, JniHandleOwnership.TransferLocalRef);
 				} finally {
 				}
 			}

--- a/tests/generator-Tests/expected.ji/NormalMethods/Xamarin.Test.C.cs
+++ b/tests/generator-Tests/expected.ji/NormalMethods/Xamarin.Test.C.cs
@@ -62,7 +62,7 @@ namespace Xamarin.Test {
 				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
 				__args [0] = new JniArgumentValue (index);
 				var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, __args);
-				return (Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+				return (global::Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (__rm.Handle, JniHandleOwnership.TransferLocalRef);
 			} finally {
 			}
 		}

--- a/tests/generator-Tests/expected.ji/TestInterface/Test.ME.IGenericPropertyInterface.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Test.ME.IGenericPropertyInterface.cs
@@ -115,7 +115,7 @@ namespace Test.ME {
 			get {
 				if (id_getObject == IntPtr.Zero)
 					id_getObject = JNIEnv.GetMethodID (class_ref, "getObject", "()Ljava/lang/Object;");
-				return (Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_getObject), JniHandleOwnership.TransferLocalRef);
+				return (global::Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_getObject), JniHandleOwnership.TransferLocalRef);
 			}
 			set {
 				if (id_setObject_Ljava_lang_Object_ == IntPtr.Zero)

--- a/tests/generator-Tests/expected/Adapters/Xamarin.Test.AbsSpinner.cs
+++ b/tests/generator-Tests/expected/Adapters/Xamarin.Test.AbsSpinner.cs
@@ -113,7 +113,7 @@ namespace Xamarin.Test {
 				if (id_getAdapter == IntPtr.Zero)
 					id_getAdapter = JNIEnv.GetMethodID (class_ref, "getAdapter", "()Lxamarin/test/Adapter;");
 				try {
-					return (Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_getAdapter), JniHandleOwnership.TransferLocalRef);
+					return (global::Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_getAdapter), JniHandleOwnership.TransferLocalRef);
 				} finally {
 				}
 			}

--- a/tests/generator-Tests/expected/Adapters/Xamarin.Test.AdapterView.cs
+++ b/tests/generator-Tests/expected/Adapters/Xamarin.Test.AdapterView.cs
@@ -86,7 +86,7 @@ namespace Xamarin.Test {
 				if (id_getAdapter == IntPtr.Zero)
 					id_getAdapter = JNIEnv.GetMethodID (class_ref, "getAdapter", "()Lxamarin/test/Adapter;");
 				try {
-					return (Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_getAdapter), JniHandleOwnership.TransferLocalRef);
+					return (global::Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_getAdapter), JniHandleOwnership.TransferLocalRef);
 				} finally {
 				}
 			}

--- a/tests/generator-Tests/expected/NormalMethods/Xamarin.Test.A.cs
+++ b/tests/generator-Tests/expected/NormalMethods/Xamarin.Test.A.cs
@@ -58,9 +58,9 @@ namespace Xamarin.Test {
 					__args [0] = new JValue (index);
 
 					if (((object) this).GetType () == ThresholdType)
-						return (Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_setCustomDimension_I, __args), JniHandleOwnership.TransferLocalRef);
+						return (global::Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_setCustomDimension_I, __args), JniHandleOwnership.TransferLocalRef);
 					else
-						return (Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallNonvirtualObjectMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "setCustomDimension", "(I)Lxamarin/test/A$B;"), __args), JniHandleOwnership.TransferLocalRef);
+						return (global::Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallNonvirtualObjectMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "setCustomDimension", "(I)Lxamarin/test/A$B;"), __args), JniHandleOwnership.TransferLocalRef);
 				} finally {
 				}
 			}

--- a/tests/generator-Tests/expected/NormalMethods/Xamarin.Test.C.cs
+++ b/tests/generator-Tests/expected/NormalMethods/Xamarin.Test.C.cs
@@ -54,9 +54,9 @@ namespace Xamarin.Test {
 				__args [0] = new JValue (index);
 
 				if (((object) this).GetType () == ThresholdType)
-					return (Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_setCustomDimension_I, __args), JniHandleOwnership.TransferLocalRef);
+					return (global::Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_setCustomDimension_I, __args), JniHandleOwnership.TransferLocalRef);
 				else
-					return (Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallNonvirtualObjectMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "setCustomDimension", "(I)Lxamarin/test/C;"), __args), JniHandleOwnership.TransferLocalRef);
+					return (global::Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallNonvirtualObjectMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "setCustomDimension", "(I)Lxamarin/test/C;"), __args), JniHandleOwnership.TransferLocalRef);
 			} finally {
 			}
 		}

--- a/tests/generator-Tests/expected/TestInterface/Test.ME.IGenericPropertyInterface.cs
+++ b/tests/generator-Tests/expected/TestInterface/Test.ME.IGenericPropertyInterface.cs
@@ -100,7 +100,7 @@ namespace Test.ME {
 			get {
 				if (id_getObject == IntPtr.Zero)
 					id_getObject = JNIEnv.GetMethodID (class_ref, "getObject", "()Ljava/lang/Object;");
-				return (Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_getObject), JniHandleOwnership.TransferLocalRef);
+				return (global::Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_getObject), JniHandleOwnership.TransferLocalRef);
 			}
 			set {
 				if (id_setObject_Ljava_lang_Object_ == IntPtr.Zero)

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/GenericTypeParameter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/GenericTypeParameter.cs
@@ -72,7 +72,7 @@ namespace MonoDroid.Generation {
 
 		public string FromNative (CodeGenerationOptions opt, string varname, bool owned)
 		{
-			return String.Format ("({0}{4}) global::Java.Lang.Object.GetObject<{3}> ({1}, {2})", type, varname, owned ? "JniHandleOwnership.TransferLocalRef" : "JniHandleOwnership.DoNotTransfer", opt.GetOutputName (FullName), opt.NullableOperator);
+			return String.Format ("({0}{4}) global::Java.Lang.Object.GetObject<{3}> ({1}, {2})", opt.GetOutputName (type), varname, owned ? "JniHandleOwnership.TransferLocalRef" : "JniHandleOwnership.DoNotTransfer", opt.GetOutputName (FullName), opt.NullableOperator);
 		}
 
 		public string GetGenericType (Dictionary<string, string> mappings)


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/5894

When creating the cast from a generic type parameter (which is currently always JLO), `global::` is not prepended to the type cast.  

```
return (Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (__rm.Handle, JniHandleOwnership.TransferLocalRef);
```

This creates a compilation error if the bound type is in a namespace that ends in "Java", like "MyProduct.Java".

```
Error CS0234: The type or namespace name 'Lang' does not exist in the namespace 'MyProduct.Java'.
```

Fix this by ensuring the cast output goes through our standard type formatting method which adds `global::` when needed.