### PR TITLE
[class-parse] `.jmod` file support

### DIFF
--- a/src/Xamarin.Android.Tools.Bytecode/AttributeInfo.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/AttributeInfo.cs
@@ -360,6 +360,8 @@ namespace Xamarin.Android.Tools.Bytecode {
 			}
 		}
 
+		public string OuterClassName => OuterClass?.Name?.Value;
+
 		public override string ToString ()
 		{
 			return string.Format ("InnerClass(InnerClass='{0}', OuterClass='{1}', InnerName='{2}', InnerClassAccessFlags={3})",

--- a/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
@@ -41,14 +41,22 @@ namespace Xamarin.Android.Tools.Bytecode {
 			Load (path);
 		}
 
-		public void Load (string jarFile)
+		public void Load (string filePath)
 		{
-			if (!IsJarFile (jarFile))
-				throw new ArgumentException ("'jarFile' is not a valid .jar file.", "jarFile");
-
-			using (var jarStream = File.OpenRead (jarFile)) { 
-				Load (jarStream);
+			if (IsJmodFile (filePath)) {
+				using (var source   = File.OpenRead (filePath)) {
+					var slice       = new PartialStream (source, 4);
+					Load (slice);
+				}
+				return;
 			}
+			if (IsJarFile (filePath)) {
+				using (var jarStream = File.OpenRead (filePath)) {
+					Load (jarStream);
+				}
+				return;
+			}
+			throw new ArgumentException ($"`{filePath}` is not a supported file format.", nameof (filePath));
 		}
 
 		public void Load (Stream jarStream, bool leaveOpen = false)
@@ -107,6 +115,23 @@ namespace Xamarin.Android.Tools.Bytecode {
 				using (new ZipArchive (f)) {
 					return true;
 				}
+			}
+			catch (Exception) {
+				return false;
+			}
+		}
+
+		public static bool IsJmodFile (string jmodFile)
+		{
+			if (jmodFile == null)
+				throw new ArgumentNullException (nameof (jmodFile));
+			try {
+				var f = File.OpenRead (jmodFile);
+				var h = new byte[4];
+				if (f.Read (h, 0, h.Length) != 4) {
+					return false;
+				}
+				return h[0] == 0x4a && h[1] == 0x4d && h[2] == 0x01 && h[3] == 0x00;
 			}
 			catch (Exception) {
 				return false;

--- a/src/Xamarin.Android.Tools.Bytecode/Log.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/Log.cs
@@ -15,6 +15,8 @@ namespace Xamarin.Android.Tools.Bytecode
 			log (TraceLevel.Warning, verbosity, format, args);
 		}
 
+		public static void Warning (int verbosity, string message) => Warning (verbosity, "{0}", message);
+
 		public static void Error (string format, params object[] args)
 		{
 			var log = OnLog;
@@ -22,6 +24,8 @@ namespace Xamarin.Android.Tools.Bytecode
 				return;
 			log (TraceLevel.Error, 0, format, args);
 		}
+
+		public static void Error (string message) => Error ("{0}", message);
 
 		public static void Message (string format, params object[] args)
 		{
@@ -31,6 +35,8 @@ namespace Xamarin.Android.Tools.Bytecode
 			log (TraceLevel.Info, 0, format, args);
 		}
 
+		public static void Message (string message) => Message ("{0}", message);
+
 		public static void Debug (string format, params object[] args)
 		{
 			var log = OnLog;
@@ -38,6 +44,8 @@ namespace Xamarin.Android.Tools.Bytecode
 				return;
 			log (TraceLevel.Verbose, 0, format, args);
 		}
+
+		public static void Debug (string message) => Debug ("{0}", message);
 	}
 }
 

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/ConfiguredJdkInfo.cs
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/ConfiguredJdkInfo.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+using Xamarin.Android.Tools;
+
+namespace Xamarin.Android.Tools.BytecodeTests {
+
+	static class ConfiguredJdkInfo {
+
+		static JdkInfo info;
+
+		static ConfiguredJdkInfo ()
+		{
+			var jdkPath = ReadJavaSdkDirectoryFromJdkInfoProps ();
+			if (jdkPath == null)
+				return;
+			info    = new JdkInfo (jdkPath);
+		}
+
+		public static Version Version => info?.Version;
+
+		static string ReadJavaSdkDirectoryFromJdkInfoProps ()
+		{
+			var location    = typeof (ConfiguredJdkInfo).Assembly.Location;
+			var binDir      = Path.GetDirectoryName (Path.GetDirectoryName (location));
+			var testDir     = Path.GetFileName (Path.GetDirectoryName (location));
+			if (!testDir.StartsWith ("Test", StringComparison.OrdinalIgnoreCase)) {
+				return null;
+			}
+			var buildName   = testDir.Replace ("Test", "Build");
+			if (buildName.IndexOf ("-", StringComparison.Ordinal) >= 0) {
+				buildName   = buildName.Substring (0, buildName.IndexOf ('-'));
+			}
+			var jdkPropFile = Path.Combine (binDir, buildName, "JdkInfo.props");
+			if (!File.Exists (jdkPropFile)) {
+				return null;
+			}
+
+			var msbuild     = XNamespace.Get ("http://schemas.microsoft.com/developer/msbuild/2003");
+
+			var jdkProps    = XDocument.Load (jdkPropFile);
+			var jdkPath     = jdkProps.Elements ()
+				.Elements (msbuild + "PropertyGroup")
+				.Elements (msbuild + "JavaSdkDirectory")
+				.FirstOrDefault ();
+			if (jdkPath == null) {
+				return null;
+			}
+			return jdkPath.Value;
+		}
+	}
+}

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/ExpectedMethodDeclaration.cs
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/ExpectedMethodDeclaration.cs
@@ -43,19 +43,21 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 			}
 
 			var parameters  = method.GetParameters ();
