### PR TITLE
[Java.Interop] Fix NRT warnings introduced by targeting 'net6.0'.

### DIFF
--- a/src/Java.Interop.Export/Java.Interop/MarshalMemberBuilder.cs
+++ b/src/Java.Interop.Export/Java.Interop/MarshalMemberBuilder.cs
@@ -158,7 +158,7 @@ namespace Java.Interop {
 			var marshalerContext    = new JniValueMarshalerContext (jvm, useVmVariable ? vm : null);
 			if (!method.IsStatic) {
 				var selfMarshaler   = Runtime.ValueManager.GetValueMarshaler (type);
-				self                = selfMarshaler.CreateParameterToManagedExpression (marshalerContext, context, 0, type);
+				self                = selfMarshaler.CreateParameterToManagedExpression (marshalerContext, context, type, 0);
 			}
 
 			var marshalParameters   = new List<ParameterExpression> (methodParameters.Length);
@@ -176,7 +176,7 @@ namespace Java.Interop {
 					else
 						throw new InvalidOperationException ("Should not be reached.");
 				}
-				var p           = marshaler.CreateParameterToManagedExpression (marshalerContext, np, methodParameters [i].Attributes, methodParameters [i].ParameterType);
+				var p           = marshaler.CreateParameterToManagedExpression (marshalerContext, np, methodParameters [i].ParameterType, methodParameters [i].Attributes);
 				marshalParameters.Add (np);
 				invokeParameters.Add (p);
 			}

--- a/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.cs
+++ b/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.cs
@@ -263,7 +263,7 @@ namespace Java.Interop {
 				JavaArray<Boolean>.DestroyArgumentState<JavaBooleanArray> (value, ref state, synchronize);
 			}
 
-			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize = 0, Type? targetType = null)
+			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, Type? targetType = null, ParameterAttributes synchronize = 0)
 	                {
 	                        Func<IntPtr, Type?, object?>  m = JavaBooleanArray.CreateMarshaledValue;
 
@@ -439,7 +439,7 @@ namespace Java.Interop {
 				JavaArray<SByte>.DestroyArgumentState<JavaSByteArray> (value, ref state, synchronize);
 			}
 
-			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize = 0, Type? targetType = null)
+			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, Type? targetType = null, ParameterAttributes synchronize = 0)
 	                {
 	                        Func<IntPtr, Type?, object?>  m = JavaSByteArray.CreateMarshaledValue;
 
@@ -615,7 +615,7 @@ namespace Java.Interop {
 				JavaArray<Char>.DestroyArgumentState<JavaCharArray> (value, ref state, synchronize);
 			}
 
-			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize = 0, Type? targetType = null)
+			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, Type? targetType = null, ParameterAttributes synchronize = 0)
 	                {
 	                        Func<IntPtr, Type?, object?>  m = JavaCharArray.CreateMarshaledValue;
 
@@ -791,7 +791,7 @@ namespace Java.Interop {
 				JavaArray<Int16>.DestroyArgumentState<JavaInt16Array> (value, ref state, synchronize);
 			}
 
-			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize = 0, Type? targetType = null)
+			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, Type? targetType = null, ParameterAttributes synchronize = 0)
 	                {
 	                        Func<IntPtr, Type?, object?>  m = JavaInt16Array.CreateMarshaledValue;
 
@@ -967,7 +967,7 @@ namespace Java.Interop {
 				JavaArray<Int32>.DestroyArgumentState<JavaInt32Array> (value, ref state, synchronize);
 			}
 
-			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize = 0, Type? targetType = null)
+			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, Type? targetType = null, ParameterAttributes synchronize = 0)
 	                {
 	                        Func<IntPtr, Type?, object?>  m = JavaInt32Array.CreateMarshaledValue;
 
@@ -1143,7 +1143,7 @@ namespace Java.Interop {
 				JavaArray<Int64>.DestroyArgumentState<JavaInt64Array> (value, ref state, synchronize);
 			}
 
-			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize = 0, Type? targetType = null)
+			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, Type? targetType = null, ParameterAttributes synchronize = 0)
 	                {
 	                        Func<IntPtr, Type?, object?>  m = JavaInt64Array.CreateMarshaledValue;
 
@@ -1319,7 +1319,7 @@ namespace Java.Interop {
 				JavaArray<Single>.DestroyArgumentState<JavaSingleArray> (value, ref state, synchronize);
 			}
 
-			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize = 0, Type? targetType = null)
+			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, Type? targetType = null, ParameterAttributes synchronize = 0)
 	                {
 	                        Func<IntPtr, Type?, object?>  m = JavaSingleArray.CreateMarshaledValue;
 
@@ -1495,7 +1495,7 @@ namespace Java.Interop {
 				JavaArray<Double>.DestroyArgumentState<JavaDoubleArray> (value, ref state, synchronize);
 			}
 
-			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize = 0, Type? targetType = null)
+			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, Type? targetType = null, ParameterAttributes synchronize = 0)
 	                {
 	                        Func<IntPtr, Type?, object?>  m = JavaDoubleArray.CreateMarshaledValue;
 

--- a/src/Java.Interop/Java.Interop/JniBuiltinMarshalers.cs
+++ b/src/Java.Interop/Java.Interop/JniBuiltinMarshalers.cs
@@ -259,7 +259,7 @@ namespace Java.Interop {
 			state   = new JniValueMarshalerState ();
 		}
 
-		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
+		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, Type? targetType, ParameterAttributes synchronize)
 		{
 		    return sourceValue;
 		}
