### PR TITLE
[build] Bump to Mono with MSBuild 16.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ bin/Build$(CONFIGURATION)/Java.Interop.BootstrapTasks.dll: build-tools/Java.Inte
 prepare-external $(PREPARE_EXTERNAL_FILES):
 	git submodule update --init --recursive
 	(cd external/xamarin-android-tools && $(MAKE) prepare)
-	nuget restore
+	dotnet restore /v:n
 
 prepare-core: bin/Build$(CONFIGURATION)/MonoInfo.props src/Java.Runtime.Environment/Java.Runtime.Environment.dll.config
 

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ bin/Build$(CONFIGURATION)/Java.Interop.BootstrapTasks.dll: build-tools/Java.Inte
 prepare-external $(PREPARE_EXTERNAL_FILES):
 	git submodule update --init --recursive
 	(cd external/xamarin-android-tools && $(MAKE) prepare)
-	dotnet restore /v:n
+	nuget restore
 
 prepare-core: bin/Build$(CONFIGURATION)/MonoInfo.props src/Java.Runtime.Environment/Java.Runtime.Environment.dll.config
 

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -109,7 +109,7 @@ jobs:
 
   - script: >
       dotnet tool install --global boots &&
-      boots --preview Mono
+      boots https://download.mono-project.com/archive/6.12.0/macos-10-universal/MonoFramework-MDK-6.12.0.145.macos10.xamarin.universal.pkg
     displayName: Install Mono
 
   - script: make prepare CONFIGURATION=$(Build.Configuration) JI_MAX_JDK=$(MaxJdkVersion)


### PR DESCRIPTION
We've been seeing a NuGet restore issue when running prepare on a macOS
system with .NET 6 Preview 4 (or greater) installed:

    Restoring packages for /Users/peter/source/java.interop/tools/logcat-parse/logcat-parse.csproj...
    NU1202: Package Mono.CSharp 4.0.0.143 is not compatible with net6.0 (.NETCoreApp,Version=v6.0). Package Mono.CSharp 4.0.0.143 supports: net45 (.NETFramework,Version=v4.5)
    ...
    Errors in /Users/peter/source/java.interop/tools/logcat-parse/logcat-parse.csproj
        NU1202: Package Mono.CSharp 4.0.0.143 is not compatible with net6.0 (.NETCoreApp,Version=v6.0). Package Mono.CSharp 4.0.0.143 supports: net45 (.NETFramework,Version=v4.5)

This issue is no longer present in a newer version of Mono 6.12 which
includes MSBuild 16.10.