### PR TITLE
[JavaTypeSystem] Support importing constructor generic type parameters from class-parse XML files.

### DIFF
--- a/src/Java.Interop.Tools.JavaTypeSystem/Adapters/JavaXmlApiImporter.cs
+++ b/src/Java.Interop.Tools.JavaTypeSystem/Adapters/JavaXmlApiImporter.cs
@@ -229,6 +229,10 @@ namespace Java.Interop.Tools.JavaTypeSystem
 				isBridge: element.XGetAttributeAsBool ("bridge")
 			);
 
+			// Yes, constructors in Java can have generic type parameters ¯\_(ツ)_/¯
+			if (element.Element ("typeParameters") is XElement tp)
+				ParseTypeParameters (method.TypeParameters, tp);
+
 			foreach (var child in element.Elements ("exception"))
 				method.Exceptions.Add (ParseException (child));
 


### PR DESCRIPTION
While testing the new JavaTypeSystem on AndroidX, the api-diff was reporting various constructors had been removed:

## Xamarin.Android.Glide.dll
#### Type Changed: Bumptech.Glide.Registry.NoModelLoaderAvailableException

Removed constructor:

```csharp
public Registry.NoModelLoaderAvailableException (Java.Lang.Object model, System.Collections.IList matchingButNotHandlingModelLoaders);
```

Investigating let to realizing Java constructors can have generic type parameters:

```java
  public static class NoModelLoaderAvailableException extends MissingComponentException {

    public <M> NoModelLoaderAvailableException(
        @NonNull M model, @NonNull List<ModelLoader<M, ?>> matchingButNotHandlingModelLoaders) {
      super(
          "Found ModelLoaders for model class: "
              + matchingButNotHandlingModelLoaders
              + ", but none that handle this specific model instance: "
              + model);
    }
```

[(source)](https://github.com/bumptech/glide/blob/master/library/src/main/java/com/bumptech/glide/Registry.java)

`class-parse` correctly emits these constructor generic types:

```xml
     <constructor
        deprecated="not deprecated"
        final="false"
        name="Registry.NoModelLoaderAvailableException"
        static="false"
        visibility="public"
        bridge="false"
        synthetic="false"
        jni-signature="(Ljava/lang/Object;Ljava/util/List;)V">
        <typeParameters>
          <typeParameter
            name="M"
            jni-classBound="Ljava/lang/Object;"
            classBound="java.lang.Object"
            interfaceBounds=""
            jni-interfaceBounds="" />
        </typeParameters>
        <parameter
          name="model"
          type="M"
          jni-type="TM;"
          not-null="true" />
        <parameter
          name="matchingButNotHandlingModelLoaders"
          type="java.util.List&lt;com.bumptech.glide.load.model.ModelLoader&lt;M, ?&gt;&gt;"
          jni-type="Ljava/util/List&lt;Lcom/bumptech/glide/load/model/ModelLoader&lt;TM;*&gt;;&gt;;"
          not-null="true" />
      </constructor>
```

We need to import this information in JavaTypeSystem so that the type parameters can be resolved.  Without them, the constructor is omitted because the type `M` cannot be resolved.

```
The constructor 'Constructor: com.bumptech.glide.Registry.NoModelLoaderAvailableException.Registry
.NoModelLoaderAvailableException' was removed because the Java parameter type 'M' could not be found.
```

Tested against AndroidX and this change restores the constructors.