### PR TITLE
[class-parse] Ignore Java Native libraries.

### DIFF
--- a/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
@@ -61,7 +61,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 					if (entry.Length == 0)
 						continue;
 					using (var s = entry.Open ()) {
-						if (!ClassFile.IsClassFile (s))
+						if (!ClassFile.IsClassFile (s) || entry.Name.EndsWith (".jnilib", StringComparison.OrdinalIgnoreCase))
 							continue;
 					}
 					using (var s = entry.Open ()) {


### PR DESCRIPTION
Fixes: https://github.com/xamarin/java.interop/issues/860

`.jnilib` files seem to be some sort of [Java Native file for Mac ](https://stackoverflow.com/questions/1495161/converting-a-so-file-to-a-jnilib-file).  It starts with the magic token of `0xcafebabe` but is not the type of compiled `.class` file we understand and are interested in.

![image](https://user-images.githubusercontent.com/179295/136593203-c8a017b6-f113-4ee2-8b44-e5ffa4eaa34b.png)

Trying to parse it results in:
```
System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection.

  StackTrace:
   at System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument argument, ExceptionResource resource)
   at System.Collections.Generic.List`1.get_Item(Int32 index)
   at Xamarin.Android.Tools.Bytecode.AttributeInfo.CreateFromStream(ConstantPool constantPool, Stream stream) in 
 Xamarin.Android.Tools.Bytecode\AttributeInfo.cs:line 101
```

We should ignore this file in a `.jar`.