### PR TITLE
[generator] Fix for fixing invalid annotation XML.

### DIFF
--- a/src/Xamarin.Android.Tools.AnnotationSupport/AndroidAnnotationsSupport.cs
+++ b/src/Xamarin.Android.Tools.AnnotationSupport/AndroidAnnotationsSupport.cs
@@ -70,6 +70,8 @@ namespace Xamarin.AndroidTools.AnnotationSupport
 			if (doc.DocumentNode.FirstChild.InnerHtml.StartsWith ("<?xml", StringComparison.Ordinal))
 				doc.DocumentNode.FirstChild.Remove ();
 
+			FixEscapedQuotes (doc.DocumentNode);
+
 			var ms = new MemoryStream ();
 			var xs = new XmlWriterSettings {
 				Encoding = new UTF8Encoding (false),
@@ -86,6 +88,18 @@ namespace Xamarin.AndroidTools.AnnotationSupport
 			return ms;
 		}
 
+		static void FixEscapedQuotes (HtmlNode node)
+		{
+			// Quotation marks in attribute values are already escaped as '&quot;', however the Save ()
+			// is interpreting them as the string '&quot;' and thinks it needs to escape the ampersand,
+			// resulting in writing '&amp;quot;'.  Here we "un-escape" the quotation mark,
+			// so that Save () will escape it correctly as '&quot;'.
+			foreach (var attr in node.Attributes)
+				attr.Value = attr.Value.Replace ("&quot;", "\"");
+
+			foreach (var child in node.ChildNodes)
+				FixEscapedQuotes (child);
+		}
 		#endregion
 
 		#region data loader


### PR DESCRIPTION
Fixes #883 

Due to invalid XML provided in Google's `annotations.zip` file, we run it through the more forgiving HtmlAgilityPack to attempt to fix it to valid XML.

However, given this snippet:
```xml
<item name="android.accounts.AccountManager android.accounts.AccountManagerFuture&lt;android.os.Bundle&gt; addAccount(java.lang.String, java.lang.String, java.lang.String[], android.os.Bundle, android.app.Activity, android.accounts.AccountManagerCallback<android.os.Bundle>, android.os.Handler)">
  <annotation name="androidx.annotation.RequiresPermission">
    <val name="value" val="&quot;android.permission.MANAGE_ACCOUNTS&quot;" />
    <val name="apis" val="&quot;..22&quot;" />
  </annotation>
</item>
```

The invalid unescaped `<` and `>` characters in the `<item name=''` attribute seem to tell HtmlAgilityPack not to expect any attribute strings to be properly escaped.  Thus when it gets to the `<val val=''` attributes, it treats `&quot;` as unescaped as well, thinking we want to value to be the literal string `"&quot;"`.   When it writes out the valid XML, it realizes it needs to escape the ampersand, and writes out `&amp;quot;`, which breaks our usage of these annotations.

The fix is to "unescape" every `&quot;` to a `"` so that it will be escaped correctly when saved as valid XML.