-			NAssert.AreEqual (Parameters.Count, parameters.Length,  $"Method {Name} Parameter Count");
+			NAssert.AreEqual (Parameters.Count, parameters.Length,  $"Method {Name} Parameter Count\n" +
+				$"Expected signature: {string.Join (", ", Parameters.Select (p => $"{p.Type.TypeSignature}: {p.Name}"))}\n" +
+				$"  Actual signature: {string.Join (", ", parameters.Select (p => $"{p.Type.TypeSignature}: {p.Name}"))}");
 			for (int i = 0; i < Parameters.Count; ++i) {
-				NAssert.AreEqual (Parameters [i].Name,                  parameters [i].Name,                message);
-				NAssert.AreEqual (i,                                    parameters [i].Position,            message);
-				NAssert.AreEqual (Parameters [i].Type.BinaryName,       parameters [i].Type.BinaryName,     message);
-				NAssert.AreEqual (Parameters [i].Type.TypeSignature,    parameters [i].Type.TypeSignature,  message);
+				NAssert.AreEqual (Parameters [i].Name,                  parameters [i].Name,                message + $": parameter {i} name");
+				NAssert.AreEqual (i,                                    parameters [i].Position,            message + $": parameter {i} position");
+				NAssert.AreEqual (Parameters [i].Type.BinaryName,       parameters [i].Type.BinaryName,     message + $": parameter {i} binary name");
+				NAssert.AreEqual (Parameters [i].Type.TypeSignature,    parameters [i].Type.TypeSignature,  message + $": parameter {i} type signature");
 			}
 
 			var exceptions  = method.GetThrows ();
 			NAssert.AreEqual (Throws.Count, exceptions.Count);
 			for (int i = 0; i < Throws.Count; ++i) {
-				NAssert.AreEqual (Throws [i].BinaryName,    exceptions [i].BinaryName,      message);
-				NAssert.AreEqual (Throws [i].TypeSignature, exceptions [i].TypeSignature,   message);
+				NAssert.AreEqual (Throws [i].BinaryName,    exceptions [i].BinaryName,      message + $": throws {i} binary name");
+				NAssert.AreEqual (Throws [i].TypeSignature, exceptions [i].TypeSignature,   message + $": throws {i} type signature");
 			}
 		}
 	}

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/JavaType.1MyStringListTests.cs
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/JavaType.1MyStringListTests.cs
@@ -1,0 +1,138 @@
+﻿using System;
+
+using Xamarin.Android.Tools.Bytecode;
+
+using NUnit.Framework;
+
+namespace Xamarin.Android.Tools.BytecodeTests {
+
+	[TestFixture]
+	public class JavaType_1MyStringListTests : ClassFileFixture {
+
+		const string JavaType = "JavaType$1MyStringList";
+
+		static readonly bool Jdk8   = ConfiguredJdkInfo.Version == null
+				? false
+				: ConfiguredJdkInfo.Version < new Version (1, 9);
+
+		[Test]
+		public void ClassFileDescription ()
+		{
+			var vallist = Jdk8
+				? new ParameterInfo ("val$value1",        "Ljava/util/List;",     "Ljava/util/List;")
+				: new ParameterInfo ("val$unboundedList", "Ljava/util/List;",     "Ljava/util/List;");
+			var valobj  = Jdk8
+				? new ParameterInfo ("val$unboundedList", "Ljava/lang/Object;",   "Ljava/lang/Object;")
+				: new ParameterInfo ("val$value1",        "Ljava/lang/Object;",   "Ljava/lang/Object;");
+			var c       = LoadClassFile (JavaType + ".class");
+			new ExpectedTypeDeclaration {
+				MajorVersion        = 0x34,
+				MinorVersion        = 0,
+				ConstantPoolCount   = 73,
+				AccessFlags         = ClassAccessFlags.Super,
+				FullName            = "com/xamarin/JavaType$1MyStringList",
+				Superclass          = new TypeInfo ("java/util/ArrayList", "Ljava/util/ArrayList<Ljava/lang/String;>;"),
+				InnerClasses = {
+					new ExpectedInnerClassInfo {
+						InnerClassName  = "com/xamarin/JavaType$1MyStringList",
+						OuterClassName  = null,
+						InnerName       = "MyStringList",
+						AccessFlags     = 0,
+					},
+				},
+				Fields = {
+					new ExpectedFieldDeclaration {
+						Name                = "val$unboundedList",
+						Descriptor          = "Ljava/util/List;",
+						AccessFlags         = FieldAccessFlags.Final | FieldAccessFlags.Synthetic,
+					},
+					new ExpectedFieldDeclaration {
+						Name                = "val$value1",
+						Descriptor          = "Ljava/lang/Object;",
+						AccessFlags         = FieldAccessFlags.Final | FieldAccessFlags.Synthetic,
+					},
+				},
+				Methods = {
+					new ExpectedMethodDeclaration {
+						Name                    = "<init>",
+						AccessFlags             = MethodAccessFlags.Public,
+						ReturnDescriptor        = "V",
+						Parameters = {
+							// "actual" parameters:
+							new ParameterInfo ("a",                 "Ljava/lang/String;",   "Ljava/lang/String;"),
+							new ParameterInfo ("b",                 "I",                    "I"),
+							// declaring method parameters:
+							vallist,
+							valobj,
+						},
+					},
+					new ExpectedMethodDeclaration {
+						Name                    = "<init>",
+						AccessFlags             = MethodAccessFlags.Public,
+						ReturnDescriptor        = "V",
+						Parameters = {
+							// "actual" parameters:
+							new ParameterInfo ("value1",            "Ljava/lang/Object;",   "TT;"),
+							new ParameterInfo ("a",                 "Ljava/lang/String;",   "Ljava/lang/String;"),
+							new ParameterInfo ("b",                 "I",                    "I"),
+							// declaring method parameters:
+							vallist,
+							valobj,
+						},
+					},
+					new ExpectedMethodDeclaration {
+						Name                    = "<init>",
+						AccessFlags             = MethodAccessFlags.Public,
+						ReturnDescriptor        = "V",
+						Parameters = {
+							// "actual" parameters:
+							new ParameterInfo ("a",                 "Ljava/lang/String;",   "Ljava/lang/String;"),
+							new ParameterInfo ("value2",            "Ljava/lang/Number;",   "TTExtendsNumber;"),
+							new ParameterInfo ("b",                 "I",                    "I"),
+							// declaring method parameters:
+							vallist,
+							valobj,
+						},
+					},
+					new ExpectedMethodDeclaration {
+						Name                    = "<init>",
+						AccessFlags             = MethodAccessFlags.Public,
+						ReturnDescriptor        = "V",
+						Parameters = {
+							// "actual" parameters:
+							new ParameterInfo ("a",                 "Ljava/lang/String;",   "Ljava/lang/String;"),
+							new ParameterInfo ("b",                 "I",                    "I"),
+							new ParameterInfo ("unboundedList",     "Ljava/util/List;",     "Ljava/util/List<*>;"),
+							// declaring method parameters:
+							vallist,
+							valobj,
+						},
+					},
+					new ExpectedMethodDeclaration {
+						Name                    = "get",
+						AccessFlags             = MethodAccessFlags.Public,
+						ReturnDescriptor        = "Ljava/lang/String;",
+						Parameters = {
+							new ParameterInfo ("index", "I",     "I"),
+						},
+					},
+					new ExpectedMethodDeclaration {
+						Name                    = "get",
+						AccessFlags             = MethodAccessFlags.Public | MethodAccessFlags.Bridge | MethodAccessFlags.Synthetic,
+						ReturnDescriptor        = "Ljava/lang/Object;",
+						Parameters = {
+							new ParameterInfo ("index", "I",     "I"),
+						},
+					},
+				}
+			}.Assert (c);
+		}
+
+		[Test]
+		public void XmlDescription ()
+		{
+			var resourceName = JavaType + (Jdk8 ? "-1.8" : "") + ".xml";
+			AssertXmlDeclaration (JavaType + ".class", resourceName);
+		}
+	}
+}

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/JavaTypeTests.cs
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/JavaTypeTests.cs
@@ -20,7 +20,7 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 			new ExpectedTypeDeclaration {
 				MajorVersion        = 0x34,
 				MinorVersion        = 0,
-				ConstantPoolCount   = 195,
+				ConstantPoolCount   = 198,
 				AccessFlags         = ClassAccessFlags.Public | ClassAccessFlags.Super,
 				FullName            = "com/xamarin/JavaType",
 				Superclass          = new TypeInfo ("java/lang/Object", "Ljava/lang/Object;"),
@@ -53,6 +53,12 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 						OuterClassName  = "com/xamarin/JavaType",
 						InnerName       = "PSC",
 						AccessFlags     = ClassAccessFlags.Public | ClassAccessFlags.Static | ClassAccessFlags.Abstract,
+					},
+					new ExpectedInnerClassInfo {
+						InnerClassName  = "com/xamarin/JavaType$1MyStringList",
+						OuterClassName  = null,
+						InnerName       = "MyStringList",
+						AccessFlags     = 0,
 					},
 					new ExpectedInnerClassInfo {
 						InnerClassName  = "com/xamarin/JavaType$1",
@@ -138,7 +144,7 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 						Name                = "STATIC_FINAL_STRING",
 						Descriptor          = "Ljava/lang/String;",
 						AccessFlags         = FieldAccessFlags.Public | FieldAccessFlags.Static | FieldAccessFlags.Final,
-						ConstantValue       = "String(stringIndex=185 Utf8=\"Hello, \\\"embedded\0Nulls\" and \ud83d\udca9!\")",
+						ConstantValue       = "String(stringIndex=188 Utf8=\"Hello, \\\"embedded\0Nulls\" and \ud83d\udca9!\")",
 					},
 					new ExpectedFieldDeclaration {
 						Name                = "STATIC_FINAL_BOOL_FALSE",

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/Resources/JavaType$1MyStringList-1.8.xml
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/Resources/JavaType$1MyStringList-1.8.xml
@@ -1,0 +1,177 @@
+<api
+  api-source="class-parse">
+  <package
+    name="com.xamarin"
+    jni-name="com/xamarin">
+    <class
+      abstract="false"
+      deprecated="not deprecated"
+      enclosing-method-jni-type="Lcom/xamarin/JavaType;"
+      enclosing-method-name="staticActionWithGenerics"
+      enclosing-method-signature="(Ljava/lang/Object;Ljava/lang/Number;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V"
+      jni-extends="Ljava/util/ArrayList;"
+      extends="java.util.ArrayList"
+      extends-generic-aware="java.util.ArrayList&lt;java.lang.String&gt;"
+      final="false"
+      name="JavaType.1MyStringList"
+      jni-signature="Lcom/xamarin/JavaType$1MyStringList;"
+      source-file-name="JavaType.java"
+      static="false"
+      visibility="">
+      <constructor
+        deprecated="not deprecated"
+        final="false"
+        name="JavaType.1MyStringList"
+        static="false"
+        visibility="public"
+        bridge="false"
+        synthetic="false"
+        jni-signature="(Ljava/lang/Object;Ljava/lang/String;ILjava/util/List;Ljava/lang/Object;)V">
+        <parameter
+          name="value1"
+          type="T"
+          jni-type="TT;" />
+        <parameter
+          name="a"
+          type="java.lang.String"
+          jni-type="Ljava/lang/String;" />
+        <parameter
+          name="b"
+          type="int"
+          jni-type="I" />
+        <parameter
+          name="val$value1"
+          type="java.util.List"
+          jni-type="Ljava/util/List;" />
+        <parameter
+          name="val$unboundedList"
+          type="java.lang.Object"
+          jni-type="Ljava/lang/Object;" />
+      </constructor>
+      <constructor
+        deprecated="not deprecated"
+        final="false"
+        name="JavaType.1MyStringList"
+        static="false"
+        visibility="public"
+        bridge="false"
+        synthetic="false"
+        jni-signature="(Ljava/lang/String;ILjava/util/List;Ljava/lang/Object;)V">
+        <parameter
+          name="a"
+          type="java.lang.String"
+          jni-type="Ljava/lang/String;" />
+        <parameter
+          name="b"
+          type="int"
+          jni-type="I" />
+        <parameter
+          name="val$value1"
+          type="java.util.List"
+          jni-type="Ljava/util/List;" />
+        <parameter
+          name="val$unboundedList"
+          type="java.lang.Object"
+          jni-type="Ljava/lang/Object;" />
+      </constructor>
+      <constructor
+        deprecated="not deprecated"
+        final="false"
+        name="JavaType.1MyStringList"
+        static="false"
+        visibility="public"
+        bridge="false"
+        synthetic="false"
+        jni-signature="(Ljava/lang/String;ILjava/util/List;Ljava/util/List;Ljava/lang/Object;)V">
+        <parameter
+          name="a"
+          type="java.lang.String"
+          jni-type="Ljava/lang/String;" />
+        <parameter
+          name="b"
+          type="int"
+          jni-type="I" />
+        <parameter
+          name="unboundedList"
+          type="java.util.List&lt;?&gt;"
+          jni-type="Ljava/util/List&lt;*&gt;;" />
+        <parameter
+          name="val$value1"
+          type="java.util.List"
+          jni-type="Ljava/util/List;" />
+        <parameter
+          name="val$unboundedList"
+          type="java.lang.Object"
+          jni-type="Ljava/lang/Object;" />
+      </constructor>
+      <constructor
+        deprecated="not deprecated"
+        final="false"
+        name="JavaType.1MyStringList"
+        static="false"
+        visibility="public"
+        bridge="false"
+        synthetic="false"
+        jni-signature="(Ljava/lang/String;Ljava/lang/Number;ILjava/util/List;Ljava/lang/Object;)V">
+        <parameter
+          name="a"
+          type="java.lang.String"
+          jni-type="Ljava/lang/String;" />
+        <parameter
+          name="value2"
+          type="TExtendsNumber"
+          jni-type="TTExtendsNumber;" />
+        <parameter
+          name="b"
+          type="int"
+          jni-type="I" />
+        <parameter
+          name="val$value1"
+          type="java.util.List"
+          jni-type="Ljava/util/List;" />
+        <parameter
+          name="val$unboundedList"
+          type="java.lang.Object"
+          jni-type="Ljava/lang/Object;" />
+      </constructor>
+      <method
+        abstract="false"
+        deprecated="not deprecated"
+        final="false"
+        name="get"
+        native="false"
+        return="java.lang.Object"
+        jni-return="Ljava/lang/Object;"
+        static="false"
+        synchronized="false"
+        visibility="public"
+        bridge="true"
+        synthetic="true"
+        jni-signature="(I)Ljava/lang/Object;">
+        <parameter
+          name="index"
+          type="int"
+          jni-type="I" />
+      </method>
+      <method
+        abstract="false"
+        deprecated="not deprecated"
+        final="false"
+        name="get"
+        native="false"
+        return="java.lang.String"
+        jni-return="Ljava/lang/String;"
+        static="false"
+        synchronized="false"
+        visibility="public"
+        bridge="false"
+        synthetic="false"
+        jni-signature="(I)Ljava/lang/String;">
+        <parameter
+          name="index"
+          type="int"
+          jni-type="I" />
+      </method>
+    </class>
+  </package>
+</api>

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/Resources/JavaType$1MyStringList.xml
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/Resources/JavaType$1MyStringList.xml
@@ -1,0 +1,177 @@
+<api
+  api-source="class-parse">
+  <package
+    name="com.xamarin"
+    jni-name="com/xamarin">
+    <class
+      abstract="false"
+      deprecated="not deprecated"
+      enclosing-method-jni-type="Lcom/xamarin/JavaType;"
+      enclosing-method-name="staticActionWithGenerics"
+      enclosing-method-signature="(Ljava/lang/Object;Ljava/lang/Number;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V"
+      jni-extends="Ljava/util/ArrayList;"
+      extends="java.util.ArrayList"
+      extends-generic-aware="java.util.ArrayList&lt;java.lang.String&gt;"
+      final="false"
+      name="JavaType.1MyStringList"
+      jni-signature="Lcom/xamarin/JavaType$1MyStringList;"
+      source-file-name="JavaType.java"
+      static="false"
+      visibility="">
+      <constructor
+        deprecated="not deprecated"
+        final="false"
+        name="JavaType.1MyStringList"
+        static="false"
+        visibility="public"
+        bridge="false"
+        synthetic="false"
+        jni-signature="(Ljava/lang/Object;Ljava/lang/String;ILjava/util/List;Ljava/lang/Object;)V">
+        <parameter
+          name="value1"
+          type="T"
+          jni-type="TT;" />
+        <parameter
+          name="a"
+          type="java.lang.String"
+          jni-type="Ljava/lang/String;" />
+        <parameter
+          name="b"
+          type="int"
+          jni-type="I" />
+        <parameter
+          name="val$unboundedList"
+          type="java.util.List"
+          jni-type="Ljava/util/List;" />
+        <parameter
+          name="val$value1"
+          type="java.lang.Object"
+          jni-type="Ljava/lang/Object;" />
+      </constructor>
+      <constructor
+        deprecated="not deprecated"
+        final="false"
+        name="JavaType.1MyStringList"
+        static="false"
+        visibility="public"
+        bridge="false"
+        synthetic="false"
+        jni-signature="(Ljava/lang/String;ILjava/util/List;Ljava/lang/Object;)V">
+        <parameter
+          name="a"
+          type="java.lang.String"
+          jni-type="Ljava/lang/String;" />
+        <parameter
+          name="b"
+          type="int"
+          jni-type="I" />
+        <parameter
+          name="val$unboundedList"
+          type="java.util.List"
+          jni-type="Ljava/util/List;" />
+        <parameter
+          name="val$value1"
+          type="java.lang.Object"
+          jni-type="Ljava/lang/Object;" />
+      </constructor>
+      <constructor
+        deprecated="not deprecated"
+        final="false"
+        name="JavaType.1MyStringList"
+        static="false"
+        visibility="public"
+        bridge="false"
+        synthetic="false"
+        jni-signature="(Ljava/lang/String;ILjava/util/List;Ljava/util/List;Ljava/lang/Object;)V">
+        <parameter
+          name="a"
+          type="java.lang.String"
+          jni-type="Ljava/lang/String;" />
+        <parameter
+          name="b"
+          type="int"
+          jni-type="I" />
+        <parameter
+          name="unboundedList"
+          type="java.util.List&lt;?&gt;"
+          jni-type="Ljava/util/List&lt;*&gt;;" />
+        <parameter
+          name="val$unboundedList"
+          type="java.util.List"
+          jni-type="Ljava/util/List;" />
+        <parameter
+          name="val$value1"
+          type="java.lang.Object"
+          jni-type="Ljava/lang/Object;" />
+      </constructor>
+      <constructor
+        deprecated="not deprecated"
+        final="false"
+        name="JavaType.1MyStringList"
+        static="false"
+        visibility="public"
+        bridge="false"
+        synthetic="false"
+        jni-signature="(Ljava/lang/String;Ljava/lang/Number;ILjava/util/List;Ljava/lang/Object;)V">
+        <parameter
+          name="a"
+          type="java.lang.String"
+          jni-type="Ljava/lang/String;" />
+        <parameter
+          name="value2"
+          type="TExtendsNumber"
+          jni-type="TTExtendsNumber;" />
+        <parameter
+          name="b"
+          type="int"
+          jni-type="I" />
+        <parameter
+          name="val$unboundedList"
+          type="java.util.List"
+          jni-type="Ljava/util/List;" />
+        <parameter
+          name="val$value1"
+          type="java.lang.Object"
+          jni-type="Ljava/lang/Object;" />
+      </constructor>
+      <method
+        abstract="false"
+        deprecated="not deprecated"
+        final="false"
+        name="get"
+        native="false"
+        return="java.lang.Object"
+        jni-return="Ljava/lang/Object;"
+        static="false"
+        synchronized="false"
+        visibility="public"
+        bridge="true"
+        synthetic="true"
+        jni-signature="(I)Ljava/lang/Object;">
+        <parameter
+          name="index"
+          type="int"
+          jni-type="I" />
+      </method>
+      <method
+        abstract="false"
+        deprecated="not deprecated"
+        final="false"
+        name="get"
+        native="false"
+        return="java.lang.String"
+        jni-return="Ljava/lang/String;"
+        static="false"
+        synchronized="false"
+        visibility="public"
+        bridge="false"
+        synthetic="false"
+        jni-signature="(I)Ljava/lang/String;">
+        <parameter
+          name="index"
+          type="int"
+          jni-type="I" />
+      </method>
+    </class>
+  </package>
+</api>

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Xamarin.Android.Tools.Bytecode\Xamarin.Android.Tools.Bytecode.csproj" />
+    <ProjectReference Include="$(XamarinAndroidToolsFullPath)\src\Xamarin.Android.Tools.AndroidSdk\Xamarin.Android.Tools.AndroidSdk.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -31,6 +32,7 @@
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\xamarin\JavaAnnotation.class" />
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\xamarin\JavaEnum.class" />
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\xamarin\JavaType%241.class" />
+    <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\xamarin\JavaType%241MyStringList.class" />
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\xamarin\JavaType%24ASC.class" />
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\xamarin\JavaType%24PSC.class" />
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\xamarin\JavaType%24RNC%24RPNC.class" />
@@ -45,25 +47,6 @@
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\NonGenericGlobalType.class" />
   </ItemGroup>
 
-  <ItemGroup>
-    <TestJar Include="java\**\*.java" Exclude="java\java\util\Collection.java,java\android\annotation\NonNull.java" />
-    <TestJarNoParameters Include="java\java\util\Collection.java" />
-    <TestKotlinJar Include="kotlin\**\*.kt" />
-  </ItemGroup>
-
-  <Target Name="BuildClasses" BeforeTargets="BeforeBuild" Inputs="@(TestJar)" Outputs="@(TestJar->'$(IntermediateOutputPath)classes\%(RecursiveDir)%(Filename).class')">
-    <MakeDir Directories="$(IntermediateOutputPath)classes" />
-    <Exec Command="&quot;$(JavaCPath)&quot; -parameters $(_JavacSourceOptions) -g -d &quot;$(IntermediateOutputPath)classes&quot; java/android/annotation/NonNull.java @(TestJar->'%(Identity)', ' ')" />
-    <Exec Command="&quot;$(JavaCPath)&quot; $(_JavacSourceOptions) -g -d &quot;$(IntermediateOutputPath)classes&quot; @(TestJarNoParameters->'%(Identity)', ' ')" />
-  </Target>
-
-  <!-- 
-      If the Kotlin compiler is available this step will compile .kt files into .class
-      files. Useful for writing new tests. It is not used by CI, you must commit the
-      resulting .class files.  
-  -->
-  <Target Name="BuildKotlinClasses" BeforeTargets="BeforeBuild" Inputs="@(TestKotlinJar)" Outputs="@(TestKotlinJar->'%(RecursiveDir)%(Filename).class')" Condition=" '$(KotlinCPath)' != '' ">
-    <Exec Command="&quot;$(KotlinCPath)&quot; @(TestKotlinJar->'%(Identity)', ' ') -d &quot;kotlin&quot;" />
-  </Target>
+  <Import Project="Xamarin.Android.Tools.Bytecode-Tests.targets" />
 
 </Project>

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.targets
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.targets
@@ -1,0 +1,31 @@
+<Project>
+
+  <ItemGroup>
+    <TestJar Include="java\**\*.java" Exclude="java\java\util\Collection.java,java\android\annotation\NonNull.java" />
+    <TestJarNoParameters Include="java\java\util\Collection.java" />
+    <TestKotlinJar Include="kotlin\**\*.kt" />
+  </ItemGroup>
+
+  <Target Name="BuildClasses"
+        BeforeTargets="BeforeBuild"
+        Inputs="@(TestJar)"
+        Outputs="@(TestJar->'$(IntermediateOutputPath)classes\%(RecursiveDir)%(Filename).class')">
+    <MakeDir Directories="$(IntermediateOutputPath)classes" />
+    <Exec Command="&quot;$(JavaCPath)&quot; -parameters $(_JavacSourceOptions) -g -d &quot;$(IntermediateOutputPath)classes&quot; java/android/annotation/NonNull.java @(TestJar->'%(Identity)', ' ')" />
+    <Exec Command="&quot;$(JavaCPath)&quot; $(_JavacSourceOptions) -g -d &quot;$(IntermediateOutputPath)classes&quot; @(TestJarNoParameters->'%(Identity)', ' ')" />
+  </Target>
+
+  <!-- 
+      If the Kotlin compiler is available this step will compile .kt files into .class
+      files. Useful for writing new tests. It is not used by CI, you must commit the
+      resulting .class files.  
+  -->
+  <Target Name="BuildKotlinClasses"
+        Condition=" '$(KotlinCPath)' != '' "
+        BeforeTargets="BeforeBuild"
+        Inputs="@(TestKotlinJar)"
+        Outputs="@(TestKotlinJar->'%(RecursiveDir)%(Filename).class')">
+    <Exec Command="&quot;$(KotlinCPath)&quot; @(TestKotlinJar->'%(Identity)', ' ') -d &quot;kotlin&quot;" />
+  </Target>
+
+</Project>

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/java/com/xamarin/JavaType.java
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/java/com/xamarin/JavaType.java
@@ -1,6 +1,7 @@
 package com.xamarin;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -199,6 +200,21 @@ public class JavaType<E>
 			List<? extends Number> extendsList,
 			List<? super Throwable> superList)
 		throws IllegalArgumentException, NumberFormatException, TThrowable {
+
+		class MyStringList extends ArrayList<String> {
+			public MyStringList(String a, int b) {
+			}
+			public MyStringList(T value1, String a, int b) {
+			}
+			public MyStringList(String a, TExtendsNumber value2, int b) {
+			}
+			public MyStringList(String a, int b, List<?> unboundedList) {
+			}
+			public String get(int index) {
+				unboundedList.add (null);
+				return value1.toString();
+			}
+		}
 	}
 
 	/** JNI sig: instanceActionWithGenerics.(Ljava/lang/Object;java/lang/Object;)V */

