### PR TITLE
[generator] remove __TypeRegistrations.Lookup()

### DIFF
--- a/tests/generator-Tests/expected.ji/Adapters/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/Adapters/Java.Interop.__TypeRegistrations.cs
@@ -23,12 +23,5 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
-		static Type Lookup (string[] mappings, string javaType)
-		{
-			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
-			if (managedType == null)
-				return null;
-			return Type.GetType (managedType);
-		}
 	}
 }

--- a/tests/generator-Tests/expected.ji/Android.Graphics.Color/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/Android.Graphics.Color/Java.Interop.__TypeRegistrations.cs
@@ -23,12 +23,5 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
-		static Type Lookup (string[] mappings, string javaType)
-		{
-			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
-			if (managedType == null)
-				return null;
-			return Type.GetType (managedType);
-		}
 	}
 }

--- a/tests/generator-Tests/expected.ji/Arrays/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/Arrays/Java.Interop.__TypeRegistrations.cs
@@ -23,12 +23,5 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
-		static Type Lookup (string[] mappings, string javaType)
-		{
-			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
-			if (managedType == null)
-				return null;
-			return Type.GetType (managedType);
-		}
 	}
 }

--- a/tests/generator-Tests/expected.ji/Constructors/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/Constructors/Java.Interop.__TypeRegistrations.cs
@@ -23,12 +23,5 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
-		static Type Lookup (string[] mappings, string javaType)
-		{
-			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
-			if (managedType == null)
-				return null;
-			return Type.GetType (managedType);
-		}
 	}
 }

--- a/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/Java.Interop.__TypeRegistrations.cs
@@ -23,12 +23,5 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
-		static Type Lookup (string[] mappings, string javaType)
-		{
-			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
-			if (managedType == null)
-				return null;
-			return Type.GetType (managedType);
-		}
 	}
 }

--- a/tests/generator-Tests/expected.ji/NestedTypes/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/NestedTypes/Java.Interop.__TypeRegistrations.cs
@@ -23,12 +23,5 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
-		static Type Lookup (string[] mappings, string javaType)
-		{
-			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
-			if (managedType == null)
-				return null;
-			return Type.GetType (managedType);
-		}
 	}
 }

--- a/tests/generator-Tests/expected.ji/NonStaticFields/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/NonStaticFields/Java.Interop.__TypeRegistrations.cs
@@ -23,12 +23,5 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
-		static Type Lookup (string[] mappings, string javaType)
-		{
-			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
-			if (managedType == null)
-				return null;
-			return Type.GetType (managedType);
-		}
 	}
 }

--- a/tests/generator-Tests/expected.ji/NormalMethods/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/NormalMethods/Java.Interop.__TypeRegistrations.cs
@@ -23,12 +23,5 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
-		static Type Lookup (string[] mappings, string javaType)
-		{
-			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
-			if (managedType == null)
-				return null;
-			return Type.GetType (managedType);
-		}
 	}
 }

--- a/tests/generator-Tests/expected.ji/NormalProperties/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/NormalProperties/Java.Interop.__TypeRegistrations.cs
@@ -23,12 +23,5 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
-		static Type Lookup (string[] mappings, string javaType)
-		{
-			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
-			if (managedType == null)
-				return null;
-			return Type.GetType (managedType);
-		}
 	}
 }

--- a/tests/generator-Tests/expected.ji/ParameterXPath/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/ParameterXPath/Java.Interop.__TypeRegistrations.cs
@@ -23,12 +23,5 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
-		static Type Lookup (string[] mappings, string javaType)
-		{
-			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
-			if (managedType == null)
-				return null;
-			return Type.GetType (managedType);
-		}
 	}
 }

--- a/tests/generator-Tests/expected.ji/StaticFields/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/StaticFields/Java.Interop.__TypeRegistrations.cs
@@ -23,12 +23,5 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
-		static Type Lookup (string[] mappings, string javaType)
-		{
-			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
-			if (managedType == null)
-				return null;
-			return Type.GetType (managedType);
-		}
 	}
 }

--- a/tests/generator-Tests/expected.ji/StaticMethods/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/StaticMethods/Java.Interop.__TypeRegistrations.cs
@@ -23,12 +23,5 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
-		static Type Lookup (string[] mappings, string javaType)
-		{
-			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
-			if (managedType == null)
-				return null;
-			return Type.GetType (managedType);
-		}
 	}
 }

--- a/tests/generator-Tests/expected.ji/StaticProperties/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/StaticProperties/Java.Interop.__TypeRegistrations.cs
@@ -23,12 +23,5 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
-		static Type Lookup (string[] mappings, string javaType)
-		{
-			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
-			if (managedType == null)
-				return null;
-			return Type.GetType (managedType);
-		}
 	}
 }