@@ -386,7 +386,7 @@ namespace Java.Interop {
 			state   = new JniValueMarshalerState ();
 		}
 
-		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
+		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, Type? targetType, ParameterAttributes synchronize)
 		{
 		    return sourceValue;
 		}
@@ -513,7 +513,7 @@ namespace Java.Interop {
 			state   = new JniValueMarshalerState ();
 		}
 
-		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
+		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, Type? targetType, ParameterAttributes synchronize)
 		{
 		    return sourceValue;
 		}
@@ -640,7 +640,7 @@ namespace Java.Interop {
 			state   = new JniValueMarshalerState ();
 		}
 
-		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
+		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, Type? targetType, ParameterAttributes synchronize)
 		{
 		    return sourceValue;
 		}
@@ -767,7 +767,7 @@ namespace Java.Interop {
 			state   = new JniValueMarshalerState ();
 		}
 
-		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
+		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, Type? targetType, ParameterAttributes synchronize)
 		{
 		    return sourceValue;
 		}
@@ -894,7 +894,7 @@ namespace Java.Interop {
 			state   = new JniValueMarshalerState ();
 		}
 
-		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
+		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, Type? targetType, ParameterAttributes synchronize)
 		{
 		    return sourceValue;
 		}
@@ -1021,7 +1021,7 @@ namespace Java.Interop {
 			state   = new JniValueMarshalerState ();
 		}
 
-		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
+		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, Type? targetType, ParameterAttributes synchronize)
 		{
 		    return sourceValue;
 		}
@@ -1148,7 +1148,7 @@ namespace Java.Interop {
 			state   = new JniValueMarshalerState ();
 		}
 
-		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
+		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, Type? targetType, ParameterAttributes synchronize)
 		{
 		    return sourceValue;
 		}

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniMarshalMemberBuilder.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniMarshalMemberBuilder.cs
@@ -178,7 +178,7 @@ namespace Java.Interop {
 			return sourceValue;
 		}
 
