### PR TITLE
[tests] use FinalizerHelper from mono/mono

### DIFF
--- a/tests/Java.Interop-Tests/Java.Interop/FinalizerHelpers.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/FinalizerHelpers.cs
@@ -1,0 +1,47 @@
+// Originally from: https://github.com/mono/mono/blob/8266c5604b8c03882f2b06af27fdea46b142d6b9/mono/mini/TestHelpers.cs#L12
+
+using System;
+using System.Threading;
+
+namespace Java.InteropTests
+{
+	// False pinning cases are still possible. For example the thread can die
+	// and its stack reused by another thread. It also seems that a thread that
+	// does a GC can keep on the stack references to objects it encountered
+	// during the collection which are never released afterwards. This would
+	// be more likely to happen with the interpreter which reuses more stack.
+	static class FinalizerHelpers
+	{
+		private static IntPtr aptr;
+
+		private static unsafe void NoPinActionHelper (int depth, Action act)
+		{
+			// Avoid tail calls
+			int* values = stackalloc int [20];
+			aptr = new IntPtr (values);
+
+			if (depth <= 0) {
+				//
+				// When the action is called, this new thread might have not allocated
+				// anything yet in the nursery. This means that the address of the first
+				// object that would be allocated would be at the start of the tlab and
+				// implicitly the end of the previous tlab (address which can be in use
+				// when allocating on another thread, at checking if an object fits in
+				// this other tlab). We allocate a new dummy object to avoid this type
+				// of false pinning for most common cases.
+				//
+				new object ();
+				act ();
+			} else {
+				NoPinActionHelper (depth - 1, act);
+			}
+		}
+
+		public static void PerformNoPinAction (Action act)
+		{
+			Thread thr = new Thread (() => NoPinActionHelper (128, act));
+			thr.Start ();
+			thr.Join ();
+		}
+	}
+}

--- a/tests/Java.Interop-Tests/Java.Interop/JavaObjectTest.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JavaObjectTest.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading;
 
 using Java.Interop;
 
@@ -18,13 +17,11 @@ namespace Java.InteropTests
 			using (var t = new JniType ("java/lang/Object")) {
 				var oldHandle = IntPtr.Zero;
 				var array     = new JavaObjectArray<JavaObject> (1);
-				var w = new Thread (() => {
+				FinalizerHelpers.PerformNoPinAction (() => {
 						var v       = new JavaObject ();
 						oldHandle   = v.PeerReference.Handle;
 						array [0] = v;
 				});
-				w.Start ();
-				w.Join ();
 				JniEnvironment.Runtime.ValueManager.CollectPeers ();
 				GC.WaitForPendingFinalizers ();
 				GC.WaitForPendingFinalizers ();
@@ -80,13 +77,11 @@ namespace Java.InteropTests
 		{
 			JniObjectReference  oldHandle = new JniObjectReference ();
 			WeakReference r = null;
-			var t = new Thread (() => {
+			FinalizerHelpers.PerformNoPinAction (() => {
 					var v     = new JavaObject ();
 					oldHandle = v.PeerReference.NewWeakGlobalRef ();
 					r         = new WeakReference (v);
 			});
-			t.Start ();
-			t.Join ();
 			JniEnvironment.Runtime.ValueManager.CollectPeers ();
 			GC.WaitForPendingFinalizers ();
 			GC.WaitForPendingFinalizers ();
@@ -114,12 +109,10 @@ namespace Java.InteropTests
 		{
 			var d = false;
 			var f = false;
-			var t = new Thread (() => {
+			FinalizerHelpers.PerformNoPinAction (() => {
 				var v     = new JavaDisposedObject (() => d = true, () => f = true);
 				GC.KeepAlive (v);
 			});
-			t.Start ();
-			t.Join ();
 			JniEnvironment.Runtime.ValueManager.CollectPeers ();
 			GC.WaitForPendingFinalizers ();
 			JniEnvironment.Runtime.ValueManager.CollectPeers ();
@@ -183,11 +176,9 @@ namespace Java.InteropTests
 		public void CrossThreadSharingRequresRegistration ()
 		{
 			JavaObject o = null;
-			var t = new Thread (() => {
+			FinalizerHelpers.PerformNoPinAction (() => {
 					o = new JavaObject ();
 			});
-			t.Start ();
-			t.Join ();
 			o.ToString ();
 			o.Dispose ();
 		}


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/6363

We're seeing a test failure in the latest .NET 6 bump:

    Expected: True
    But was:  False
    at Java.InteropTests.JavaObjectTest.Dispose_Finalized()
    at System.Reflection.RuntimeMethodInfo.Invoke(Object , BindingFlags , Binder , Object[] , CultureInfo )

The recommendation was to use a helper method from mono/mono's unit
tests:

https://github.com/mono/mono/blob/8266c5604b8c03882f2b06af27fdea46b142d6b9/mono/mini/TestHelpers.cs#L12

I removed usage of all `System.Threading` in `JavaObjectTest` in favor
of this helper method.