--- a/tools/class-parse/Program.cs
+++ b/tools/class-parse/Program.cs
@@ -106,7 +106,7 @@ namespace Xamarin.Android.Tools {
 					return;
 				}
 			}
-			if (ClassPath.IsJarFile (file)) {
+			if (ClassPath.IsJmodFile (file) || ClassPath.IsJarFile (file)) {
 				jar.Load (file);
 				return;
 			}


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/issues/858
Context: https://stackoverflow.com/questions/44732915/why-did-java-9-introduce-the-jmod-file-format/64202720#64202720
Context: https://openjdk.java.net/projects/jigsaw/
Context: https://github.com/xamarin/monodroid/commit/c9e5cbd61fe80e183b44356149abe95578a13d06

JDK 9 replaced the "venerable" (and huge, ~63MB) `jre/lib/rt.jar`
with a set of `.jmod` files.

Thus, as of JDK 9, there is no `.jar` file to try to parse with
`class-parse`, only `.jmod` files!

A `.jmod` file, in turn, is still a ZIP container, much like `.jar`
files, but:

 1. With a different internal directory structure, and
 2. With a custom file header.

The result of (2) is that while `unzip -l` can show and extract the
contents of a `.jmod` file -- with a warning --
`System.IO.Compression.ZipArchive` cannot process the file:

	% mono …/class-parse.exe $HOME/android-toolchain/jdk-11/jmods/java.base.jmod
	class-parse: Unable to read file 'java.base.jmod': Number of entries expected in End Of Central Directory does not correspond to number of entries in Central Directory.
	<api
	  api-source="class-parse" />

Update `Xamarin.Android.Tools.Bytecode.ClassPath` to support `.jmod`
files by using `PartialStream` (73096d9f) to skip the first 4 bytes.

Once able to read a `.jmod` file, lots of debug messages appeared
while parsing `java.base.jmod`, a'la:

	class-parse: method com/xamarin/JavaType$1MyStringList.<init>(Lcom/xamarin/JavaType;Ljava/lang/String;ILjava/lang/StringBuilder;)V:
	  Local variables array has 2 entries ('LocalVariableTableAttribute(
	      LocalVariableTableEntry(Name='this', Descriptor='Lcom/xamarin/JavaType$1MyStringList;', StartPC=0, Index=0),
	      LocalVariableTableEntry(Name='this$0', Descriptor='Lcom/xamarin/JavaType;', StartPC=0, Index=1),
	      LocalVariableTableEntry(Name='a', Descriptor='Ljava/lang/String;', StartPC=0, Index=2),
	      LocalVariableTableEntry(Name='b', Descriptor='I', StartPC=0, Index=3))'
	  ); descriptor has 3 entries!
	class-parse: method com/xamarin/JavaType$1MyStringList.<init>(Lcom/xamarin/JavaType;Ljava/lang/String;ILjava/lang/StringBuilder;)V:
	Signature ('Signature((Ljava/lang/String;I)V)') has 2 entries; Descriptor '(Lcom/xamarin/JavaType;Ljava/lang/String;ILjava/lang/StringBuilder;)V' has 3 entries!

