### PR TITLE
[logcat-parse] Use C# verbatim strings for paths

### DIFF
--- a/tools/logcat-parse/Program.cs
+++ b/tools/logcat-parse/Program.cs
@@ -48,11 +48,11 @@ namespace Xamarin.Android.Tools.LogcatParse {
 			if (files.Count > 0) {
 				if (files.Count > 1)
 					Console.Error.WriteLine ("logcat-parse: More than one file is unsupported. Loading: {0}", files [0]);
-				Console.WriteLine ("var grefs = Grefs.Parse(\"{0}\"{1});", files [0],
+				Console.WriteLine ("var grefs = Grefs.Parse(@\"{0}\"{1});", files [0],
 						pid.HasValue ? ", " + pid.Value : "");
 				eval.Run ("Grefs grefs;");
 				eval.Run (
-						"using (var __source = new System.IO.StreamReader(\"" +
+						"using (var __source = new System.IO.StreamReader(@\"" +
 						files [0] +
 						"\")) grefs = Grefs.Parse(__source" +
 						(pid.HasValue ? (", " + pid.ToString ()) : "") + ");");


### PR DESCRIPTION
`logcat-parse` didn't properly deal with execution on Windows; when
specifying a Windows-style path on Windows:

	> cd "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Xamarin\Android"
	> .\logcat-parse.exe \path\to\my\grefs.txt
	var grefs = Grefs.Parse("\path\to\my\grefs.txt");
	(1,52): error CS1009: Unrecognized escape sequence `\p'
	(1,60): error CS1009: Unrecognized escape sequence `\m'
	(1,63): error CS1009: Unrecognized escape sequence `\g'

`logcat-parse` could still be used, but you'd either have to use `/`
instead of `\`, or invoke `logcat-parse` from where `grefs.txt` is:

	> cd \path\to\my
	> "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Xamarin\Android\logcat-parse.exe" ^
	  grefs.txt
	// `adb logcat` GREF parsing utility
	//
	// Use `Grefs.Parse(stream)` to parse a file containing `adb logcat` output.
	// Grefs.AllocatedPeers contains all exposed Java.Lang.Object instances.
	// Grefs.AlivePeers contains those still alive by the end of parsing.
	var grefs = Grefs.Parse("grefs.txt");
	Mono C# Shell, type "help;" for help

	Enter statements below.
	csharp>

Fix `logcat-parse` so that [C# verbatim strings][0] are used:

	> "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Xamarin\Android\logcat-parse.exe" ^
	  \path\to\my\grefs.txt
	…
	var grefs = Grefs.Parse(@"\path\to\my\grefs.txt");

This allows straightforward usage on Windows.

[0]: https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/strings/#regular-and-verbatim-string-literals