### PR TITLE
[ci] Ignore publishing JUnit tests on .NET Framework - Windows

### DIFF
--- a/build-tools/automation/templates/publish-test-results.yaml
+++ b/build-tools/automation/templates/publish-test-results.yaml
@@ -9,7 +9,7 @@ steps:
 
 - task: PublishTestResults@2
   displayName: Publish JUnit Test Results
-  condition: ne('$(Agent.OS)', 'Windows_NT')
+  condition: ne(variables['agent.os'], 'Windows_NT')
   inputs:
     testResultsFormat: JUnit
     testResultsFiles: '**/TEST-*.xml'

--- a/build-tools/automation/templates/publish-test-results.yaml
+++ b/build-tools/automation/templates/publish-test-results.yaml
@@ -9,7 +9,7 @@ steps:
 
 - task: PublishTestResults@2
   displayName: Publish JUnit Test Results
-  condition: ne('$(Agent.OS)', 'Windows')
+  condition: ne('$(Agent.OS)', 'Windows_NT')
   inputs:
     testResultsFormat: JUnit
     testResultsFiles: '**/TEST-*.xml'


### PR DESCRIPTION
The Windows value for Azure Pipeline's `Agent.OS` is `Windows_NT`:

https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#agent-variables-devops-services