### PR TITLE
[generator] Import NRT data from managed assemblies.

### DIFF
--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/NullableReferenceTypesRocks.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/NullableReferenceTypesRocks.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Linq;
+using Mono.Cecil;
+using Mono.Collections.Generic;
+
+namespace Java.Interop.Tools.Cecil
+{
+	// Partial support for determining NRT status of method and field types.
+	// Reference: https://github.com/dotnet/roslyn/blob/main/docs/features/nullable-metadata.md
+	// The basics are supported, but advanced annotations like array elements,
+	// type parameters, and tuples are not supported.  Our use case doesn't really need them.
+	public static class NullableReferenceTypesRocks
+	{
+		public static Nullability GetTypeNullability (this FieldDefinition field)
+		{
+			if (field.FieldType.FullName == "System.Void")
+				return Nullability.NotNull;
+
+			// Look for explicit annotation on field
+			var metadata = NullableMetadata.FromAttributeCollection (field.CustomAttributes);
+
+			if (metadata != null)
+				return (Nullability) metadata.Data [0];
+
+			// Default nullability status for type
+			return GetNullableContext (field.DeclaringType.CustomAttributes);
+		}
+
+		public static Nullability GetReturnTypeNullability (this MethodDefinition method)
+		{
+			if (method.MethodReturnType.ReturnType.FullName == "System.Void")
+				return Nullability.NotNull;
+
+			// Look for explicit annotation on return type
+			var metadata = NullableMetadata.FromAttributeCollection (method.MethodReturnType.CustomAttributes);
+
+			if (metadata != null)
+				return (Nullability) metadata.Data [0];
+
+			// Default nullability status for method
+			var nullable = GetNullableContext (method.CustomAttributes);
+
+			if (nullable != Nullability.Oblivous)
+				return nullable;
+
+			// Default nullability status for type
+			return GetNullableContext (method.DeclaringType.CustomAttributes);
+		}
+
+		public static Nullability GetTypeNullability (this ParameterDefinition parameter, MethodDefinition method)
+		{
+			if (parameter.ParameterType.FullName == "System.Void")
+				return Nullability.NotNull;
+
+			// Look for explicit annotation on parameter
+			var metadata = NullableMetadata.FromAttributeCollection (parameter.CustomAttributes);
+
+			if (metadata != null)
+				return (Nullability) metadata.Data [0];
+
+			// Default nullability status for method
+			var nullable = GetNullableContext (method.CustomAttributes);
+
+			if (nullable != Nullability.Oblivous)
+				return nullable;
+
+			// Default nullability status for type
+			return GetNullableContext (method.DeclaringType.CustomAttributes);
+		}
+
+		static Nullability GetNullableContext (Collection<CustomAttribute> attrs)
+		{
+			var attribute = attrs.FirstOrDefault (t => t.AttributeType.FullName == "System.Runtime.CompilerServices.NullableContextAttribute");
+
+			if (attribute != null)
+				return (Nullability) (byte) attribute.ConstructorArguments.First ().Value;
+
+			return Nullability.Oblivous;
+		}
+	}
+
+	public enum Nullability
+	{
+		Oblivous,
+		NotNull,
+		Nullable
+	}
+
+	class NullableMetadata
+	{
+		public byte [] Data { get; private set; }
+
+		NullableMetadata (byte [] data) => Data = data;
+
+		NullableMetadata (byte data) => Data = new [] { data };
+
+		public static NullableMetadata? FromAttributeCollection (Collection<CustomAttribute> attrs)
+		{
+			if (attrs is null)
+				return null;
+
+			var attribute = attrs.FirstOrDefault (t => t.AttributeType.FullName == "System.Runtime.CompilerServices.NullableAttribute");
+
+			if (attribute is null)
+				return null;
+
+			var ctor_arg = attribute.ConstructorArguments.First ();
+
+			if (ctor_arg.Value is CustomAttributeArgument [] caa)
+				ctor_arg = caa [0];
+
+			if (ctor_arg.Value is byte b)
+				return new NullableMetadata (b);
+
+			if (ctor_arg.Value is byte [] b2)
+				return new NullableMetadata (b2);
+
+			return null;
+		}
+	}
+}

--- a/tests/generator-Tests/generator-Tests.csproj
+++ b/tests/generator-Tests/generator-Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tools/generator/Extensions/ManagedExtensions.cs
+++ b/tools/generator/Extensions/ManagedExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Java.Interop.Tools.TypeNameMappings;
+using Java.Interop.Tools.Cecil;
+using Java.Interop.Tools.TypeNameMappings;
 using Mono.Cecil;
 using System.Collections.Generic;
 using System.Linq;
@@ -42,7 +43,9 @@ namespace MonoDroid.Generation
 				// custom enum types and cannot simply use JNI signature here.
 				var rawtype = e?.Current.Type;
 				var type = p.ParameterType.FullName == "System.IO.Stream" && e != null ? e.Current.Type : null;
-				yield return CecilApiImporter.CreateParameter (p, type, rawtype);
+				var isNotNull = p.GetTypeNullability (m) == Nullability.NotNull;
+
+				yield return CecilApiImporter.CreateParameter (p, type, rawtype, isNotNull);
 			}
 		}
 


### PR DESCRIPTION
Fixes: https://github.com/xamarin/java.interop/issues/857

Implement enough of [decoding C# NRT attributes](https://github.com/dotnet/roslyn/blob/main/docs/features/nullable-metadata.md) to support our use case.

This will allow us to better generate members that match nullability of members they are overriding/implementing when the base member is coming from a managed assembly.