### PR TITLE
[ci] Use descriptive test run titles.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ TESTS = \
 	bin/Test$(CONFIGURATION)/logcat-parse-Tests.dll \
 	bin/Test$(CONFIGURATION)/generator-Tests.dll \
 	bin/Test$(CONFIGURATION)/Xamarin.Android.Tools.ApiXmlAdjuster-Tests.dll \
+	bin/Test$(CONFIGURATION)/Java.Interop.Tools.JavaTypeSystem-Tests.dll \
 	bin/Test$(CONFIGURATION)/Xamarin.Android.Tools.Bytecode-Tests.dll \
 	bin/Test$(CONFIGURATION)/Java.Interop.Tools.Generator-Tests.dll \
 	bin/Test$(CONFIGURATION)/Xamarin.SourceWriter-Tests.dll

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -67,7 +67,7 @@ jobs:
     inputs:
       solution: build-tools/scripts/RunNUnitTests.targets
       configuration: $(Build.Configuration)
-      msbuildArguments: /p:TestAssembly="bin\Test$(Build.Configuration)\generator-Tests.dll;bin\Test$(Build.Configuration)\Java.Interop.Tools.JavaCallableWrappers-Tests.dll;bin\Test$(Build.Configuration)\logcat-parse-Tests.dll;bin\Test$(Build.Configuration)\Xamarin.Android.Tools.ApiXmlAdjuster-Tests.dll;bin\Test$(Build.Configuration)\Xamarin.Android.Tools.Bytecode-Tests.dll;bin\Test$(Build.Configuration)\Java.Interop.Tools.Generator-Tests.dll;bin\Test$(Build.Configuration)\Xamarin.SourceWriter-Tests.dll"
+      msbuildArguments: /p:TestAssembly="bin\Test$(Build.Configuration)\generator-Tests.dll;bin\Test$(Build.Configuration)\Java.Interop.Tools.JavaCallableWrappers-Tests.dll;bin\Test$(Build.Configuration)\logcat-parse-Tests.dll;bin\Test$(Build.Configuration)\Xamarin.Android.Tools.ApiXmlAdjuster-Tests.dll;bin\Test$(Build.Configuration)\Java.Interop.Tools.JavaTypeSystem-Tests.dll;bin\Test$(Build.Configuration)\Xamarin.Android.Tools.Bytecode-Tests.dll;bin\Test$(Build.Configuration)\Java.Interop.Tools.Generator-Tests.dll;bin\Test$(Build.Configuration)\Xamarin.SourceWriter-Tests.dll"
     condition: succeededOrFailed()
 
   - template: templates\publish-test-results.yaml
@@ -90,6 +90,7 @@ jobs:
   - template: templates\core-tests.yaml
     parameters:
       runNativeDotnetTests: true
+      platformName: .NET - Windows
 
   - template: templates\fail-on-issue.yaml
 
@@ -180,5 +181,6 @@ jobs:
     parameters:
       runNativeTests: true
       runJavaTests: true
+      platformName: .NET - MacOS
 
   - template: templates\fail-on-issue.yaml

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -71,6 +71,8 @@ jobs:
     condition: succeededOrFailed()
 
   - template: templates\publish-test-results.yaml
+    parameters:
+      platformName: .NET Framework - Windows
 
 - job: windows_dotnet_build
   displayName: Windows - .NET Core
@@ -142,6 +144,8 @@ jobs:
     displayName: Run Tests
 
   - template: templates\publish-test-results.yaml
+    parameters:
+      platformName: Mono - Mac
 
   - task: CopyFiles@2
     displayName: 'Copy Files to: Artifact Staging Directory'

--- a/build-tools/automation/templates/core-tests.yaml
+++ b/build-tools/automation/templates/core-tests.yaml
@@ -2,12 +2,14 @@ parameters:
   condition: succeeded()
   runNativeTests: false
   runJavaTests: false
+  platformName:
 
 steps:
 - task: DotNetCoreCLI@2
   displayName: 'Tests: generator'
   inputs:
     command: test
+    testRunTitle: generator (${{ parameters.platformName }})
     arguments: bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/generator-Tests.dll
   continueOnError: true
   
@@ -15,6 +17,7 @@ steps:
   displayName: 'Tests: JavaCallableWrappers'
   inputs:
     command: test
+    testRunTitle: Java.Interop.Tools.JavaCallableWrappers (${{ parameters.platformName }})
     arguments: bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Tools.JavaCallableWrappers-Tests.dll
   continueOnError: true
    
@@ -22,6 +25,7 @@ steps:
   displayName: 'Tests: logcat-parse'
   inputs:
     command: test
+    testRunTitle: logcat-parse (${{ parameters.platformName }})
     arguments: bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/logcat-parse-Tests.dll
   continueOnError: true
   
@@ -29,13 +33,23 @@ steps:
   displayName: 'Tests: ApiXmlAdjuster'
   inputs:
     command: test
+    testRunTitle: Xamarin.Android.Tools.ApiXmlAdjuster (${{ parameters.platformName }})
     arguments: bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Xamarin.Android.Tools.ApiXmlAdjuster-Tests.dll
