### PR TITLE
[build] Import $(MSBuildProjectDirectory).override.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,6 +17,10 @@
       Condition="Exists('$(MSBuildThisFileDirectory)Configuration.Override.props')"
   />
   <Import
+      Project="$(MSBuildProjectDirectory).override.props"
+      Condition="Exists('$(MSBuildProjectDirectory).override.props')"
+  />
+  <Import
       Project="$(_OutputPath)JdkInfo.props"
       Condition="Exists('$(_OutputPath)JdkInfo.props')"
   />


### PR DESCRIPTION
Commit b6431ac8 introduced support for `Configuration.Override.props`,
which eventually allowed overriding the `external/xamarin-android-tools`
path via the `$(XamarinAndroidToolsDirectory)` MSBuild property in
commit 32f0c9cf9.

A problem with this approach is that it requires that the host repo
create the `Java.Interop/Configuration.Override.props` file before
running `make -C …/Java.Interop prepare`.

This can be simplified: update `Directory.Build.props` so that it
will also `<Import/>` the file
`$(MSBuildProjectDirectory).override.props`.
[`$(MSBuildProjectDirectory)`][0] is:

> The absolute path of the directory where the project file is
> located, for example `C:\MyCompany\MyProduct`.
>
> Do not include the final backslash on this property.

The "Do not" is grammatically odd, as it's set by MSBuild.
It *does not* include a final backslash.

This means that we can place the `.override.props` file in the
directory containing the Java.Interop checkout, with a name that
matches the git submodule directory name:

	external/my-Java.Interop-checkout                   # git submodule to xamarin/Java.Interop
	external/my-Java.Interop-checkout.override.props    # now automatically imported

[0]: https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-reserved-and-well-known-properties?view=vs-2019