### PR TITLE
[generator] Ensure we don't generate unexpected NRT types, like 'void?'.

### DIFF
--- a/tests/generator-Tests/Unit-Tests/CodeGenerationOptionsTests.cs
+++ b/tests/generator-Tests/Unit-Tests/CodeGenerationOptionsTests.cs
@@ -51,5 +51,21 @@ namespace generatortests
 			Assert.AreEqual ("global::System.Collections.Generic.List<global::System.Collections.Generic.List<string>.Enumerator[]>",
 				opt.GetOutputName ("System.Collections.Generic.List<System.Collections.Generic.List<string>.Enumerator[]>"));
 		}
+
+		[Test]
+		public void GetTypeReferenceName_Nullable ()
+		{
+			var opt = new CodeGenerationOptions { SupportNullableReferenceTypes = true };
+
+			var system_void = new ReturnValue (null, "void", "System.Void", false, false);
+			system_void.Validate (opt, null, null);
+
+			Assert.AreEqual ("void", opt.GetTypeReferenceName (system_void));
+
+			var primitive_void = new ReturnValue (null, "void", "void", false, false);
+			primitive_void.Validate (opt, null, null);
+
+			Assert.AreEqual ("void", opt.GetTypeReferenceName (primitive_void));
+		}
 	}
 }

--- a/tests/generator-Tests/Unit-Tests/ManagedTests.cs
+++ b/tests/generator-Tests/Unit-Tests/ManagedTests.cs
@@ -121,7 +121,7 @@ namespace generatortests
 
 			Assert.AreEqual ("public", method.Visibility);
 			Assert.AreEqual ("void", method.Return);
-			Assert.AreEqual ("System.Void", method.ReturnType);
+			Assert.AreEqual ("void", method.ReturnType);
 			Assert.AreEqual ("Bar", method.Name);
 			Assert.AreEqual ("bar", method.JavaName);
 			Assert.AreEqual ("()V", method.JniSignature);
@@ -165,7 +165,7 @@ namespace generatortests
 			Assert.IsTrue (method.Validate (new CodeGenerationOptions (), new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "method.Validate failed!");
 			Assert.AreEqual ("(ZID)Ljava/lang/String;", method.JniSignature);
 			Assert.AreEqual ("java.lang.String", method.Return);
-			Assert.AreEqual ("System.String", method.ManagedReturn);
+			Assert.AreEqual ("string", method.ManagedReturn);
 
 			var parameter = method.Parameters [0];
 			Assert.AreEqual ("a", parameter.Name);

--- a/tools/generator/CodeGenerationOptions.cs
+++ b/tools/generator/CodeGenerationOptions.cs
@@ -141,21 +141,23 @@ namespace MonoDroid.Generation
 			switch (s) {
 				case "void":
 				case "int":
-				//case "int[]":
 				case "bool":
-				//case "bool[]":
 				case "float":
-				//case "float[]":
 				case "sbyte":
-				//case "sbyte[]":
 				case "long":
-				//case "long[]":
 				case "char":
-				//case "char[]":
 				case "double":
-				//case "double[]":
 				case "short":
-				//case "short[]":
+				case "System.Boolean":
+				case "System.Byte":
+				case "System.Char":
+				case "System.Double":
+				case "System.Int16":
+				case "System.Int32":
+				case "System.Int64":
+				case "System.Single":
+				case "System.SByte":
+				case "System.Void":
 				case "Android.Graphics.Color":
 					return string.Empty;
 			}

--- a/tools/generator/Extensions/ManagedExtensions.cs
+++ b/tools/generator/Extensions/ManagedExtensions.cs
@@ -65,6 +65,25 @@ namespace MonoDroid.Generation
 
 			return type;
 		}
+
+		// Convert a fully qualified type like "System.Void" to the primitive type "void" if applicable
+		public static string FilterPrimitive (this string type)
+		{
+			return type switch {
+				"System.Boolean" => "bool",
+				"System.Char" => "char",
+				"System.Byte" => "byte",
+				"System.SByte" => "byte",
+				"System.Int16" => "short",
+				"System.Int32" => "int",
+				"System.Int64" => "long",
+				"System.Single" => "float",
+				"System.Double" => "double",
+				"System.Void" => "void",
+				"System.String" => "string",
+				_ => type
+			};
+		}
 	}
 #endif
 }

--- a/tools/generator/Java.Interop.Tools.Generator.Importers/CecilApiImporter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Importers/CecilApiImporter.cs
@@ -196,8 +196,8 @@ namespace MonoDroid.Generation
 				IsStatic = m.IsStatic,
 				IsVirtual = m.IsVirtual,
 				JavaName = reg_attr != null ? ((string) reg_attr.ConstructorArguments [0].Value) : m.Name,
-				ManagedReturn = m.ReturnType.FullNameCorrected ().StripArity (),
-				Return = m.ReturnType.FullNameCorrected ().StripArity (),
+				ManagedReturn = m.ReturnType.FullNameCorrected ().StripArity ().FilterPrimitive (),
+				Return = m.ReturnType.FullNameCorrected ().StripArity ().FilterPrimitive (),
 				Visibility = m.Visibility ()
 			};
 


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/issues/850

When a user binds a library that contains an interface that implements another interface, we pull in all invokable members from both interfaces to create the `Invoker` type for the user's interface.  If the base interface is a referenced assembly, the information we are working from has been read in via Cecil.  Due to a bug caused by the combination of Cecil-read info and NRT generation, we will interpret the return types on the imported methods as always `nullable`, even for types like `void`, which results in the uncompilable `void?`.

Example from `AndroidX.Core.Core`:

```csharp
// In AndroidX.Core.Core
public interface AndroidX.Core.Internal.View.ISupportMenu : Android.Views.IMenu { ... }

// In Mono.Android.dll
public interface Android.Views.IMenu {
  public void Clear ();
}
```

This generates the `ISupportMenuInvoker` type:
```csharp
internal partial class ISupportMenuInvoker : global::Java.Lang.Object, ISupportMenu {
  public unsafe void? Clear () { ... }
}
```

Which cause these following CSC errors:
```
Error CS1519 Invalid token '?' in class, record, struct, or interface member declaration
Error CS1520 Method must have a return type
Error CS0535 'ISupportMenuInvoker' does not implement interface member 'IMenu.Clear()'
```

The culprit is twofold:
- In `CecilApiImporter`, we set the `Method.ManagedReturn` to `System.Void` instead of `void`.
- In `CodeGenerationOptions`, we only check for `void` to omit the null operator, not `System.Void`.

Note this also happens for all primitive types like `System.Int32`/`int`.

This commit fixes both aspects:
- Change `Method.ManagedReturn` to contain primitive types instead of fully qualified types.
- Update `GetNullable` to correctly handle fully qualified types if one slips through.

With this change, all of AndroidX/GPS/FB/MLKit can be successfully compiled with `<Nullable>enable</Nullable>`.