### PR TITLE
[class-parse] Import parameter names for unresolvable types

### DIFF
--- a/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
@@ -304,14 +304,23 @@ namespace Xamarin.Android.Tools.Bytecode {
 					if (!parameterElements.Select (x => x.Attribute ("name")?.Value).Any (p => p != null && IsGeneratedName (p)))
 						continue;
 
-					var parameters = parameterElements
-						.Select (p => p.Attribute ("type")?.Value!)
-						.Where (p => p != null);
+					var parameterTypes = parameterElements
+						.Select (p => new JavaMethodParameterTypeInfo ((string) p.Attribute ("jni-type"), (string) p.Attribute ("type")))
+						.ToArray ();
 
-					if (!parameters.Any ())
+					if (!parameterTypes.Any ())
 						continue;
 
-					var pnames = jdoc.GetParameterNames (currentpackage, className, currentMethod, parameters.ToArray (), isVarArgs: false);
+					var nameInfo = new JavaMethodParameterNameInfo (
+							currentpackage,
+							className,
+							currentMethod,
+							(string) method.Attribute ("jni-signature"),
+							parameterTypes,
+							isVarArgs: false
+					);
+
+					var pnames = jdoc.GetParameterNames (nameInfo);
 					if (pnames == null || pnames.Length != parameterElements.Count)
 						continue;
 					for (int i = 0; i < parameterElements.Count; i++) {

--- a/src/Xamarin.Android.Tools.Bytecode/JavaParameterNamesLoader.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/JavaParameterNamesLoader.cs
@@ -114,8 +114,13 @@ namespace Xamarin.Android.Tools.Bytecode
 			return fixup;
 		}
 
-		public string[]? GetParameterNames (string package, string type, string method, string[] ptypes, bool isVarArgs)
+		public string[]? GetParameterNames (JavaMethodParameterNameInfo info)
 		{
+			var package = info.PackageName;
+			var type    = info.TypeName;
+			var method  = info.MethodName;
+			var ptypes  = info.ParameterTypes.Select (p => p.JavaType).ToArray ();
+
 			var methods = this.packages
 				.Where(p => p.Name == package && p.Types != null)
 				.SelectMany(p => p.Types!)

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/ParameterFixupTests.cs
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/ParameterFixupTests.cs
@@ -46,6 +46,21 @@ namespace Xamarin.Android.Tools.BytecodeTests
 		}
 
 		[Test]
+		public void XmlDeclaration_FixedUpFromUnresolvedApiXmlDocumentation ()
+		{
+			string docsPath = null;
+
+			try {
+				docsPath = LoadToTempFile ("ParameterFixup_JavaInterfaceNoParameters_JavaSourceUtils.xml");
+
+				AssertXmlDeclaration ("JavaInterfaceNoParameters.class", "ParameterFixup_JavaInterfaceNoParameters.xml", docsPath);
+			} finally {
+				if (File.Exists (docsPath))
+					File.Delete (docsPath);
+			}
+		}
+
+		[Test]
 		public void XmlDeclaration_DoesNotThrowAnExceptionIfDocumentationNotFound ()
 		{
 			try {

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/Resources/ParameterFixup_JavaInterfaceNoParameters.xml
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/Resources/ParameterFixup_JavaInterfaceNoParameters.xml
@@ -1,0 +1,75 @@
+<api
+  api-source="class-parse">
+  <package
+    name="com.xamarin"
+    jni-name="com/xamarin">
+    <interface
+      abstract="true"
+      deprecated="not deprecated"
+      final="false"
+      name="JavaInterfaceNoParameters"
+      jni-signature="Lcom/xamarin/JavaInterfaceNoParameters;"
+      source-file-name="JavaInterfaceNoParameters.java"
+      static="false"
+      visibility="public">
+      <method
+        abstract="true"
+        deprecated="not deprecated"
+        final="false"
+        name="asList"
+        native="false"
+        return="java.util.List&lt;T&gt;"
+        jni-return="Ljava/util/List&lt;TT;&gt;;"
+        static="false"
+        synchronized="false"
+        visibility="public"
+        bridge="false"
+        synthetic="false"
+        jni-signature="([Ljava/lang/Object;)Ljava/util/List;">
+        <typeParameters>
+          <typeParameter
+            name="T"
+            jni-classBound="Ljava/lang/Object;"
+            classBound="java.lang.Object"
+            interfaceBounds=""
+            jni-interfaceBounds="" />
+        </typeParameters>
+        <parameter
+          name="a"
+          type="T..."
+          jni-type="[TT;" />
+      </method>
+      <method
+        abstract="true"
+        deprecated="not deprecated"
+        final="false"
+        name="binarySearch"
+        native="false"
+        return="int"
+        jni-return="I"
+        static="false"
+        synchronized="false"
+        visibility="public"
+        bridge="false"
+        synthetic="false"
+        jni-signature="([Ljava/lang/Object;IILjava/lang/Object;)I">
+        <parameter
+          name="a"
+          type="java.lang.Object[]"
+          jni-type="[Ljava/lang/Object;" />
+        <parameter
+          name="fromIndex"
+          type="int"
+          jni-type="I" />
+        <parameter
+          name="toIndex"
+          type="int"
+          jni-type="I" />
+        <parameter
+          name="key"
+          type="java.lang.Object"
+          jni-type="Ljava/lang/Object;" />
+      </method>
+    </interface>
+  </package>
+</api>

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/Resources/ParameterFixup_JavaInterfaceNoParameters_JavaSourceUtils.xml
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/Resources/ParameterFixup_JavaInterfaceNoParameters_JavaSourceUtils.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<api api-source="java-source-utils">
+  <package jni-name="com/xamarin" name="com.xamarin">
+    <interface jni-signature="Lcom/xamarin/JavaInterfaceNoParameters;" name="JavaInterfaceNoParameters">
+      <method jni-return="L.*List;" jni-signature="([L.*Object;)L.*List;" name="asList" return=".*List&lt;T&gt;">
+        <parameter jni-type="[L.*Object;" name="a" type="T..."/>
+        <javadoc>
+          <![CDATA[JNI sig: (Lcom/xamarin/JavaTypeNoParameters;)V]]>
+        </javadoc>
+      </method>
+      <method jni-return="I" jni-signature="([L.*Object;IIL.*Object;)I" name="binarySearch" return="int">
+        <parameter jni-type="[L.*Object;" name="a" type=".*Object[]"/>
+        <parameter jni-type="I" name="fromIndex" type="int"/>
+        <parameter jni-type="I" name="toIndex" type="int"/>
+        <parameter jni-type="L.*Object;" name="key" type=".*Object"/>
+      </method>
+    </interface>
+  </package>
+</api>

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj
@@ -32,6 +32,7 @@
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\xamarin\IParameterInterface.class" />
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\xamarin\JavaAnnotation.class" />
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\xamarin\JavaEnum.class" />
+    <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\xamarin\JavaInterfaceNoParameters.class" />
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\xamarin\JavaType%241.class" />
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\xamarin\JavaType%241MyStringList.class" />
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\xamarin\JavaType%24ASC.class" />

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/java/com/xamarin/JavaInterfaceNoParameters.java
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/java/com/xamarin/JavaInterfaceNoParameters.java
@@ -1,0 +1,19 @@
+package com.xamarin;
+
+public interface JavaInterfaceNoParameters {
+	/**
+	 * JNI sig: ([Ljava/lang/Object;)Ljava/util/List;
+	 */
+	<T> java.util.List<T> asList(T... a);
+
+	/**
+	 * JNI sig: ([Ljava/lang/Object;IILjava/lang/Object;)I
+	 *
+	 * @param a [Ljava/lang/Object;
+	 * @param fromIndex int
+	 * @param toIndex int
+	 * @param key Ljava/lang/Object
+	 * @return int
+	 */
+	int binarySearch(Object[] a, int fromIndex, int toIndex, Object key);
+}

--- a/tools/java-source-utils/src/test/resources/UnresolvedTypes.txt
+++ b/tools/java-source-utils/src/test/resources/UnresolvedTypes.txt
@@ -6,6 +6,6 @@ public class UnresolvedTypes {
 	 *
 	 * JNI Sig: method.(L.*example.name.UnresolvedParameterType;)L.*UnresolvedReturnType;
 	 */
-	public static UnresolvedReturnType<String, Integer> method(example.name.UnresolvedParameterType<Class> parameter) {
+	public static UnresolvedReturnType<String, Integer> method(example.name.UnresolvedParameterType<Class>... parameter) {
 	}
 }

--- a/tools/java-source-utils/src/test/resources/UnresolvedTypes.xml
+++ b/tools/java-source-utils/src/test/resources/UnresolvedTypes.xml
@@ -3,7 +3,7 @@
   <package jni-name="example" name="example">
     <class jni-signature="Lexample/UnresolvedTypes;" name="UnresolvedTypes">
       <method jni-return="L.*UnresolvedReturnType;" jni-signature="(L.*example.name.UnresolvedParameterType;)L.*UnresolvedReturnType;" name="method" return=".*UnresolvedReturnType">
-        <parameter jni-type="L.*example.name.UnresolvedParameterType;" name="parameter" type=".*example.name.UnresolvedParameterType"/>
+        <parameter jni-type="[L.*example.name.UnresolvedParameterType;" name="parameter" type=".*example.name.UnresolvedParameterType..."/>
         <javadoc><![CDATA[Method using unresolvable types.  As such, we make do.
 
 JNI Sig: method.(L.*example.name.UnresolvedParameterType;)L.*UnresolvedReturnType;]]></javadoc>


### PR DESCRIPTION
Fixes: https://github.com/xamarin/java.interop/issues/920

Context: 69e1b80afd81ac502494e4bc2a2de75f5171c73f

`java-source-utils.jar` isn't always able to fully resolve types.
When it is unable to do so, it uses an "alternate encoding":

> In some scenarios, types won't be resolvable.  What should output be?
>
> We don't want to *require* that everything be resolvable -- it's painful, and
> possibly impossible, e.g. w/ internal types -- so instead we should "demark"
> the unresolvable types.
>
> `.params.txt` output will use `.*` as a type prefix, e.g.
>
>         method(.*UnresolvableType foo, int bar);
>
> `docs.xml` will output `L.*UnresolvableType;`.

The problem is that `class-parse --parameter-names=PATH` didn't check
for this "unresolvable type" pattern, so if you had a method which
contained them, e.g. the `target` parameter in:

	<interface jni-signature="Landroidx/core/view/NestedScrollingParent3;" name="NestedScrollingParent3">
	  <method jni-return="V" jni-signature="(L.*View;IIIII[I)V" name="onNestedScroll" return="void">
	    <parameter jni-type="L.*View;" name="target" type=".*View"/>
	    <parameter jni-type="I" name="dxConsumed" type="int"/>
	    <parameter jni-type="I" name="dyConsumed" type="int"/>
	    <parameter jni-type="I" name="dxUnconsumed" type="int"/>
	    <parameter jni-type="I" name="dyUnconsumed" type="int"/>
	    <parameter jni-type="I" name="type" type="int"/>
	    <parameter jni-type="[I" name="consumed" type="int[]"/>

then `class-parse --parameter-names=params.xml lib.jar` wouldn't
try to "loosely match" these parameter types.  Consequently,
parameter names were not imported.

Update the `IJavaMethodParameterNameProvider.GetParameterNames()`
method to take a new `JavaMethodParameterNameInfo` type, instead of
five (5) parameters, as I wanted to increase the amount of data
available to `GetParameterNames()`.

Update `ApiXmlDocScraper.GetParameterNames()` twofold:

 1. Use XLinq instead of computing an XPath expression, and
 2. Loosely match parameter types when `//parameter/@jni-name`
    starts with `L.*`.

This allows us to import parameter names for unresolvable types.

"Force" the issue by adding `JavaInterfaceNoParameters.java` and a
`ParameterFixup_JavaInterfaceNoParameters_JavaSourceUtils.xml`,
generated via:

	java -jar bin/Debug/java-source-utils.jar \
	  tests/Xamarin.Android.Tools.Bytecode-Tests/java/com/xamarin/JavaInterfaceNoParameters.java \
	  > tests/Xamarin.Android.Tools.Bytecode-Tests/Resources/ParameterFixup_JavaInterfaceNoParameters_JavaSourceUtils.xml

then altering the resulting XML so that instead of e.g.
`Ljava/lang/Object;`, `L.*Object;` is used.

This should permit appropriate parameter name overrides e.g. via:

	mono bin/Debug/class-parse.exe \
	  --parameter-names tests/Xamarin.Android.Tools.Bytecode-Tests/Resources/ParameterFixup_JavaInterfaceNoParameters_JavaSourceUtils.xml \
	  tests/Xamarin.Android.Tools.Bytecode-Tests/obj/Debug/classes/com/xamarin/JavaInterfaceNoParameters.class

Testing found a deficiency in `java-source-utils`: it didn't properly
represent "varargs" arrays.  Update `tools/java-source-utils` so that
params-arrays are properly represented.