### PR TITLE
[Java.Interop] Treat warnings as errors.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,8 @@
   <!-- Note: MUST be imported *after* $(Configuration) is set! -->
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <!-- Mono's MSBuild does not support some implicit .NET6 source generator stuff -->
+    <TreatWarningsAsErrors Condition=" '$(Configuration)' == 'Release' And '$(MSBuildRuntimeType)' != 'Mono' ">true</TreatWarningsAsErrors>
     <_OutputPath>$(MSBuildThisFileDirectory)bin\Build$(Configuration)\</_OutputPath>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
   </PropertyGroup>


### PR DESCRIPTION
Turn on `<TreatWarningsAsErrors>` for `Release` builds only.

Also, Mono's `net6.0` (MSBuild 16) support causes warnings so we aren't going to enable it there.
```
warning NETSDK1182: Targeting .NET 6.0 in Visual Studio 2019 is not supported. 
warning CS8032: An instance of analyzer System.Text.Json.SourceGeneration.JsonSourceGenerator cannot be created from /Users/runner/hostedtoolcache/dotnet/packs/Microsoft.NETCore.App.Ref/6.0.0/analyzers/dotnet/cs/System.Text.Json.SourceGeneration.dll : Could not resolve type with token 01000027 from typeref (expected class 'Microsoft.CodeAnalysis.IIncrementalGenerator' in assembly 'Microsoft.CodeAnalysis, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35') assembly:Microsoft.CodeAnalysis, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35 type:Microsoft.CodeAnalysis.IIncrementalGenerator member:(null). [/Users/runner/work/1/s/src/Xamarin.Android.Tools.Bytecode/Xamarin.Android.Tools.Bytecode.csproj]
```

We also saw these warnings on Windows before we moved to Visual Studio 2022 agents.