### PR TITLE
[Java.Interop.Tools.JavaSource] Add {@ docRoot} support

### DIFF
--- a/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/SourceJavadocToXmldocGrammar.InlineTagsBnfTerms.cs
+++ b/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/SourceJavadocToXmldocGrammar.InlineTagsBnfTerms.cs
@@ -36,7 +36,15 @@ namespace Java.Interop.Tools.JavaSource {
 
 				DocRootDeclaration.Rule = grammar.ToTerm ("{@docRoot}");
 				DocRootDeclaration.AstConfig.NodeCreator = (context, parseNode) => {
-					parseNode.AstNode = new XText ("[TODO: @docRoot]");
+					var docRoot = grammar.XmldocSettings.DocRootValue;
+					if (!string.IsNullOrEmpty (docRoot)) {
+						if (!docRoot.EndsWith ("/", StringComparison.OrdinalIgnoreCase)) {
+							docRoot += "/";
+						}
+					} else {
+						docRoot = "{@docRoot}";
+					}
+					parseNode.AstNode = new XText (docRoot);
 				};
 
 				InheritDocDeclaration.Rule = grammar.ToTerm ("{@inheritDoc}");

--- a/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/SourceJavadocToXmldocGrammar.cs
+++ b/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/SourceJavadocToXmldocGrammar.cs
@@ -16,15 +16,15 @@ namespace Java.Interop.Tools.JavaSource {
 		public  readonly    InlineTagsBnfTerms  InlineTagsTerms;
 		public  readonly    HtmlBnfTerms        HtmlTerms;
 
-		public  readonly    XmldocStyle         XmldocStyle;
+		public  readonly    XmldocSettings      XmldocSettings;
 
-		public SourceJavadocToXmldocGrammar (XmldocStyle style)
+		public SourceJavadocToXmldocGrammar (XmldocSettings settings)
 		{
 			BlockTagsTerms  = new BlockTagsBnfTerms ();
 			InlineTagsTerms = new InlineTagsBnfTerms ();
 			HtmlTerms       = new HtmlBnfTerms ();
 
-			XmldocStyle     = style;
+			XmldocSettings	= settings;
 
 			BlockTagsTerms.CreateRules (this);
 			InlineTagsTerms.CreateRules (this);
@@ -55,7 +55,7 @@ namespace Java.Interop.Tools.JavaSource {
 
 		internal bool ShouldImport (ImportJavadoc value)
 		{
-			var v = (ImportJavadoc) XmldocStyle;
+			var v = (ImportJavadoc) XmldocSettings.Style;
 			return v.HasFlag (value);
 		}
 

--- a/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/SourceJavadocToXmldocParser.cs
+++ b/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/SourceJavadocToXmldocParser.cs
@@ -56,19 +56,19 @@ namespace Java.Interop.Tools.JavaSource {
 
 	public class SourceJavadocToXmldocParser : Irony.Parsing.Parser {
 
-		public SourceJavadocToXmldocParser (XmldocStyle style = XmldocStyle.Full)
-			: base (CreateGrammar (style))
+		public SourceJavadocToXmldocParser (XmldocSettings settings)
+			: base (CreateGrammar (settings))
 		{
-			XmldocStyle = style;
+			XmldocSettings = settings;
 		}
 
-		public  XmldocStyle     XmldocStyle                 { get; }
+		public  XmldocSettings XmldocSettings { get; }
 
-		public  XElement[]?     ExtraRemarks                { get; set; }
 
-		static Grammar CreateGrammar (XmldocStyle style)
+
+		static Grammar CreateGrammar (XmldocSettings settings)
 		{
-			return new SourceJavadocToXmldocGrammar (style) {
+			return new SourceJavadocToXmldocGrammar (settings) {
 				LanguageFlags = LanguageFlags.Default | LanguageFlags.CreateAst,
 			};
 		}
@@ -102,13 +102,13 @@ namespace Java.Interop.Tools.JavaSource {
 				var summary = CreateSummaryNode (info);
 				if (summary != null)
 					yield return summary;
-				var style   = (ImportJavadoc) XmldocStyle;
+				var style   = (ImportJavadoc) XmldocSettings.Style;
 				if (style.HasFlag (ImportJavadoc.Remarks) &&
-						(info.Remarks.Count > 0 || ExtraRemarks?.Length > 0)) {
-					yield return new XElement ("remarks", info.Remarks, ExtraRemarks);
+						(info.Remarks.Count > 0 || XmldocSettings.ExtraRemarks?.Length > 0)) {
+					yield return new XElement ("remarks", info.Remarks, XmldocSettings.ExtraRemarks);
 				}
-				else if (style.HasFlag (ImportJavadoc.ExtraRemarks) && ExtraRemarks?.Length > 0) {
-					yield return new XElement ("remarks", ExtraRemarks);
+				else if (style.HasFlag (ImportJavadoc.ExtraRemarks) && XmldocSettings.ExtraRemarks?.Length > 0) {
+					yield return new XElement ("remarks", XmldocSettings.ExtraRemarks);
 				}
 				foreach (var n in info.Returns) {
 					yield return n;

--- a/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/XmldocSettings.cs
+++ b/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/XmldocSettings.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Xml.Linq;
+
+namespace Java.Interop.Tools.JavaSource
+{
+	public class XmldocSettings
+	{
+		public string DocRootValue { get; set; } = string.Empty;
+		public XElement []? ExtraRemarks { get; set; }
+		public XmldocStyle Style { get; set; } = XmldocStyle.Full;
+	}
+}

--- a/tests/Java.Interop.Tools.JavaSource-Tests/SourceJavadocToXmldocGrammar.HtmlBnfTermsTests.cs
+++ b/tests/Java.Interop.Tools.JavaSource-Tests/SourceJavadocToXmldocGrammar.HtmlBnfTermsTests.cs
@@ -47,5 +47,21 @@ namespace Java.Interop.Tools.JavaSource.Tests
 					r.Root.AstNode.ToString ());
 
 		}
+
+		[Test]
+		public void HyperLinkDeclaration ()
+		{
+			var p = CreateParser (g => g.HtmlTerms.InlineHyperLinkDeclaration);
+
+			var r = p.Parse ("<a href=\"https://developer.android.com/guide/topics/manifest/application-element.html\">application</a>");
+			Assert.IsFalse (r.HasErrors (), DumpMessages (r, p));
+			Assert.AreEqual ("<see href=\"https://developer.android.com/guide/topics/manifest/application-element.html\">application</see>",
+					r.Root.AstNode.ToString ());
+
+			r = p.Parse ("<a href=\"AutofillService.html#FieldClassification\">field classification</a>");
+			Assert.IsFalse (r.HasErrors (), DumpMessages (r, p));
+			Assert.AreEqual ("\"AutofillService.html#FieldClassification\"&gt;field classification",
+					r.Root.AstNode.ToString ());
+		}
 	}
 }

--- a/tests/Java.Interop.Tools.JavaSource-Tests/SourceJavadocToXmldocGrammar.InlineTagsBnfTermsTests.cs
+++ b/tests/Java.Interop.Tools.JavaSource-Tests/SourceJavadocToXmldocGrammar.InlineTagsBnfTermsTests.cs
@@ -31,7 +31,7 @@ namespace Java.Interop.Tools.JavaSource.Tests
 
 			var r = p.Parse ("{@docRoot}");
 			Assert.IsFalse (r.HasErrors (), DumpMessages (r, p));
-			Assert.AreEqual ("[TODO: @docRoot]", r.Root.AstNode.ToString ());
+			Assert.AreEqual (DocRootPrefixExpected, r.Root.AstNode.ToString ());
 		}
 
 		[Test]

--- a/tests/Java.Interop.Tools.JavaSource-Tests/SourceJavadocToXmldocGrammarFixture.cs
+++ b/tests/Java.Interop.Tools.JavaSource-Tests/SourceJavadocToXmldocGrammarFixture.cs
@@ -17,9 +17,16 @@ namespace Java.Interop.Tools.JavaSource.Tests
 	[TestFixture]
 	public class SourceJavadocToXmldocGrammarFixture {
 
+		protected const string DocRootPrefixActual = "https://developer.android.com";
+		protected const string DocRootPrefixExpected = DocRootPrefixActual + "/";
+
 		public static Parser CreateParser (Func<SourceJavadocToXmldocGrammar, NonTerminal> root)
 		{
-			var g = new SourceJavadocToXmldocGrammar (XmldocStyle.Full) {
+			var g = new SourceJavadocToXmldocGrammar (new XmldocSettings {
+				Style = XmldocStyle.Full,
+				DocRootValue = DocRootPrefixActual,
+			})
+			{
 				LanguageFlags = LanguageFlags.Default | LanguageFlags.CreateAst,
 			};
 			g.Root = root (g);

--- a/tests/Java.Interop.Tools.JavaSource-Tests/SourceJavadocToXmldocParserTests.cs
+++ b/tests/Java.Interop.Tools.JavaSource-Tests/SourceJavadocToXmldocParserTests.cs
@@ -21,12 +21,18 @@ namespace Java.Interop.Tools.JavaSource.Tests
 		public void TryParse (ParseResult parseResult)
 		{
 			ParseTree parseTree;
-			var p = new SourceJavadocToXmldocParser (XmldocStyle.Full);
+			var p = new SourceJavadocToXmldocParser (new XmldocSettings {
+				Style = XmldocStyle.Full,
+				DocRootValue = DocRootPrefixActual,
+			});
 			var n = p.TryParse (parseResult.Javadoc, null, out parseTree);
 			Assert.IsFalse (parseTree.HasErrors (), DumpMessages (parseTree, p));
 			Assert.AreEqual (parseResult.FullXml, GetMemberXml (n), $"while parsing input: ```{parseResult.Javadoc}```");
 
-			p = new SourceJavadocToXmldocParser (XmldocStyle.IntelliSense);
+			p = new SourceJavadocToXmldocParser (new XmldocSettings {
+				Style = XmldocStyle.IntelliSense,
+				DocRootValue = DocRootPrefixActual,
+			});
 			n = p.TryParse (parseResult.Javadoc, null, out parseTree);
 			Assert.IsFalse (parseTree.HasErrors (), DumpMessages (parseTree, p));
 			Assert.AreEqual (parseResult.IntelliSenseXml, GetMemberXml (n), $"while parsing input: ```{parseResult.Javadoc}```");
@@ -168,6 +174,28 @@ more description here.</para>
 </member>",
 				IntelliSenseXml = @"<member>
   <summary>Summary.</summary>
+</member>",
+			},
+			new ParseResult {
+				Javadoc = @"See <a href=""http://man7.org/linux/man-pages/man2/accept.2.html"">accept(2)</a>.  Insert
+more description here.
+How about another link <a href=""http://man7.org/linux/man-pages/man2/accept.2.html"">accept(2)</a>
+@param manifest The value of the <a
+href=""{@docRoot}guide/topics/manifest/manifest-element.html#vcode"">{@code
+android:versionCode}</a> manifest attribute.
+",
+				FullXml = $@"<member>
+  <param name=""manifest"">The value of the <see href=""{DocRootPrefixExpected}guide/topics/manifest/manifest-element.html#vcode""><c>android:versionCode</c></see> manifest attribute.</param>
+  <summary>See <see href=""http://man7.org/linux/man-pages/man2/accept.2.html"">accept(2)</see>.</summary>
+  <remarks>
+    <para>See <see href=""http://man7.org/linux/man-pages/man2/accept.2.html"">accept(2)</see>.  Insert
+more description here.
+How about another link <see href=""http://man7.org/linux/man-pages/man2/accept.2.html"">accept(2)</see></para>
+  </remarks>
+</member>",
+				IntelliSenseXml = $@"<member>
+  <param name=""manifest"">The value of the <see href=""{DocRootPrefixExpected}guide/topics/manifest/manifest-element.html#vcode""><c>android:versionCode</c></see> manifest attribute.</param>
+  <summary>See <see href=""http://man7.org/linux/man-pages/man2/accept.2.html"">accept(2)</see>.</summary>
 </member>",
 			},
 		};

--- a/tools/java-source-utils/src/main/java/com/microsoft/android/App.java
+++ b/tools/java-source-utils/src/main/java/com/microsoft/android/App.java
@@ -68,7 +68,7 @@ public class App {
 
 	static void generateXml(JavaSourceUtilsOptions options, JniPackagesInfo packages) throws Throwable {
 		try (final   JavadocXmlGenerator       javadocXmlGen   = new JavadocXmlGenerator(options.outputJavadocXml)) {
-			javadocXmlGen.writeCopyrightInfo(options.docCopyrightFile, options.docUrlPrefix, options.docUrlStyle);
+			javadocXmlGen.writeCopyrightInfo(options.docCopyrightFile, options.docUrlPrefix, options.docUrlStyle, options.docRootUrl);
 			javadocXmlGen.writePackages(packages);
 		}
 	}

--- a/tools/java-source-utils/src/main/java/com/microsoft/android/JavaSourceUtilsOptions.java
+++ b/tools/java-source-utils/src/main/java/com/microsoft/android/JavaSourceUtilsOptions.java
@@ -74,6 +74,8 @@ public class JavaSourceUtilsOptions implements AutoCloseable {
 		"                               Stored in //javadoc-metadata/link/@style.\n" +
 		"                               Supported styles include:\n" +
 		"                               - developer.android.com/reference@2020-Nov\n" +
+		"      --doc-root-url URL     Base URL to use in place of @{docRoot} elements.\n" +
+		"                               Stored in //javadoc-metadata/link/@docroot.\n" +
 		"\n" +
 		"Output file options:\n" +
 		"  -P, --output-params FILE   Write method parameter names to FILE.\n" +
@@ -94,6 +96,7 @@ public class JavaSourceUtilsOptions implements AutoCloseable {
 	public  File    docCopyrightFile;
 	public  String  docUrlPrefix;
 	public  String  docUrlStyle;
+	public  String  docRootUrl;
 
 	private final   Collection<File>    sourceDirectoryFiles  = new ArrayList<File>();
 	private         File                extractedTempDir;
@@ -202,6 +205,11 @@ public class JavaSourceUtilsOptions implements AutoCloseable {
 				case "--doc-url-style": {
 					final   String  style   = getNextOptionValue(args, arg);
 					docUrlStyle             = style;
+					break;
+				}
+				case "--doc-root-url": {
+					final   String  docRoot  = getNextOptionValue(args, arg);
+					docRootUrl               = docRoot;
 					break;
 				}
 				case "-j":

--- a/tools/java-source-utils/src/main/java/com/microsoft/android/JavadocXmlGenerator.java
+++ b/tools/java-source-utils/src/main/java/com/microsoft/android/JavadocXmlGenerator.java
@@ -80,7 +80,7 @@ public final class JavadocXmlGenerator implements AutoCloseable {
 		}
 	}
 
-	public final void writeCopyrightInfo(final File copyright, final String urlPrefix, final String urlStyle) throws IOException, ParserConfigurationException {
+	public final void writeCopyrightInfo(final File copyright, final String urlPrefix, final String urlStyle, final String docRootUrl) throws IOException, ParserConfigurationException {
 		final   Element    info         = document.createElement("javadoc-metadata");
 		if (copyright != null) {
 			final   Element    blurb    = document.createElement("copyright");
@@ -95,13 +95,19 @@ public final class JavadocXmlGenerator implements AutoCloseable {
 			}
 			info.appendChild(blurb);
 		}
-		if (urlPrefix != null && urlStyle != null) {
-			final   Element    link = document.createElement("link");
-			link.setAttribute("prefix", urlPrefix);
-			link.setAttribute("style", urlStyle);
 
-			info.appendChild(link);
+		final   Element    link = document.createElement("link");
+		if (urlPrefix != null) {
+			link.setAttribute("prefix", urlPrefix);
 		}
+		if (urlStyle != null) {
+			link.setAttribute("style", urlStyle);
+		}
+		if (docRootUrl != null) {
+			link.setAttribute("docroot", docRootUrl);
+		}
+
+		info.appendChild(link);
 
 		if (info.hasChildNodes()) {
 			api.appendChild(info);


### PR DESCRIPTION
Context: https://docs.microsoft.com/en-us/dotnet/api/android.app.backup.backupagent.onrestore?view=xamarin-android-sdk-12#Android_App_Backup_BackupAgent_OnRestore_Android_App_Backup_BackupDataInput_System_Int64_Android_OS_ParcelFileDescriptor_
Context: https://docs.microsoft.com/en-us/dotnet/api/android.animation.animatorlisteneradapter.onanimationend?view=xamarin-android-sdk-12#definition
Partially fixes: https://github.com/xamarin/java.interop/issues/907

Support for `{@ docRoot}` has been added, and an additional
parser for `<a href/>` elements has been added to convert
these to `<see/>` elements.

