### PR TITLE
[Java.Interop.Tools.*] IMetadataResolver not TypeDefinitionCache

### DIFF
--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/TypeDefinitionCache.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/TypeDefinitionCache.cs
@@ -1,21 +1,39 @@
 using System.Collections.Generic;
 using Mono.Cecil;
 
+using Java.Interop.Tools.Diagnostics;
+
 namespace Java.Interop.Tools.Cecil
 {
 	/// <summary>
 	/// A class for caching lookups from TypeReference -> TypeDefinition.
 	/// Generally its lifetime should match an AssemblyResolver instance.
 	/// </summary>
-	public class TypeDefinitionCache
+	public class TypeDefinitionCache : IMetadataResolver
 	{
-		readonly Dictionary<TypeReference, TypeDefinition> cache = new Dictionary<TypeReference, TypeDefinition> ();
+		readonly    Dictionary<TypeReference, TypeDefinition?>      types   = new Dictionary<TypeReference, TypeDefinition?> ();
+		readonly    Dictionary<FieldReference, FieldDefinition?>    fields  = new Dictionary<FieldReference, FieldDefinition?> ();
+		readonly    Dictionary<MethodReference, MethodDefinition?>  methods = new Dictionary<MethodReference, MethodDefinition?> ();
 
-		public virtual TypeDefinition Resolve (TypeReference typeReference)
+		public virtual TypeDefinition? Resolve (TypeReference typeReference)
 		{
-			if (cache.TryGetValue (typeReference, out var typeDefinition))
+			if (types.TryGetValue (typeReference, out var typeDefinition))
 				return typeDefinition;
-			return cache [typeReference] = typeReference.Resolve ();
+			return types [typeReference] = typeReference.Resolve ();
+		}
+
+		public virtual FieldDefinition? Resolve (FieldReference field)
+		{
+			if (fields.TryGetValue (field, out var fieldDefinition))
+				return fieldDefinition;
+			return fields [field] = field.Resolve ();
+		}
+
+		public virtual MethodDefinition? Resolve (MethodReference method)
+		{
+			if (methods.TryGetValue (method, out var methodDefinition))
+				return methodDefinition;
+			return methods [method] = method.Resolve ();
 		}
 	}
 }

