### PR TITLE
[Java.Interop.Tools.JavaSource] Replace TODO with To be added

### DIFF
--- a/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/SourceJavadocToXmldocGrammar.InlineTagsBnfTerms.cs
+++ b/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/SourceJavadocToXmldocGrammar.InlineTagsBnfTerms.cs
@@ -41,7 +41,8 @@ namespace Java.Interop.Tools.JavaSource {
 
 				InheritDocDeclaration.Rule = grammar.ToTerm ("{@inheritDoc}");
 				InheritDocDeclaration.AstConfig.NodeCreator = (context, parseNode) => {
-					parseNode.AstNode = new XText ("[TODO: @inheritDoc]");
+					// TODO: Iterate through parents for corresponding javadoc element.
+					parseNode.AstNode = new XText ("To be added");
 				};
 
 				LinkDeclaration.Rule = grammar.ToTerm ("{@link") + InlineValue + "}";
@@ -70,11 +71,13 @@ namespace Java.Interop.Tools.JavaSource {
 					| grammar.ToTerm ("{@value") + InlineValue + "}";
 				ValueDeclaration.AstConfig.NodeCreator = (context, parseNode) => {
 					if (parseNode.ChildNodes.Count > 1) {
+						// TODO: Need to convert to appropriate CREF value, use code text for now.
 						var field = parseNode.ChildNodes [1].AstNode.ToString ();
-						parseNode.AstNode = new XText ($"[TODO: @value for `{field}`]");
+						parseNode.AstNode = new XElement ("c", field);
 					}
 					else {
-						parseNode.AstNode = new XText ("[TODO: @value]");
+						// TODO: Display the value of the corresponding static field.
+						parseNode.AstNode = new XText ("To be added");
 					}
 				};
 			}

--- a/tests/Java.Interop.Tools.JavaSource-Tests/SourceJavadocToXmldocGrammar.InlineTagsBnfTermsTests.cs
+++ b/tests/Java.Interop.Tools.JavaSource-Tests/SourceJavadocToXmldocGrammar.InlineTagsBnfTermsTests.cs
@@ -41,7 +41,7 @@ namespace Java.Interop.Tools.JavaSource.Tests
 
 			var r = p.Parse ("{@inheritDoc}");
 			Assert.IsFalse (r.HasErrors (), DumpMessages (r, p));
-			Assert.AreEqual ("[TODO: @inheritDoc]", r.Root.AstNode.ToString ());
+			Assert.AreEqual ("To be added", r.Root.AstNode.ToString ());
 		}
 
 		[Test]
@@ -82,11 +82,11 @@ namespace Java.Interop.Tools.JavaSource.Tests
 
 			var r = p.Parse ("{@value}");
 			Assert.IsFalse (r.HasErrors (), DumpMessages (r, p));
-			Assert.AreEqual ("[TODO: @value]", r.Root.AstNode.ToString ());
+			Assert.AreEqual ("To be added", r.Root.AstNode.ToString ());
 
 			r = p.Parse ("{@value #field}");
 			Assert.IsFalse (r.HasErrors (), DumpMessages (r, p));
-			Assert.AreEqual ("[TODO: @value for `#field`]", r.Root.AstNode.ToString ());
+			Assert.AreEqual ("<c>#field</c>", r.Root.AstNode.ToString ());
 		}
 	}
 }


### PR DESCRIPTION
Partially fixes: https://github.com/xamarin/java.interop/issues/907

Replaces `[TODO: @tag]` values in generated docs with `To be added` to
better mirror mdoc behavior for missing elements.

Inline `{@value }` tags that contain an argument have been updated to
display the argument in a `<c/>` block.  These should be fixed to use
an appropriate CREF element in the future, see https://github.com/xamarin/java.interop/issues/843.

The last remaining `[TODO: @{docRoot}]` output will be fixed as part of
https://github.com/xamarin/java.interop/pull/930.