### PR TITLE
[Java.Interop{,Export}] Set Version to 0.1.0.0

### DIFF
--- a/build-tools/scripts/Version.props.in
+++ b/build-tools/scripts/Version.props.in
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>@VERSION@</Version>
+    <Version Condition=" '$(Version)' == '' ">@VERSION@</Version>
     <InformationalVersion>@VERSION@ git-rev-head:@COMMIT@ git-branch:@BRANCH@</InformationalVersion>
     <Company>Microsoft Corporation</Company>
     <Copyright>Microsoft Corporation</Copyright>

--- a/src/Java.Interop.Dynamic/Java.Interop.Dynamic.csproj
+++ b/src/Java.Interop.Dynamic/Java.Interop.Dynamic.csproj
@@ -7,6 +7,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
     <AssemblyTitle>Java.Interop.Dynamic</AssemblyTitle>
+    <Version>0.1.0.0</Version>
   </PropertyGroup>
   <PropertyGroup>
     <OutputPath>$(ToolOutputFullPath)</OutputPath>

--- a/src/Java.Interop.Export/Java.Interop.Export.csproj
+++ b/src/Java.Interop.Export/Java.Interop.Export.csproj
@@ -7,6 +7,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
     <AssemblyTitle>Java.Interop.Export</AssemblyTitle>
+    <Version>0.1.0.0</Version>
   </PropertyGroup>
   <PropertyGroup>
     <OutputPath>$(ToolOutputFullPath)</OutputPath>

--- a/src/Java.Interop/Java.Interop-MonoAndroid.csproj
+++ b/src/Java.Interop/Java.Interop-MonoAndroid.csproj
@@ -17,6 +17,7 @@
     <LangVersion>8.0</LangVersion>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+    <Version>0.1.0.0</Version>
   </PropertyGroup>
   <Import Project="..\..\Directory.Build.props" />
   <PropertyGroup>

--- a/src/Java.Interop/Java.Interop.csproj
+++ b/src/Java.Interop/Java.Interop.csproj
@@ -30,6 +30,7 @@
     <Nullable>enable</Nullable>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <MSBuildWarningsAsMessages>NU1702</MSBuildWarningsAsMessages>
+    <Version>0.1.0.0</Version>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DefineConstants>DEBUG;$(DefineConstants)</DefineConstants>


### PR DESCRIPTION
Commit 3e6a6232d904acfc95017eeae58408787b0f8dc9
Context: https://discord.com/channels/732297728826277939/732297837953679412/898675755779768330

An unfortunate unexpected breakage occurred due to commit 3e6a6232:
the version of `Java.Interop.dll` changed -- which we *should* have
expected but completely overlooked & forgot -- which in turn meant
that *everything* which depends upon it -- which is everything --
started breaking due to the version change, e.g.

	error CS1705: Assembly 'Microsoft.Maui' with identity 'Microsoft.Maui, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null'
	uses 'Java.Interop, Version=0.1.6.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065'
	which has a higher version than referenced assembly
	'Java.Interop' with identity 'Java.Interop, Version=0.1.2.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065'

As the primary motivation with 3e6a6232 was to improve the use of
*MSBuild* task assemblies -- which `Java.Interop.dll` is *not* --
modify the logic of 3e6a6232 so that:

 1. `build-tools/scripts/Version.props` allows the `$(Version)`
    property to be *overridden*, and

 2. Override `$(Version)` within `src/Java.Interop`,
    `src/Java.Interop.Dynamic`, and `src/Java.Interop.Export`.

`Java.Interop.Dynamic.dll` and `Java.Interop.Export.dll` aren't
shipped (yet), but we would like them to eventually, and it's "nicer"
if they all share the same assembly version.