### PR TITLE
Bump to mono/linker/main@b888d67 Mono.Cecil 0.11.4

### DIFF
--- a/build-tools/scripts/cecil.projitems
+++ b/build-tools/scripts/cecil.projitems
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <_XamarinAndroidCecilVersion Condition=" '$(_XamarinAndroidCecilVersion)' == '' ">0.11.4</_XamarinAndroidCecilVersion>
+  </PropertyGroup>
   <ItemGroup Condition=" '$(_XamarinAndroidCecilPath)' == '' ">
-    <PackageReference Include="Mono.Cecil" Version="0.11.2" />
+    <PackageReference Include="Mono.Cecil" Version="$(_XamarinAndroidCecilVersion)" />
   </ItemGroup>
   <ItemGroup Condition=" '$(_XamarinAndroidCecilPath)' != '' ">
     <Reference Include="$(_XamarinAndroidCecilPath)" />


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/6131

Changes: Unknown; can't find commit which matches 0.11.2.

xamarin/xamarin-android#6131 is currently failing to build due to a
Mono.Cecil version mismatch:

	CSC : error CS1705: Assembly 'illink' with identity 'illink, Version=6.0.100.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
	uses 'Mono.Cecil, Version=0.11.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e'
	which has a higher version than referenced assembly
	'Mono.Cecil' with identity 'Mono.Cecil, Version=0.11.3.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e'

We thus need to bump all use of Mono.Cecil 0.11.2 to 0.11.4.

Unfortunately, at this point in time there's no way for
xamarin/xamarin-android to explicitly control which Mono.Cecil
NuGet package version is used by Java.Interop.

Introduce a new `$(_XamarinAndroidCecilVersion)` MSBuild property
which can be used to override the default Mono.Cecil package version
of 0.11.4 (up from 0.11.2).  The xamarin-android build can then
set `$(_XamarinAndroidCecilVersion)` by using
`Configuration.Override.props`.