-		public override Expression CreateParameterToManagedExpression (Java.Interop.Expressions.JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
+		public override Expression CreateParameterToManagedExpression (Java.Interop.Expressions.JniValueMarshalerContext context, ParameterExpression sourceValue, Type? targetType, ParameterAttributes synchronize)
 		{
 			return sourceValue;
 		}

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
@@ -176,7 +176,7 @@ namespace Java.Interop {
 			static  readonly    Type[]      EmptyTypeArray      = Array.Empty<Type> ();
 
 
-			public  Type    GetType (JniTypeSignature typeSignature)
+			public  Type?    GetType (JniTypeSignature typeSignature)
 			{
 				AssertValid ();
 

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -333,7 +333,7 @@ namespace Java.Interop
 				return GetActivationConstructor (fallbackType);
 			}
 
-			static ConstructorInfo GetActivationConstructor (Type type)
+			static ConstructorInfo? GetActivationConstructor (Type type)
 			{
 				return
 					(from c in type.GetConstructors (BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
@@ -673,7 +673,7 @@ namespace Java.Interop
 			return ReturnObjectReferenceToJni (context, sourceValue.Name, CreateIntermediaryExpressionFromManagedExpression (context, sourceValue));
 		}
 
-		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
+		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, Type targetType, ParameterAttributes synchronize)
 		{
 			var r   = Expression.Variable (targetType, sourceValue.Name + "_val");
 			context.LocalVariables.Add (r);
@@ -718,9 +718,9 @@ namespace Java.Interop
 			return ValueMarshaler.CreateParameterFromManagedExpression (context, sourceValue, synchronize);
 		}
 
-		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
+		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, Type targetType, ParameterAttributes synchronize)
 		{
-			return ValueMarshaler.CreateParameterToManagedExpression (context, sourceValue, synchronize, targetType);
+			return ValueMarshaler.CreateParameterToManagedExpression (context, sourceValue, targetType, synchronize);
 		}
 
 		public override Expression CreateReturnValueFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue)

--- a/src/Java.Interop/Java.Interop/JniStringValueMarshaler.cs
+++ b/src/Java.Interop/Java.Interop/JniStringValueMarshaler.cs
@@ -57,7 +57,7 @@ namespace Java.Interop {
 			return ReturnObjectReferenceToJni (context, sourceValue.Name, obj);
 		}
 
-		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
+		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, Type targetType, ParameterAttributes synchronize)
 		{
 			Func<IntPtr, string?>   m   = JniEnvironment.Strings.ToString;
 

--- a/src/Java.Interop/Java.Interop/JniValueMarshaler.cs
+++ b/src/Java.Interop/Java.Interop/JniValueMarshaler.cs
@@ -15,7 +15,7 @@ namespace Java.Interop.Expressions {
 
 		protected override string GetKeyForItem (ParameterExpression item)
 		{
-			return item.Name;
+			return item.Name!;
 		}
 	}
 
@@ -142,7 +142,7 @@ namespace Java.Interop {
 			return CreateValue (ref r, JniObjectReferenceOptions.Copy, targetType);
 		}
 
-		public  virtual     Expression              CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize = 0, Type? targetType = null)
+		public  virtual     Expression              CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, Type targetType, ParameterAttributes synchronize = 0)
 		{
 			Func<IntPtr, Type, object?> m   = CreateValue;
 
@@ -169,7 +169,7 @@ namespace Java.Interop {
 			return ReturnObjectReferenceToJni (context, sourceValue.Name, Expression.Property (s, "ReferenceValue"));
 		}
 
-		protected Expression ReturnObjectReferenceToJni (JniValueMarshalerContext context, string namePrefix, Expression sourceValue)
+		protected Expression ReturnObjectReferenceToJni (JniValueMarshalerContext context, string? namePrefix, Expression sourceValue)
 		{
 			Func<JniObjectReference, IntPtr>    m = JniEnvironment.References.NewReturnToJniRef;
 			var r   = Expression.Variable (MarshalType, namePrefix + "_rtn");

--- a/tests/Java.Interop.Export-Tests/Java.Interop/ExportTest.cs
+++ b/tests/Java.Interop.Export-Tests/Java.Interop/ExportTest.cs
@@ -209,7 +209,7 @@ namespace Java.InteropTests
 			throw new NotImplementedException ();
 		}
 
-		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type targetType)
+		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, Type targetType, ParameterAttributes synchronize)
 		{
 			var c = typeof (MyColor).GetConstructor (new[]{typeof (int)});
 			var v = Expression.Variable (typeof (MyColor), sourceValue.Name + "_val");
@@ -253,7 +253,7 @@ namespace Java.InteropTests
 			throw new NotImplementedException ();
 		}
 
-		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type targetType)
+		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, Type targetType, ParameterAttributes synchronize)
 		{
 			var c = typeof (MyLegacyColor).GetConstructor (new[]{typeof (int)});
 			var v = Expression.Variable (typeof (MyLegacyColor), sourceValue.Name + "_val");


### PR DESCRIPTION
In https://github.com/xamarin/java.interop/pull/829 we began targeting `net6.0` instead of `netcoreapp3.1`.  This framework contains additional nullable annotations that resulted in new warnings.

One problem with fixing these is that we needed to make `type` not-nullable here, which means removing the default type. However removing the default type meant the parameter had to be moved before other parameter(s) with a default type.

https://github.com/xamarin/java.interop/blob/main/src/Java.Interop/Java.Interop/JniValueMarshaler.cs#L145

I am not very familiar with this code, so I do not know if there are side-effects of changing this, or if this is considered "public API" which cannot be changed?

