### PR TITLE
[generator] emit UnconditionalSuppressMessage in __TypeRegistrations

### DIFF
--- a/tests/generator-Tests/expected.ji/Adapters/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/Adapters/Java.Interop.__TypeRegistrations.cs
@@ -23,6 +23,9 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
+#if NET5_0_OR_GREATER
+		[System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage ("Trimming", "IL2057")]
+#endif
 		static Type Lookup (string[] mappings, string javaType)
 		{
 			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);

--- a/tests/generator-Tests/expected.ji/Android.Graphics.Color/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/Android.Graphics.Color/Java.Interop.__TypeRegistrations.cs
@@ -23,6 +23,9 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
+#if NET5_0_OR_GREATER
+		[System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage ("Trimming", "IL2057")]
+#endif
 		static Type Lookup (string[] mappings, string javaType)
 		{
 			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);

--- a/tests/generator-Tests/expected.ji/Arrays/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/Arrays/Java.Interop.__TypeRegistrations.cs
@@ -23,6 +23,9 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
+#if NET5_0_OR_GREATER
+		[System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage ("Trimming", "IL2057")]
+#endif
 		static Type Lookup (string[] mappings, string javaType)
 		{
 			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);

--- a/tests/generator-Tests/expected.ji/Constructors/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/Constructors/Java.Interop.__TypeRegistrations.cs
@@ -23,6 +23,9 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
+#if NET5_0_OR_GREATER
+		[System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage ("Trimming", "IL2057")]
+#endif
 		static Type Lookup (string[] mappings, string javaType)
 		{
 			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);

--- a/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/InterfaceMethodsConflict/Java.Interop.__TypeRegistrations.cs
@@ -23,6 +23,9 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
+#if NET5_0_OR_GREATER
+		[System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage ("Trimming", "IL2057")]
+#endif
 		static Type Lookup (string[] mappings, string javaType)
 		{
 			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);

--- a/tests/generator-Tests/expected.ji/NestedTypes/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/NestedTypes/Java.Interop.__TypeRegistrations.cs
@@ -23,6 +23,9 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
+#if NET5_0_OR_GREATER
+		[System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage ("Trimming", "IL2057")]
+#endif
 		static Type Lookup (string[] mappings, string javaType)
 		{
 			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);

--- a/tests/generator-Tests/expected.ji/NonStaticFields/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/NonStaticFields/Java.Interop.__TypeRegistrations.cs
@@ -23,6 +23,9 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
+#if NET5_0_OR_GREATER
+		[System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage ("Trimming", "IL2057")]
+#endif
 		static Type Lookup (string[] mappings, string javaType)
 		{
 			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);

--- a/tests/generator-Tests/expected.ji/NormalMethods/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/NormalMethods/Java.Interop.__TypeRegistrations.cs
@@ -23,6 +23,9 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
+#if NET5_0_OR_GREATER
+		[System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage ("Trimming", "IL2057")]
+#endif
 		static Type Lookup (string[] mappings, string javaType)
 		{
 			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);

--- a/tests/generator-Tests/expected.ji/NormalProperties/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/NormalProperties/Java.Interop.__TypeRegistrations.cs
@@ -23,6 +23,9 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
+#if NET5_0_OR_GREATER
+		[System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage ("Trimming", "IL2057")]
+#endif
 		static Type Lookup (string[] mappings, string javaType)
 		{
 			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);

--- a/tests/generator-Tests/expected.ji/ParameterXPath/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/ParameterXPath/Java.Interop.__TypeRegistrations.cs
@@ -23,6 +23,9 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
+#if NET5_0_OR_GREATER
+		[System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage ("Trimming", "IL2057")]
+#endif
 		static Type Lookup (string[] mappings, string javaType)
 		{
 			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);

--- a/tests/generator-Tests/expected.ji/StaticFields/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/StaticFields/Java.Interop.__TypeRegistrations.cs
@@ -23,6 +23,9 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
+#if NET5_0_OR_GREATER
+		[System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage ("Trimming", "IL2057")]
+#endif
 		static Type Lookup (string[] mappings, string javaType)
 		{
 			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);

--- a/tests/generator-Tests/expected.ji/StaticMethods/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/StaticMethods/Java.Interop.__TypeRegistrations.cs
@@ -23,6 +23,9 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
+#if NET5_0_OR_GREATER
+		[System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage ("Trimming", "IL2057")]
+#endif
 		static Type Lookup (string[] mappings, string javaType)
 		{
 			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);

--- a/tests/generator-Tests/expected.ji/StaticProperties/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/StaticProperties/Java.Interop.__TypeRegistrations.cs
@@ -23,6 +23,9 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
+#if NET5_0_OR_GREATER
+		[System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage ("Trimming", "IL2057")]
+#endif
 		static Type Lookup (string[] mappings, string javaType)
 		{
 			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);

