### PR TITLE
[generator] Improve Javadoc remarks on properties

### DIFF
--- a/tools/generator/Java.Interop.Tools.Generator.Transformation/JavadocFixups.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Transformation/JavadocFixups.cs
@@ -70,11 +70,11 @@ namespace Java.Interop.Tools.Generator.Transformation
 			foreach (var property in type.Properties) {
 				if (property.Getter != null && property.Getter.JavadocInfo == null) {
 					var getterJavadoc           = GetMemberJavadoc (typeJavadoc, "method", property.Getter.JavaName, property.Getter.JniSignature);
-					property.Getter.JavadocInfo = JavadocInfo.CreateInfo (getterJavadoc?.Parent, style);
+					property.Getter.JavadocInfo = JavadocInfo.CreateInfo (getterJavadoc?.Parent, style, appendCopyrightExtra: false);
 				}
 				if (property.Setter != null && property.Setter.JavadocInfo == null) {
 					var setterJavadoc           = GetMemberJavadoc (typeJavadoc, "method", property.Setter.JavaName, property.Setter.JniSignature);
-					property.Setter.JavadocInfo = JavadocInfo.CreateInfo (setterJavadoc?.Parent, style);
+					property.Setter.JavadocInfo = JavadocInfo.CreateInfo (setterJavadoc?.Parent, style, appendCopyrightExtra: false);
 				}
 			}
 

--- a/tools/generator/SourceWriters/BoundProperty.cs
+++ b/tools/generator/SourceWriters/BoundProperty.cs
@@ -158,18 +158,28 @@ namespace generator.SourceWriters
 				return;
 
 			var memberDocs = new XElement ("member");
+			XElement[] copyrightExtra = null;
 
 			if (property.Getter?.JavadocInfo != null) {
 				memberDocs.Add (property.Getter.JavadocInfo.ParseJavadoc ());
+				copyrightExtra = property.Getter.JavadocInfo.Copyright;
 			}
 
 			if (property.Setter?.JavadocInfo != null) {
 				var setterDocs  = new XElement ("member", property.Setter.JavadocInfo.ParseJavadoc ());
+				if (copyrightExtra == null) {
+					copyrightExtra = property.Setter.JavadocInfo.Copyright;
+				}
 
 				MergeSummary (memberDocs, setterDocs);
 				MergeRemarks (memberDocs, setterDocs);
 
-				memberDocs.Add (setterDocs.DescendantNodes ());
+				memberDocs.Add (setterDocs.Nodes ());
+			}
+
+			if (copyrightExtra != null) {
+				var remarks = memberDocs.Element ("remarks");
+				remarks?.Add (copyrightExtra);
 			}
 
 			JavadocInfo.AddComments (Comments, memberDocs.Elements ());
@@ -187,7 +197,7 @@ namespace generator.SourceWriters
 			else if (toContent != null && fromContent != null) {
 				fromContent.Remove ();
 				toContent.Add (" -or- ");
-				toContent.Add (fromContent.DescendantNodes ());
+				toContent.Add (fromContent.Nodes ());
 			}
 		}
 
@@ -204,7 +214,7 @@ namespace generator.SourceWriters
 				fromContent.Remove ();
 				toContent.AddFirst (new XElement ("para", "Property getter documentation:"));
 				toContent.Add (new XElement ("para", "Property setter documentation:"));
-				toContent.Add (fromContent.DescendantNodes ());
+				toContent.Add (fromContent.Nodes ());
 			}
 		}
 	}


### PR DESCRIPTION
Fixes: https://github.com/xamarin/java.interop/issues/905

Property getters and setters will no longer automatically include
copyright info in their generated `<remarks>` elements.  Instead, this
copyright data will be appended to the `<remarks>` element after
`<remarks>` merging is complete.

The custom `<summary>` and `<remarks>` merging that happens for
properties will now also use Nodes instead of DescendantNodes to avoid
content duplication.