### PR TITLE
[Java.Interop] Type & Member Remapping Support

### DIFF
--- a/src/Java.Interop/Java.Interop.csproj
+++ b/src/Java.Interop/Java.Interop.csproj
@@ -26,7 +26,8 @@
     <OutputPath>$(ToolOutputFullPath)</OutputPath>
     <DocumentationFile>$(ToolOutputFullPath)Java.Interop.xml</DocumentationFile>
     <JNIEnvGenPath>$(BuildToolOutputFullPath)</JNIEnvGenPath>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion Condition=" '$(JIBuildingForNetCoreApp)' == 'True' ">9.0</LangVersion>
+    <LangVersion Condition=" '$(LangVersion)' == '' ">8.0</LangVersion>
     <Nullable>enable</Nullable>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <MSBuildWarningsAsMessages>NU1702</MSBuildWarningsAsMessages>

--- a/src/Java.Interop/Java.Interop/JavaArray.cs
+++ b/src/Java.Interop/Java.Interop/JavaArray.cs
@@ -231,9 +231,9 @@ namespace Java.Interop
 
 		object? IList.this [int index] {
 			get {return this [index];}
-#pragma warning disable 8601
+#pragma warning disable 8600,8601
 			set {this [index] = (T) value;}
-#pragma warning restore 8601
+#pragma warning restore 8600,8601
 		}
 
 		void ICollection.CopyTo (Array array, int index)

--- a/src/Java.Interop/Java.Interop/JniMemberSignature.cs
+++ b/src/Java.Interop/Java.Interop/JniMemberSignature.cs
@@ -1,0 +1,134 @@
+#nullable enable
+
+#if NET
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+namespace Java.Interop
+{
+	public struct JniMemberSignature : IEquatable<JniMemberSignature>
+	{
+		public   static readonly    JniMemberSignature  Empty;
+
+		string?                 memberName;
+		string?                 memberSignature;
+
+		public      string      MemberName        => memberName ?? throw new InvalidOperationException ();
+		public      string      MemberSignature   => memberSignature ?? throw new InvalidOperationException ();
+
+		public JniMemberSignature (string memberName, string memberSignature)
+		{
+			if (string.IsNullOrEmpty (memberName)) {
+				throw new ArgumentNullException (nameof (memberName));
+			}
+			if (string.IsNullOrEmpty (memberSignature)) {
+				throw new ArgumentNullException (nameof (memberSignature));
+			}
+			this.memberName         = memberName;
+			this.memberSignature    = memberSignature;
+		}
+
+		public static int GetParameterCountFromMethodSignature (string jniMethodSignature)
+		{
+			if (jniMethodSignature.Length < "()V".Length || jniMethodSignature [0] != '(' ) {
+				throw new ArgumentException (
+						$"Member signature `{jniMethodSignature}` is not a method signature.  Method signatures must start with `(`.",
+						nameof (jniMethodSignature));
+			}
+			int count = 0;
+			int index = 1;
+			while (index < jniMethodSignature.Length &&
+					jniMethodSignature [index] != ')') {
+				ExtractType (jniMethodSignature, ref index);
+				count++;
+			}
+			return count;
+		}
+
+		internal static (int StartIndex, int Length) ExtractType (string signature, ref int index)
+		{
+			AssertSignatureIndex (signature, index);
+			var i = index++;
+			switch (signature [i]) {
+			case '[':
+				if ((i+1) >= signature.Length)
+					throw new InvalidOperationException ($"Missing array type after '[' at index {i} in: `{signature}`");
+				var rest    = ExtractType (signature, ref index);
+				return (StartIndex: i, Length: index - i);
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'F':
+			case 'I':
+			case 'J':
+			case 'S':
+			case 'V':
+			case 'Z':
+				return (StartIndex: i, Length: 1);
+			case 'L':
+				int depth = 0;
+				int e = index;
+				while (e < signature.Length) {
+					var c = signature [e++];
+					if (depth == 0 && c == ';')
+						break;
+				}
+				if (e > signature.Length)
+					throw new InvalidOperationException ($"Missing reference type after `{signature [i]}` at index {i} in `{signature}`!");
+				index = e;
+				return (StartIndex: i, Length: (e - i));
+			default:
+				throw new InvalidOperationException ($"Unknown JNI Type `{signature [i]}` within: `{signature}`!");
+			}
+		}
+
+		internal static void AssertSignatureIndex (string signature, int index)
+		{
+			if (signature == null)
+				throw new ArgumentNullException (nameof (signature));
+			if (signature.Length == 0)
+				throw new ArgumentException ("Descriptor cannot be empty string", nameof (signature));
+			if (index >= signature.Length)
+				throw new ArgumentException ("index >= descriptor.Length", nameof (index));
+		}
+
+		public override int GetHashCode ()
+		{
+			return (memberName?.GetHashCode () ?? 0) ^
+				(memberSignature?.GetHashCode () ?? 0);
+		}
+
+		public override bool Equals (object? obj)
+		{
+			var v = obj as JniMemberSignature?;
+			if (v.HasValue)
+				return Equals (v.Value);
+			return false;
+		}
+
+		public bool Equals (JniMemberSignature other)
+		{
+			return memberName == other.memberName &&
+				memberSignature == other.memberSignature;
+		}
+
+		public override string ToString ()
+		{
+			return $"{nameof (JniMemberSignature)} {{ " +
+				$"{nameof (MemberName)} = {(memberName == null ? "null" : "\"" + memberName + "\"")}" +
+				$", {nameof (MemberSignature)} = {(memberSignature == null ? "null" : "\"" + memberSignature + "\"")}" +
+				$"}}";
+		}
+
+		public static bool operator== (JniMemberSignature a, JniMemberSignature b) => a.Equals (b);
+		public static bool operator!= (JniMemberSignature a, JniMemberSignature b) => !a.Equals (b);
+	}
+}
+
+#endif  // NET

--- a/src/Java.Interop/Java.Interop/JniMethodInfo.cs
+++ b/src/Java.Interop/Java.Interop/JniMethodInfo.cs
@@ -10,6 +10,11 @@ namespace Java.Interop
 
 		public      bool    IsStatic    {get; private set;}
 
+#if NET
+		internal    JniType?    StaticRedirect;
+		internal    int?        ParameterCount;
+#endif  //NET
+
 		internal    bool    IsValid {
 			get {return ID != IntPtr.Zero;}
 		}

--- a/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods_Invoke.cs
+++ b/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods_Invoke.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 
 using System;
