### PR TITLE
[ci] Update to VS2022 build agents.

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -3,12 +3,14 @@
 trigger:
   - main
   - d16-*
+  - d17-*
 
 pr:
   branches:
     include:
     - main
     - d16-*
+    - d17-*
   paths:
     exclude:
     - README.md
@@ -21,14 +23,15 @@ variables:
   MaxJdkVersion: 8
   DotNetCoreVersion: 6.0.x
   HostedMacImage: macOS-10.15
-  HostedWinVS2019: Hosted Windows 2019 with VS2019
+  HostedWinImage: windows-2022
   NetCoreTargetFrameworkPathSuffix: -net6.0
-  VSInstallRoot: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
+  VSInstallRoot: C:\Program Files\Microsoft Visual Studio\2022\Enterprise
 
 jobs:
 - job: windows_build
   displayName: Windows - .NET Framework
-  pool: $(HostedWinVS2019)
+  pool:
+    vmImage: $(HostedWinImage)
   timeoutInMinutes: 20
   workspace:
     clean: all
@@ -76,7 +79,8 @@ jobs:
 
 - job: windows_dotnet_build
   displayName: Windows - .NET Core
-  pool: $(HostedWinVS2019)
+  pool:
+    vmImage: $(HostedWinImage)
   timeoutInMinutes: 20
   workspace:
     clean: all


### PR DESCRIPTION
Now that VS2019 doesn't ***officially*** support .NET 6, we are getting lots of warnings trying to build out `net6.0` assemblies on VS2019 build agents:

```
Warning NETSDK1182: Targeting .NET 6.0 in Visual Studio 2019 is not supported.
Warning CS8032: An instance of analyzer System.Text.Json.SourceGeneration.JsonSourceGenerator cannot be created from C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.0\analyzers\dotnet\cs\System.Text.Json.SourceGeneration.dll : Could not load file or assembly 'Microsoft.CodeAnalysis, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35' or one of its dependencies. The system cannot find the file specified..
```

[DevOps now offers VS2022 build agents](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted) we can switch to in order to build `net6.0` assemblies with no warnings.