### PR TITLE
[build] Properly implement "parent directory.override.props" (#300)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,8 +17,8 @@
       Condition="Exists('$(MSBuildThisFileDirectory)Configuration.Override.props')"
   />
   <Import
-      Project="$(MSBuildProjectDirectory).override.props"
-      Condition="Exists('$(MSBuildProjectDirectory).override.props')"
+      Project="$([System.IO.Path]::GetDirectoryName($(MSBuildThisFileDirectory))).override.props"
+      Condition=" Exists('$([System.IO.Path]::GetDirectoryName($(MSBuildThisFileDirectory))).override.props') "
   />
   <Import
       Project="$(_OutputPath)JdkInfo.props"


### PR DESCRIPTION
Commit 8898bc14 put too much faith into `$(MSBuildProjectDirectory)).
The problem is that `$(MSBuildProjectDirectory)` *isn't necessarily*
the path to `Directory.Build.props`; it's the directory for the
`.csproj` being built!

The *intent* for 8898bc14 is that e.g. `xamarin/xamarin-android`
should be able to create a `Java.Interop.override.props` file
alongside the `Java.Interop` git submodule, and the Java.Interop
build would use the overrides within `Java.Interop.override.props`.

That didn't happen; due to using `$(MSBuildProjectDirectory)`, the
build may instead attempting to import e.g.
`Java.Interop/src/Java.Interop.override.props`!

        Project "$(MSBuildProjectDirectory).override.props" was not imported by "…/external/Java.Interop/Directory.Build.props" at (6,3), due to false condition;
        (Exists('$(MSBuildProjectDirectory).override.props')) was evaluated as
        (Exists('…/xamarin-android/external/Java.Interop/src/Java.Interop.override.props')).

Oops.

Fix the `<Import/>` expressions so that we instead try to import:

        $([System.IO.Path]::GetDirectoryName($(MSBuildThisFileDirectory))).override.props

We need `$(MSBuildThisFileDirectory)`, as that's the easiest way to
get the checkout directory -- the directory containing
`Directory.Build.props` -- but `$(MSBuildThisFileDirectory)` always
ends in a directory separator character.  Remove the directory
separator character by using `Path.GetDirectoryName()`.

This allows e.g. the `Java.Interop.csproj` build to appropriately
import `Java.Interop.override.props`.