+using System.Diagnostics;
 
 namespace Java.Interop {
 
@@ -8,33 +9,76 @@ namespace Java.Interop {
 
 		partial class JniInstanceMethods {
 
+#pragma warning disable CA1801
+			static unsafe bool TryInvokeVoidStaticRedirect (JniMethodInfo method, IJavaPeerable self, JniArgumentValue* parameters)
+			{
+				
+#if !NET
+				return false;
+#else  // NET
+				if (method.StaticRedirect == null || !method.ParameterCount.HasValue) {
+					return false;
+				}
+
+				int c   = method.ParameterCount.Value;
+				Debug.Assert (c > 0);
+				var p   = stackalloc JniArgumentValue [c];
+				p [0]   = new JniArgumentValue (self);
+				for (int i = 0; i < c-1; ++i) {
+					p [i+1] = parameters [i];
+				}
+
+				JniEnvironment.StaticMethods.CallStaticVoidMethod (method.StaticRedirect.PeerReference, method, p);
+				return true;
+#endif   // NET
+			}
+#pragma warning restore CA1801
+
 			public unsafe void InvokeAbstractVoidMethod (string encodedMember, IJavaPeerable self, JniArgumentValue* parameters)
 			{
 				JniPeerMembers.AssertSelf (self);
 
-				var m   = GetMethodInfo (encodedMember);
+				try {
+					var m   = GetMethodInfo (encodedMember);
+					if (TryInvokeVoidStaticRedirect (m, self, parameters)) {
+						return;
+					}
 
-				JniEnvironment.InstanceMethods.CallVoidMethod (self.PeerReference, m, parameters);
-				GC.KeepAlive (self);
-				return;
+					JniEnvironment.InstanceMethods.CallVoidMethod (self.PeerReference, m, parameters);
+					return;
+				}
+				finally {
+					GC.KeepAlive (self);
+				}
 			}
 
 			public unsafe void InvokeVirtualVoidMethod (string encodedMember, IJavaPeerable self, JniArgumentValue* parameters)
 			{
 				JniPeerMembers.AssertSelf (self);
 
-				var declaringType   = DeclaringType;
-				if (Members.UsesVirtualDispatch (self, declaringType)) {
-					var m   = GetMethodInfo (encodedMember);
-					JniEnvironment.InstanceMethods.CallVoidMethod (self.PeerReference, m, parameters);
-					GC.KeepAlive (self);
-					return;
+				try {
+					var declaringType   = DeclaringType;
+					if (Members.UsesVirtualDispatch (self, declaringType)) {
+						var m   = GetMethodInfo (encodedMember);
+						if (TryInvokeVoidStaticRedirect (m, self, parameters)) {
+							return;
+						}
+						JniEnvironment.InstanceMethods.CallVoidMethod (self.PeerReference, m, parameters);
+						return;
+					}
+					var j = Members.GetPeerMembers (self);
+					var n = j.InstanceMethods.GetMethodInfo (encodedMember);
+					do {
+						if (TryInvokeVoidStaticRedirect (n, self, parameters)) {
+							return;
+						}
+						JniEnvironment.InstanceMethods.CallNonvirtualVoidMethod (self.PeerReference, j.JniPeerType.PeerReference, n, parameters);
+						return;
+					} while (false);
 				}
-				var j = Members.GetPeerMembers (self);
-				var n = j.InstanceMethods.GetMethodInfo (encodedMember);
-				JniEnvironment.InstanceMethods.CallNonvirtualVoidMethod (self.PeerReference, j.JniPeerType.PeerReference, n, parameters);
-				GC.KeepAlive (self);
-				return;
+				finally {
+					GC.KeepAlive (self);
+				}
 			}
 
 			public unsafe void InvokeNonvirtualVoidMethod (string encodedMember, IJavaPeerable self, JniArgumentValue* parameters)
@@ -42,39 +86,88 @@ namespace Java.Interop {
 				JniPeerMembers.AssertSelf (self);
 
 				var m   = GetMethodInfo (encodedMember);
-
-				JniEnvironment.InstanceMethods.CallNonvirtualVoidMethod (self.PeerReference, JniPeerType.PeerReference, m, parameters);
-				GC.KeepAlive (self);
-				return;
+				try {
+					if (TryInvokeVoidStaticRedirect (m, self, parameters)) {
+						return;
+					}
+					JniEnvironment.InstanceMethods.CallNonvirtualVoidMethod (self.PeerReference, JniPeerType.PeerReference, m, parameters);
+					return;
+				}
+				finally {
+					GC.KeepAlive (self);
+				}
 			}
+
+#pragma warning disable CA1801
+			static unsafe bool TryInvokeBooleanStaticRedirect (JniMethodInfo method, IJavaPeerable self, JniArgumentValue* parameters, out bool r)
+			{
+				r = default;
+#if !NET
+				return false;
+#else  // NET
+				if (method.StaticRedirect == null || !method.ParameterCount.HasValue) {
+					return false;
+				}
+
+				int c   = method.ParameterCount.Value;
+				Debug.Assert (c > 0);
+				var p   = stackalloc JniArgumentValue [c];
+				p [0]   = new JniArgumentValue (self);
+				for (int i = 0; i < c-1; ++i) {
+					p [i+1] = parameters [i];
+				}
+
+				r = JniEnvironment.StaticMethods.CallStaticBooleanMethod (method.StaticRedirect.PeerReference, method, p);
+				return true;
+#endif   // NET
+			}
+#pragma warning restore CA1801
 
 			public unsafe bool InvokeAbstractBooleanMethod (string encodedMember, IJavaPeerable self, JniArgumentValue* parameters)
 			{
 				JniPeerMembers.AssertSelf (self);
 
-				var m   = GetMethodInfo (encodedMember);
+				try {
+					var m   = GetMethodInfo (encodedMember);
+					if (TryInvokeBooleanStaticRedirect (m, self, parameters, out bool r)) {
+						return r;
+					}
 
-				var r   = JniEnvironment.InstanceMethods.CallBooleanMethod (self.PeerReference, m, parameters);
-				GC.KeepAlive (self);
-				return r;
+					r = JniEnvironment.InstanceMethods.CallBooleanMethod (self.PeerReference, m, parameters);
+					return r;
+				}
+				finally {
+					GC.KeepAlive (self);
+				}
 			}
 
 			public unsafe bool InvokeVirtualBooleanMethod (string encodedMember, IJavaPeerable self, JniArgumentValue* parameters)
 			{
 				JniPeerMembers.AssertSelf (self);
 
-				var declaringType   = DeclaringType;
-				if (Members.UsesVirtualDispatch (self, declaringType)) {
-					var m   = GetMethodInfo (encodedMember);
-					var _nr = JniEnvironment.InstanceMethods.CallBooleanMethod (self.PeerReference, m, parameters);
-					GC.KeepAlive (self);
-					return _nr;
+				try {
+					var declaringType   = DeclaringType;
+					if (Members.UsesVirtualDispatch (self, declaringType)) {
+						var m   = GetMethodInfo (encodedMember);
+						if (TryInvokeBooleanStaticRedirect (m, self, parameters, out bool r)) {
+							return r;
+						}
+						r = JniEnvironment.InstanceMethods.CallBooleanMethod (self.PeerReference, m, parameters);
+						return r;
+					}
+					var j = Members.GetPeerMembers (self);
+					var n = j.InstanceMethods.GetMethodInfo (encodedMember);
+					do {
+						if (TryInvokeBooleanStaticRedirect (n, self, parameters, out bool r)) {
+							return r;
+						}
+						r = JniEnvironment.InstanceMethods.CallNonvirtualBooleanMethod (self.PeerReference, j.JniPeerType.PeerReference, n, parameters);
+						return r;
+					} while (false);
 				}
-				var j = Members.GetPeerMembers (self);
-				var n = j.InstanceMethods.GetMethodInfo (encodedMember);
-				var r = JniEnvironment.InstanceMethods.CallNonvirtualBooleanMethod (self.PeerReference, j.JniPeerType.PeerReference, n, parameters);
-				GC.KeepAlive (self);
-				return r;
+				finally {
+					GC.KeepAlive (self);
+				}
 			}
 
 			public unsafe bool InvokeNonvirtualBooleanMethod (string encodedMember, IJavaPeerable self, JniArgumentValue* parameters)
@@ -82,39 +175,88 @@ namespace Java.Interop {
 				JniPeerMembers.AssertSelf (self);
 
 				var m   = GetMethodInfo (encodedMember);
-
-				var r   = JniEnvironment.InstanceMethods.CallNonvirtualBooleanMethod (self.PeerReference, JniPeerType.PeerReference, m, parameters);
-				GC.KeepAlive (self);
-				return r;
+				try {
+					if (TryInvokeBooleanStaticRedirect (m, self, parameters, out bool r)) {
+						return r;
+					}
+					r = JniEnvironment.InstanceMethods.CallNonvirtualBooleanMethod (self.PeerReference, JniPeerType.PeerReference, m, parameters);
+					return r;
+				}
+				finally {
+					GC.KeepAlive (self);
+				}
 			}
+
+#pragma warning disable CA1801
+			static unsafe bool TryInvokeSByteStaticRedirect (JniMethodInfo method, IJavaPeerable self, JniArgumentValue* parameters, out sbyte r)
+			{
+				r = default;
+#if !NET
+				return false;
+#else  // NET
+				if (method.StaticRedirect == null || !method.ParameterCount.HasValue) {
+					return false;
+				}
+
+				int c   = method.ParameterCount.Value;
+				Debug.Assert (c > 0);
+				var p   = stackalloc JniArgumentValue [c];
+				p [0]   = new JniArgumentValue (self);
+				for (int i = 0; i < c-1; ++i) {
+					p [i+1] = parameters [i];
+				}
+
+				r = JniEnvironment.StaticMethods.CallStaticByteMethod (method.StaticRedirect.PeerReference, method, p);
+				return true;
+#endif   // NET
+			}
+#pragma warning restore CA1801
 
 			public unsafe sbyte InvokeAbstractSByteMethod (string encodedMember, IJavaPeerable self, JniArgumentValue* parameters)
 			{
 				JniPeerMembers.AssertSelf (self);
 
-				var m   = GetMethodInfo (encodedMember);
+				try {
+					var m   = GetMethodInfo (encodedMember);
+					if (TryInvokeSByteStaticRedirect (m, self, parameters, out sbyte r)) {
+						return r;
+					}
 
-				var r   = JniEnvironment.InstanceMethods.CallByteMethod (self.PeerReference, m, parameters);
-				GC.KeepAlive (self);
-				return r;
+					r = JniEnvironment.InstanceMethods.CallByteMethod (self.PeerReference, m, parameters);
+					return r;
+				}
+				finally {
+					GC.KeepAlive (self);
+				}
 			}
 
 			public unsafe sbyte InvokeVirtualSByteMethod (string encodedMember, IJavaPeerable self, JniArgumentValue* parameters)
 			{
 				JniPeerMembers.AssertSelf (self);
 
-				var declaringType   = DeclaringType;
-				if (Members.UsesVirtualDispatch (self, declaringType)) {
-					var m   = GetMethodInfo (encodedMember);
-					var _nr = JniEnvironment.InstanceMethods.CallByteMethod (self.PeerReference, m, parameters);
-					GC.KeepAlive (self);
-					return _nr;
+				try {
+					var declaringType   = DeclaringType;
+					if (Members.UsesVirtualDispatch (self, declaringType)) {
+						var m   = GetMethodInfo (encodedMember);
+						if (TryInvokeSByteStaticRedirect (m, self, parameters, out sbyte r)) {
+							return r;
+						}
+						r = JniEnvironment.InstanceMethods.CallByteMethod (self.PeerReference, m, parameters);
+						return r;
+					}
+					var j = Members.GetPeerMembers (self);
+					var n = j.InstanceMethods.GetMethodInfo (encodedMember);
+					do {
+						if (TryInvokeSByteStaticRedirect (n, self, parameters, out sbyte r)) {
+							return r;
+						}
+						r = JniEnvironment.InstanceMethods.CallNonvirtualByteMethod (self.PeerReference, j.JniPeerType.PeerReference, n, parameters);
+						return r;
+					} while (false);
 				}
-				var j = Members.GetPeerMembers (self);
-				var n = j.InstanceMethods.GetMethodInfo (encodedMember);
-				var r = JniEnvironment.InstanceMethods.CallNonvirtualByteMethod (self.PeerReference, j.JniPeerType.PeerReference, n, parameters);
-				GC.KeepAlive (self);
-				return r;
+				finally {
+					GC.KeepAlive (self);
+				}
 			}
 
 			public unsafe sbyte InvokeNonvirtualSByteMethod (string encodedMember, IJavaPeerable self, JniArgumentValue* parameters)
@@ -122,39 +264,88 @@ namespace Java.Interop {
 				JniPeerMembers.AssertSelf (self);
 
 				var m   = GetMethodInfo (encodedMember);
-
-				var r   = JniEnvironment.InstanceMethods.CallNonvirtualByteMethod (self.PeerReference, JniPeerType.PeerReference, m, parameters);
-				GC.KeepAlive (self);
-				return r;
+				try {
+					if (TryInvokeSByteStaticRedirect (m, self, parameters, out sbyte r)) {
+						return r;
+					}
+					r = JniEnvironment.InstanceMethods.CallNonvirtualByteMethod (self.PeerReference, JniPeerType.PeerReference, m, parameters);
+					return r;
+				}
+				finally {
+					GC.KeepAlive (self);
+				}
 			}
+
+#pragma warning disable CA1801
+			static unsafe bool TryInvokeCharStaticRedirect (JniMethodInfo method, IJavaPeerable self, JniArgumentValue* parameters, out char r)
+			{
+				r = default;
+#if !NET
+				return false;
+#else  // NET
+				if (method.StaticRedirect == null || !method.ParameterCount.HasValue) {
+					return false;
+				}
+
+				int c   = method.ParameterCount.Value;
+				Debug.Assert (c > 0);
+				var p   = stackalloc JniArgumentValue [c];
+				p [0]   = new JniArgumentValue (self);
+				for (int i = 0; i < c-1; ++i) {
+					p [i+1] = parameters [i];
+				}
+
+				r = JniEnvironment.StaticMethods.CallStaticCharMethod (method.StaticRedirect.PeerReference, method, p);
+				return true;
+#endif   // NET
+			}
+#pragma warning restore CA1801
 
 			public unsafe char InvokeAbstractCharMethod (string encodedMember, IJavaPeerable self, JniArgumentValue* parameters)
 			{
 				JniPeerMembers.AssertSelf (self);
 
-				var m   = GetMethodInfo (encodedMember);
+				try {
+					var m   = GetMethodInfo (encodedMember);
+					if (TryInvokeCharStaticRedirect (m, self, parameters, out char r)) {
+						return r;
+					}
 
-				var r   = JniEnvironment.InstanceMethods.CallCharMethod (self.PeerReference, m, parameters);
-				GC.KeepAlive (self);
-				return r;
+					r = JniEnvironment.InstanceMethods.CallCharMethod (self.PeerReference, m, parameters);
+					return r;
+				}
+				finally {
+					GC.KeepAlive (self);
+				}
 			}
 
 			public unsafe char InvokeVirtualCharMethod (string encodedMember, IJavaPeerable self, JniArgumentValue* parameters)
 			{
 				JniPeerMembers.AssertSelf (self);
 
-				var declaringType   = DeclaringType;
-				if (Members.UsesVirtualDispatch (self, declaringType)) {
-					var m   = GetMethodInfo (encodedMember);
-					var _nr = JniEnvironment.InstanceMethods.CallCharMethod (self.PeerReference, m, parameters);
-					GC.KeepAlive (self);
-					return _nr;
+				try {
+					var declaringType   = DeclaringType;
+					if (Members.UsesVirtualDispatch (self, declaringType)) {
+						var m   = GetMethodInfo (encodedMember);
+						if (TryInvokeCharStaticRedirect (m, self, parameters, out char r)) {
+							return r;
+						}
+						r = JniEnvironment.InstanceMethods.CallCharMethod (self.PeerReference, m, parameters);
+						return r;
+					}
+					var j = Members.GetPeerMembers (self);
+					var n = j.InstanceMethods.GetMethodInfo (encodedMember);
+					do {
+						if (TryInvokeCharStaticRedirect (n, self, parameters, out char r)) {
+							return r;
+						}
+						r = JniEnvironment.InstanceMethods.CallNonvirtualCharMethod (self.PeerReference, j.JniPeerType.PeerReference, n, parameters);
+						return r;
+					} while (false);
 				}
-				var j = Members.GetPeerMembers (self);
-				var n = j.InstanceMethods.GetMethodInfo (encodedMember);
-				var r = JniEnvironment.InstanceMethods.CallNonvirtualCharMethod (self.PeerReference, j.JniPeerType.PeerReference, n, parameters);
-				GC.KeepAlive (self);
-				return r;
+				finally {
+					GC.KeepAlive (self);
+				}
 			}
 
 			public unsafe char InvokeNonvirtualCharMethod (string encodedMember, IJavaPeerable self, JniArgumentValue* parameters)
@@ -162,39 +353,88 @@ namespace Java.Interop {
 				JniPeerMembers.AssertSelf (self);
 
 				var m   = GetMethodInfo (encodedMember);
-
-				var r   = JniEnvironment.InstanceMethods.CallNonvirtualCharMethod (self.PeerReference, JniPeerType.PeerReference, m, parameters);
-				GC.KeepAlive (self);
-				return r;
+				try {
+					if (TryInvokeCharStaticRedirect (m, self, parameters, out char r)) {
+						return r;
+					}
+					r = JniEnvironment.InstanceMethods.CallNonvirtualCharMethod (self.PeerReference, JniPeerType.PeerReference, m, parameters);
+					return r;
+				}
+				finally {
+					GC.KeepAlive (self);
+				}
 			}
+
+#pragma warning disable CA1801
+			static unsafe bool TryInvokeInt16StaticRedirect (JniMethodInfo method, IJavaPeerable self, JniArgumentValue* parameters, out short r)
+			{
+				r = default;
+#if !NET
+				return false;
+#else  // NET
+				if (method.StaticRedirect == null || !method.ParameterCount.HasValue) {
+					return false;
+				}
+
+				int c   = method.ParameterCount.Value;
+				Debug.Assert (c > 0);
+				var p   = stackalloc JniArgumentValue [c];
+				p [0]   = new JniArgumentValue (self);
+				for (int i = 0; i < c-1; ++i) {
+					p [i+1] = parameters [i];
+				}
+
+				r = JniEnvironment.StaticMethods.CallStaticShortMethod (method.StaticRedirect.PeerReference, method, p);
+				return true;
+#endif   // NET
+			}
+#pragma warning restore CA1801
 
 			public unsafe short InvokeAbstractInt16Method (string encodedMember, IJavaPeerable self, JniArgumentValue* parameters)
 			{
 				JniPeerMembers.AssertSelf (self);
 
-				var m   = GetMethodInfo (encodedMember);
+				try {
+					var m   = GetMethodInfo (encodedMember);
+					if (TryInvokeInt16StaticRedirect (m, self, parameters, out short r)) {
+						return r;
+					}
 
-				var r   = JniEnvironment.InstanceMethods.CallShortMethod (self.PeerReference, m, parameters);
-				GC.KeepAlive (self);
-				return r;
+					r = JniEnvironment.InstanceMethods.CallShortMethod (self.PeerReference, m, parameters);
+					return r;
+				}
+				finally {
+					GC.KeepAlive (self);
+				}
 			}
 
 			public unsafe short InvokeVirtualInt16Method (string encodedMember, IJavaPeerable self, JniArgumentValue* parameters)
 			{
 				JniPeerMembers.AssertSelf (self);
 
-				var declaringType   = DeclaringType;
-				if (Members.UsesVirtualDispatch (self, declaringType)) {
-					var m   = GetMethodInfo (encodedMember);
-					var _nr = JniEnvironment.InstanceMethods.CallShortMethod (self.PeerReference, m, parameters);
-					GC.KeepAlive (self);
-					return _nr;
+				try {
+					var declaringType   = DeclaringType;
+					if (Members.UsesVirtualDispatch (self, declaringType)) {
+						var m   = GetMethodInfo (encodedMember);
+						if (TryInvokeInt16StaticRedirect (m, self, parameters, out short r)) {
+							return r;
+						}
+						r = JniEnvironment.InstanceMethods.CallShortMethod (self.PeerReference, m, parameters);
+						return r;
+					}
+					var j = Members.GetPeerMembers (self);
+					var n = j.InstanceMethods.GetMethodInfo (encodedMember);
+					do {
+						if (TryInvokeInt16StaticRedirect (n, self, parameters, out short r)) {
+							return r;
+						}
+						r = JniEnvironment.InstanceMethods.CallNonvirtualShortMethod (self.PeerReference, j.JniPeerType.PeerReference, n, parameters);
+						return r;
+					} while (false);
 				}
-				var j = Members.GetPeerMembers (self);
-				var n = j.InstanceMethods.GetMethodInfo (encodedMember);
-				var r = JniEnvironment.InstanceMethods.CallNonvirtualShortMethod (self.PeerReference, j.JniPeerType.PeerReference, n, parameters);
-				GC.KeepAlive (self);
-				return r;
+				finally {
+					GC.KeepAlive (self);
+				}
 			}
 
 			public unsafe short InvokeNonvirtualInt16Method (string encodedMember, IJavaPeerable self, JniArgumentValue* parameters)
@@ -202,39 +442,88 @@ namespace Java.Interop {
 				JniPeerMembers.AssertSelf (self);
 
 				var m   = GetMethodInfo (encodedMember);
-
-				var r   = JniEnvironment.InstanceMethods.CallNonvirtualShortMethod (self.PeerReference, JniPeerType.PeerReference, m, parameters);
-				GC.KeepAlive (self);
-				return r;
+				try {
+					if (TryInvokeInt16StaticRedirect (m, self, parameters, out short r)) {
+						return r;
+					}
+					r = JniEnvironment.InstanceMethods.CallNonvirtualShortMethod (self.PeerReference, JniPeerType.PeerReference, m, parameters);
+					return r;
+				}
+				finally {
+					GC.KeepAlive (self);
+				}
 			}
+
+#pragma warning disable CA1801
+			static unsafe bool TryInvokeInt32StaticRedirect (JniMethodInfo method, IJavaPeerable self, JniArgumentValue* parameters, out int r)
+			{
+				r = default;
+#if !NET
+				return false;
+#else  // NET
+				if (method.StaticRedirect == null || !method.ParameterCount.HasValue) {
+					return false;
+				}
+
+				int c   = method.ParameterCount.Value;
+				Debug.Assert (c > 0);
+				var p   = stackalloc JniArgumentValue [c];
+				p [0]   = new JniArgumentValue (self);
+				for (int i = 0; i < c-1; ++i) {
+					p [i+1] = parameters [i];
+				}
+
+				r = JniEnvironment.StaticMethods.CallStaticIntMethod (method.StaticRedirect.PeerReference, method, p);
+				return true;
+#endif   // NET
+			}
+#pragma warning restore CA1801
 
 			public unsafe int InvokeAbstractInt32Method (string encodedMember, IJavaPeerable self, JniArgumentValue* parameters)
 			{
 				JniPeerMembers.AssertSelf (self);
 
-				var m   = GetMethodInfo (encodedMember);
+				try {
+					var m   = GetMethodInfo (encodedMember);
+					if (TryInvokeInt32StaticRedirect (m, self, parameters, out int r)) {
+						return r;
+					}
 
-				var r   = JniEnvironment.InstanceMethods.CallIntMethod (self.PeerReference, m, parameters);
-				GC.KeepAlive (self);
-				return r;
+					r = JniEnvironment.InstanceMethods.CallIntMethod (self.PeerReference, m, parameters);
+					return r;
+				}
+				finally {
+					GC.KeepAlive (self);
+				}
 			}
 
 			public unsafe int InvokeVirtualInt32Method (string encodedMember, IJavaPeerable self, JniArgumentValue* parameters)
 			{
 				JniPeerMembers.AssertSelf (self);
 
-				var declaringType   = DeclaringType;
-				if (Members.UsesVirtualDispatch (self, declaringType)) {
-					var m   = GetMethodInfo (encodedMember);
-					var _nr = JniEnvironment.InstanceMethods.CallIntMethod (self.PeerReference, m, parameters);
-					GC.KeepAlive (self);
-					return _nr;
+				try {
+					var declaringType   = DeclaringType;
+					if (Members.UsesVirtualDispatch (self, declaringType)) {
+						var m   = GetMethodInfo (encodedMember);
+						if (TryInvokeInt32StaticRedirect (m, self, parameters, out int r)) {
+							return r;
+						}
+						r = JniEnvironment.InstanceMethods.CallIntMethod (self.PeerReference, m, parameters);
+						return r;
+					}
+					var j = Members.GetPeerMembers (self);
+					var n = j.InstanceMethods.GetMethodInfo (encodedMember);
+					do {
+						if (TryInvokeInt32StaticRedirect (n, self, parameters, out int r)) {
+							return r;
+						}
+						r = JniEnvironment.InstanceMethods.CallNonvirtualIntMethod (self.PeerReference, j.JniPeerType.PeerReference, n, parameters);
+						return r;
+					} while (false);
 				}
-				var j = Members.GetPeerMembers (self);
-				var n = j.InstanceMethods.GetMethodInfo (encodedMember);
-				var r = JniEnvironment.InstanceMethods.CallNonvirtualIntMethod (self.PeerReference, j.JniPeerType.PeerReference, n, parameters);
-				GC.KeepAlive (self);
-				return r;
+				finally {
+					GC.KeepAlive (self);
+				}
 			}
 
 			public unsafe int InvokeNonvirtualInt32Method (string encodedMember, IJavaPeerable self, JniArgumentValue* parameters)
@@ -242,39 +531,88 @@ namespace Java.Interop {
 				JniPeerMembers.AssertSelf (self);
 
 				var m   = GetMethodInfo (encodedMember);
-
-				var r   = JniEnvironment.InstanceMethods.CallNonvirtualIntMethod (self.PeerReference, JniPeerType.PeerReference, m, parameters);
-				GC.KeepAlive (self);
-				return r;
+				try {
+					if (TryInvokeInt32StaticRedirect (m, self, parameters, out int r)) {
+						return r;
+					}
+					r = JniEnvironment.InstanceMethods.CallNonvirtualIntMethod (self.PeerReference, JniPeerType.PeerReference, m, parameters);
+					return r;
+				}
+				finally {
+					GC.KeepAlive (self);
+				}
 			}
+
+#pragma warning disable CA1801
+			static unsafe bool TryInvokeInt64StaticRedirect (JniMethodInfo method, IJavaPeerable self, JniArgumentValue* parameters, out long r)
+			{
+				r = default;
+#if !NET
+				return false;
+#else  // NET
+				if (method.StaticRedirect == null || !method.ParameterCount.HasValue) {
+					return false;
+				}
+
+				int c   = method.ParameterCount.Value;
+				Debug.Assert (c > 0);
+				var p   = stackalloc JniArgumentValue [c];
+				p [0]   = new JniArgumentValue (self);
+				for (int i = 0; i < c-1; ++i) {
+					p [i+1] = parameters [i];
+				}
+
+				r = JniEnvironment.StaticMethods.CallStaticLongMethod (method.StaticRedirect.PeerReference, method, p);
+				return true;
+#endif   // NET
+			}
+#pragma warning restore CA1801
 
 			public unsafe long InvokeAbstractInt64Method (string encodedMember, IJavaPeerable self, JniArgumentValue* parameters)
 			{
 				JniPeerMembers.AssertSelf (self);
 
-				var m   = GetMethodInfo (encodedMember);
+				try {
+					var m   = GetMethodInfo (encodedMember);
+					if (TryInvokeInt64StaticRedirect (m, self, parameters, out long r)) {
+						return r;
+					}
 
-				var r   = JniEnvironment.InstanceMethods.CallLongMethod (self.PeerReference, m, parameters);
-				GC.KeepAlive (self);
-				return r;
+					r = JniEnvironment.InstanceMethods.CallLongMethod (self.PeerReference, m, parameters);
+					return r;
+				}
+				finally {
+					GC.KeepAlive (self);
+				}
 			}
 
 			public unsafe long InvokeVirtualInt64Method (string encodedMember, IJavaPeerable self, JniArgumentValue* parameters)
 			{
 				JniPeerMembers.AssertSelf (self);
 
-				var declaringType   = DeclaringType;
-				if (Members.UsesVirtualDispatch (self, declaringType)) {
-					var m   = GetMethodInfo (encodedMember);
-					var _nr = JniEnvironment.InstanceMethods.CallLongMethod (self.PeerReference, m, parameters);
-					GC.KeepAlive (self);
-					return _nr;
+				try {
+					var declaringType   = DeclaringType;
+					if (Members.UsesVirtualDispatch (self, declaringType)) {
+						var m   = GetMethodInfo (encodedMember);
+						if (TryInvokeInt64StaticRedirect (m, self, parameters, out long r)) {
+							return r;
+						}
+						r = JniEnvironment.InstanceMethods.CallLongMethod (self.PeerReference, m, parameters);
+						return r;
+					}
+					var j = Members.GetPeerMembers (self);
+					var n = j.InstanceMethods.GetMethodInfo (encodedMember);
+					do {
+						if (TryInvokeInt64StaticRedirect (n, self, parameters, out long r)) {
+							return r;
+						}
+						r = JniEnvironment.InstanceMethods.CallNonvirtualLongMethod (self.PeerReference, j.JniPeerType.PeerReference, n, parameters);
+						return r;
+					} while (false);
 				}
-				var j = Members.GetPeerMembers (self);
-				var n = j.InstanceMethods.GetMethodInfo (encodedMember);
-				var r = JniEnvironment.InstanceMethods.CallNonvirtualLongMethod (self.PeerReference, j.JniPeerType.PeerReference, n, parameters);
-				GC.KeepAlive (self);
-				return r;
+				finally {
+					GC.KeepAlive (self);
+				}
 			}
 
 			public unsafe long InvokeNonvirtualInt64Method (string encodedMember, IJavaPeerable self, JniArgumentValue* parameters)
@@ -282,39 +620,88 @@ namespace Java.Interop {
 				JniPeerMembers.AssertSelf (self);
 
 				var m   = GetMethodInfo (encodedMember);
-
-				var r   = JniEnvironment.InstanceMethods.CallNonvirtualLongMethod (self.PeerReference, JniPeerType.PeerReference, m, parameters);
-				GC.KeepAlive (self);
-				return r;
+				try {
+					if (TryInvokeInt64StaticRedirect (m, self, parameters, out long r)) {
+						return r;
+					}
+					r = JniEnvironment.InstanceMethods.CallNonvirtualLongMethod (self.PeerReference, JniPeerType.PeerReference, m, parameters);
+					return r;
+				}
+				finally {
+					GC.KeepAlive (self);
+				}
 			}
+
+#pragma warning disable CA1801
+			static unsafe bool TryInvokeSingleStaticRedirect (JniMethodInfo method, IJavaPeerable self, JniArgumentValue* parameters, out float r)
+			{
+				r = default;
+#if !NET
+				return false;
+#else  // NET
+				if (method.StaticRedirect == null || !method.ParameterCount.HasValue) {
+					return false;
+				}
+
+				int c   = method.ParameterCount.Value;
+				Debug.Assert (c > 0);
+				var p   = stackalloc JniArgumentValue [c];
+				p [0]   = new JniArgumentValue (self);
+				for (int i = 0; i < c-1; ++i) {
+					p [i+1] = parameters [i];
+				}
+
+				r = JniEnvironment.StaticMethods.CallStaticFloatMethod (method.StaticRedirect.PeerReference, method, p);
+				return true;
+#endif   // NET
+			}
+#pragma warning restore CA1801
 
 			public unsafe float InvokeAbstractSingleMethod (string encodedMember, IJavaPeerable self, JniArgumentValue* parameters)
 			{
 				JniPeerMembers.AssertSelf (self);
 
-				var m   = GetMethodInfo (encodedMember);
+				try {
+					var m   = GetMethodInfo (encodedMember);
+					if (TryInvokeSingleStaticRedirect (m, self, parameters, out float r)) {
+						return r;
+					}
 
-				var r   = JniEnvironment.InstanceMethods.CallFloatMethod (self.PeerReference, m, parameters);
-				GC.KeepAlive (self);
-				return r;
+					r = JniEnvironment.InstanceMethods.CallFloatMethod (self.PeerReference, m, parameters);
+					return r;
+				}
+				finally {
+					GC.KeepAlive (self);
+				}
 			}
 
 			public unsafe float InvokeVirtualSingleMethod (string encodedMember, IJavaPeerable self, JniArgumentValue* parameters)
 			{
 				JniPeerMembers.AssertSelf (self);
 
-				var declaringType   = DeclaringType;
-				if (Members.UsesVirtualDispatch (self, declaringType)) {
-					var m   = GetMethodInfo (encodedMember);
-					var _nr = JniEnvironment.InstanceMethods.CallFloatMethod (self.PeerReference, m, parameters);
-					GC.KeepAlive (self);
-					return _nr;
+				try {
+					var declaringType   = DeclaringType;
+					if (Members.UsesVirtualDispatch (self, declaringType)) {
+						var m   = GetMethodInfo (encodedMember);
+						if (TryInvokeSingleStaticRedirect (m, self, parameters, out float r)) {
+							return r;
+						}
+						r = JniEnvironment.InstanceMethods.CallFloatMethod (self.PeerReference, m, parameters);
+						return r;
+					}
+					var j = Members.GetPeerMembers (self);
+					var n = j.InstanceMethods.GetMethodInfo (encodedMember);
+					do {
+						if (TryInvokeSingleStaticRedirect (n, self, parameters, out float r)) {
+							return r;
+						}
+						r = JniEnvironment.InstanceMethods.CallNonvirtualFloatMethod (self.PeerReference, j.JniPeerType.PeerReference, n, parameters);
+						return r;
+					} while (false);
 				}
-				var j = Members.GetPeerMembers (self);
-				var n = j.InstanceMethods.GetMethodInfo (encodedMember);
-				var r = JniEnvironment.InstanceMethods.CallNonvirtualFloatMethod (self.PeerReference, j.JniPeerType.PeerReference, n, parameters);
-				GC.KeepAlive (self);
-				return r;
+				finally {
+					GC.KeepAlive (self);
+				}
 			}
 
 			public unsafe float InvokeNonvirtualSingleMethod (string encodedMember, IJavaPeerable self, JniArgumentValue* parameters)
@@ -322,39 +709,88 @@ namespace Java.Interop {
 				JniPeerMembers.AssertSelf (self);
 
 				var m   = GetMethodInfo (encodedMember);
-
-				var r   = JniEnvironment.InstanceMethods.CallNonvirtualFloatMethod (self.PeerReference, JniPeerType.PeerReference, m, parameters);
-				GC.KeepAlive (self);
-				return r;
+				try {
+					if (TryInvokeSingleStaticRedirect (m, self, parameters, out float r)) {
+						return r;
+					}
+					r = JniEnvironment.InstanceMethods.CallNonvirtualFloatMethod (self.PeerReference, JniPeerType.PeerReference, m, parameters);
+					return r;
+				}
+				finally {
+					GC.KeepAlive (self);
+				}
 			}
+
+#pragma warning disable CA1801
+			static unsafe bool TryInvokeDoubleStaticRedirect (JniMethodInfo method, IJavaPeerable self, JniArgumentValue* parameters, out double r)
+			{
+				r = default;
+#if !NET
+				return false;
+#else  // NET
+				if (method.StaticRedirect == null || !method.ParameterCount.HasValue) {
+					return false;
+				}
+
+				int c   = method.ParameterCount.Value;
+				Debug.Assert (c > 0);
+				var p   = stackalloc JniArgumentValue [c];
+				p [0]   = new JniArgumentValue (self);
+				for (int i = 0; i < c-1; ++i) {
+					p [i+1] = parameters [i];
+				}
+
+				r = JniEnvironment.StaticMethods.CallStaticDoubleMethod (method.StaticRedirect.PeerReference, method, p);
+				return true;
+#endif   // NET
+			}
+#pragma warning restore CA1801
 
 			public unsafe double InvokeAbstractDoubleMethod (string encodedMember, IJavaPeerable self, JniArgumentValue* parameters)
 			{
 				JniPeerMembers.AssertSelf (self);
 
-				var m   = GetMethodInfo (encodedMember);
+				try {
+					var m   = GetMethodInfo (encodedMember);
+					if (TryInvokeDoubleStaticRedirect (m, self, parameters, out double r)) {
+						return r;
+					}
 
-				var r   = JniEnvironment.InstanceMethods.CallDoubleMethod (self.PeerReference, m, parameters);
-				GC.KeepAlive (self);
-				return r;
+					r = JniEnvironment.InstanceMethods.CallDoubleMethod (self.PeerReference, m, parameters);
+					return r;
+				}
+				finally {
+					GC.KeepAlive (self);
+				}
 			}
 
 			public unsafe double InvokeVirtualDoubleMethod (string encodedMember, IJavaPeerable self, JniArgumentValue* parameters)
 			{
 				JniPeerMembers.AssertSelf (self);
 
-				var declaringType   = DeclaringType;
-				if (Members.UsesVirtualDispatch (self, declaringType)) {
-					var m   = GetMethodInfo (encodedMember);
-					var _nr = JniEnvironment.InstanceMethods.CallDoubleMethod (self.PeerReference, m, parameters);
-					GC.KeepAlive (self);
-					return _nr;
+				try {
+					var declaringType   = DeclaringType;
+					if (Members.UsesVirtualDispatch (self, declaringType)) {
+						var m   = GetMethodInfo (encodedMember);
+						if (TryInvokeDoubleStaticRedirect (m, self, parameters, out double r)) {
+							return r;
+						}
+						r = JniEnvironment.InstanceMethods.CallDoubleMethod (self.PeerReference, m, parameters);
+						return r;
+					}
+					var j = Members.GetPeerMembers (self);
+					var n = j.InstanceMethods.GetMethodInfo (encodedMember);
+					do {
+						if (TryInvokeDoubleStaticRedirect (n, self, parameters, out double r)) {
+							return r;
+						}
+						r = JniEnvironment.InstanceMethods.CallNonvirtualDoubleMethod (self.PeerReference, j.JniPeerType.PeerReference, n, parameters);
+						return r;
+					} while (false);
 				}
-				var j = Members.GetPeerMembers (self);
-				var n = j.InstanceMethods.GetMethodInfo (encodedMember);
-				var r = JniEnvironment.InstanceMethods.CallNonvirtualDoubleMethod (self.PeerReference, j.JniPeerType.PeerReference, n, parameters);
-				GC.KeepAlive (self);
-				return r;
+				finally {
+					GC.KeepAlive (self);
+				}
 			}
 
 			public unsafe double InvokeNonvirtualDoubleMethod (string encodedMember, IJavaPeerable self, JniArgumentValue* parameters)
@@ -362,39 +798,88 @@ namespace Java.Interop {
 				JniPeerMembers.AssertSelf (self);
 
 				var m   = GetMethodInfo (encodedMember);
-
-				var r   = JniEnvironment.InstanceMethods.CallNonvirtualDoubleMethod (self.PeerReference, JniPeerType.PeerReference, m, parameters);
-				GC.KeepAlive (self);
-				return r;
+				try {
+					if (TryInvokeDoubleStaticRedirect (m, self, parameters, out double r)) {
+						return r;
+					}
+					r = JniEnvironment.InstanceMethods.CallNonvirtualDoubleMethod (self.PeerReference, JniPeerType.PeerReference, m, parameters);
+					return r;
+				}
+				finally {
+					GC.KeepAlive (self);
+				}
 			}
+
+#pragma warning disable CA1801
+			static unsafe bool TryInvokeObjectStaticRedirect (JniMethodInfo method, IJavaPeerable self, JniArgumentValue* parameters, out JniObjectReference r)
+			{
+				r = default;
+#if !NET
+				return false;
+#else  // NET
+				if (method.StaticRedirect == null || !method.ParameterCount.HasValue) {
+					return false;
+				}
+
+				int c   = method.ParameterCount.Value;
+				Debug.Assert (c > 0);
+				var p   = stackalloc JniArgumentValue [c];
+				p [0]   = new JniArgumentValue (self);
+				for (int i = 0; i < c-1; ++i) {
+					p [i+1] = parameters [i];
+				}
+
+				r = JniEnvironment.StaticMethods.CallStaticObjectMethod (method.StaticRedirect.PeerReference, method, p);
+				return true;
+#endif   // NET
+			}
+#pragma warning restore CA1801
 
 			public unsafe JniObjectReference InvokeAbstractObjectMethod (string encodedMember, IJavaPeerable self, JniArgumentValue* parameters)
 			{
 				JniPeerMembers.AssertSelf (self);
 
-				var m   = GetMethodInfo (encodedMember);
+				try {
+					var m   = GetMethodInfo (encodedMember);
+					if (TryInvokeObjectStaticRedirect (m, self, parameters, out JniObjectReference r)) {
+						return r;
+					}
 
-				var r   = JniEnvironment.InstanceMethods.CallObjectMethod (self.PeerReference, m, parameters);
-				GC.KeepAlive (self);
-				return r;
+					r = JniEnvironment.InstanceMethods.CallObjectMethod (self.PeerReference, m, parameters);
+					return r;
+				}
+				finally {
+					GC.KeepAlive (self);
+				}
 			}
 
 			public unsafe JniObjectReference InvokeVirtualObjectMethod (string encodedMember, IJavaPeerable self, JniArgumentValue* parameters)
 			{
 				JniPeerMembers.AssertSelf (self);
 
-				var declaringType   = DeclaringType;
-				if (Members.UsesVirtualDispatch (self, declaringType)) {
-					var m   = GetMethodInfo (encodedMember);
-					var _nr = JniEnvironment.InstanceMethods.CallObjectMethod (self.PeerReference, m, parameters);
-					GC.KeepAlive (self);
-					return _nr;
+				try {
+					var declaringType   = DeclaringType;
+					if (Members.UsesVirtualDispatch (self, declaringType)) {
+						var m   = GetMethodInfo (encodedMember);
+						if (TryInvokeObjectStaticRedirect (m, self, parameters, out JniObjectReference r)) {
+							return r;
+						}
+						r = JniEnvironment.InstanceMethods.CallObjectMethod (self.PeerReference, m, parameters);
+						return r;
+					}
+					var j = Members.GetPeerMembers (self);
+					var n = j.InstanceMethods.GetMethodInfo (encodedMember);
+					do {
+						if (TryInvokeObjectStaticRedirect (n, self, parameters, out JniObjectReference r)) {
+							return r;
+						}
+						r = JniEnvironment.InstanceMethods.CallNonvirtualObjectMethod (self.PeerReference, j.JniPeerType.PeerReference, n, parameters);
+						return r;
+					} while (false);
 				}
-				var j = Members.GetPeerMembers (self);
-				var n = j.InstanceMethods.GetMethodInfo (encodedMember);
-				var r = JniEnvironment.InstanceMethods.CallNonvirtualObjectMethod (self.PeerReference, j.JniPeerType.PeerReference, n, parameters);
-				GC.KeepAlive (self);
-				return r;
+				finally {
+					GC.KeepAlive (self);
+				}
 			}
 
 			public unsafe JniObjectReference InvokeNonvirtualObjectMethod (string encodedMember, IJavaPeerable self, JniArgumentValue* parameters)
@@ -402,10 +887,16 @@ namespace Java.Interop {
 				JniPeerMembers.AssertSelf (self);
 
 				var m   = GetMethodInfo (encodedMember);
-
-				var r   = JniEnvironment.InstanceMethods.CallNonvirtualObjectMethod (self.PeerReference, JniPeerType.PeerReference, m, parameters);
-				GC.KeepAlive (self);
-				return r;
+				try {
+					if (TryInvokeObjectStaticRedirect (m, self, parameters, out JniObjectReference r)) {
+						return r;
+					}
+					r = JniEnvironment.InstanceMethods.CallNonvirtualObjectMethod (self.PeerReference, JniPeerType.PeerReference, m, parameters);
+					return r;
+				}
+				finally {
+					GC.KeepAlive (self);
+				}
 			}
 		}
 	}

--- a/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods_Invoke.tt
+++ b/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods_Invoke.tt
@@ -21,6 +21,7 @@
 #nullable enable
 
 using System;
+using System.Diagnostics;
 
 namespace Java.Interop {
 
@@ -29,35 +30,83 @@ namespace Java.Interop {
 		partial class JniInstanceMethods {
 <#
 	foreach (var returnType in jniReturnTypes) {
+		string byRefParamDecl       = returnType.ReturnType == "void" ? "" : ", out " + returnType.ReturnType + " r";
+		// string byRefParam           = returnType.ReturnType == "void" ? "" : " r";
+		string setByRefToDefault    = returnType.ReturnType == "void" ? "" : "r = default;";
+		string setByRefParam        = returnType.ReturnType == "void" ? "" : "r = ";
+		string returnByRefParam     = returnType.ReturnType == "void" ? "return" : "return r";
 #>
+
+#pragma warning disable CA1801
+			static unsafe bool TryInvoke<#= returnType.ManagedType #>StaticRedirect (JniMethodInfo method, IJavaPeerable self, JniArgumentValue* parameters<#= byRefParamDecl #>)
+			{
+				<#= setByRefToDefault #>
+#if !NET
+				return false;
+#else  // NET
+				if (method.StaticRedirect == null || !method.ParameterCount.HasValue) {
+					return false;
+				}
+
+				int c   = method.ParameterCount.Value;
+				Debug.Assert (c > 0);
+				var p   = stackalloc JniArgumentValue [c];
+				p [0]   = new JniArgumentValue (self);
+				for (int i = 0; i < c-1; ++i) {
+					p [i+1] = parameters [i];
+				}
+
+				<#= setByRefParam #>JniEnvironment.StaticMethods.CallStatic<#= returnType.JniCallType #>Method (method.StaticRedirect.PeerReference, method, p);
+				return true;
+#endif   // NET
+			}
+#pragma warning restore CA1801
 
 			public unsafe <#= returnType.ReturnType #> InvokeAbstract<#= returnType.ManagedType #>Method (string encodedMember, IJavaPeerable self, JniArgumentValue* parameters)
 			{
 				JniPeerMembers.AssertSelf (self);
 
-				var m   = GetMethodInfo (encodedMember);
+				try {
+					var m   = GetMethodInfo (encodedMember);
+					if (TryInvoke<#= returnType.ManagedType #>StaticRedirect (m, self, parameters<#= byRefParamDecl #>)) {
+						<#= returnByRefParam #>;
+					}
 
-				<#= returnType.ReturnType != "void" ? "var r   = " : "" #>JniEnvironment.InstanceMethods.Call<#= returnType.JniCallType #>Method (self.PeerReference, m, parameters);
-				GC.KeepAlive (self);
-				return<#= returnType.ReturnType == "void" ? "" : " r" #>;
+					<#= setByRefParam #>JniEnvironment.InstanceMethods.Call<#= returnType.JniCallType #>Method (self.PeerReference, m, parameters);
+					<#= returnByRefParam #>;
+				}
+				finally {
+					GC.KeepAlive (self);
+				}
 			}
 
 			public unsafe <#= returnType.ReturnType #> InvokeVirtual<#= returnType.ManagedType #>Method (string encodedMember, IJavaPeerable self, JniArgumentValue* parameters)
 			{
 				JniPeerMembers.AssertSelf (self);
 
-				var declaringType   = DeclaringType;
-				if (Members.UsesVirtualDispatch (self, declaringType)) {
-					var m   = GetMethodInfo (encodedMember);
-					<#= returnType.ReturnType != "void" ? "var _nr = " : "" #>JniEnvironment.InstanceMethods.Call<#= returnType.JniCallType #>Method (self.PeerReference, m, parameters);
-					GC.KeepAlive (self);
-					return<#= returnType.ReturnType == "void" ? "" : " _nr" #>;
+				try {
+					var declaringType   = DeclaringType;
+					if (Members.UsesVirtualDispatch (self, declaringType)) {
+						var m   = GetMethodInfo (encodedMember);
+						if (TryInvoke<#= returnType.ManagedType #>StaticRedirect (m, self, parameters<#= byRefParamDecl #>)) {
+							<#= returnByRefParam #>;
+						}
+						<#= setByRefParam #>JniEnvironment.InstanceMethods.Call<#= returnType.JniCallType #>Method (self.PeerReference, m, parameters);
+						<#= returnByRefParam #>;
+					}
+					var j = Members.GetPeerMembers (self);
+					var n = j.InstanceMethods.GetMethodInfo (encodedMember);
+					do {
+						if (TryInvoke<#= returnType.ManagedType #>StaticRedirect (n, self, parameters<#= byRefParamDecl #>)) {
+							<#= returnByRefParam #>;
+						}
+						<#= setByRefParam #>JniEnvironment.InstanceMethods.CallNonvirtual<#= returnType.JniCallType #>Method (self.PeerReference, j.JniPeerType.PeerReference, n, parameters);
+						<#= returnByRefParam #>;
+					} while (false);
 				}
-				var j = Members.GetPeerMembers (self);
-				var n = j.InstanceMethods.GetMethodInfo (encodedMember);
-				<#= returnType.ReturnType != "void" ? "var r = " : "" #>JniEnvironment.InstanceMethods.CallNonvirtual<#= returnType.JniCallType #>Method (self.PeerReference, j.JniPeerType.PeerReference, n, parameters);
-				GC.KeepAlive (self);
-				return<#= returnType.ReturnType == "void" ? "" : " r" #>;
+				finally {
+					GC.KeepAlive (self);
+				}
 			}
 
 			public unsafe <#= returnType.ReturnType #> InvokeNonvirtual<#= returnType.ManagedType #>Method (string encodedMember, IJavaPeerable self, JniArgumentValue* parameters)
@@ -65,10 +114,16 @@ namespace Java.Interop {
 				JniPeerMembers.AssertSelf (self);
 
 				var m   = GetMethodInfo (encodedMember);
-
-				<#= returnType.ReturnType != "void" ? "var r   = " : "" #>JniEnvironment.InstanceMethods.CallNonvirtual<#= returnType.JniCallType #>Method (self.PeerReference, JniPeerType.PeerReference, m, parameters);
-				GC.KeepAlive (self);
-				return<#= returnType.ReturnType == "void" ? "" : " r" #>;
+				try {
+					if (TryInvoke<#= returnType.ManagedType #>StaticRedirect (m, self, parameters<#= byRefParamDecl #>)) {
+						<#= returnByRefParam #>;
+					}
+					<#= setByRefParam #>JniEnvironment.InstanceMethods.CallNonvirtual<#= returnType.JniCallType #>Method (self.PeerReference, JniPeerType.PeerReference, m, parameters);
+					<#= returnByRefParam #>;
+				}
+				finally {
+					GC.KeepAlive (self);
+				}
 			}
 <#
 	}

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -402,9 +402,9 @@ namespace Java.Interop
 				targetType  = targetType ?? typeof (T);
 
 				if (typeof (IJavaPeerable).IsAssignableFrom (targetType)) {
-#pragma warning disable CS8601 // Possible null reference assignment.
+#pragma warning disable CS8600,CS8601 // Possible null reference assignment.
 					return (T) JavaPeerableValueMarshaler.Instance.CreateGenericValue (ref reference, options, targetType);
-#pragma warning restore CS8601 // Possible null reference assignment.
+#pragma warning restore CS8600,CS8601 // Possible null reference assignment.
 				}
 
 				var marshaler   = GetValueMarshaler<T> ();
@@ -481,9 +481,9 @@ namespace Java.Interop
 				}
 
 				if (typeof (IJavaPeerable).IsAssignableFrom (targetType)) {
-#pragma warning disable CS8601 // Possible null reference assignment.
+#pragma warning disable CS8600,CS8601 // Possible null reference assignment.
 					return (T) JavaPeerableValueMarshaler.Instance.CreateGenericValue (ref reference, options, targetType);
-#pragma warning restore CS8601 // Possible null reference assignment.
+#pragma warning restore CS8600,CS8601 // Possible null reference assignment.
 				}
 
 				var marshaler   = GetValueMarshaler<T> ();

--- a/src/Java.Interop/Java.Interop/JniTypeSignatureAttribute.cs
+++ b/src/Java.Interop/Java.Interop/JniTypeSignatureAttribute.cs
@@ -11,14 +11,7 @@ namespace Java.Interop
 
 		public JniTypeSignatureAttribute (string simpleReference)
 		{
-			if (simpleReference == null)
-				throw new ArgumentNullException (nameof (simpleReference));
-			if (simpleReference.IndexOf (".", StringComparison.Ordinal) >= 0)
-				throw new ArgumentException ("JNI type names do not contain '.', they use '/'. Are you sure you're using a JNI type name?", nameof (simpleReference));
-			if (simpleReference.StartsWith ("[", StringComparison.Ordinal))
-				throw new ArgumentException ("Arrays cannot be present in simple type references.", nameof (simpleReference));
-			if (simpleReference.StartsWith ("L", StringComparison.Ordinal) && simpleReference.EndsWith (";", StringComparison.Ordinal))
-				throw new ArgumentException ("JNI type references are not supported.", nameof (simpleReference));
+			JniRuntime.JniTypeManager.AssertSimpleReference (simpleReference, nameof (simpleReference));
 
 			SimpleReference     = simpleReference;
 		}

--- a/tests/Java.Interop-Tests/Java.Interop-Tests.csproj
+++ b/tests/Java.Interop-Tests/Java.Interop-Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -46,6 +47,10 @@
     <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\CallVirtualFromConstructorBase.java" />
     <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\CallVirtualFromConstructorDerived.java" />
     <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\GetThis.java" />
+    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\ObjectHelper.java" />
+    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\RenameClassBase1.java" />
+    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\RenameClassBase2.java" />
+    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\RenameClassDerived.java" />
     <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\SelfRegistration.java" />
     <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\TestType.java" />
   </ItemGroup>

--- a/tests/Java.Interop-Tests/Java.Interop/JavaVMFixture.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JavaVMFixture.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -10,20 +11,149 @@ namespace Java.InteropTests {
 
 	partial class JavaVMFixture {
 
+		internal static TestJVM?                    VM;
+		internal static JavaVMFixtureTypeManager?   TypeManager;
+
 		static partial void CreateJavaVM ()
 		{
-			var c = new TestJVM (
-					jars:           new[]{ "interop-test.jar" },
-					typeMappings:   new Dictionary<string, Type> () {
+			var o = new TestJVMOptions {
+				JarFilePaths    = {
+					"interop-test.jar",
+				},
+				TypeManager	    = new JavaVMFixtureTypeManager (),
+			};
+			VM          = new TestJVM (o);
+			TypeManager	= (JavaVMFixtureTypeManager) VM.TypeManager;
+			JniRuntime.SetCurrent (VM);
+		}
+	}
+
+	class JavaVMFixtureTypeManager : JniRuntime.JniTypeManager {
+
+		Dictionary<string, Type> TypeMappings = new() {
 #if !NO_MARSHAL_MEMBER_BUILDER_SUPPORT
-						{ TestType.JniTypeName, typeof (TestType) },
+			[TestType.JniTypeName]              = typeof (TestType),
 #endif  // !NO_MARSHAL_MEMBER_BUILDER_SUPPORT
-						{ GenericHolder<int>.JniTypeName,   typeof (GenericHolder<>) },
-					}
-			);
-			JniRuntime.SetCurrent (c);
+			[GenericHolder<int>.JniTypeName]    = typeof (GenericHolder<>),
+			[RenameClassBase.JniTypeName]       = typeof (RenameClassBase),
+			[RenameClassDerived.JniTypeName]    = typeof (RenameClassDerived),
+		};
+
+		public JavaVMFixtureTypeManager ()
+		{
 		}
 
+		protected override IEnumerable<Type> GetTypesForSimpleReference (string jniSimpleReference)
+		{
+			foreach (var t in base.GetTypesForSimpleReference (jniSimpleReference))
+				yield return t;
+			Type target;
+#pragma warning disable CS8600	// huh?
+			if (TypeMappings.TryGetValue (jniSimpleReference, out target))
+				yield return target;
+#pragma warning restore CS8600
+		}
+
+		protected override IEnumerable<string> GetSimpleReferences (Type type)
+		{
+			return base.GetSimpleReferences (type)
+				.Concat (CreateSimpleReferencesEnumerator (type));
+		}
+
+		IEnumerable<string> CreateSimpleReferencesEnumerator (Type type)
+		{
+			foreach (var e in TypeMappings) {
+				if (e.Value == type) {
+#if NET
+					if (ReplacmentTypes.TryGetValue (e.Key, out var alt)) {
+						yield return alt;
+						continue;
+					}
+#endif  // NET
+					yield return e.Key;
+				}
+			}
+		}
+
+#if NET
+		public string? RequestedFallbackTypesForSimpleReference;
+		protected override IReadOnlyList<string>? GetStaticMethodFallbackTypesCore (string jniSimpleReference)
+		{
+			RequestedFallbackTypesForSimpleReference = jniSimpleReference;
+			Debug.WriteLine ($"# GetStaticMethodFallbackTypes (jniSimpleReference={jniSimpleReference})");
+
+			var slash       = jniSimpleReference.LastIndexOf ('/');
+			var desugarType = slash <= 0
+				? "Desugar" + jniSimpleReference
+				: jniSimpleReference.Substring (0, slash+1) + "Desugar" + jniSimpleReference.Substring (slash+1);
+
+			// These types likely won't ever exist on Desktop, but providing
+			// "potentially non-existent" types ensures that we don't throw
+			// from places we don't want to internally throw.
+			return new[]{
+				desugarType,
+				$"{jniSimpleReference}$-CC"
+			};
+		}
+
+		Dictionary<string, string> ReplacmentTypes = new() {
+			["com/xamarin/interop/RenameClassBase1"] = "com/xamarin/interop/RenameClassBase2",
+		};
+
+		protected override string? GetReplacementTypeCore (string jniSimpleReference) =>
+			ReplacmentTypes.TryGetValue (jniSimpleReference, out var v)
+			? v
+			: null;
+
+		Dictionary<(string SourceType, string SourceName, string? SourceSignature), (string? TargetType, string? TargetName, string? TargetSignature, int? ParamCount, bool TurnStatic)> ReplacementMethods = new() {
+			[("java/lang/Object",                       "remappedToToString",       "()Ljava/lang/String;")]    = (null, "toString", null, null, false),
+			[("java/lang/Object",                       "remappedToStaticHashCode", null)]                      = ("com/xamarin/interop/ObjectHelper", "getHashCodeHelper", null, null, true),
+			[("java/lang/Runtime",                      "remappedToGetRuntime",     null)]                      = (null, "getRuntime", null, null, false),
+
+			// NOTE: key must use *post-renamed* value, not pre-renamed value
+			// NOTE: SourceSignature lacking return type; "closer in spirit" to what `remapping-config.json` allows
+			[("com/xamarin/interop/RenameClassBase2",   "hashCode",                 "()")]                      = ("com/xamarin/interop/RenameClassBase2", "myNewHashCode", null, null, false),
+		};
+
+		protected override JniRuntime.ReplacementMethodInfo? GetReplacementMethodInfoCore (string jniSourceType, string jniMethodName, string jniMethodSignature)
+		{
+			// Console.Error.WriteLine ($"# jonp: looking for replacement method for (\"{jniSourceType}\", \"{jniMethodName}\", \"{jniMethodSignature}\")");
+			if (!ReplacementMethods.TryGetValue ((jniSourceType, jniMethodName, jniMethodSignature), out var r) &&
+					!ReplacementMethods.TryGetValue ((jniSourceType, jniMethodName, GetAlternateMethodSignature ()), out r) &&
+					!ReplacementMethods.TryGetValue ((jniSourceType, jniMethodName, null), out r)) {
+				return null;
+			}
+			var targetSig   = r.TargetSignature;
+			var paramCount  = r.ParamCount;
+			if (targetSig == null && r.TurnStatic) {
+				targetSig   = $"(L{jniSourceType};" + jniMethodSignature.Substring ("(".Length);
+				paramCount  = paramCount ?? JniMemberSignature.GetParameterCountFromMethodSignature (jniMethodSignature);
+				paramCount++;
+			}
+			// Console.Error.WriteLine ($"# jonp: found replacement: ({GetValue (r.TargetType)}, {GetValue (r.TargetName)}, {GetValue (r.TargetSignature)}, {r.ParamCount?.ToString () ?? "null"}, {r.IsStatic})");
+			return new JniRuntime.ReplacementMethodInfo {
+					SourceJniType                   = jniSourceType,
+					SourceJniMethodName             = jniMethodName,
+					SourceJniMethodSignature        = jniMethodSignature,
+					TargetJniType                   = r.TargetType ?? jniSourceType,
+					TargetJniMethodName             = r.TargetName ?? jniMethodName,
+					TargetJniMethodSignature        = targetSig    ?? jniMethodSignature,
+					TargetJniMethodParameterCount   = paramCount,
+					TargetJniMethodInstanceToStatic = r.TurnStatic,
+			};
+
+			string GetAlternateMethodSignature ()
+			{
+				int i = jniMethodSignature.IndexOf (')');
+				return jniMethodSignature.Substring (0, i+1);
+			}
+
+			// string GetValue (string? value)
+			// {
+			// 	return value == null ? "null" : $"\"{value}\"";
+			// }
+		}
+#endif  // NET
 	}
 }
 

--- a/tests/Java.Interop-Tests/Java.Interop/JniPeerMembersTests.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JniPeerMembersTests.cs
@@ -36,6 +36,79 @@ namespace Java.InteropTests
 			var f   = typeof (JniPeerMembers.JniInstanceMethods).GetField ("InstanceMethods", BindingFlags.NonPublic | BindingFlags.Instance);
 			return (Dictionary<string, JniMethodInfo>) f.GetValue (methods);
 		}
+
+#if NET
+		[Test]
+		public void MethodLookupForNonexistentStaticMethodWillTryFallbacks ()
+		{
+			try {
+				JavaLangRemappingTestRuntime.doesNotExist ();
+				Assert.Fail ("java.lang.Runtime.doesNotExist() exists?!  Not expected to exist.");
+			}
+			catch (Exception e) {
+				Console.WriteLine ($"# jonp: MethodLookupForNonexistentStaticMethodWillTryFallbacks: e={e}");
+				// On Desktop, expect `e` to be:
+				// ```
+				// Java.Interop.JavaException: doesNotExist
+				//    at Java.Interop.JniEnvironment.StaticMethods.GetMethodID(JniObjectReference type, String name, String signature)
+				//    …
+				//    at Java.InteropTests.JavaLangRuntime.doesNotExist()
+				//    at Java.InteropTests.JniStaticMethodIDTest.MethodLookupForNonexistentMethodWillTryFallbacks()
+				//   --- End of managed Java.Interop.JavaException stack trace ---
+				// java.lang.NoSuchMethodError: doesNotExist
+				// ```
+				// On Android, expect `e` to be:
+				// ```
+				// Java.Lang.NoSuchMethodError: no static method "Ljava/lang/Runtime;.doesNotExist()V"
+				//    at Java.Interop.JniEnvironment.StaticMethods.GetStaticMethodID(JniObjectReference type, String name, String signature)
+				//    at Java.Interop.JniType.GetStaticMethod(String name, String signature)
+				//    at Java.Interop.JniPeerMembers.JniStaticMethods.GetMethodInfo(String method, String signature)
+				//    at Java.Interop.JniPeerMembers.JniStaticMethods.GetMethodInfo(String encodedMember)
+				//    at Java.Interop.JniPeerMembers.JniStaticMethods.InvokeVoidMethod(String encodedMember, JniArgumentValue* parameters)
+				//    at Java.InteropTests.JavaLangRemappingTestRuntime.doesNotExist()
+				//    at Java.InteropTests.JniPeerMembersTests.MethodLookupForNonexistentStaticMethodWillTryFallbacks()
+				//   --- End of managed Java.Lang.NoSuchMethodError stack trace ---
+				// ```
+				Assert.IsTrue (e.Message.Contains ("doesNotExist", StringComparison.Ordinal));
+#if !ANDROID    // Android doesn't allow providing a custom TypeManager
+				Assert.AreEqual ("java/lang/Runtime",
+						JavaVMFixture.TypeManager.RequestedFallbackTypesForSimpleReference);
+#endif  // !ANDROID
+			}
+		}
+
+		[Test]
+		public void ReplacementTypeUsedForMethodLookup ()
+		{
+			using var o = new RenameClassDerived ();
+			int r = o.hashCode();
+			Assert.AreEqual (33, r);
+		}
+
+		[Test]
+		public void ReplaceInstanceMethodName ()
+		{
+			using var o = new JavaLangRemappingTestObject ();
+			// Shouldn't throw; should instead invoke Object.toString()
+			var r = o.remappedToToString ();
+			JniObjectReference.Dispose (ref r);
+		}
+
+		[Test]
+		public void ReplaceStaticMethodName ()
+		{
+			var r = JavaLangRemappingTestRuntime.remappedToGetRuntime ();
+			JniObjectReference.Dispose (ref r);
+		}
+
+		[Test]
+		public void ReplaceInstanceMethodWithStaticMethod ()
+		{
+			using var o = new JavaLangRemappingTestObject ();
+			// Shouldn't throw; should instead invoke ObjectHelper.getHashCodeHelper(Object)
+			o.remappedToStaticHashCode ();
+		}
+#endif  // NET
 	}
 
 	[JniTypeSignature (JniTypeName)]
@@ -57,5 +130,82 @@ namespace Java.InteropTests
 			_members.InstanceMethods.FinishGenericCreateInstance (id, this, value);
 		}
 	}
-}
 
+
+	[JniTypeSignature (JniTypeName)]
+	class JavaLangRemappingTestObject : JavaObject {
+		internal    const    string         JniTypeName = "java/lang/Object";
+		static      readonly JniPeerMembers _members    = new JniPeerMembers (JniTypeName, typeof (JavaLangRemappingTestObject));
+
+		public JavaLangRemappingTestObject ()
+		{
+		}
+
+		public unsafe void doesNotExist ()
+		{
+			const string id = "doesNotExist.()V";
+			_members.InstanceMethods.InvokeNonvirtualVoidMethod (id, this, null);
+		}
+
+		public unsafe JniObjectReference remappedToToString ()
+		{
+			const string id = "remappedToToString.()Ljava/lang/String;";
+			return _members.InstanceMethods.InvokeNonvirtualObjectMethod (id, this, null);
+		}
+
+		public unsafe int remappedToStaticHashCode ()
+		{
+			const string id = "remappedToStaticHashCode.()I";
+			return _members.InstanceMethods.InvokeVirtualInt32Method (id, this, null);
+		}
+	}
+
+	[JniTypeSignature (JavaLangRemappingTestRuntime.JniTypeName)]
+	internal class JavaLangRemappingTestRuntime : JavaObject {
+		internal    const    string         JniTypeName = "java/lang/Runtime";
+		static      readonly JniPeerMembers _members    = new JniPeerMembers (JniTypeName, typeof (JavaLangRemappingTestRuntime));
+
+		public static unsafe JniObjectReference remappedToGetRuntime()
+		{
+			const string id = "remappedToGetRuntime.()Ljava/lang/Runtime;";
+			return _members.StaticMethods.InvokeObjectMethod (id, null);
+		}
+
+		public static unsafe void doesNotExist ()
+		{
+			const string id = "doesNotExist.()V";
+			_members.StaticMethods.InvokeVoidMethod (id, null);
+		}
+	}
+
+	[JniTypeSignature (JniTypeName)]
+	class RenameClassBase : JavaObject {
+		internal    const       string          JniTypeName    = "com/xamarin/interop/RenameClassBase1";
+		static      readonly    JniPeerMembers  _members        = new JniPeerMembers (JniTypeName, typeof (RenameClassBase));
+
+		public      override    JniPeerMembers  JniPeerMembers  => _members;
+
+		public RenameClassBase ()
+		{
+		}
+
+		public virtual unsafe int hashCode ()
+		{
+			const string id = "hashCode.()I";
+			return _members.InstanceMethods.InvokeVirtualInt32Method (id, this, null);
+		}
+	}
+
+	[JniTypeSignature (JniTypeName)]
+	class RenameClassDerived : RenameClassBase {
+		internal    new     const       string          JniTypeName    = "com/xamarin/interop/RenameClassDerived";
+		public RenameClassDerived ()
+		{
+		}
+
+		public override unsafe int hashCode ()
+		{
+			return base.hashCode ();
+		}
+	}
+}

--- a/tests/Java.Interop-Tests/java/com/xamarin/interop/ObjectHelper.java
+++ b/tests/Java.Interop-Tests/java/com/xamarin/interop/ObjectHelper.java
@@ -1,0 +1,11 @@
+package com.xamarin.interop;
+
+public class ObjectHelper {
+	private ObjectHelper()
+	{
+	}
+
+	public static int getHashCodeHelper (Object o) {
+		return o.hashCode();
+	}
+}

--- a/tests/Java.Interop-Tests/java/com/xamarin/interop/RenameClassBase1.java
+++ b/tests/Java.Interop-Tests/java/com/xamarin/interop/RenameClassBase1.java
@@ -1,0 +1,39 @@
+package com.xamarin.interop;
+
+import java.util.ArrayList;
+
+import com.xamarin.java_interop.GCUserPeerable;
+
+public class RenameClassBase1
+	implements GCUserPeerable
+{
+	static  final   String  assemblyQualifiedName   = "Java.InteropTests.RenameClassBase, Java.Interop-Tests";
+
+	ArrayList<Object>       managedReferences     = new ArrayList<Object>();
+
+	public RenameClassBase1 () {
+		System.out.println("RenameClassBase.<init>()");
+		if (RenameClassBase1.class == getClass ()) {
+			com.xamarin.java_interop.ManagedPeer.construct (
+					this,
+					assemblyQualifiedName,
+					""
+			);
+		}
+	}
+
+	public int hashCode () {
+		System.out.println("RenameClassBase1.hashCode()");
+		return 16;
+	}
+
+	public void jiAddManagedReference (java.lang.Object obj)
+	{
+		managedReferences.add (obj);
+	}
+
+	public void jiClearManagedReferences ()
+	{
+		managedReferences.clear ();
+	}
+}

--- a/tests/Java.Interop-Tests/java/com/xamarin/interop/RenameClassBase2.java
+++ b/tests/Java.Interop-Tests/java/com/xamarin/interop/RenameClassBase2.java
@@ -1,0 +1,45 @@
+package com.xamarin.interop;
+
+import java.util.ArrayList;
+
+import com.xamarin.java_interop.GCUserPeerable;
+
+public class RenameClassBase2
+	extends RenameClassBase1
+	implements GCUserPeerable
+{
+	static  final   String  assemblyQualifiedName   = "Java.InteropTests.RenameClassBase, Java.Interop-Tests";
+
+	ArrayList<Object>       managedReferences     = new ArrayList<Object>();
+
+	public RenameClassBase2 () {
+		System.out.println("RenameClassBase.<init>()");
+		if (RenameClassBase2.class == getClass ()) {
+			com.xamarin.java_interop.ManagedPeer.construct (
+					this,
+					assemblyQualifiedName,
+					""
+			);
+		}
+	}
+
+	public int hashCode () {
+		System.out.println("RenameClassBase2.hashCode()");
+		return 32;
+	}
+
+	public int myNewHashCode() {
+		System.out.println("RenameClassBase2.myNewHashCode()");
+		return 33;
+	}
+
+	public void jiAddManagedReference (java.lang.Object obj)
+	{
+		managedReferences.add (obj);
+	}
+
+	public void jiClearManagedReferences ()
+	{
+		managedReferences.clear ();
+	}
+}

--- a/tests/Java.Interop-Tests/java/com/xamarin/interop/RenameClassDerived.java
+++ b/tests/Java.Interop-Tests/java/com/xamarin/interop/RenameClassDerived.java
@@ -1,0 +1,45 @@
+package com.xamarin.interop;
+
+import java.util.ArrayList;
+
+import com.xamarin.java_interop.GCUserPeerable;
+
+public class RenameClassDerived
+	extends RenameClassBase2        // Note: does NOT match C# binding!  This is "post Bytecode rewriting"
+	implements GCUserPeerable
+{
+	static  final   String  assemblyQualifiedName   = "Java.InteropTests.RenameClassDerived, Java.Interop-Tests";
+
+	ArrayList<Object>       managedReferences     = new ArrayList<Object>();
+
+	public RenameClassDerived () {
+		System.out.println("RenameClassDerived.<init>()");
+		if (RenameClassDerived.class == getClass ()) {
+			com.xamarin.java_interop.ManagedPeer.construct (
+					this,
+					assemblyQualifiedName,
+					""
+			);
+		}
+	}
+
+	// Note: while *at runtime* `RenameClassBase1` is replaced with `RenameClassBase2`,
+	// Java Callable Wrapper generator doesn't know about that (yet?), and thus the
+	// *original* method name will be present.
+	// Not sure if this is actually a problem; perhaps Bytecode rewriting happens *after*
+	// Java Callable Wrapper generation?
+	public int hashCode () {
+		System.out.println("RenameClassDerived.hashCode()");
+		return 64;
+	}
+
+	public void jiAddManagedReference (java.lang.Object obj)
+	{
+		managedReferences.add (obj);
+	}
+
+	public void jiClearManagedReferences ()
+	{
+		managedReferences.clear ();
+	}
+}

--- a/tests/TestJVM/TestJVM.csproj
+++ b/tests/TestJVM/TestJVM.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;net6.0</TargetFrameworks>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/issues/867

There are two scenarios for which a "generalized" type & member
remapping solution would be useful:

 1. Desugaring
 2. Microsoft Intune MAM

Note: this new support is only present when targeting .NET 6+,
and will not (currently) be present in Classic Xamarin.Android.

~~ Desugaring ~~

Context: https://github.com/xamarin/xamarin-android/issues/4574#issuecomment-615363285
Context: https://github.com/xamarin/xamarin-android/issues/6142#issuecomment-889435599

The [Android Runtime][0] is responsible for running the Dalvik
bytecode within e.g. `classes.dex`.  The Android runtime and Dalvik
bytecode formats have apparently changed over time in order to
support newer Java language features, such as support for static
interface methods:

	package org.webrtc;

	public /* partial */ interface EGLBase {
	    public static EGLBase create() { /* … */}
	}

Support for static interface methods was added in Java 8 and in
Android v8.0 (API-26).  If you want to use static interface methods
on an Android device running API-25 or earlier, you must [desugar][1]
the Java Bytecode.  The result of [desugaring][2] the above
`org.webrtc.EGLBase` type is that the static methods are moved to a
*new* type, with a `$-CC` suffix, "as if" the Java code were instead:

	package org.webrtc;

	public /* partial */ interface EGLBase {
	    // …
	}

	public final /* partial */ class EGLBase$-CC {
	    public static EGLBase create { /* … */ }
	}

While this works for pure Java code, this *does not work* with
Xamarin.Android, because our bindings currently expect (require) that
the types & members our binding process detects don't "move":

	// C# Binding for EGLBase
	namespace Org.Webrtc {
	    public partial interface IEGLBase {
	        private static readonly JniPeerMembers _members = new JniPeerMembers ("org/webrtc/EGLBase", typeof (IEGLBase));
	        public static IEGLBase Create()
	        {
	            const string __id = "create.()Lorg/webrtc/EglBase;"
	            var __rm = _members.StaticMethods.InvokeObjectMethod (__id, null);
	            return Java.Lang.Object.GetObject<IEGLBase>(__rm.Handle, JniHandleOwnership.TransferLocalRef);
	        }
	    }
	}

The `new JniPeerMembers(…)` invocation will use `JNIEnv::FindClass()`
to lookup the `org/webrtc/EGLBase` type, and `IEGLBase.Create()` will
use `JNIEnv::GetStaticMethodID()` and `JNIEnv::CallStaticObjectMethod()`
to lookup and invoke the `EGLBase.create()` method.

However, when desugaring is used, *there is no* `EGLBase.create()`
method.  Consequently, in a "desugared" environment,
`Java.Lang.NoSuchMethodError` will be thrown when `IEGLBase.Create()`
is invoked, as `EGLBase.create()` doesn't exist; it "should" instead
be looking for `EGLBase$-CC.create()`!

Introduce partial support for this scenario by adding the new method:

	namespace Java.Interop {
	    public partial class JniRuntime {
	        public partial class JniTypeManager {
	            public IReadOnlyList<string>? GetStaticMethodFallbackTypes (string jniSimpleReference) =>
	                GetStaticMethodFallbackTypesCore (jniSimpleReference);
	            protected virtual IReadOnlyList<string>? GetStaticMethodFallbackTypesCore (string jniSimpleReference) => null;
	        }
	    }
	}

`JniPeerMembers.JniStaticMethods.GetMethodInfo()` will attempt to
lookup the static method, "as normal".  If the method cannot be
found, then `JniRuntime.JniTypeManager.GetStaticMethodFallbackTypes()`
will be called, and we'll attempt to resolve the static method on each
type returned by `GetStaticMethodFallbackTypes()`.
If `GetStaticMethodFallbackTypes()` returns `null` or no fallback type
provides the method, then a `NoSuchMethodError` will be thrown.

TODO: Update xamarin-android to override
`GetStaticMethodFallbackTypes()`, to return
`$"{jniSimpleReference}$-CC"`.

~~ Microsoft Intune MAM ~~

Context: https://www.nuget.org/packages/Microsoft.Intune.MAM.Remapper.Tasks/
Context: https://docs.microsoft.com/en-us/mem/intune/developer/app-sdk-xamarin#remapper

The [Microsoft Intune App SDK Xamarin Bindings][3] is in a
similar-yet-different position: it involves Java & Dalvik Bytecode
manipulation for various security purposes, and in order to make that
work reasonably from Xamarin.Android, they *also* rewrite
Xamarin.Android IL so that it's consistent with the manipulated
Dalvik bytecode.

See `readme.md` and `content/MonoAndroid10/remapping-config.json`
within the [`Microsoft.Intune.MAM.Remapper.Tasks NuGet package`][4]
for some additional details/tidbits such as:

> This task operates on assemblies to replace the base type classes
> which Microsoft Intune requires to implement its SDK (for example,
> Intune requires using a `MAMActivity` in place of `Activity` and
> methods such as `OnMAMCreate` instead of `OnCreate`).

	"ClassRewrites": [
	  {
	    "Class": {
	      "From": "android.app.Activity",
	      "To": "com.microsoft.intune.mam.client.app.MAMActivity"
	    },
	    "Methods": [
	      {
	        "MakeStatic": false,
	        "OriginalName": "onCreate",
	        "NewName": "onMAMCreate",
	        "OriginalParams": [
	          "android.os.Bundle"
	        ]
	      }
	    ]
	  },
	  {	
	    "Class": {
	      "From": "android.content.pm.PackageManager",
	      "To": "com.microsoft.intune.mam.client.content.pm.MAMPackageManagement"
	    },
	    "Methods": [
	      {
	        "MakeStatic": true,
	        "OriginalName": "checkPermission",
	      }
	    ]
	  }
	]
	"GlobalMethodCalls": [
	  {
	    "Class": {
	      "From": "android.app.PendingIntent",
	      "To": "com.microsoft.intune.mam.client.app.MAMPendingIntent"
	    },
	    "Methods": [
	      {
	        "MakeStatic": false,
	        "OriginalName": "getActivities"
	      },
	    ]
	  }
	]

While what the InTune team has *works*, it suffers from a number of
"workflow" problems, e.g. incremental builds are problematic (they
might try to rewrite assemblies which were already rewritten), IL
rewriting is *always* "fun", and if we change IL binding patterns,
they'll need to support previous "binding styles" and newer styles.

Introduce partial support for this scenario by adding the following
members to `Java.Interop.JniRuntime.JniTypeManager`:

	namespace Java.Interop {
	    public partial class JniRuntime {

	        public struct ReplacementMethodInfo {
	            public  string? SourceJniType                   {get; set;}
	            public  string? SourceJniMethodName             {get; set;}
	            public  string? SourceJniMethodSignature        {get; set;}
	            public  string? TargetJniType                   {get; set;}
	            public  string? TargetJniMethodName             {get; set;}
	            public  string? TargetJniMethodSignature        {get; set;}
	            public  int?    TargetJniMethodParameterCount   {get; set;}
	            public  bool    TargetJniMethodIsStatic         {get; set;}
	        }

	        public partial class JniTypeManager {

	            public string? GetReplacementType (string jniSimpleReference) =>
	                GetReplacementTypeCore (jniSimpleReference);
	            protected virtual string? GetReplacementTypeCore (string jniSimpleReference) => null;

	            public ReplacementMethodInfo? GetReplacementMethodInfo (string jniSimpleReference, string jniMethodName, string jniMethodSignature) =>
	                GetReplacementMethodInfoCore (jniSimpleReference, jniMethodName,jniMethodSignature);
	            protected virtual ReplacementMethodInfo? GetReplacementMethodInfoCore (string jniSimpleReference, string jniMethodName, string jniMethodSignature) => null;
	        }
	    }
	}

These new methods are used by `JniPeerMembers`.

Consider "normal" usage of `JniPeerMembers`, within a binding:

	partial class Activity {
	    static readonly JniPeerMembers _members = new XAPeerMembers (jniPeerTypeName:"android/app/Activity", managedPeerType:typeof (Activity));
	}

`JniRuntime.JniTypeManager.GetReplacementType()` allows "replacing"
the `jniPeerTypeName` value with a "replacement" JNI type name.
The "replacement" type will be used for all field and method lookups.
This allows supporting the `ClassRewrites[0].Class.From` / 
`ClassRewrites[0].Class.To` semantics.

`JniRuntime.JniTypeManager.GetReplacementMethodInfo()` is the key
integration for all other "replacement" semantics.  Given the
source type, source method name, and source JNI signature, it is
responsible for providing an *overriding* target type, target method
name, and target JNI signature.

For `ClassRewrites[0].Methods[0]`, this allows "renaming"
`Activity.onCreate()` to `MAMActivity.onMAMCreate()`:

	var r = JniEnvironment.Runtime.TypeManager.GetReplacementMethodInfo (
	    // Note: must match GetReplacementType() *output*, and since
	    // `Activity` is mapped to `MAMActivity`…
	    "com/microsoft/intune/mam/client/app/MAMActivity",
	    "onCreate",
	    "(Landroid/os/Bundle;)V"
	);
	// is equivalent to:
	var r = new JniRuntime.ReplacementMethodInfo {
	    SourceJniType                   = "com/microsoft/intune/mam/client/app/MAMActivity",
	                                                                // from input parameter
	    SourceJniMethodName             = "onCreate",               // from input parameter
	    SourceJniMethodSignature        = "(Landroid/os/Bundle;)V", // from input parameter

	    TargetJniType                   = "com/microsoft/intune/mam/client/app/MAMActivity",
	    TargetJniMethodName             = "onMAMCreate",
	    TargetJniMethodSignature        = null,                     // "use original value"
	    TargetJniMethodParameterCount   = null,                     // unchanged
	    TargetJniMethodIsStatic         = false,
	}

`ClassRewrites[1].Methods[0]` is "weird", in that it has
`MakeStatic: true`.  The semantics for when `MakeStatic: true` exists
is that the "original" method is an *instance* method, and the target
method is a *`static`* method, *and* the `this` instance now becomes
a *parameter* to the method.  This is likewise supported via
`JniRuntime.JniTypeManager.GetReplacementMethodInfo()`, and is
identified by:

 1. `ReplacementMethodInfo.TargetJniMethodParameterCount` being a
    non-`null` value, and

 2. `ReplacementMethodInfo.TargetJniMethodIsStatic` is true.

Thus, `ClassRewrites[1].Methods[0]` is akin to:

	var r = JniEnvironment.Runtime.TypeManager.GetReplacementMethodInfo (
	    "android/content/pm/PackageManager",
	    "checkPermission",
	    "(Ljava/lang/String;Ljava/lang/String;)I"
	);
	// is equivalent to:
	var r = new JniRuntime.ReplacementMethodInfo {
	    SourceJniType                   = "android/content/pm/PackageManager",          // from input parameter
	    SourceJniMethodName             = "checkPermission",                            // from input parameter
	    SourceJniMethodSignature        = "(Ljava/lang/String;Ljava/lang/String;)I",    // from input parameter

	    TargetJniType                   = "com/microsoft/intune/mam/client/content/pm/MAMPackageManagement",
	    TargetJniMethodName             = "CheckPermission",
	    TargetJniMethodSignature        = "(Landroid/content/pm/PackageManager;Ljava/lang/String;Ljava/lang/String;)I",
	                                      // Note: `PackageManager` is inserted as new first parameter
	    TargetJniMethodParameterCount   = 3,
	    TargetJniMethodIsStatic         = true,
	}

(Note that the subclass is responsible for providing this data.)

`ReplacementMethodInfo.TargetJniMethodParameterCount` must be the
number of parameters that the target method accepts.  This is needed
so that `JniPeerMembers.JniInstanceMethods.TryInvoke*StaticRedirect()`
can appropriately reallocate the `JniArgumentValue*` array, so that
the `this` parameter can be added to the beginning of the parameters.

~~ Overhead? ~~

All these extra invocations into `JniRuntime.JniTypeManager` imply
additional overhead to invoke a Java method.  However, this is all
done during the *first* time a method is looked up, after which the
`JniMethodInfo` instance is *cached* for a given
(type, method, signature) tuple.

To demonstrate overheads, `samples/Hello` has been updated to accept
a new `-t` value; when provided, it invokes the
`java.lang.Object.hashCode()` method 1 million times and calculates
the average invocation overhead:

	% dotnet run --project samples/Hello -- -t
	Object.hashCode: 1000000 invocations. Total=00:00:00.5196758; Average=0.0005196758ms

If we replace the .NET 6 `samples/Hello/bin/Debug/Java.Interop.dll`
assembly with e.g. `bin/Debug/Java.Interop.dll`, we can compare to
performance *without* these new changes, as the changes are only in
the .NET 6 build:

	% \cp bin/Debug/Java.Interop{.dll,.pdb} samples/Hello/bin/Debug
	% dotnet samples/Hello/bin/Debug/Hello.dll -t
	Object.hashCode: 1000000 invocations. Total=00:00:00.5386676; Average=0.0005386676ms

There is a fair bit of variation in `dotnet Hello.dll -t` output,
but they're all roughly similar.  There doesn't appear to be
significant overhead for this particular test.

~~ Other Changes ~~

Cleaned up the `JniPeerMembers` constructors.  The `Debug.Assert()`
calls were duplicative and redundant.

Replace the `Debug.Assert()` with `Debug.WriteLine()`.
`Mono.Android.NET-Tests.apk` was running into an "unfixable" scenario:

	WARNING: ManagedPeerType <=> JniTypeName Mismatch!
	javaVM.GetJniTypeInfoForType(typeof(Android.Runtime.JavaList)).JniTypeName="java/util/ArrayList" != "java/util/List"

This was because of [`Android.Runtime.JavaList`][5] using a
`JniPeerMembers` for `List` while registering `ArrayList`, causing
typemaps to associate `JavaList` with `ArrayList`:

	[Register ("java/util/ArrayList", DoNotGenerateAcw=true)]
	partial class JavaList {
	    internal static readonly JniPeerMembers list_members =
	        new XAPeerMembers ("java/util/List", typeof (JavaList), isInterface: true);
	}

@jonpryor doesn't want to try fixing this right now; turning the
assertion into a diagnostic message feels preferable.

[0]: https://en.wikipedia.org/wiki/Android_Runtime
[1]: https://developer.android.com/studio/write/java8-support
[2]: https://developer.android.com/studio/write/java8-support-table
[3]: https://docs.microsoft.com/en-us/mem/intune/developer/app-sdk-xamarin
[4]: https://www.nuget.org/packages/Microsoft.Intune.MAM.Remapper.Tasks/
[5]: https://github.com/xamarin/xamarin-android/blob/b250c04b09a2b725336ae6d6c5693e0b9f37e4cc/src/Mono.Android/Android.Runtime/JavaList.cs#L9-L13
