### PR TITLE
[build] Copy Mono.Options.pdb to output directory

### DIFF
--- a/tools/generator/generator.csproj
+++ b/tools/generator/generator.csproj
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="Irony" />
-    <PackageReference Include="Mono.Options" />
+    <PackageReference Include="Mono.Options" GeneratePathProperty="true" />
     <!-- Since we are sharing an OutputDirectory, and HtmlAgilityPack is also referenced by a different netstandard2.0 libary,
           we can explicitly reference the netstandard2.0 version here. This will also ensure symbol files are copied to the output directory. -->
     <PackageReference Include="HtmlAgilityPack" ExcludeAssets="Compile" GeneratePathProperty="true" />
@@ -39,6 +39,11 @@
         <HintPath>$(PkgHtmlAgilityPack)\lib\netstandard2.0\HtmlAgilityPack.dll</HintPath>
     </Reference>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Condition=" '$(TargetFramework)' == 'net472' " Include="$(PkgMono_Options)\lib\net40\Mono.Options.pdb" CopyToOutputDirectory="PreserveNewest" />
+    <None Condition=" '$(TargetFramework)' == 'net6.0' " Include="$(PkgMono_Options)\lib\netstandard2.0\Mono.Options.pdb" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1421424/

A recent update to Mono.Options.dll (presumably commit c936d09a) has
caused a symbol check failure in our latest VS insertion.  We can fix
this by updating one of the tools projects that references this package
to copy Mono.Options.pdb to the Output directory.  Once the file is in
the right output path we can include it in the XA installers.