This was a variation on the "JDK 8?" block that previously didn't
have much detail, in part because it didn't have a repro.  Now we
have a repro, based on [JDK code][0] which contains a class
declaration within a method declaration

	// Java
	public List<String> staticActionWithGenerics(…) {
	    class MyStringList extends ArrayList<String> {
	        public MyStringList(String a, int b) {
	        }
	        public String get(int index) {
	            return unboundedList.toString() + value1.toString();
	        }
	    }
	}

The deal is that `staticActionWithGenerics()` contains a `MyStringList`
class, which in turn contains a constructor with two parameters.
*However*, as far as Java bytecode is concerned, the constructor
contains *3* local variables with StartPC==0, which is what we use to
infer parameter names.

Refactor, cleanup, and otherwise modify huge swaths of `Methods.cs`
to get to a "happy medium" of:

  * No warnings from our unit tests, ensured by updating
    `ClassFileFixture` to have a `[SetUp]` method which sets the
    `Log.OnLog` field to a delegate which may call `Assert.Fail()`
    when invoked.  This asserts for all messages starting with
    `class-parse: methods`, which are produced by `Methods.cs`.

  * No warnings when processing `java.base.jmod`:

        % mono bin/Debug/class-parse.exe $HOME/android-toolchain/jdk-11/jmods/java.base.jmod >/dev/null
        # no error messages

  * No warnings when processing Android API-31:

        % mono bin/Debug/class-parse.exe $HOME/android-toolchain/sdk/platforms/android-31/android.jar >/dev/null
        # no error messages

