### PR TITLE
Bump various NuGets to match related repositories.

### DIFF
--- a/src/Java.Interop.Localization/Java.Interop.Localization.csproj
+++ b/src/Java.Interop.Localization/Java.Interop.Localization.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="XliffTasks" Version="1.0.0-beta.20206.1" />
+    <PackageReference Include="XliffTasks" Version="1.0.0-beta.20420.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/class-parse/class-parse.csproj
+++ b/tools/class-parse/class-parse.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Options" Version="5.3.0.1" />
+    <PackageReference Include="Mono.Options" Version="6.6.0.161" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
   </ItemGroup>
 

--- a/tools/generator/generator.csproj
+++ b/tools/generator/generator.csproj
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="Irony" Version="1.1.0" />
-    <PackageReference Include="Mono.Options" Version="5.3.0.1" />
+    <PackageReference Include="Mono.Options" Version="6.6.0.161" />
     <!-- Since we are sharing an OutputDirectory, and HtmlAgilityPack is also referenced by a different netstandard2.0 libary,
           we can explicitly reference the netstandard2.0 version here. This will also ensure symbol files are copied to the output directory. -->
     <PackageReference Include="HtmlAgilityPack" Version="1.11.24" ExcludeAssets="Compile" GeneratePathProperty="true" />

--- a/tools/jcw-gen/jcw-gen.csproj
+++ b/tools/jcw-gen/jcw-gen.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Options" Version="5.3.0.1" />
+    <PackageReference Include="Mono.Options" Version="6.6.0.161" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
   </ItemGroup>
 

--- a/tools/jnimarshalmethod-gen/Xamarin.Android.Tools.JniMarshalMethodGenerator.csproj
+++ b/tools/jnimarshalmethod-gen/Xamarin.Android.Tools.JniMarshalMethodGenerator.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Options" Version="5.3.0.1" />
+    <PackageReference Include="Mono.Options" Version="6.6.0.161" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
   </ItemGroup>
 

--- a/tools/logcat-parse/logcat-parse.csproj
+++ b/tools/logcat-parse/logcat-parse.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Options" Version="5.3.0.1" />
+    <PackageReference Include="Mono.Options" Version="6.6.0.161" />
     <PackageReference Include="Mono.Terminal" Version="5.4.2" GeneratePathProperty="True" />
     <PackageReference Include="Mono.CSharp" Version="4.0.0.143" NoWarn="NU1701" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />

--- a/tools/param-name-importer/param-name-importer.csproj
+++ b/tools/param-name-importer/param-name-importer.csproj
@@ -19,7 +19,7 @@
     <Reference Include="SgmlReader">
       <HintPath>$(PkgMicrosoft_Xml_SgmlReader)\lib\netstandard2.0\SgmlReaderDll.dll</HintPath>
     </Reference>
-    <PackageReference Include="Mono.Options" Version="5.3.0.1" />
+    <PackageReference Include="Mono.Options" Version="6.6.0.161" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
- Bump `XliffTasks` to `1.0.0-beta.20420.1` to match [`xamarin-android-tools`](https://github.com/xamarin/xamarin-android-tools/blob/main/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj#L37).
- Bump `Mono.Options` to `6.6.0.161` to match [`xamarin-android`](https://github.com/xamarin/xamarin-android/blob/bcc315857f2cd61351ba469973043d91c902c50e/Directory.Build.props#L36).