### PR TITLE
[generator] Remove buggy annotation loose match.

### DIFF
--- a/src/Xamarin.Android.Tools.AnnotationSupport/Objects/AnnotationData.cs
+++ b/src/Xamarin.Android.Tools.AnnotationSupport/Objects/AnnotationData.cs
@@ -11,6 +11,7 @@ namespace Xamarin.AndroidTools.AnnotationSupport
 			"android.support.annotation.",
 			"androidx.annotation.",
 		};
+
 		public AnnotationData (XElement e)
 		{
 			var a = e.Attribute ("name");

--- a/src/Xamarin.Android.Tools.AnnotationSupport/Objects/AnnotationData.cs
+++ b/src/Xamarin.Android.Tools.AnnotationSupport/Objects/AnnotationData.cs
@@ -7,13 +7,20 @@ namespace Xamarin.AndroidTools.AnnotationSupport
 {
 	public class AnnotationData : AnnotationObject
 	{
+		static readonly string[] Prefixes = new[] {
+			"android.support.annotation.",
+			"androidx.annotation.",
+		};
 		public AnnotationData (XElement e)
 		{
 			var a = e.Attribute ("name");
 			Name = a == null ? null : a.Value;
-			string predef = "android.support.annotation.";
-			if (Name.StartsWith (predef, StringComparison.Ordinal))
+			foreach (var predef in Prefixes) {
+				if (!Name.StartsWith (predef, StringComparison.Ordinal))
+					continue;
 				Name = Name.Substring (predef.Length);
+				break;
+			}
 			Values = e.Elements ("val").Select (c => new AnnotationValue (c)).ToArray ();
 		}
 		

--- a/tools/generator/ManagedTypeFinderGeneratorTypeSystem.cs
+++ b/tools/generator/ManagedTypeFinderGeneratorTypeSystem.cs
@@ -119,27 +119,6 @@ namespace Xamarin.AndroidTools.AnnotationSupport
 				m.Parameters.Count == item.Arguments.Length)
 				.ToArray ();
 
-			// First, try loose match.
-
-			MethodBase candidate = null;
-			bool overloaded = false;
-			foreach (var m in methods) {
-				if (overloaded)
-					break;
-				if (candidate != null) {
-					overloaded = true;
-					break;
-				} else
-					candidate = m;
-			}
-			if (!overloaded) {
-				if (candidate == null)
-					Errors.Add ("warning: method with matching argument count not found: " + t.FullName + " member: " + item.FormatMember ());
-				return candidate.Wrap ();
-			}
-
-			// Second, try strict match.
-
 			var argTypeLists = methods.Select (m => new { Method = m, Jni = m is Ctor ? ((Ctor) m).JniSignature : ((Method) m).JniSignature})
 			                          .Select (p => new { Method = p.Method, Arguments = p.Jni == null ? null : ParseJniMethodArgumentsSignature (p.Jni)})
 			                          .ToArray ();


### PR DESCRIPTION
Context: #885 

When updating to the latest `annotations.zip` file, some `Mono.Android.dll` members are getting multiple `[RequiresPermission]` attributes applied.  This is because the `.zip` contains the following entries:
```xml
<item name="android.os.Vibrator void vibrate(android.os.VibrationEffect)">
  <annotation name="androidx.annotation.RequiresPermission">
    <val name="value" val="&quot;android.permission.VIBRATE&quot;" />
  </annotation>
</item>
<item name="android.os.Vibrator void vibrate(long)">
  <annotation name="androidx.annotation.RequiresPermission">
    <val name="value" val="&quot;android.permission.VIBRATE&quot;" />
  </annotation>
</item>
```

Which correspond to these overloads:
```csharp
public virtual void Vibrate (Android.OS.VibrationEffect vibe);
public virtual void Vibrate (long milliseconds);
```

However, the overload that takes `Android.OS.VibrationEffect` wasn't added until API-26, so when binding API-21 only the overload taking `long` exists.

Our [method finding code](https://github.com/xamarin/java.interop/blob/main/tools/generator/ManagedTypeFinderGeneratorTypeSystem.cs#L113) first does a "loose" match where it sees if there is only 1 bound method that has the same number of parameters as the annotation.  If so, it uses that overload without checking if the parameter types match.

In this case, both annotations "match" the only overload with a single parameter, so both annotations get applied to it, causing the duplicate.  The fix is to remove the "loose" match and require all matches to be "strict".

A test XA PR was run to ensure this does not cause a regression.  It only changed a few attributes, and seems to have made them more accurate: https://github.com/xamarin/xamarin-android/pull/6344/files.