### PR TITLE
Revert "[generator] Disable [SupportedOSPlatform] until .NET 5/6."

### DIFF
--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
@@ -276,20 +276,18 @@ namespace generatortests
 	{
 		protected override CodeGenerationTarget Target => CodeGenerationTarget.XAJavaInterop1;
 
+		[Test]
+		public void SupportedOSPlatform ()
+		{
+			var klass = SupportTypeBuilder.CreateClass ("java.code.MyClass", options);
+			klass.ApiAvailableSince = 30;
 
-		// Disabled until we can properly build .NET 5/6 assemblies in our XA tree.
-		//[Test]
-		//public void SupportedOSPlatform ()
-		//{
-		//	var klass = SupportTypeBuilder.CreateClass ("java.code.MyClass", options);
-		//	klass.ApiAvailableSince = 30;
+			generator.Context.ContextTypes.Push (klass);
+			generator.WriteType (klass, string.Empty, new GenerationInfo ("", "", "MyAssembly"));
+			generator.Context.ContextTypes.Pop ();
 
-		//	generator.Context.ContextTypes.Push (klass);
-		//	generator.WriteType (klass, string.Empty, new GenerationInfo ("", "", "MyAssembly"));
-		//	generator.Context.ContextTypes.Pop ();
-
-		//	StringAssert.Contains ("[global::System.Runtime.Versioning.SupportedOSPlatformAttribute (\"android30.0\")]", builder.ToString (), "Should contain SupportedOSPlatform!");
-		//}
+			StringAssert.Contains ("[global::System.Runtime.Versioning.SupportedOSPlatformAttribute (\"android30.0\")]", builder.ToString (), "Should contain SupportedOSPlatform!");
+		}
 	}
 
 	[TestFixture]

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/NamespaceMapping.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/NamespaceMapping.cs
@@ -32,21 +32,20 @@ namespace MonoDroid.Generation
 				foreach (var jni in opt.GetJniMarshalDelegates ())
 					sw.WriteLine ($"delegate {FromJniType (jni[jni.Length - 1])} {jni} (IntPtr jnienv, IntPtr klass{GetDelegateParameters (jni)});");
 
-				// Disabled until we can properly build .NET 5/6 assemblies in our XA tree.
 				// [SupportedOSPlatform] only exists in .NET 5.0+, so we need to generate a
 				// dummy one so earlier frameworks can compile.
-				//if (opt.CodeGenerationTarget == Xamarin.Android.Binder.CodeGenerationTarget.XAJavaInterop1) {
-				//	sw.WriteLine ("#if !NET");
-				//	sw.WriteLine ("namespace System.Runtime.Versioning {");
-				//	sw.WriteLine ("    [System.Diagnostics.Conditional(\"NEVER\")]");
-				//	sw.WriteLine ("    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Event | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]");
-				//	sw.WriteLine ("    internal sealed class SupportedOSPlatformAttribute : Attribute {");
-				//	sw.WriteLine ("        public SupportedOSPlatformAttribute (string platformName) { }");
-				//	sw.WriteLine ("    }");
-				//	sw.WriteLine ("}");
-				//	sw.WriteLine ("#endif");
-				//	sw.WriteLine ("");
-				//}
+				if (opt.CodeGenerationTarget == Xamarin.Android.Binder.CodeGenerationTarget.XAJavaInterop1) {
+					sw.WriteLine ("#if !NET");
+					sw.WriteLine ("namespace System.Runtime.Versioning {");
+					sw.WriteLine ("    [System.Diagnostics.Conditional(\"NEVER\")]");
+					sw.WriteLine ("    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Event | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]");
+					sw.WriteLine ("    internal sealed class SupportedOSPlatformAttribute : Attribute {");
+					sw.WriteLine ("        public SupportedOSPlatformAttribute (string platformName) { }");
+					sw.WriteLine ("    }");
+					sw.WriteLine ("}");
+					sw.WriteLine ("#endif");
+					sw.WriteLine ("");
+				}
 			}
 		}
 

--- a/tools/generator/SourceWriters/Attributes/SupportedOSPlatformAttr.cs
+++ b/tools/generator/SourceWriters/Attributes/SupportedOSPlatformAttr.cs
@@ -15,8 +15,7 @@ namespace generator.SourceWriters
 
 		public override void WriteAttribute (CodeWriter writer)
 		{
-			// Disabled until we can properly build .NET 5/6 assemblies in our XA tree.
-			//writer.WriteLine ($"[global::System.Runtime.Versioning.SupportedOSPlatformAttribute (\"android{Version}.0\")]");
+			writer.WriteLine ($"[global::System.Runtime.Versioning.SupportedOSPlatformAttribute (\"android{Version}.0\")]");
 		}
 	}
 }


### PR DESCRIPTION
This reverts commit 00862adaf1f5447f2dcbff7b957083076da31a7b.

Now that we are properly building with the `net6.0` TF we can re-enable the `[SupportedOSPlatform]` support.

XA companion test bump to ensure this works: https://github.com/xamarin/xamarin-android/pull/5932