### PR TITLE
[build] set $(DisableImplicitNamespaceImports) by default

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,6 +24,8 @@
       Condition="Exists('$(_OutputPath)MonoInfo.props')"
   />
   <PropertyGroup>
+    <!-- Workaround: https://github.com/dotnet/sdk/issues/19050 -->
+    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
     <AppendTargetFrameworkToOutputPath Condition=" '$(AppendTargetFrameworkToOutputPath)' == '' ">False</AppendTargetFrameworkToOutputPath>
     <BaseIntermediateOutputPath Condition=" '$(BaseIntermediateOutputPath)' == '' ">obj\</BaseIntermediateOutputPath>
   </PropertyGroup>


### PR DESCRIPTION
Context: https://github.com/dotnet/sdk/issues/19050

xamarin-android is hitting this build error with .NET 6 Preview 7:

    C:\src\xamarin-android\external\Java.Interop\src\Java.Interop\obj\Debug\net6.0\Java.Interop.ImplicitNamespaceImports.cs(2,1):
    error CS8400: Feature 'global using directive' is not available in C# 8.0. Please use language version 10.0 or greater.
    [C:\src\xamarin-android\external\Java.Interop\src\Java.Interop\Java.Interop.csproj]

In fact, you can reproduce this by doing:

    dotnet new console
    dotnet build -p:LangVersion=8.0

It seems like `@(Import)` item group should not be present unless the
project is C# 10 or higher?

For now, we can set `$(DisableImplicitNamespaceImports)` to workaround
the issue.