+  continueOnError: true
+  
+- task: DotNetCoreCLI@2
+  displayName: 'Tests: JavaTypeSystem'
+  inputs:
+    command: test
+    testRunTitle: Xamarin.Android.Tools.JavaTypeSystem (${{ parameters.platformName }})
+    arguments: bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Tools.JavaTypeSystem-Tests.dll
   continueOnError: true
   
 - task: DotNetCoreCLI@2
   displayName: 'Tests: Bytecode'
   inputs:
     command: test
+    testRunTitle: Xamarin.Android.Tools.Bytecode (${{ parameters.platformName }})
     arguments: bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Xamarin.Android.Tools.Bytecode-Tests.dll
   continueOnError: true
 
@@ -43,6 +57,7 @@ steps:
   displayName: 'Tests: Java.Interop.Tools.Generator'
   inputs:
     command: test
+    testRunTitle: Java.Interop.Tools.Generator (${{ parameters.platformName }})
     arguments: bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Tools.Generator-Tests.dll
   continueOnError: true
 
@@ -50,6 +65,7 @@ steps:
   displayName: 'Tests: Java.Interop.Tools.JavaSource'
   inputs:
     command: test
+    testRunTitle: Java.Interop.Tools.JavaSource (${{ parameters.platformName }})
     arguments: bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Tools.JavaSource-Tests.dll
   continueOnError: true
 
@@ -57,6 +73,7 @@ steps:
   displayName: 'Tests: Xamarin.SourceWriter'
   inputs:
     command: test
+    testRunTitle: Xamarin.SourceWriter (${{ parameters.platformName }})
     arguments: bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Xamarin.SourceWriter-Tests.dll
   continueOnError: true
 
@@ -65,6 +82,7 @@ steps:
   condition: eq('${{ parameters.runNativeTests }}', 'true')
   inputs:
     command: test
+    testRunTitle: Java.Interop (netstandard2.0 - ${{ parameters.platformName }})
     arguments: bin/Test$(Build.Configuration)/Java.Interop-Tests.dll
   continueOnError: true
 
@@ -73,6 +91,7 @@ steps:
   condition: or(eq('${{ parameters.runNativeDotnetTests }}', 'true'), eq('${{ parameters.runNativeTests }}', 'true'))
   inputs:
     command: test
+    testRunTitle: Java.Interop (net6.0 - ${{ parameters.platformName }})
     arguments: bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop-Tests.dll
   continueOnError: true
 
@@ -81,6 +100,7 @@ steps:
   condition: eq('${{ parameters.runNativeTests }}', 'true')
   inputs:
     command: test
+    testRunTitle: Java.Interop.Dynamic (${{ parameters.platformName }})
     arguments: bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Dynamic-Tests.dll
   continueOnError: true
 
@@ -89,22 +109,25 @@ steps:
   condition: eq('${{ parameters.runNativeTests }}', 'true')
   inputs:
     command: test
+    testRunTitle: Java.Interop.Export (${{ parameters.platformName }})
     arguments: bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Export-Tests.dll
   continueOnError: true
 
 - task: DotNetCoreCLI@2
-  displayName: 'Tests: Java.Interop'
+  displayName: 'Tests: Java.Interop-Performance-net472'
   condition: eq('${{ parameters.runNativeTests }}', 'true')
   inputs:
     command: test
+    testRunTitle: Java.Interop-Performance (net472 - ${{ parameters.platformName }})
     arguments: bin/Test$(Build.Configuration)/Java.Interop-PerformanceTests.dll
   continueOnError: true
 
 - task: DotNetCoreCLI@2
-  displayName: 'Tests: Java.Interop'
+  displayName: 'Tests: Java.Interop-Performance-net6.0'
   condition: eq('${{ parameters.runNativeTests }}', 'true')
   inputs:
     command: test
+    testRunTitle: Java.Interop-Performance (net6.0 - ${{ parameters.platformName }})
     arguments: bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop-PerformanceTests.dll
   continueOnError: true
 

--- a/build-tools/automation/templates/core-tests.yaml
+++ b/build-tools/automation/templates/core-tests.yaml
@@ -142,4 +142,5 @@ steps:
   inputs:
     testResultsFormat: JUnit
     testResultsFiles: 'tools/java-source-utils/build/test-results/**/TEST-*.xml'
+    testRunTitle: java-source-utils (${{ parameters.platformName }})
   continueOnError: true

--- a/build-tools/automation/templates/publish-test-results.yaml
+++ b/build-tools/automation/templates/publish-test-results.yaml
@@ -1,3 +1,6 @@
+parameters:
+  platformName:
+
 steps:
 - task: PublishTestResults@2
   displayName: Publish NUnit Test Results
@@ -5,6 +8,7 @@ steps:
   inputs:
     testResultsFormat: NUnit
     testResultsFiles: TestResult-*.xml
+    testRunTitle: NUnit test results (${{ parameters.platformName }})
   continueOnError: true
 
 - task: PublishTestResults@2
@@ -12,4 +16,5 @@ steps:
   inputs:
     testResultsFormat: JUnit
     testResultsFiles: '**/TEST-*.xml'
+    testRunTitle: JUnit test results (${{ parameters.platformName }})
   continueOnError: true


### PR DESCRIPTION
Add `testRunTitle` information to our .NET tests so they are easier to read in the Azure Pipelines Test tab.

Additionally, auditing the test suites we run revealed we are not currently running `Java.Interop.Tools.JavaTypeSystem-Tests`, so this test suite was also added to CI.