### PR TITLE
[build] .NET 6 P7 Support (#869)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,6 +26,8 @@
   <PropertyGroup>
     <!-- Workaround: https://github.com/dotnet/sdk/issues/19050 -->
     <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
+    <!-- Workaround: https://github.com/dotnet/runtime/issues/55992 -->
+    <UseAppHost>False</UseAppHost>
     <AppendTargetFrameworkToOutputPath Condition=" '$(AppendTargetFrameworkToOutputPath)' == '' ">False</AppendTargetFrameworkToOutputPath>
     <BaseIntermediateOutputPath Condition=" '$(BaseIntermediateOutputPath)' == '' ">obj\</BaseIntermediateOutputPath>
   </PropertyGroup>

--- a/tools/generator/SourceWriters/Attributes/RegisterAttr.cs
+++ b/tools/generator/SourceWriters/Attributes/RegisterAttr.cs
@@ -32,12 +32,12 @@ namespace generator.SourceWriters
 			var sb = new StringBuilder ();
 
 			if (UseGlobal)
-				sb.Append ($"[global::Android.Runtime.Register (\"{Name}\"");
+				sb.Append ((string) $"[global::Android.Runtime.Register (\"{Name}\"");
 			else
-				sb.Append ($"[Register (\"{Name}\"");
+				sb.Append ((string) $"[Register (\"{Name}\"");
 
 			if ((Signature.HasValue () || Connector.HasValue ()) && !UseShortForm)
-				sb.Append ($", \"{Signature}\", \"{Connector}\"");
+				sb.Append ((string) $", \"{Signature}\", \"{Connector}\"");
 
 			if (DoNotGenerateAcw && !AcwLast)
 				sb.Append (", DoNotGenerateAcw=true");


### PR DESCRIPTION
Context: https://github.com/dotnet/roslyn/issues/55564
Context: https://discord.com/channels/732297728826277939/732297837953679412/874959446747533323
Context: https://github.com/dotnet/runtime/issues/55992
Context: https://github.com/dotnet/sdk/issues/19653#issuecomment-896676414

Fix the Java.Interop build when .NET 6 Preview 7 is installed.

.NET 6 Preview 7 introduced a C# compiler regression: use of
[C#6 string interpolation][0] with `StringBuilder.Append()` when
`$(LangVersion)` < 10.0 results in a CS8400 error:

	error CS8400: Feature 'interpolated string handlers' is not available in C# 8.0. Please use language version 10.0 or greater.

Because `azure-pipelines.yaml` specifies `DotNetCoreVersion: 6.0.x`,
our CI machines get auto-bumped to .NET 6 Preview 7, causing *all*
PR builds to now fail with this CS8400 failure.

There are two possible solutions:

 1. *Avoid* .NET 6 Preview 7.
 2. Remove select use of string interpolation.

(1) was initially done on xamarin/Java.Interop#865, by using:

	DotNetCoreVersion: 6.0.100-preview.6.21355.2

However, it's not *all* use of string interpolation which triggers
the CS8400 error.  It's just use of string interpolation within
`StringBuilder.Append()` calls, in 3 locations.

Update `RegisterAttr.cs` to use a `(string)` cast with the existing
string interpolation use.  This works around the CS8400 error.

*Additionally*, macOS+Mono builds would fail in `make all` when
.NET 6 Preview 7 is present:

	/usr/local/share/dotnet/sdk/6.0.100-preview.7.21379.14/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.targets(536,5): error MSB4018: The "CreateAppHost" task failed unexpectedly.
	/usr/local/share/dotnet/sdk/6.0.100-preview.7.21379.14/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.targets(536,5): error MSB4018: System.InvalidOperationException: The Process object must have the UseShellExecute property set to false in order to redirect IO streams.
	/usr/local/share/dotnet/sdk/6.0.100-preview.7.21379.14/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.targets(536,5): error MSB4018:   at System.Diagnostics.Process.StartWithShellExecuteEx (System.Diagnostics.ProcessStartInfo startInfo)
	/usr/local/share/dotnet/sdk/6.0.100-preview.7.21379.14/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.targets(536,5): error MSB4018:   at System.Diagnostics.Process.Start ()
	/usr/local/share/dotnet/sdk/6.0.100-preview.7.21379.14/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.targets(536,5): error MSB4018:   at (wrapper remoting-invoke-with-check) System.Diagnostics.Process.Start()
	/usr/local/share/dotnet/sdk/6.0.100-preview.7.21379.14/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.targets(536,5): error MSB4018:   at System.Diagnostics.Process.Start (System.Diagnostics.ProcessStartInfo startInfo)
	/usr/local/share/dotnet/sdk/6.0.100-preview.7.21379.14/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.targets(536,5): error MSB4018:   at Microsoft.NET.HostModel.AppHost.HostWriter.CodeSign (System.String appHostPath)
	/usr/local/share/dotnet/sdk/6.0.100-preview.7.21379.14/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.targets(536,5): error MSB4018:   at Microsoft.NET.HostModel.AppHost.HostWriter.CreateAppHost (System.String appHostSourceFilePath, System.String appHostDestinationFilePath, System.String appBinaryFilePath, System.Boolean windowsGraphicalUserInterface, System.String assemblyToCopyResorcesFrom, System.Boolean enableMacOSCodeSign)
	/usr/local/share/dotnet/sdk/6.0.100-preview.7.21379.14/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.targets(536,5): error MSB4018:   at Microsoft.NET.Build.Tasks.CreateAppHost.ExecuteCore ()
	/usr/local/share/dotnet/sdk/6.0.100-preview.7.21379.14/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.targets(536,5): error MSB4018:   at Microsoft.NET.Build.Tasks.TaskBase.Execute ()
	/usr/local/share/dotnet/sdk/6.0.100-preview.7.21379.14/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.targets(536,5): error MSB4018:   at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute ()
	/usr/local/share/dotnet/sdk/6.0.100-preview.7.21379.14/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.targets(536,5): error MSB4018:   at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask (Microsoft.Build.BackEnd.ITaskExecutionHost taskExecutionHost, Microsoft.Build.BackEnd.Logging.TaskLoggingContext taskLoggingContext, Microsoft.Build.BackEnd.TaskHost taskHost, Microsoft.Build.BackEnd.ItemBucket bucket, Microsoft.Build.BackEnd.TaskExecutionMode howToExecuteTask)

This was filed as dotnet/runtime#55992, and can be worked around by
setting `$(UseAppHost)`=False in the "offending" projects.

[0]: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/interpolated