### PR TITLE
[JavaTypeSystem] Enable resolving generic types on declaring types.

### DIFF
--- a/src/Java.Interop.Tools.JavaTypeSystem/JavaModels/JavaTypeModel.cs
+++ b/src/Java.Interop.Tools.JavaTypeSystem/JavaModels/JavaTypeModel.cs
@@ -106,13 +106,9 @@ namespace Java.Interop.Tools.JavaTypeSystem.Models
 			foreach (var jtp in TypeParameters)
 				yield return jtp;
 
-			yield break;
-
-			// TODO, this is more correct, but disabled for ApiXmlAdjuster compatibility.
-			// https://github.com/xamarin/java.interop/issues/815
-			//if (DeclaringType != null)
-			//	foreach (var jtp in DeclaringType.GetApplicableTypeParameters ())
-			//		yield return jtp;
+			if (DeclaringType != null)
+				foreach (var jtp in DeclaringType.GetApplicableTypeParameters ())
+					yield return jtp;
 		}
 	}
 }

--- a/tests/Java.Interop.Tools.JavaTypeSystem-Tests/Java.Interop.Tools.JavaTypeSystem-Tests.csproj
+++ b/tests/Java.Interop.Tools.JavaTypeSystem-Tests/Java.Interop.Tools.JavaTypeSystem-Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <RootNamespace>Java.Interop.Tools.JavaTypeSystem.Tests</RootNamespace>
   </PropertyGroup>


### PR DESCRIPTION
Fixes #815.

Given Java like this:
```java
public class MyClass<T>
{
    public class MyNestedClass<U>
    {
      public void DoT (T value) { }
      public void DoU (U value) { }
    }
}
```

`ApiXmlAdjuster` does not look for generic parameter types on parent types, resulting in the method `DoT` being removed:

```
api.xml.class-parse : warning BG8605: The Java type 'T' could not be found (are you missing a Java reference jar/aar or a Java binding library NuGet?)
```

java-resolution-report.log:
```
==== Cycle 1 ====

The method '[Method] void DoT(T p0)' was removed because the Java parameter type 'T' could not be found.
```

`JavaTypeSystem` supports this, but it was initially disabled to help ensure that it was producing the same output as `ApiXmlAdjuster` for testing purposes.  We can now enable it.