### PR TITLE
[Java.Interop{,Export}] Set <Version> to 0.1.0.

### DIFF
--- a/build-tools/scripts/AssemblyInfo.g.cs.in
+++ b/build-tools/scripts/AssemblyInfo.g.cs.in
@@ -14,7 +14,7 @@ using System.Reflection;
 [assembly: System.Reflection.AssemblyCompanyAttribute("Microsoft Corporation")]
 [assembly: System.Reflection.AssemblyConfigurationAttribute("@CONFIGURATION@")]
 [assembly: System.Reflection.AssemblyCopyrightAttribute("Microsoft Corporation")]
-[assembly: System.Reflection.AssemblyFileVersionAttribute("@VERSION@.0")]
+[assembly: System.Reflection.AssemblyFileVersionAttribute("@VERSION@")]
 [assembly: System.Reflection.AssemblyInformationalVersionAttribute("@INFORMATIONALVERSION@")]
 [assembly: System.Reflection.AssemblyProductAttribute("@PRODUCT@")]
 [assembly: System.Reflection.AssemblyTitleAttribute("@TITLE@")]

--- a/build-tools/scripts/VersionInfo.targets
+++ b/build-tools/scripts/VersionInfo.targets
@@ -16,7 +16,7 @@
       DependsOnTargets="GitVersion"
       Condition="!Exists ('$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Version.props')">
     <ItemGroup>
-      <Replacements Include="@VERSION@" Replacement="$(GitSemVerMajor).$(GitSemVerMinor).$(GitSemVerPatch)"/>
+      <Replacements Include="@VERSION@" Replacement="$(GitSemVerMajor).$(GitSemVerMinor).$(GitSemVerPatch).0"/>
       <Replacements Include="@COMMIT@" Replacement="$(GitCommit)"/>
       <Replacements Include="@BRANCH@" Replacement="$(GitBranch)"/>
     </ItemGroup>


### PR DESCRIPTION
Context: #894 

Setting `<Version>0.1.0.0</Version>` causes us to generate:
```chsarp
[assembly: AssemblyVersion("0.1.0.0")]
[assembly: AssemblyFileVersion("0.1.0.0.0")]
```

because of the extra tuple added to `AssemblyFileVersion` in `AssemblyInfo.g.cs.in`:
```csharp
[assembly: System.Reflection.AssemblyFileVersionAttribute("@VERSION@.0")]
[assembly: System.Reflection.AssemblyVersionAttribute("@VERSION@")]
```
This is fine from an assembly reference standpoint because it uses `[AssemblyVersion]`, but `[AssemblyFileVersion]` isn't a valid file version and Windows can't parse it:

![image](https://user-images.githubusercontent.com/179295/138962305-18ddf670-97b9-4040-bc39-653d82ddf32d.png)

Instead, set `@VERSION@` to always use a 4-tuple, and remove the extra tuple added to `AssemblyFileVersion`.

This creates the expected information for both hard-coded version assemblies:

![image](https://user-images.githubusercontent.com/179295/139737058-5242c3c5-80ec-49c9-b0f8-6d8ed23a0f58.png)

and auto-versioned assemblies:

![image](https://user-images.githubusercontent.com/179295/139737132-110fbdb0-2428-4e50-a9aa-af2874eda8b1.png)
