### PR TITLE
[Xamarin.Android.Tools.Bytecode] Fix Nullability warnings

### DIFF
--- a/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
@@ -305,7 +305,9 @@ namespace Xamarin.Android.Tools.Bytecode {
 						continue;
 
 					var parameterTypes = parameterElements
-						.Select (p => new JavaMethodParameterTypeInfo ((string) p.Attribute ("jni-type"), (string) p.Attribute ("type")))
+						.Select (p => new JavaMethodParameterTypeInfo (
+								jniType: (string?) p.Attribute ("jni-type") ?? "",
+								javaType: (string?) p.Attribute ("type") ?? ""))
 						.ToArray ();
 
 					if (!parameterTypes.Any ())
@@ -315,7 +317,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 							currentpackage,
 							className,
 							currentMethod,
-							(string) method.Attribute ("jni-signature"),
+							(string?) method.Attribute ("jni-signature"),
 							parameterTypes,
 							isVarArgs: false
 					);

--- a/src/Xamarin.Android.Tools.Bytecode/JavaDocumentScraper.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/JavaDocumentScraper.cs
@@ -400,9 +400,9 @@ namespace Xamarin.Android.Tools.Bytecode
 			var xtype = xdoc
 				.Elements ("api")
 				.Elements ("package")
-				.Where (p => ((string) p.Attribute ("name")) == info.PackageName)
+				.Where (p => ((string?) p.Attribute ("name")) == info.PackageName)
 				.Elements ()
-				.Where (t => ((string) t.Attribute ("name")) == info.TypeName)
+				.Where (t => ((string?) t.Attribute ("name")) == info.TypeName)
 				.FirstOrDefault ();
 			if (xtype == null) {
 				return null;
@@ -410,13 +410,13 @@ namespace Xamarin.Android.Tools.Bytecode
 
 			var members = info.MethodName == "constructor"
 				? xtype.Elements ("constructor")
-				: xtype.Elements ("method").Where (m => ((string) m.Attribute ("name")) == info.MethodName);
+				: xtype.Elements ("method").Where (m => ((string?) m.Attribute ("name")) == info.MethodName);
 			var pcount  = info.ParameterTypes.Length;
 			members     = members
 				.Where (m => m.Elements ("parameter").Count () == pcount);
 
 			XElement? member =
-				members.FirstOrDefault (m => info.MethodSignature == (string) m.Attribute ("jni-signature"));
+				members.FirstOrDefault (m => info.MethodSignature == (string?) m.Attribute ("jni-signature"));
 			if (member == null) {
 				foreach (var m in members) {
 					var found   = true;
@@ -436,12 +436,15 @@ namespace Xamarin.Android.Tools.Bytecode
 			if (member == null)
 				return null;
 			return member.Elements ("parameter")
-				.Select (p => (string) p.Attribute ("name"))
+				.Select (p => ((string?) p.Attribute ("name")) ?? "")
 				.ToArray ();
 
 			bool ParameterTypesMatch (XElement parameter, string ptype)
 			{
-				var jtype = (string) parameter.Attribute ("type");
+				var jtype = (string?) parameter.Attribute ("type");
+				if (jtype == null) {
+					return false;
+				}
 				if (!jtype.StartsWith (".*", StringComparison.Ordinal)) {
 					return jtype == ptype;
 				}


### PR DESCRIPTION
Context: 77c9c5fa617f50817eda3d358e881f437165c07d

Commit 77c9c5fa inadvertently introduced nullability warnings:

	…\Xamarin.Android.Tools.Bytecode\ClassPath.cs(308,89): warning CS8600: Converting null literal or possible null value to non-nullable type.
	…\Xamarin.Android.Tools.Bytecode\ClassPath.cs(308,54): warning CS8604: Possible null reference argument for parameter 'jniType' in 'JavaMethodParameterTypeInfo.JavaMethodParameterTypeInfo(string jniType, string javaType)'.
	…\Xamarin.Android.Tools.Bytecode\ClassPath.cs(308,89): warning CS8604: Possible null reference argument for parameter 'javaType' in 'JavaMethodParameterTypeInfo.JavaMethodParameterTypeInfo(string jniType, string javaType)'.
	…\Xamarin.Android.Tools.Bytecode\ClassPath.cs(318,8): warning CS8600: Converting null literal or possible null value to non-nullable type.
	…\Xamarin.Android.Tools.Bytecode\JavaDocumentScraper.cs(403,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
	…\Xamarin.Android.Tools.Bytecode\JavaDocumentScraper.cs(405,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
	…\Xamarin.Android.Tools.Bytecode\JavaDocumentScraper.cs(413,46): warning CS8600: Converting null literal or possible null value to non-nullable type.
	…\Xamarin.Android.Tools.Bytecode\JavaDocumentScraper.cs(419,58): warning CS8600: Converting null literal or possible null value to non-nullable type.
	…\Xamarin.Android.Tools.Bytecode\JavaDocumentScraper.cs(439,19): warning CS8600: Converting null literal or possible null value to non-nullable type.
	…\Xamarin.Android.Tools.Bytecode\JavaDocumentScraper.cs(438,11): warning CS8619: Nullability of reference types in value of type 'string?[]' doesn't match target type 'string[]'.
	…\Xamarin.Android.Tools.Bytecode\JavaDocumentScraper.cs(444,17): warning CS8600: Converting null literal or possible null value to non-nullable type.
	…\Xamarin.Android.Tools.Bytecode\JavaDocumentScraper.cs(445,10): warning CS8602: Dereference of a possibly null reference.

Fix these nullability warnings.