### PR TITLE
[java-source-utils] Transform XML using XSLT

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -179,6 +179,5 @@ jobs:
   - template: templates\core-tests.yaml
     parameters:
       runNativeTests: true
-      runJavaTests: true
 
   - template: templates\fail-on-issue.yaml

--- a/build-tools/automation/templates/core-tests.yaml
+++ b/build-tools/automation/templates/core-tests.yaml
@@ -1,7 +1,6 @@
 parameters:
   condition: succeeded()
   runNativeTests: false
-  runJavaTests: false
 
 steps:
 - task: DotNetCoreCLI@2
@@ -110,7 +109,6 @@ steps:
 
 - task: DotNetCoreCLI@2
   displayName: 'Tests: java-source-utils'
-  condition: eq('${{ parameters.runJavaTests }}', 'true')
   inputs:
     command: build
     arguments: -c $(Build.Configuration) tools/java-source-utils/java-source-utils.csproj -t:RunTests
@@ -118,7 +116,6 @@ steps:
 
 - task: PublishTestResults@2
   displayName: Publish JUnit Test Results
-  condition: eq('${{ parameters.runJavaTests }}', 'true')
   inputs:
     testResultsFormat: JUnit
     testResultsFiles: 'tools/java-source-utils/build/test-results/**/TEST-*.xml'

--- a/build-tools/automation/templates/publish-test-results.yaml
+++ b/build-tools/automation/templates/publish-test-results.yaml
@@ -9,7 +9,6 @@ steps:
 
 - task: PublishTestResults@2
   displayName: Publish JUnit Test Results
-  condition: ne('$(Agent.OS)', 'Windows')
   inputs:
     testResultsFormat: JUnit
     testResultsFiles: '**/TEST-*.xml'

--- a/build-tools/scripts/RunNUnitTests.targets
+++ b/build-tools/scripts/RunNUnitTests.targets
@@ -30,7 +30,7 @@
         ContinueOnError="ErrorAndContinue"
     />
     <MSBuild
-        Condition=" !$([MSBuild]::IsOSPlatform ('windows')) "
+        Condition=" '$(SkipJSUTests)' != 'true' "
         Projects="$(MSBuildThisFileDirectory)..\..\tools\java-source-utils\java-source-utils.csproj"
         Targets="RunTests"
     />

--- a/tools/java-source-utils/src/main/java/com/microsoft/android/JavadocXmlGenerator.java
+++ b/tools/java-source-utils/src/main/java/com/microsoft/android/JavadocXmlGenerator.java
@@ -2,6 +2,8 @@ package com.microsoft.android;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
@@ -17,6 +19,7 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -65,10 +68,10 @@ public final class JavadocXmlGenerator implements AutoCloseable {
 	}
 
 	public void close() throws TransformerException {
+		InputStream is = getClass().getClassLoader().getResourceAsStream("transform-style.xsl");
+		InputStreamReader isr = new InputStreamReader(is);
 		Transformer transformer = TransformerFactory.newInstance()
-			.newTransformer();
-		transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-		transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+			.newTransformer(new StreamSource (isr));
 		transformer.transform(new DOMSource(document), new StreamResult(output));
 
 		if (output != System.out) {

--- a/tools/java-source-utils/src/main/resources/transform-style.xsl
+++ b/tools/java-source-utils/src/main/resources/transform-style.xsl
@@ -1,0 +1,45 @@
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xalan="http://xml.apache.org/xalan">
+
+  <xsl:output method="xml"
+              encoding="UTF-8"
+              indent="yes"
+              xalan:indent-amount="2"
+              standalone="no"
+              cdata-section-elements="javadoc"/>
+
+  <xsl:strip-space elements="*"/>
+
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+    <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+
+
+  <!-- Remove extra carriage returns from `<javadoc/>` CDATA elements to help standardize output across Unix and Windows -->
+  <xsl:template match="javadoc/text()">
+    <xsl:call-template name="removeCarriageReturn"/>
+  </xsl:template>
+
+  <xsl:template name="removeCarriageReturn">
+    <xsl:param name="pText" select="."/>
+
+    <xsl:if test="string-length($pText) >0">
+      <xsl:choose>
+        <xsl:when test="not(contains($pText,'&#13;'))">
+          <xsl:value-of select="$pText"/>
+        </xsl:when>
+
+        <xsl:otherwise>
+          <xsl:value-of select="substring-before($pText, '&#13;')"/>
+          <xsl:call-template name="removeCarriageReturn">
+            <xsl:with-param name="pText" select="substring-after($pText, '&#13;')"/>
+          </xsl:call-template>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
I've seen inconsistent XML output from java-source-utils when running on
macOS vs. Windows, or JDK 8 vs. JDK 11.  On Windows I've seen extra
carriage returns in CDATA blocks, and when using JDK 9+ we've seen
additional new lines added between XML elements.

An XSL style sheet can be used to improve the formatting consistency of
the XML that is produced.  This should prevent us from generating
inconsistent API docs across macOS and Windows.

There is still [an outstanding issue][0] concerning CDATA blocks between
JDK 8 and JDK 11 that I have not yet been able to sort out.  This issue
has seemingly been "fixed" in JDK 14.

[0]: https://stackoverflow.com/questions/55853220/handling-change-in-newlines-by-xml-transformation-for-cdata-from-java-8-to-java