--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/TypeDefinitionRocks.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/TypeDefinitionRocks.cs
@@ -9,62 +9,74 @@ namespace Java.Interop.Tools.Cecil {
 
 		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
 		public static TypeDefinition? GetBaseType (this TypeDefinition type) =>
-			GetBaseType (type, cache: null);
+			GetBaseType (type, resolver: null);
 
-		public static TypeDefinition? GetBaseType (this TypeDefinition type, TypeDefinitionCache? cache)
+		public static TypeDefinition? GetBaseType (this TypeDefinition type, TypeDefinitionCache? cache) =>
+			GetBaseType (type, (IMetadataResolver?) cache);
+
+		public static TypeDefinition? GetBaseType (this TypeDefinition type, IMetadataResolver? resolver)
 		{
 			var bt = type.BaseType;
 			if (bt == null)
 				return null;
-			if (cache != null)
-				return cache.Resolve (bt);
+			if (resolver != null)
+				return resolver.Resolve (bt);
 			return bt.Resolve ();
 		}
 
 		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
 		public static IEnumerable<TypeDefinition> GetTypeAndBaseTypes (this TypeDefinition type) =>
-			GetTypeAndBaseTypes (type, cache: null);
+			GetTypeAndBaseTypes (type, resolver: null);
 
-		public static IEnumerable<TypeDefinition> GetTypeAndBaseTypes (this TypeDefinition type, TypeDefinitionCache? cache)
+		public static IEnumerable<TypeDefinition> GetTypeAndBaseTypes (this TypeDefinition type, TypeDefinitionCache? cache) =>
+			GetTypeAndBaseTypes (type, (IMetadataResolver?) cache);
+
+		public static IEnumerable<TypeDefinition> GetTypeAndBaseTypes (this TypeDefinition type, IMetadataResolver? resolver)
 		{
 			TypeDefinition? t = type;
 
 			while (t != null) {
 				yield return t;
-				t = t.GetBaseType (cache);
+				t = t.GetBaseType (resolver);
 			}
 		}
 
 		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
 		public static IEnumerable<TypeDefinition> GetBaseTypes (this TypeDefinition type) =>
-			GetBaseTypes (type, cache: null);
+			GetBaseTypes (type, resolver: null);
 
-		public static IEnumerable<TypeDefinition> GetBaseTypes (this TypeDefinition type, TypeDefinitionCache? cache)
+		public static IEnumerable<TypeDefinition> GetBaseTypes (this TypeDefinition type, TypeDefinitionCache? cache) =>
+			GetBaseTypes (type, (IMetadataResolver?) cache);
+
+		public static IEnumerable<TypeDefinition> GetBaseTypes (this TypeDefinition type, IMetadataResolver? resolver)
 		{
 			TypeDefinition? t = type;
 
-			while ((t = t.GetBaseType (cache)) != null) {
+			while ((t = t.GetBaseType (resolver)) != null) {
 				yield return t;
 			}
 		}
 
 		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
 		public static bool IsAssignableFrom (this TypeReference type, TypeReference c) =>
-			IsAssignableFrom (type, c, cache: null);
+			IsAssignableFrom (type, c, resolver: null);
 
-		public static bool IsAssignableFrom (this TypeReference type, TypeReference c, TypeDefinitionCache? cache)
+		public static bool IsAssignableFrom (this TypeReference type, TypeReference c, TypeDefinitionCache? cache) =>
+			IsAssignableFrom (type, c, (IMetadataResolver?) cache);
+
+		public static bool IsAssignableFrom (this TypeReference type, TypeReference c, IMetadataResolver? resolver)
 		{
 			if (type.FullName == c.FullName)
 				return true;
-			var d = c.Resolve ();
+			var d = (resolver?.Resolve (c)) ?? c.Resolve ();
 			if (d == null)
 				return false;
-			foreach (var t in d.GetTypeAndBaseTypes (cache)) {
+			foreach (var t in d.GetTypeAndBaseTypes (resolver)) {
 				if (type.FullName == t.FullName)
 					return true;
 				foreach (var ifaceImpl in t.Interfaces) {
 					var i   = ifaceImpl.InterfaceType;
-					if (IsAssignableFrom (type, i, cache))
+					if (IsAssignableFrom (type, i, resolver))
 						return true;
 				}
 			}
@@ -73,11 +85,13 @@ namespace Java.Interop.Tools.Cecil {
 
 		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
 		public static bool IsSubclassOf (this TypeDefinition type, string typeName) =>
-			IsSubclassOf (type, typeName, cache: null);
+			IsSubclassOf (type, typeName, resolver: null);
 
-		public static bool IsSubclassOf (this TypeDefinition type, string typeName, TypeDefinitionCache? cache)
+		public static bool IsSubclassOf (this TypeDefinition type, string typeName, TypeDefinitionCache? cache) =>
+			IsSubclassOf (type, typeName, (IMetadataResolver?) cache);
+		public static bool IsSubclassOf (this TypeDefinition type, string typeName, IMetadataResolver? resolver)
 		{
-			foreach (var t in type.GetTypeAndBaseTypes (cache)) {
+			foreach (var t in type.GetTypeAndBaseTypes (resolver)) {
 				if (t.FullName == typeName) {
 					return true;
 				}
@@ -87,11 +101,14 @@ namespace Java.Interop.Tools.Cecil {
 
 		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
 		public static bool ImplementsInterface (this TypeDefinition type, string interfaceName) =>
-			ImplementsInterface (type, interfaceName, cache: null);
+			ImplementsInterface (type, interfaceName, resolver: null);
 
-		public static bool ImplementsInterface (this TypeDefinition type, string interfaceName, TypeDefinitionCache? cache)
+		public static bool ImplementsInterface (this TypeDefinition type, string interfaceName, TypeDefinitionCache? cache) =>
+			ImplementsInterface (type, interfaceName, (IMetadataResolver?) cache);
+
+		public static bool ImplementsInterface (this TypeDefinition type, string interfaceName, IMetadataResolver? resolver)
 		{
-			foreach (var t in type.GetTypeAndBaseTypes (cache)) {
+			foreach (var t in type.GetTypeAndBaseTypes (resolver)) {
 				foreach (var i in t.Interfaces) {
 					if (i.InterfaceType.FullName == interfaceName) {
 						return true;
@@ -103,34 +120,43 @@ namespace Java.Interop.Tools.Cecil {
 
 		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
 		public static string GetPartialAssemblyName (this TypeReference type) =>
-			GetPartialAssemblyName (type, cache: null);
+			GetPartialAssemblyName (type, resolver: null);
 
-		public static string GetPartialAssemblyName (this TypeReference type, TypeDefinitionCache? cache)
+		public static string GetPartialAssemblyName (this TypeReference type, TypeDefinitionCache? cache) =>
+			GetPartialAssemblyName (type, (IMetadataResolver?) cache);
+
+		public static string GetPartialAssemblyName (this TypeReference type, IMetadataResolver? resolver)
 		{
-			TypeDefinition def = cache != null ? cache.Resolve (type) : type.Resolve ();
+			TypeDefinition? def = (resolver?.Resolve (type)) ?? type.Resolve ();
 			return (def ?? type).Module.Assembly.Name.Name;
 		}
 
 		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
 		public static string GetPartialAssemblyQualifiedName (this TypeReference type) =>
-			GetPartialAssemblyQualifiedName (type, cache: null);
+			GetPartialAssemblyQualifiedName (type, resolver: null);
 
-		public static string GetPartialAssemblyQualifiedName (this TypeReference type, TypeDefinitionCache? cache)
+		public static string GetPartialAssemblyQualifiedName (this TypeReference type, TypeDefinitionCache? cache) =>
+			GetPartialAssemblyQualifiedName (type, (IMetadataResolver?) cache);
+
+		public static string GetPartialAssemblyQualifiedName (this TypeReference type, IMetadataResolver? resolver)
 		{
 			return string.Format ("{0}, {1}",
 					// Cecil likes to use '/' as the nested type separator, while
 					// Reflection uses '+' as the nested type separator. Use Reflection.
 					type.FullName.Replace ('/', '+'),
-					type.GetPartialAssemblyName (cache));
+					type.GetPartialAssemblyName (resolver));
 		}
 
 		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
 		public static string GetAssemblyQualifiedName (this TypeReference type) =>
-			GetAssemblyQualifiedName (type, cache: null);
+			GetAssemblyQualifiedName (type, resolver: null);
 
-		public static string GetAssemblyQualifiedName (this TypeReference type, TypeDefinitionCache? cache)
+		public static string GetAssemblyQualifiedName (this TypeReference type, TypeDefinitionCache? cache) =>
+			GetAssemblyQualifiedName (type, (IMetadataResolver?) cache);
+
+		public static string GetAssemblyQualifiedName (this TypeReference type, IMetadataResolver? resolver)
 		{
-			TypeDefinition def = cache != null ? cache.Resolve (type) : type.Resolve ();
+			TypeDefinition? def = (resolver?.Resolve (type)) ?? type.Resolve ();
 			return string.Format ("{0}, {1}",
 					// Cecil likes to use '/' as the nested type separator, while
 					// Reflection uses '+' as the nested type separator. Use Reflection.

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/TypeNameMapGenerator.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/TypeNameMapGenerator.cs
@@ -61,11 +61,11 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 		List<TypeDefinition>            Types;
 		DirectoryAssemblyResolver       Resolver;
 		JavaTypeScanner                 Scanner;
-		readonly TypeDefinitionCache    Cache;
+		readonly IMetadataResolver      Cache;
 
 		[Obsolete ("Use TypeNameMapGenerator(IEnumerable<string>, Action<TraceLevel, string>, TypeDefinitionCache)")]
 		public TypeNameMapGenerator (IEnumerable<string> assemblies, Action<string, object []> logMessage)
-			: this (assemblies, (TraceLevel level, string value) => logMessage?.Invoke ("{0}", new[]{value}), cache: null)
+			: this (assemblies, (TraceLevel level, string value) => logMessage?.Invoke ("{0}", new[]{value}), resolver: null)
 		{
 			if (logMessage == null)
 				throw new ArgumentNullException (nameof (logMessage));
@@ -73,17 +73,22 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 
 		[Obsolete ("Use TypeNameMapGenerator(IEnumerable<string>, Action<TraceLevel, string>, TypeDefinitionCache)")]
 		public TypeNameMapGenerator (IEnumerable<string> assemblies, Action<TraceLevel, string> logger)
-			: this (assemblies, logger, cache: null)
+			: this (assemblies, logger, resolver: null)
 		{ }
 
 		public TypeNameMapGenerator (IEnumerable<string> assemblies, Action<TraceLevel, string> logger, TypeDefinitionCache cache)
+			: this (assemblies, logger, (IMetadataResolver) cache)
+		{
+		}
+
+		public TypeNameMapGenerator (IEnumerable<string> assemblies, Action<TraceLevel, string> logger, IMetadataResolver resolver)
 		{
 			if (assemblies == null)
 				throw new ArgumentNullException ("assemblies");
 			if (logger == null)
 				throw new ArgumentNullException (nameof (logger));
-			Cache = cache ?? new TypeDefinitionCache ();
 
+			Cache           = resolver ?? new TypeDefinitionCache ();
 			Log             = logger;
 			var Assemblies  = assemblies.ToList ();
 			var rp          = new ReaderParameters ();
@@ -100,7 +105,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 				Resolver.Load (Path.GetFullPath (assembly));
 			}
 
-			Scanner     = new JavaTypeScanner (Log, cache) {
+			Scanner     = new JavaTypeScanner (Log, Cache) {
 				ErrorOnCustomJavaObject     = false,
 			};
 			Types       = Scanner.GetJavaTypes (Assemblies, Resolver);
@@ -108,7 +113,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 
 		[Obsolete ("Use TypeNameMapGenerator(IEnumerable<TypeDefinition>, Action<TraceLevel, string>, TypeDefinitionCache)")]
 		public TypeNameMapGenerator (IEnumerable<TypeDefinition> types, Action<string, object[]> logMessage)
-			: this (types, (TraceLevel level, string value) => logMessage?.Invoke ("{0}", new [] { value }), cache: null)
+			: this (types, (TraceLevel level, string value) => logMessage?.Invoke ("{0}", new [] { value }), resolver: null)
 		{
 			if (logMessage == null)
 				throw new ArgumentNullException (nameof (logMessage));
@@ -116,16 +121,22 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 
 		[Obsolete ("Use TypeNameMapGenerator(IEnumerable<TypeDefinition>, Action<TraceLevel, string>, TypeDefinitionCache)")]
 		public TypeNameMapGenerator (IEnumerable<TypeDefinition> types, Action<TraceLevel, string> logger)
-			: this (types, logger, cache: null)
+			: this (types, logger, resolver: null)
 		{ }
 
 		public TypeNameMapGenerator (IEnumerable<TypeDefinition> types, Action<TraceLevel, string> logger, TypeDefinitionCache cache)
+			: this (types, logger, (IMetadataResolver) cache)
+		{
+		}
+
+		public TypeNameMapGenerator (IEnumerable<TypeDefinition> types, Action<TraceLevel, string> logger, IMetadataResolver resolver)
 		{
 			if (types == null)
 				throw new ArgumentNullException ("types");
 			if (logger == null)
 				throw new ArgumentNullException (nameof (logger));
-			Cache = cache ?? new TypeDefinitionCache ();
+
+			Cache       = resolver ?? new TypeDefinitionCache ();
 
 			Log         = logger;
 			Types       = types.ToList ();


### PR DESCRIPTION
Context: b81cfbb9ab8efa647a3bfcc2b2b97a5f1b1fa71e
Context: https://github.com/xamarin/xamarin-android/pull/5748
Context: https://github.com/xamarin/xamarin-android/pull/5748#discussion_r634716239

Commit b81cfbb9 introduced `TypeDefinitionCache`, which caches
`TypeReference.Resolve()` invocations so as to speed things up.

Enter xamarin/xamarin-android#5748: we want to adopt some linker API
changes, and mono/linker's [`LinkContext` API][0] *also* has a
`TypeDefinition` cache construct.

Consequently, to "fully embrace" the new `LinkContext` API changes,
*large portions* of `Java.Interop.Tools.Cecil.dll` are copied so that
`LinkContext`'s caching can be used instead of `TypeDefinitionCache`'s
caching, because mono/linker doesn't use Java.Interop, and thus
can't use `TypeDefinitionCache`.

Clean this up and split the difference: "duplicate" the APIs in
`Java.Interop.Tools.Cecil.dll`,
`Java.Interop.Tools.JavaCallableWrappers.dll`, and
`src/Java.Interop.Tools.TypeNameMappings` so that instead of
optionally using `TypeDefinitionCache`, we instead permit the use
of the [`Mono.Cecil.IMetadataResolver` interface][1], which is a
"superset" of `TypeDefinitionCache` functionality.

Update `TypeDefinitionCache` implement the `IMetadataResolver`
interface, implementing `IMetadataResolver.Resolver()` so that
previous caching functionality is preserved.

This *should* result in no breakage of existing xamarin-android code,
while allowing for a reasonable integration point between
`Java.Interop.Tools.Cecil.dll` and mono/linker, by way of
`IMetadataResolver`.

[0]: https://github.com/mono/linker/blob/30f2498c2a3de1f7e236d5793f5f1aca6e5ba456/src/linker/Linker/LinkContext.cs
[1]: https://github.com/mono/cecil/blob/e069cd8d25d5b61b0e28fe65e75959c20af7aa80/Mono.Cecil/MetadataResolver.cs#L22-L26