Additionally, improve `Log.cs` so that there are `M(string)`
overloads for the existing `M(string, params object[])` methods.
This is a "sanity-preserving" change, as "innocuous-looking" code
such as `Log.Debug("{foo}")` will throw `FormatException` when the
`(string, params object[])` overload is used.

Aside: closures are *weird* and finicky.
Consider the following Java code:

	class ClosureDemo {
	    public void m(String a) {
	        class Example {
	            public Example(int x) {
	                System.out.println (a);
	            }
	        }
	    }
	}

It looks like the JNI signature for the `Example` constructor might
be `(I)V`, but isn't.  It is instead:

	(LClosureDemo;ILjava/lang/String;)V

Breaking that down:

  * `LClosureDemo;`: `Example` is an inner class, and thus has an
    implicit reference to the containing type.  OK, easy to forget.

  * `I`: the `int x` parameter.  Expected.

  * `Ljava/lang/String`: the `String a` parameter from the enclosing
    scope!  This is the closure parameter.

This does make sense.  The problem is that it's *selective*: only
variables used within `Example` become extra parameters.
If the `Example` constructor is updated to remove the
`System.out.println(a)` statement, then `a` is no longer used, and
is no longer present as a constructor parameter.

The only way I found to "reasonably" determine if a constructor
parameter was a closure parameter was by checking all fields in the
class with names starting with `val$`, and then comparing the types
of those fields to types within the enclosing method's descriptor.
I can't think of a way to avoid using `val$`. :-(

