### PR TITLE
[build] Fix 'BuildVersionInfo_g_cs' build target.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -40,7 +40,7 @@
     <AppendTargetFrameworkToOutputPath Condition=" '$(AppendTargetFrameworkToOutputPath)' == '' ">False</AppendTargetFrameworkToOutputPath>
     <BaseIntermediateOutputPath Condition=" '$(BaseIntermediateOutputPath)' == '' ">obj\</BaseIntermediateOutputPath>
   </PropertyGroup>
-  <PropertyGroup Condition=" ( '$(TargetFramework)' != '' AND !$(TargetFramework.StartsWith('nets'))) AND (!$(TargetFramework.StartsWith('net4'))) "> 
+  <PropertyGroup Condition=" '$(TargetFramework)' != '' And (!$(TargetFramework.StartsWith('nets')) And !$(TargetFramework.StartsWith('net4')) And !$(TargetFramework.StartsWith('monoandroid'))) ">
     <JIBuildingForNetCoreApp>True</JIBuildingForNetCoreApp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(JIBuildingForNetCoreApp)' == 'True' ">

--- a/src/Java.Interop/Directory.Build.targets
+++ b/src/Java.Interop/Directory.Build.targets
@@ -41,6 +41,7 @@
       <Replacements Include="@PRODUCT@" Replacement="$(AssemblyName)"/>
       <Replacements Include="@CONFIGURATION@" Replacement="$(Configuration)"/>
     </ItemGroup>
+    <MakeDir Directories="$(IntermediateOutputPath)" />
     <GenerateVersionFile
         InputFile="$(MSBuildThisFileDirectory)..\..\build-tools\scripts\AssemblyInfo.g.cs.in"
         OutputFile="$(IntermediateOutputPath)$(AssemblyName).AssemblyInfo.g.cs"

--- a/src/Java.Interop/Directory.Build.targets
+++ b/src/Java.Interop/Directory.Build.targets
@@ -41,7 +41,6 @@
       <Replacements Include="@PRODUCT@" Replacement="$(AssemblyName)"/>
       <Replacements Include="@CONFIGURATION@" Replacement="$(Configuration)"/>
     </ItemGroup>
-    <MakeDir Directories="$(IntermediateOutputPath)" />
     <GenerateVersionFile
         InputFile="$(MSBuildThisFileDirectory)..\..\build-tools\scripts\AssemblyInfo.g.cs.in"
         OutputFile="$(IntermediateOutputPath)$(AssemblyName).AssemblyInfo.g.cs"

--- a/src/Java.Interop/Java.Interop-MonoAndroid.csproj
+++ b/src/Java.Interop/Java.Interop-MonoAndroid.csproj
@@ -86,8 +86,8 @@
   <Import Project="Directory.Build.targets" />
   <PropertyGroup>
     <BuildDependsOn>
-      BuildVersionInfo_g_cs;
       BuildJniEnvironment_g_cs;
+      BuildVersionInfo_g_cs;
       BuildInteropJar;
       $(BuildDependsOn)
     </BuildDependsOn>


### PR DESCRIPTION
The commit 3e6a6232 added a new target 'BuildVersionInfo_g_cs' which is
responsible for generating the `BuildVersionInfo_g_cs` in the
`$(IntermediateOutputPath)`.

However it turns out the `$(IntermediateOutputPath)` has not been created when the target is
run, so we end up with the following error.