--- a/tests/generator-Tests/expected.ji/Streams/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/Streams/Java.Interop.__TypeRegistrations.cs
@@ -23,12 +23,5 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
-		static Type Lookup (string[] mappings, string javaType)
-		{
-			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
-			if (managedType == null)
-				return null;
-			return Type.GetType (managedType);
-		}
 	}
 }

--- a/tests/generator-Tests/expected.ji/TestInterface/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Java.Interop.__TypeRegistrations.cs
@@ -23,12 +23,5 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
-		static Type Lookup (string[] mappings, string javaType)
-		{
-			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
-			if (managedType == null)
-				return null;
-			return Type.GetType (managedType);
-		}
 	}
 }

--- a/tests/generator-Tests/expected.ji/java.lang.Enum/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/java.lang.Enum/Java.Interop.__TypeRegistrations.cs
@@ -23,12 +23,5 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
-		static Type Lookup (string[] mappings, string javaType)
-		{
-			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
-			if (managedType == null)
-				return null;
-			return Type.GetType (managedType);
-		}
 	}
 }

--- a/tests/generator-Tests/expected.ji/java.lang.Object/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/java.lang.Object/Java.Interop.__TypeRegistrations.cs
@@ -23,12 +23,5 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
-		static Type Lookup (string[] mappings, string javaType)
-		{
-			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
-			if (managedType == null)
-				return null;
-			return Type.GetType (managedType);
-		}
 	}
 }

--- a/tests/generator-Tests/expected.ji/java.util.List/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/java.util.List/Java.Interop.__TypeRegistrations.cs
@@ -23,12 +23,5 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
-		static Type Lookup (string[] mappings, string javaType)
-		{
-			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
-			if (managedType == null)
-				return null;
-			return Type.GetType (managedType);
-		}
 	}
 }

--- a/tests/generator-Tests/expected/EnumerationFixup/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected/EnumerationFixup/Java.Interop.__TypeRegistrations.cs
@@ -23,12 +23,5 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
-		static Type Lookup (string[] mappings, string javaType)
-		{
-			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
-			if (managedType == null)
-				return null;
-			return Type.GetType (managedType);
-		}
 	}
 }

--- a/tests/generator-Tests/expected/InterfaceMethodsConflict/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected/InterfaceMethodsConflict/Java.Interop.__TypeRegistrations.cs
@@ -23,12 +23,5 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
-		static Type Lookup (string[] mappings, string javaType)
-		{
-			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
-			if (managedType == null)
-				return null;
-			return Type.GetType (managedType);
-		}
 	}
 }

--- a/tests/generator-Tests/expected/java.lang.Object/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected/java.lang.Object/Java.Interop.__TypeRegistrations.cs
@@ -23,12 +23,5 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
-		static Type Lookup (string[] mappings, string javaType)
-		{
-			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);
-			if (managedType == null)
-				return null;
-			return Type.GetType (managedType);
-		}
 	}
 }

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ClassGen.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ClassGen.cs
@@ -208,13 +208,6 @@ namespace MonoDroid.Generation
 				sw.WriteLine ("#endif // def MONODROID_TIMING");
 				sw.WriteLine ("\t\t}");
 				sw.WriteLine ();
-				sw.WriteLine ("\t\tstatic Type{0} Lookup (string[] mappings, string javaType)", opt.NullableOperator);
-				sw.WriteLine ("\t\t{");
-				sw.WriteLine ("\t\t\tvar managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);");
-				sw.WriteLine ("\t\t\tif (managedType == null)");
-				sw.WriteLine ("\t\t\t\treturn null;");
-				sw.WriteLine ("\t\t\treturn Type.GetType (managedType);");
-				sw.WriteLine ("\t\t}");
 				foreach (KeyValuePair<string, List<KeyValuePair<string, string>>> map in mapping) {
 					sw.WriteLine ();
 					string package = map.Key.Replace ('/', '_');


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/5652

In .NET 6 projects we get illink warnings such as:

    src\Compatibility\Android.FormsViewGroup\src\obj\Release\net6.0-android\generated\src\Java.Interop.__TypeRegistrations.cs(35,4):
    error IL2057: Java.Interop.__TypeRegistrations.Lookup(String[],String): Unrecognized value passed to the parameter 'typeName' of method 'System.Type.GetType(String)'.
    It's not possible to guarantee the availability of the target type.

Nothing even appears to call `__TypeRegistrations.Lookup()`. Let's
stop generating this method?