Another aside: closure parameter behavior *differs* between JDK 1.8
and JDK-11: there appears to be a JDK 1.8 `javac` bug in which it
assigns the *wrong* parameter names.  Consider `MyStringList`:
The Java constructor declaration is:

	public static <T, …>
	void staticActionWithGenerics (
	        T value1, …
	        List<?> unboundedList, …)
	{
	    class MyStringList extends ArrayList<String> {
	        public MyStringList(String a, int b) {
	        }
	        // …
	    }
	}

The JNI signature for the `MyStringList` constructor is:

	(Ljava/lang/String;ILjava/util/List;Ljava/lang/Object;)V

which is:

  * `String`: parameter `a`
  * `I`: parameter `b`
  * `List`: closure parameter for `unboundedList`
  * `Object`: closure parameter for `value1`.

If we build with JDK 1.8 `javac -parameters`, the `MethodParameters`
annotation states that the closure parameters are:

	MyStringList(String a, int b, List val$value1, Object val$unboundedList);

which is *wrong*; `unboundedList` is the `List`, `value1` is `Object`!

This was fixed in JDK-11, with the `MethodParameters` annotations
specifying:

	MyStringList(String a, int b, List val$unboundedList, Object val$value1);

This means that the unit tests need to take this into consideration.

Add a new `ConfiguredJdkInfo` class, which contains code similar to
`tests/TestJVM/TestJVM.cs`: it will read `bin/Build*/JdkInfo.props`
to find the path to the JDK found in `make prepare`, and then
determine the JDK version from that directory's `release` file.

[0]: https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/util/stream/WhileOps.java#L334
