### PR TITLE
[Java.Interop] fix .NET 6 linker warnings

### DIFF
--- a/src/Java.Interop/Java.Interop/JniRuntime.JniMarshalMemberBuilder.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniMarshalMemberBuilder.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace Java.Interop {
@@ -27,6 +28,11 @@ namespace Java.Interop {
 		}
 
 		[System.Diagnostics.CodeAnalysis.SuppressMessage ("Design", "CA1031:Do not catch general exception types", Justification = "the *.Export assemblies are optional, so we don't care when they cannot be loaded (they are presumably missing)")]
+#if NET
+		[DynamicDependency (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, "Java.Interop.MarshalMemberBuilder", "Java.Interop.Export")]
+		[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "DynamicDependency should preserve the constructor.")]
+		[UnconditionalSuppressMessage ("Trimming", "IL2035", Justification = "Java.Interop.Export.dll is not always present.")]
+#endif
 		partial void SetMarshalMemberBuilder (CreationOptions options)
 		{
 			if (!options.UseMarshalMemberBuilder) {


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/5652

If you build a .NET 6 Android app:

    dotnet new android
    dotnet build -c Release -bl -p:SuppressTrimAnalysisWarnings=false

You get warnings like:

    external\Java.Interop\src\Java.Interop\Java.Interop\JniRuntime.JniMarshalMemberBuilder.cs(53,4): warning IL2026: Java.Interop.JniRuntime.SetMarshalMemberBuilder(JniRuntime.CreationOptions): Using method 'System.Reflection.Assembly.GetType(String)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Types might be removed.

Adding this is not sufficient to fix the warning:

    [DynamicDependency (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, "Java.Interop.MarshalMemberBuilder", "Java.Interop.Export")]

You also need to suppress `IL2026`:

    [UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "DynamicDependency should preserve the constructor.")]

Then, because `Java.Interop.Export.dll` is not always included in
apps, we also need to suppress:

    [UnconditionalSuppressMessage ("Trimming", "IL2035", Justification = "Java.Interop.Export.dll is not always present.")]