### PR TITLE
[generator] Use the correct javadoc element

### DIFF
--- a/tools/generator/Java.Interop.Tools.Generator.Transformation/JavadocFixups.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Transformation/JavadocFixups.cs
@@ -100,7 +100,7 @@ namespace Java.Interop.Tools.Generator.Transformation
 			return typeJavadoc
 				.Elements (elementName)
 				.Where (e => jniSignature == (string) e.Attribute ("jni-signature") &&
-						name == null ? true : name == (string) e.Attribute ("name"))
+						(name == null ? true : name == (string) e.Attribute ("name")))
 				.Elements ("javadoc")
 				.FirstOrDefault ();
 		}


### PR DESCRIPTION
Fixes: https://github.com/xamarin/java.interop/issues/933

Fixes a bug when attempting to find the `<javadoc/>` element that is
associated with a specific member name and jni-signature.  When a type
contained multiple members with the same name, we would always return
the first `<javadoc/>` that matched the member name, rather than the
one that matched both the name and signature.