### PR TITLE
[Java.Interop] Fix NRT warnings introduced by targeting 'net6.0'.

### DIFF
--- a/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
@@ -176,7 +176,7 @@ namespace Java.Interop {
 			static  readonly    Type[]      EmptyTypeArray      = Array.Empty<Type> ();
 
 
-			public  Type    GetType (JniTypeSignature typeSignature)
+			public  Type?    GetType (JniTypeSignature typeSignature)
 			{
 				AssertValid ();
 

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -333,7 +333,7 @@ namespace Java.Interop
 				return GetActivationConstructor (fallbackType);
 			}
 
-			static ConstructorInfo GetActivationConstructor (Type type)
+			static ConstructorInfo? GetActivationConstructor (Type type)
 			{
 				return
 					(from c in type.GetConstructors (BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
@@ -675,6 +675,8 @@ namespace Java.Interop
 
 		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
 		{
+			targetType ??= typeof (object);
+
 			var r   = Expression.Variable (targetType, sourceValue.Name + "_val");
 			context.LocalVariables.Add (r);
 			context.CreationStatements.Add (

--- a/src/Java.Interop/Java.Interop/JniStringValueMarshaler.cs
+++ b/src/Java.Interop/Java.Interop/JniStringValueMarshaler.cs
@@ -61,6 +61,8 @@ namespace Java.Interop {
 		{
 			Func<IntPtr, string?>   m   = JniEnvironment.Strings.ToString;
 
+			targetType ??= typeof (object);
+
 			var value = Expression.Variable (targetType, sourceValue.Name + "_val");
 			context.LocalVariables.Add (value);
 			context.CreationStatements.Add (Expression.Assign (value, Expression.Call (m.GetMethodInfo (), sourceValue)));

--- a/src/Java.Interop/Java.Interop/JniValueMarshaler.cs
+++ b/src/Java.Interop/Java.Interop/JniValueMarshaler.cs
@@ -15,7 +15,7 @@ namespace Java.Interop.Expressions {
 
 		protected override string GetKeyForItem (ParameterExpression item)
 		{
-			return item.Name;
+			return item.Name!;
 		}
 	}
 
@@ -169,7 +169,7 @@ namespace Java.Interop {
 			return ReturnObjectReferenceToJni (context, sourceValue.Name, Expression.Property (s, "ReferenceValue"));
 		}
 
-		protected Expression ReturnObjectReferenceToJni (JniValueMarshalerContext context, string namePrefix, Expression sourceValue)
+		protected Expression ReturnObjectReferenceToJni (JniValueMarshalerContext context, string? namePrefix, Expression sourceValue)
 		{
 			Func<JniObjectReference, IntPtr>    m = JniEnvironment.References.NewReturnToJniRef;
 			var r   = Expression.Variable (MarshalType, namePrefix + "_rtn");


### PR DESCRIPTION
In https://github.com/xamarin/java.interop/pull/829 we began targeting `net6.0` instead of `netcoreapp3.1`.  This framework contains additional nullable annotations that resulted in new warnings.