```
/mnt/vss/_work/1/s/xamarin-android/external/Java.Interop/src/Java.Interop/Directory.Build.targets(44,5): error MSB4018: The "GenerateVersionFile" task failed unexpectedly. [/mnt/vss/_work/1/s/xamarin-android/external/Java.Interop/src/Java.Interop/Java.Interop-MonoAndroid.csproj]
/mnt/vss/_work/1/s/xamarin-android/external/Java.Interop/src/Java.Interop/Directory.Build.targets(44,5): error MSB4018: System.IO.DirectoryNotFoundException: Could not find a part of the path "/mnt/vss/_work/1/s/xamarin-android/external/Java.Interop/src/Java.Interop/obj/Release-monoandroid10/Java.Interop.AssemblyInfo.g.cs". [/mnt/vss/_work/1/s/xamarin-android/external/Java.Interop/src/Java.Interop/Java.Interop-MonoAndroid.csproj]
/mnt/vss/_work/1/s/xamarin-android/external/Java.Interop/src/Java.Interop/Directory.Build.targets(44,5): error MSB4018:   at System.IO.FileStream..ctor (System.String path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, System.Int32 bufferSize, System.Boolean anonymous, System.IO.FileOptions options) [0x00164] in <85ce94efa4ba468a921bc3ed4ecd0dbe>:0  [/mnt/vss/_work/1/s/xamarin-android/external/Java.Interop/src/Java.Interop/Java.Interop-MonoAndroid.csproj]
/mnt/vss/_work/1/s/xamarin-android/external/Java.Interop/src/Java.Interop/Directory.Build.targets(44,5): error MSB4018:   at System.IO.FileStream..ctor (System.String path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, System.Int32 bufferSize, System.IO.FileOptions options) [0x00000] in <85ce94efa4ba468a921bc3ed4ecd0dbe>:0  [/mnt/vss/_work/1/s/xamarin-android/external/Java.Interop/src/Java.Interop/Java.Interop-MonoAndroid.csproj]
/mnt/vss/_work/1/s/xamarin-android/external/Java.Interop/src/Java.Interop/Directory.Build.targets(44,5): error MSB4018:   at (wrapper remoting-invoke-with-check) System.IO.FileStream..ctor(string,System.IO.FileMode,System.IO.FileAccess,System.IO.FileShare,int,System.IO.FileOptions) [/mnt/vss/_work/1/s/xamarin-android/external/Java.Interop/src/Java.Interop/Java.Interop-MonoAndroid.csproj]
/mnt/vss/_work/1/s/xamarin-android/external/Java.Interop/src/Java.Interop/Directory.Build.targets(44,5): error MSB4018:   at System.IO.StreamWriter..ctor (System.String path, System.Boolean append, System.Text.Encoding encoding, System.Int32 bufferSize) [0x00055] in <85ce94efa4ba468a921bc3ed4ecd0dbe>:0  [/mnt/vss/_work/1/s/xamarin-android/external/Java.Interop/src/Java.Interop/Java.Interop-MonoAndroid.csproj]
/mnt/vss/_work/1/s/xamarin-android/external/Java.Interop/src/Java.Interop/Directory.Build.targets(44,5): error MSB4018:   at System.IO.StreamWriter..ctor (System.String path) [0x00008] in <85ce94efa4ba468a921bc3ed4ecd0dbe>:0  [/mnt/vss/_work/1/s/xamarin-android/external/Java.Interop/src/Java.Interop/Java.Interop-MonoAndroid.csproj]
/mnt/vss/_work/1/s/xamarin-android/external/Java.Interop/src/Java.Interop/Directory.Build.targets(44,5): error MSB4018:   at (wrapper remoting-invoke-with-check) System.IO.StreamWriter..ctor(string) [/mnt/vss/_work/1/s/xamarin-android/external/Java.Interop/src/Java.Interop/Java.Interop-MonoAndroid.csproj]
/mnt/vss/_work/1/s/xamarin-android/external/Java.Interop/src/Java.Interop/Directory.Build.targets(44,5): error MSB4018:   at System.IO.File.WriteAllText (System.String path, System.String contents) [0x00026] in <85ce94efa4ba468a921bc3ed4ecd0dbe>:0  [/mnt/vss/_work/1/s/xamarin-android/external/Java.Interop/src/Java.Interop/Java.Interop-MonoAndroid.csproj]
/mnt/vss/_work/1/s/xamarin-android/external/Java.Interop/src/Java.Interop/Directory.Build.targets(44,5): error MSB4018:   at Java.Interop.BootstrapTasks.GenerateVersionFile.Execute () [0x00042] in /mnt/vss/_work/1/s/xamarin-android/external/Java.Interop/build-tools/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks/GenerateVersionFile.cs:23
```

So lets create the directory before we try to create the file.

Added a check for the `monoandroid` TargetFramework as it was causing the following build error on Xamarin.Android

```
error MSB3073: The command "/Users/dean/android-toolchain/dotnet/dotnet "/Users/dean/Documents/Sandbox/Xamarin/xamarin-android/external/Java.Interop/bin/BuildDebug-monoandroid10/jnienv-gen.dll" Java.Interop/JniEnvironment.g.cs obj/Debug-monoandroid10/jni.c" exited with code 1
```