--- a/tests/generator-Tests/expected.ji/Streams/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/Streams/Java.Interop.__TypeRegistrations.cs
@@ -23,6 +23,9 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
+#if NET5_0_OR_GREATER
+		[System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage ("Trimming", "IL2057")]
+#endif
 		static Type Lookup (string[] mappings, string javaType)
 		{
 			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);

--- a/tests/generator-Tests/expected.ji/TestInterface/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Java.Interop.__TypeRegistrations.cs
@@ -23,6 +23,9 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
+#if NET5_0_OR_GREATER
+		[System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage ("Trimming", "IL2057")]
+#endif
 		static Type Lookup (string[] mappings, string javaType)
 		{
 			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);

--- a/tests/generator-Tests/expected.ji/java.lang.Enum/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/java.lang.Enum/Java.Interop.__TypeRegistrations.cs
@@ -23,6 +23,9 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
+#if NET5_0_OR_GREATER
+		[System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage ("Trimming", "IL2057")]
+#endif
 		static Type Lookup (string[] mappings, string javaType)
 		{
 			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);

--- a/tests/generator-Tests/expected.ji/java.lang.Object/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/java.lang.Object/Java.Interop.__TypeRegistrations.cs
@@ -23,6 +23,9 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
+#if NET5_0_OR_GREATER
+		[System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage ("Trimming", "IL2057")]
+#endif
 		static Type Lookup (string[] mappings, string javaType)
 		{
 			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);

--- a/tests/generator-Tests/expected.ji/java.util.List/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.ji/java.util.List/Java.Interop.__TypeRegistrations.cs
@@ -23,6 +23,9 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
+#if NET5_0_OR_GREATER
+		[System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage ("Trimming", "IL2057")]
+#endif
 		static Type Lookup (string[] mappings, string javaType)
 		{
 			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);

--- a/tests/generator-Tests/expected/EnumerationFixup/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected/EnumerationFixup/Java.Interop.__TypeRegistrations.cs
@@ -23,6 +23,9 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
+#if NET5_0_OR_GREATER
+		[System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage ("Trimming", "IL2057")]
+#endif
 		static Type Lookup (string[] mappings, string javaType)
 		{
 			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);

--- a/tests/generator-Tests/expected/InterfaceMethodsConflict/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected/InterfaceMethodsConflict/Java.Interop.__TypeRegistrations.cs
@@ -23,6 +23,9 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
+#if NET5_0_OR_GREATER
+		[System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage ("Trimming", "IL2057")]
+#endif
 		static Type Lookup (string[] mappings, string javaType)
 		{
 			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);

--- a/tests/generator-Tests/expected/java.lang.Object/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected/java.lang.Object/Java.Interop.__TypeRegistrations.cs
@@ -23,6 +23,9 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 		}
 
+#if NET5_0_OR_GREATER
+		[System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage ("Trimming", "IL2057")]
+#endif
 		static Type Lookup (string[] mappings, string javaType)
 		{
 			var managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ClassGen.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ClassGen.cs
@@ -208,6 +208,9 @@ namespace MonoDroid.Generation
 				sw.WriteLine ("#endif // def MONODROID_TIMING");
 				sw.WriteLine ("\t\t}");
 				sw.WriteLine ();
+				sw.WriteLine ("#if NET5_0_OR_GREATER");
+				sw.WriteLine("\t\t[System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage (\"Trimming\", \"IL2057\")]");
+				sw.WriteLine ("#endif");
 				sw.WriteLine ("\t\tstatic Type{0} Lookup (string[] mappings, string javaType)", opt.NullableOperator);
 				sw.WriteLine ("\t\t{");
 				sw.WriteLine ("\t\t\tvar managedType = Java.Interop.TypeManager.LookupTypeMapping (mappings, javaType);");


### PR DESCRIPTION
Building a .NET MAUI app with `-p:SuppressTrimAnalysisWarnings=false
-p:TrimmerSingleWarn=false` shows the warning:

    src\Compatibility\Android.FormsViewGroup\src\obj\Release\net6.0-android\generated\src\Java.Interop.__TypeRegistrations.cs(35,4):
    error IL2057: Java.Interop.__TypeRegistrations.Lookup(String[],String): Unrecognized value passed to the parameter 'typeName' of method 'System.Type.GetType(String)'. It's not possible to guarantee the availability of the target type.

This code path should not even be used normally. It is only called
when running inside the Android designer.

For now, let's simply emit an extra attribute to ignore the warning:

    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2057")]

This attribute was added in .NET 5, so we can always emit the code and
use `#if NET5_0_OR_GREATER`.