### PR TITLE
[generator] Add support for <ns-replace> metadata.

### DIFF
--- a/src/Java.Interop.Localization/Resources.Designer.cs
+++ b/src/Java.Interop.Localization/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Java.Interop.Localization {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -381,6 +381,15 @@ namespace Java.Interop.Localization {
         public static string Generator_BG8A00 {
             get {
                 return ResourceManager.GetString("Generator_BG8A00", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid namespace transform &apos;{0}&apos;.
+        /// </summary>
+        public static string Generator_BG8A07 {
+            get {
+                return ResourceManager.GetString("Generator_BG8A07", resourceCulture);
             }
         }
         

--- a/src/Java.Interop.Localization/Resources.resx
+++ b/src/Java.Interop.Localization/Resources.resx
@@ -286,6 +286,10 @@ The following terms should not be translated: &lt;package&gt;.</comment>
     <comment>{0} - XML transform. (example: '&lt;remove-node path="/api/package[@name='javax.sql']"')
 The following terms should not be translated: Metadata.xml.</comment>
   </data>
+  <data name="Generator_BG8A07" xml:space="preserve">
+    <value>Invalid namespace transform '{0}'</value>
+    <comment>{0} - XML transform. (example: '&lt;ns-replace source="example" replacement="Example" /&gt;')</comment>
+  </data>
   <data name="Generator_BG8B00" xml:space="preserve">
     <value>Unknown generic argument constraint type '{0}' for member '{1}'.</value>
     <comment>{0} - .NET type name

--- a/src/Java.Interop.Localization/xlf/Resources.cs.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.cs.xlf
@@ -207,6 +207,11 @@ The following terms should not be translated: &lt;package&gt;.</note>
         <note>{0} - XML transform. (example: '&lt;remove-node path="/api/package[@name='javax.sql']"')
 The following terms should not be translated: Metadata.xml.</note>
       </trans-unit>
+      <trans-unit id="Generator_BG8A07">
+        <source>Invalid namespace transform '{0}'</source>
+        <target state="new">Invalid namespace transform '{0}'</target>
+        <note>{0} - XML transform. (example: '&lt;ns-replace source="example" replacement="Example" /&gt;')</note>
+      </trans-unit>
       <trans-unit id="Generator_BG8B00">
         <source>Unknown generic argument constraint type '{0}' for member '{1}'.</source>
         <target state="new">Unknown generic argument constraint type '{0}' for member '{1}'.</target>

--- a/src/Java.Interop.Localization/xlf/Resources.de.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.de.xlf
@@ -207,6 +207,11 @@ The following terms should not be translated: &lt;package&gt;.</note>
         <note>{0} - XML transform. (example: '&lt;remove-node path="/api/package[@name='javax.sql']"')
 The following terms should not be translated: Metadata.xml.</note>
       </trans-unit>
+      <trans-unit id="Generator_BG8A07">
+        <source>Invalid namespace transform '{0}'</source>
+        <target state="new">Invalid namespace transform '{0}'</target>
+        <note>{0} - XML transform. (example: '&lt;ns-replace source="example" replacement="Example" /&gt;')</note>
+      </trans-unit>
       <trans-unit id="Generator_BG8B00">
         <source>Unknown generic argument constraint type '{0}' for member '{1}'.</source>
         <target state="new">Unknown generic argument constraint type '{0}' for member '{1}'.</target>

--- a/src/Java.Interop.Localization/xlf/Resources.es.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.es.xlf
@@ -207,6 +207,11 @@ The following terms should not be translated: &lt;package&gt;.</note>
         <note>{0} - XML transform. (example: '&lt;remove-node path="/api/package[@name='javax.sql']"')
 The following terms should not be translated: Metadata.xml.</note>
       </trans-unit>
+      <trans-unit id="Generator_BG8A07">
+        <source>Invalid namespace transform '{0}'</source>
+        <target state="new">Invalid namespace transform '{0}'</target>
+        <note>{0} - XML transform. (example: '&lt;ns-replace source="example" replacement="Example" /&gt;')</note>
+      </trans-unit>
       <trans-unit id="Generator_BG8B00">
         <source>Unknown generic argument constraint type '{0}' for member '{1}'.</source>
         <target state="new">Unknown generic argument constraint type '{0}' for member '{1}'.</target>

--- a/src/Java.Interop.Localization/xlf/Resources.fr.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.fr.xlf
@@ -207,6 +207,11 @@ The following terms should not be translated: &lt;package&gt;.</note>
         <note>{0} - XML transform. (example: '&lt;remove-node path="/api/package[@name='javax.sql']"')
 The following terms should not be translated: Metadata.xml.</note>
       </trans-unit>
+      <trans-unit id="Generator_BG8A07">
+        <source>Invalid namespace transform '{0}'</source>
+        <target state="new">Invalid namespace transform '{0}'</target>
+        <note>{0} - XML transform. (example: '&lt;ns-replace source="example" replacement="Example" /&gt;')</note>
+      </trans-unit>
       <trans-unit id="Generator_BG8B00">
         <source>Unknown generic argument constraint type '{0}' for member '{1}'.</source>
         <target state="new">Unknown generic argument constraint type '{0}' for member '{1}'.</target>

--- a/src/Java.Interop.Localization/xlf/Resources.it.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.it.xlf
@@ -207,6 +207,11 @@ The following terms should not be translated: &lt;package&gt;.</note>
         <note>{0} - XML transform. (example: '&lt;remove-node path="/api/package[@name='javax.sql']"')
 The following terms should not be translated: Metadata.xml.</note>
       </trans-unit>
+      <trans-unit id="Generator_BG8A07">
+        <source>Invalid namespace transform '{0}'</source>
+        <target state="new">Invalid namespace transform '{0}'</target>
+        <note>{0} - XML transform. (example: '&lt;ns-replace source="example" replacement="Example" /&gt;')</note>
+      </trans-unit>
       <trans-unit id="Generator_BG8B00">
         <source>Unknown generic argument constraint type '{0}' for member '{1}'.</source>
         <target state="new">Unknown generic argument constraint type '{0}' for member '{1}'.</target>

--- a/src/Java.Interop.Localization/xlf/Resources.ja.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.ja.xlf
@@ -207,6 +207,11 @@ The following terms should not be translated: &lt;package&gt;.</note>
         <note>{0} - XML transform. (example: '&lt;remove-node path="/api/package[@name='javax.sql']"')
 The following terms should not be translated: Metadata.xml.</note>
       </trans-unit>
+      <trans-unit id="Generator_BG8A07">
+        <source>Invalid namespace transform '{0}'</source>
+        <target state="new">Invalid namespace transform '{0}'</target>
+        <note>{0} - XML transform. (example: '&lt;ns-replace source="example" replacement="Example" /&gt;')</note>
+      </trans-unit>
       <trans-unit id="Generator_BG8B00">
         <source>Unknown generic argument constraint type '{0}' for member '{1}'.</source>
         <target state="new">Unknown generic argument constraint type '{0}' for member '{1}'.</target>

--- a/src/Java.Interop.Localization/xlf/Resources.ko.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.ko.xlf
@@ -207,6 +207,11 @@ The following terms should not be translated: &lt;package&gt;.</note>
         <note>{0} - XML transform. (example: '&lt;remove-node path="/api/package[@name='javax.sql']"')
 The following terms should not be translated: Metadata.xml.</note>
       </trans-unit>
+      <trans-unit id="Generator_BG8A07">
+        <source>Invalid namespace transform '{0}'</source>
+        <target state="new">Invalid namespace transform '{0}'</target>
+        <note>{0} - XML transform. (example: '&lt;ns-replace source="example" replacement="Example" /&gt;')</note>
+      </trans-unit>
       <trans-unit id="Generator_BG8B00">
         <source>Unknown generic argument constraint type '{0}' for member '{1}'.</source>
         <target state="new">Unknown generic argument constraint type '{0}' for member '{1}'.</target>

--- a/src/Java.Interop.Localization/xlf/Resources.pl.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.pl.xlf
@@ -207,6 +207,11 @@ The following terms should not be translated: &lt;package&gt;.</note>
         <note>{0} - XML transform. (example: '&lt;remove-node path="/api/package[@name='javax.sql']"')
 The following terms should not be translated: Metadata.xml.</note>
       </trans-unit>
+      <trans-unit id="Generator_BG8A07">
+        <source>Invalid namespace transform '{0}'</source>
+        <target state="new">Invalid namespace transform '{0}'</target>
+        <note>{0} - XML transform. (example: '&lt;ns-replace source="example" replacement="Example" /&gt;')</note>
+      </trans-unit>
       <trans-unit id="Generator_BG8B00">
         <source>Unknown generic argument constraint type '{0}' for member '{1}'.</source>
         <target state="new">Unknown generic argument constraint type '{0}' for member '{1}'.</target>

--- a/src/Java.Interop.Localization/xlf/Resources.pt-BR.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.pt-BR.xlf
@@ -207,6 +207,11 @@ The following terms should not be translated: &lt;package&gt;.</note>
         <note>{0} - XML transform. (example: '&lt;remove-node path="/api/package[@name='javax.sql']"')
 The following terms should not be translated: Metadata.xml.</note>
       </trans-unit>
+      <trans-unit id="Generator_BG8A07">
+        <source>Invalid namespace transform '{0}'</source>
+        <target state="new">Invalid namespace transform '{0}'</target>
+        <note>{0} - XML transform. (example: '&lt;ns-replace source="example" replacement="Example" /&gt;')</note>
+      </trans-unit>
       <trans-unit id="Generator_BG8B00">
         <source>Unknown generic argument constraint type '{0}' for member '{1}'.</source>
         <target state="new">Unknown generic argument constraint type '{0}' for member '{1}'.</target>

--- a/src/Java.Interop.Localization/xlf/Resources.ru.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.ru.xlf
@@ -207,6 +207,11 @@ The following terms should not be translated: &lt;package&gt;.</note>
         <note>{0} - XML transform. (example: '&lt;remove-node path="/api/package[@name='javax.sql']"')
 The following terms should not be translated: Metadata.xml.</note>
       </trans-unit>
+      <trans-unit id="Generator_BG8A07">
+        <source>Invalid namespace transform '{0}'</source>
+        <target state="new">Invalid namespace transform '{0}'</target>
+        <note>{0} - XML transform. (example: '&lt;ns-replace source="example" replacement="Example" /&gt;')</note>
+      </trans-unit>
       <trans-unit id="Generator_BG8B00">
         <source>Unknown generic argument constraint type '{0}' for member '{1}'.</source>
         <target state="new">Unknown generic argument constraint type '{0}' for member '{1}'.</target>

--- a/src/Java.Interop.Localization/xlf/Resources.tr.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.tr.xlf
@@ -207,6 +207,11 @@ The following terms should not be translated: &lt;package&gt;.</note>
         <note>{0} - XML transform. (example: '&lt;remove-node path="/api/package[@name='javax.sql']"')
 The following terms should not be translated: Metadata.xml.</note>
       </trans-unit>
+      <trans-unit id="Generator_BG8A07">
+        <source>Invalid namespace transform '{0}'</source>
+        <target state="new">Invalid namespace transform '{0}'</target>
+        <note>{0} - XML transform. (example: '&lt;ns-replace source="example" replacement="Example" /&gt;')</note>
+      </trans-unit>
       <trans-unit id="Generator_BG8B00">
         <source>Unknown generic argument constraint type '{0}' for member '{1}'.</source>
         <target state="new">Unknown generic argument constraint type '{0}' for member '{1}'.</target>

--- a/src/Java.Interop.Localization/xlf/Resources.zh-Hans.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.zh-Hans.xlf
@@ -207,6 +207,11 @@ The following terms should not be translated: &lt;package&gt;.</note>
         <note>{0} - XML transform. (example: '&lt;remove-node path="/api/package[@name='javax.sql']"')
 The following terms should not be translated: Metadata.xml.</note>
       </trans-unit>
+      <trans-unit id="Generator_BG8A07">
+        <source>Invalid namespace transform '{0}'</source>
+        <target state="new">Invalid namespace transform '{0}'</target>
+        <note>{0} - XML transform. (example: '&lt;ns-replace source="example" replacement="Example" /&gt;')</note>
+      </trans-unit>
       <trans-unit id="Generator_BG8B00">
         <source>Unknown generic argument constraint type '{0}' for member '{1}'.</source>
         <target state="new">Unknown generic argument constraint type '{0}' for member '{1}'.</target>

--- a/src/Java.Interop.Localization/xlf/Resources.zh-Hant.xlf
+++ b/src/Java.Interop.Localization/xlf/Resources.zh-Hant.xlf
@@ -207,6 +207,11 @@ The following terms should not be translated: &lt;package&gt;.</note>
         <note>{0} - XML transform. (example: '&lt;remove-node path="/api/package[@name='javax.sql']"')
 The following terms should not be translated: Metadata.xml.</note>
       </trans-unit>
+      <trans-unit id="Generator_BG8A07">
+        <source>Invalid namespace transform '{0}'</source>
+        <target state="new">Invalid namespace transform '{0}'</target>
+        <note>{0} - XML transform. (example: '&lt;ns-replace source="example" replacement="Example" /&gt;')</note>
+      </trans-unit>
       <trans-unit id="Generator_BG8B00">
         <source>Unknown generic argument constraint type '{0}' for member '{1}'.</source>
         <target state="new">Unknown generic argument constraint type '{0}' for member '{1}'.</target>

--- a/src/Java.Interop.Tools.Generator/Extensions/UtilityExtensions.cs
+++ b/src/Java.Interop.Tools.Generator/Extensions/UtilityExtensions.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Text;
 using System.Xml;
 using System.Xml.Linq;
 
@@ -40,6 +42,34 @@ namespace Java.Interop.Tools.Generator
 			}
 
 			return null;
+		}
+
+		// A case-insensitive Replace doesn't exist in classic .NET Framework.  Loosely based on:
+		// https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+		public static string ReplaceOrdinalIgnoreCase (this string source, string oldValue, string newValue)
+		{
+			var result = new StringBuilder ();
+			var pos = 0;
+
+			while (true) {
+				var index = source.IndexOf (oldValue, pos, StringComparison.OrdinalIgnoreCase);
+
+				// Not found, bail
+				if (index < 0)
+					break;
+
+				// Append the unmodified portion of search space
+				result.Append (source.Substring (pos, index));
+
+				// Append the replacement
+				result.Append (newValue);
+
+				pos = index + oldValue.Length;
+			}
+
+			// Append what remains of the search space, then allocate the new string.
+			result.Append (source.Substring (pos));
+			return result.ToString ();
 		}
 	}
 }

--- a/src/Java.Interop.Tools.Generator/Metadata/FixupXmlDocument.cs
+++ b/src/Java.Interop.Tools.Generator/Metadata/FixupXmlDocument.cs
@@ -169,7 +169,7 @@ namespace Java.Interop.Tools.Generator
 			}
 		}
 
-		public List<NamespaceTransform> GetNamespaceTransforms ()
+		public IList<NamespaceTransform> GetNamespaceTransforms ()
 		{
 			var list = new List<NamespaceTransform> ();
 

--- a/src/Java.Interop.Tools.Generator/Metadata/FixupXmlDocument.cs
+++ b/src/Java.Interop.Tools.Generator/Metadata/FixupXmlDocument.cs
@@ -4,6 +4,7 @@ using System.Xml.XPath;
 using System.Xml.Linq;
 
 using Xamarin.Android.Tools;
+using System.Collections.Generic;
 
 namespace Java.Interop.Tools.Generator
 {
@@ -166,6 +167,18 @@ namespace Java.Interop.Tools.Generator
 					break;
 				}
 			}
+		}
+
+		public List<NamespaceTransform> GetNamespaceTransforms ()
+		{
+			var list = new List<NamespaceTransform> ();
+
+			foreach (var xe in FixupDocument.XPathSelectElements ("/metadata/ns-replace")) {
+				if (NamespaceTransform.TryParse (xe, out var transform))
+					list.Add (transform);
+			}
+
+			return list;
 		}
 
 		bool ShouldSkip (XElement node, int apiLevel, int productVersion)

--- a/src/Java.Interop.Tools.Generator/Metadata/NamespaceTransform.cs
+++ b/src/Java.Interop.Tools.Generator/Metadata/NamespaceTransform.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Xml.Linq;
+using Xamarin.Android.Tools;
+
+namespace Java.Interop.Tools.Generator
+{
+	public class NamespaceTransform
+	{
+		public string OldValue { get; }
+		public string NewValue { get; }
+		public bool IsStartsWith { get; }
+		public bool IsEndsWith { get; }
+
+		public NamespaceTransform (string oldValue, string newValue)
+		{
+			OldValue = oldValue;
+			NewValue = newValue;
+
+			if (OldValue.EndsWith (".", StringComparison.Ordinal)) {
+				IsStartsWith = true;
+				OldValue = OldValue.Substring (0, OldValue.Length - 1);
+			}
+
+			if (OldValue.StartsWith (".", StringComparison.Ordinal)) {
+				IsEndsWith = true;
+				OldValue = OldValue.Substring (1);
+			}
+		}
+
+		public string ApplyInternal (string value)
+		{
+			string result;
+
+			while (true) {
+				result = ApplyInternal (value);
+
+				if (result == value)
+					return result;
+
+				value = result;
+			}
+		}
+
+		public string Apply (string value)
+		{
+			// Handle a "starts with" transform
+			if (IsStartsWith) {
+				if (value.StartsWith (OldValue, StringComparison.OrdinalIgnoreCase))
+					return (NewValue + value.Substring (OldValue.Length)).TrimStart ('.');
+
+				return value;
+			}
+
+			// Handle an "ends with" transform
+			if (IsEndsWith) {
+				if (value.EndsWith (OldValue, StringComparison.OrdinalIgnoreCase))
+					return (value.Substring (0, value.Length - OldValue.Length) + NewValue).TrimEnd ('.');
+
+				return value;
+			}
+
+			// Handle an "anywhere" transform
+			var value_tokens = value.Split ('.');
+			var match_tokens = OldValue.Split ('.');
+
+			var results = new List<string> ();
+
+			for (var i = 0; i < value_tokens.Length; i++) {
+				if (AtMatch (value_tokens, i, match_tokens, 0)) {
+					if (NewValue.HasValue ())
+						results.Add (NewValue);
+
+					i += match_tokens.Length - 1;
+				} else {
+					results.Add (value_tokens [i]);
+				}
+			}
+
+			return string.Join (".", results.ToArray ());
+		}
+
+		public static bool TryParse (XElement element, [NotNullWhen (true)] out NamespaceTransform? transform)
+		{
+			var source = element.XGetAttribute ("source");
+			var replacement = element.XGetAttribute ("replacement");
+
+			if (!source.HasValue () || replacement is null) {
+				Report.LogCodedWarning (0, Report.WarningInvalidNamespaceTransform, null, element, element.ToString ());
+				transform = null;
+				return false;
+			}
+
+			transform = new NamespaceTransform (source, replacement);
+			return true;
+		}
+
+		private bool AtMatch (string [] valueTokens, int valueIndex, string [] matchTokens, int matchIndex)
+		{
+			if (matchIndex >= matchTokens.Length)
+				return true;
+
+			if (valueIndex >= valueTokens.Length)
+				return false;
+
+			if (string.Compare (valueTokens [valueIndex], matchTokens [matchIndex], StringComparison.OrdinalIgnoreCase) == 0)
+				return AtMatch (valueTokens, valueIndex + 1, matchTokens, matchIndex + 1);
+
+			return false;
+		}
+	}
+}
+

--- a/src/Java.Interop.Tools.Generator/Metadata/NamespaceTransform.cs
+++ b/src/Java.Interop.Tools.Generator/Metadata/NamespaceTransform.cs
@@ -45,6 +45,15 @@ namespace Java.Interop.Tools.Generator
 
 		public string Apply (string value)
 		{
+			// Handle a "starts with" and "ends with" transform
+			if (IsStartsWith && IsEndsWith) {
+				if (value.Equals (OldValue, StringComparison.OrdinalIgnoreCase))
+					return NewValue;
+
+				// Don't let this fall through
+				return value;
+			}
+
 			// Handle a "starts with" transform
 			if (IsStartsWith) {
 				if (value.StartsWith (OldValue, StringComparison.OrdinalIgnoreCase))
@@ -78,7 +87,7 @@ namespace Java.Interop.Tools.Generator
 				}
 			}
 
-			return string.Join (".", results.ToArray ());
+			return string.Join (".", results);
 		}
 
 		public static bool TryParse (XElement element, [NotNullWhen (true)] out NamespaceTransform? transform)

--- a/src/Java.Interop.Tools.Generator/Utilities/Report.cs
+++ b/src/Java.Interop.Tools.Generator/Utilities/Report.cs
@@ -67,6 +67,7 @@ namespace Java.Interop.Tools.Generator
 		public static LocalizedMessage WarningAttrMatchedNoNodes => new LocalizedMessage (0x8A04, Localization.Resources.Generator_BG8A00);
 		public static LocalizedMessage WarningMoveNodeMatchedNoNodes => new LocalizedMessage (0x8A05, Localization.Resources.Generator_BG8A00);
 		public static LocalizedMessage WarningRemoveAttrMatchedNoNodes => new LocalizedMessage (0x8A06, Localization.Resources.Generator_BG8A00);
+		public static LocalizedMessage WarningInvalidNamespaceTransform => new LocalizedMessage (0x8A07, Localization.Resources.Generator_BG8A07);
 		public static LocalizedMessage WarningUnknownGenericConstraint => new LocalizedMessage (0x8B00, Localization.Resources.Generator_BG8B00);
 		public static LocalizedMessage WarningBaseInterfaceNotFound => new LocalizedMessage (0x8C00, Localization.Resources.Generator_BG8C00);
 		public static LocalizedMessage WarningBaseInterfaceInvalid => new LocalizedMessage (0x8C01, Localization.Resources.Generator_BG8C01);

--- a/tests/Java.Interop.Tools.Generator-Tests/Metadata/NamespaceTransformTests.cs
+++ b/tests/Java.Interop.Tools.Generator-Tests/Metadata/NamespaceTransformTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Xml.Linq;
+using Java.Interop.Tools.Generator;
+using NUnit.Framework;
+
+namespace Java.Interop.Tools.Generator_Tests
+{
+	public class NamespaceTransformTests
+	{
+		[Test]
+		public void ParseNamespaceTransform ()
+		{
+			var doc = XDocument.Parse ("<metadata><ns-replace source='com.example' replacement='Xamarin' /></metadata>");
+			var result = NamespaceTransform.TryParse (doc.Root.Element ("ns-replace"), out var nt);
+
+			Assert.IsTrue (result);
+			Assert.IsNotNull (nt);
+			Assert.AreEqual ("com.example", nt.OldValue);
+			Assert.AreEqual ("Xamarin", nt.NewValue);
+		}
+
+		[Test]
+		public void ParseNamespaceTransform2 ()
+		{
+			var doc = XDocument.Parse ("<metadata><ns-replace source='com.example' replacement='' /></metadata>");
+			var result = NamespaceTransform.TryParse (doc.Root.Element ("ns-replace"), out var nt);
+
+			Assert.IsTrue (result);
+			Assert.IsNotNull (nt);
+			Assert.AreEqual ("com.example", nt.OldValue);
+			Assert.AreEqual ("", nt.NewValue);
+		}
+
+		[Test]
+		public void ParseInvalidNamespaceTransform ()
+		{
+			// Logs: warning BG8A07: Invalid namespace transform '<ns-replace source="com.example" />'
+			var doc = XDocument.Parse ("<metadata><ns-replace source='com.example' /></metadata>");
+			var result = NamespaceTransform.TryParse (doc.Root.Element ("ns-replace"), out var nt);
+
+			Assert.IsFalse (result);
+			Assert.IsNull (nt);
+		}
+
+		[Test]
+		public void ParseInvalidNamespaceTransform2 ()
+		{
+			// Logs: warning BG8A07: Invalid namespace transform '<ns-replace source="" replacement="Xamarin" />'
+			var doc = XDocument.Parse ("<metadata><ns-replace source='' replacement='Xamarin' /></metadata>");
+			var result = NamespaceTransform.TryParse (doc.Root.Element ("ns-replace"), out var nt);
+
+			Assert.IsFalse (result);
+			Assert.IsNull (nt);
+		}
+
+		[Test]
+		public void GetTransformedNamespace ()
+		{
+			// Normal and case-insensitive
+			AssertTransformedNamespace ("Androidx.Core", "AndroidX.Core", new NamespaceTransform ("Androidx", "AndroidX"));
+			AssertTransformedNamespace ("Androidx.Core", "AndroidX.Core", new NamespaceTransform ("androidx", "AndroidX"));
+
+			// Replace 1 level with 2
+			AssertTransformedNamespace ("Androidx.Core", "Xamarin.AndroidX.Core", new NamespaceTransform ("androidx", "Xamarin.AndroidX"));
+
+			// Replace 2 levels with 1
+			AssertTransformedNamespace ("Google.Androidx.Core", "AndroidX.Core", new NamespaceTransform ("Google.Androidx", "AndroidX"));
+
+			// Replace 2 levels with 2
+			AssertTransformedNamespace ("Google.Androidx.Core", "Xamarin.AndroidX.Core", new NamespaceTransform ("Google.Androidx", "Xamarin.AndroidX"));
+
+			// Removing a match
+			AssertTransformedNamespace ("Androidx.Core.Test", "Androidx.Test", new NamespaceTransform ("core", ""));
+			AssertTransformedNamespace ("Androidx.Core.Test", "Androidx.Core", new NamespaceTransform ("test", ""));
+			AssertTransformedNamespace ("Androidx.Core.Test", "Core.Test", new NamespaceTransform ("androidx", ""));
+
+			// Multiple matches
+			AssertTransformedNamespace ("Androidx.Androidx.Core", "AndroidX.AndroidX.Core", new NamespaceTransform ("androidx", "AndroidX"));
+			AssertTransformedNamespace ("google.androidx.Core", "Xamarin.AndroidX.Core", new NamespaceTransform ("androidx", "AndroidX"), new NamespaceTransform ("google", "Xamarin"));
+
+			// Starts with
+			AssertTransformedNamespace ("Androidx.Androidx.Core", "AndroidX2.Androidx.Core", new NamespaceTransform ("AndroidX.", "AndroidX2"));
+			AssertTransformedNamespace ("Androidx.Androidx.Core", "Androidx.Core", new NamespaceTransform ("AndroidX.", ""));
+
+			// Ends with
+			AssertTransformedNamespace ("Androidx.Core.Core", "Androidx.Core.Core2", new NamespaceTransform (".core", "Core2"));
+			AssertTransformedNamespace ("Androidx.Core.Core", "Androidx.Core", new NamespaceTransform (".core", ""));
+
+			// Only matches full level
+			AssertTransformedNamespace ("AndroidX.Test.Tests", "AndroidX.NewTest.Tests", new NamespaceTransform ("Test", "NewTest"));
+		}
+
+		void AssertTransformedNamespace (string value, string expected, params NamespaceTransform [] transforms)
+		{
+			foreach (var nt in transforms)
+				value = nt.Apply (value);
+
+			Assert.AreEqual (expected, value);
+		}
+	}
+}

--- a/tests/Java.Interop.Tools.Generator-Tests/Metadata/NamespaceTransformTests.cs
+++ b/tests/Java.Interop.Tools.Generator-Tests/Metadata/NamespaceTransformTests.cs
@@ -78,6 +78,12 @@ namespace Java.Interop.Tools.Generator_Tests
 			AssertTransformedNamespace ("Androidx.Androidx.Core", "AndroidX.AndroidX.Core", new NamespaceTransform ("androidx", "AndroidX"));
 			AssertTransformedNamespace ("google.androidx.Core", "Xamarin.AndroidX.Core", new NamespaceTransform ("androidx", "AndroidX"), new NamespaceTransform ("google", "Xamarin"));
 
+			// Starts with and ends with
+			AssertTransformedNamespace ("example", "Transformed", new NamespaceTransform (".example.", "Transformed"));
+			AssertTransformedNamespace ("Androidx.Core", "Transformed", new NamespaceTransform (".Androidx.Core.", "Transformed"));
+			AssertTransformedNamespace ("Androidx.Core", "Androidx.Core", new NamespaceTransform (".Core.", "Transformed"));
+			AssertTransformedNamespace ("Androidx.Core", "Androidx.Core", new NamespaceTransform (".AndroidX.", "Transformed"));
+
 			// Starts with
 			AssertTransformedNamespace ("Androidx.Androidx.Core", "AndroidX2.Androidx.Core", new NamespaceTransform ("AndroidX.", "AndroidX2"));
 			AssertTransformedNamespace ("Androidx.Androidx.Core", "Androidx.Core", new NamespaceTransform ("AndroidX.", ""));

--- a/tests/generator-Tests/Integration-Tests/BaseGeneratorTest.cs
+++ b/tests/generator-Tests/Integration-Tests/BaseGeneratorTest.cs
@@ -121,12 +121,12 @@ namespace generatortests
 			}
 		}
 
-		protected void RunAllTargets (string outputRelativePath, string apiDescriptionFile, string expectedRelativePath, string[] additionalSupportPaths = null, string enumFieldsMapFile = null, string enumMethodMapFile = null)
+		protected void RunAllTargets (string outputRelativePath, string apiDescriptionFile, string expectedRelativePath, string[] additionalSupportPaths = null, string enumFieldsMapFile = null, string enumMethodMapFile = null, string metadataFile = null)
 		{
-			Run (CodeGenerationTarget.XamarinAndroid,   Path.Combine ("out", outputRelativePath),       apiDescriptionFile,     Path.Combine ("expected", expectedRelativePath),        additionalSupportPaths, enumFieldsMapFile, enumMethodMapFile);
-			Run (CodeGenerationTarget.XAJavaInterop1,   Path.Combine ("out.xaji", outputRelativePath),  apiDescriptionFile,     Path.Combine ("expected.xaji", expectedRelativePath),     additionalSupportPaths, enumFieldsMapFile, enumMethodMapFile);
+			Run (CodeGenerationTarget.XamarinAndroid,   Path.Combine ("out", outputRelativePath),       apiDescriptionFile,     Path.Combine ("expected", expectedRelativePath),        additionalSupportPaths, enumFieldsMapFile, enumMethodMapFile, metadataFile);
+			Run (CodeGenerationTarget.XAJavaInterop1,   Path.Combine ("out.xaji", outputRelativePath),  apiDescriptionFile,     Path.Combine ("expected.xaji", expectedRelativePath),     additionalSupportPaths, enumFieldsMapFile, enumMethodMapFile, metadataFile);
 			if (TryJavaInterop1) {
-				Run (CodeGenerationTarget.JavaInterop1,     Path.Combine ("out.ji", outputRelativePath),    apiDescriptionFile,     Path.Combine ("expected.ji", expectedRelativePath),     additionalSupportPaths, enumFieldsMapFile, enumMethodMapFile);
+				Run (CodeGenerationTarget.JavaInterop1,     Path.Combine ("out.ji", outputRelativePath),    apiDescriptionFile,     Path.Combine ("expected.ji", expectedRelativePath),     additionalSupportPaths, enumFieldsMapFile, enumMethodMapFile, metadataFile);
 			}
 		}
 
@@ -136,7 +136,7 @@ namespace generatortests
 			return Path.Combine (dir, path.Replace ('/', Path.DirectorySeparatorChar));
 		}
 
-		protected void Run (CodeGenerationTarget target, string outputPath, string apiDescriptionFile, string expectedPath, string[] additionalSupportPaths = null, string enumFieldsMapFile = null, string enumMethodMapFile = null)
+		protected void Run (CodeGenerationTarget target, string outputPath, string apiDescriptionFile, string expectedPath, string[] additionalSupportPaths = null, string enumFieldsMapFile = null, string enumMethodMapFile = null, string metadataFile = null)
 		{
 			Cleanup (outputPath);
 			AdditionalSourceDirectories.Clear ();
@@ -150,6 +150,9 @@ namespace generatortests
 
 			if (!string.IsNullOrWhiteSpace (enumMethodMapFile))
 				Options.EnumMethodsMapFile = FullPath (enumMethodMapFile);
+
+			if (!string.IsNullOrWhiteSpace (metadataFile))
+				Options.FixupFiles.Add (metadataFile);
 
 			var adjuster_output = Path.Combine (Path.GetTempPath (), "generator-tests");
 			Directory.CreateDirectory (adjuster_output);

--- a/tests/generator-Tests/Integration-Tests/Core_ClassParse.cs
+++ b/tests/generator-Tests/Integration-Tests/Core_ClassParse.cs
@@ -14,7 +14,8 @@ namespace generatortests
 			RunAllTargets (
 					outputRelativePath: "Core_ClassParse",
 					apiDescriptionFile: "expected/Core_ClassParse/api.xml",
-					expectedRelativePath: "Core_ClassParse");
+					expectedRelativePath: "Core_ClassParse",
+					metadataFile: FullPath ("expected/Core_ClassParse/metadata.xml"));
 		}
 	}
 }

--- a/tests/generator-Tests/Unit-Tests/FixupXmlDocumentTests.cs
+++ b/tests/generator-Tests/Unit-Tests/FixupXmlDocumentTests.cs
@@ -85,6 +85,19 @@ namespace generatortests
 			Assert.AreEqual ("<api><package /><package name='java' jni-name='java' /></api>", api.ApiDocument.ToString (SaveOptions.DisableFormatting).Replace ('\"', '\''));
 		}
 
+		[Test]
+		public void ParseNamespaceTransforms ()
+		{
+			var fixup = GetFixupXmlDocument ("<ns-replace source='androidx' replacement='AndroidX' /><ns-replace source='com.google' replacement='Xamarin' />");
+			var transforms = fixup.GetNamespaceTransforms ();
+
+			Assert.AreEqual (2, transforms.Count);
+			Assert.AreEqual ("androidx", transforms [0].OldValue);
+			Assert.AreEqual ("AndroidX", transforms [0].NewValue);
+			Assert.AreEqual ("com.google", transforms [1].OldValue);
+			Assert.AreEqual ("Xamarin", transforms [1].NewValue);
+		}
+
 		ApiXmlDocument GetXmlApiDocument ()
 		{
 			var api = "<api><package name='android' jni-name='android' /><package name='java' jni-name='java' /></api>";

--- a/tests/generator-Tests/Unit-Tests/XmlApiImporterTests.cs
+++ b/tests/generator-Tests/Unit-Tests/XmlApiImporterTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
+using Java.Interop.Tools.Generator;
 using MonoDroid.Generation;
 using NUnit.Framework;
 
@@ -301,6 +302,26 @@ namespace generatortests
 
 			// None of these should be parsed because the user has said they are obfuscated
 			Assert.AreEqual (0, gens.Count);
+		}
+
+		[Test]
+		public void TransformNamespaces ()
+		{
+			var xml = XDocument.Parse (@"
+				<api>
+					<package name='com.example.test' jni-name='com/example/test'>
+						<class name='MyClass' visibility='public' />
+					</package>
+				</api>");
+
+			var opt = new CodeGenerationOptions ();
+			opt.NamespaceTransforms.Add (new NamespaceTransform ("com.example", "Example"));
+			opt.NamespaceTransforms.Add (new NamespaceTransform (".test", "Tests"));
+
+			var gens = XmlApiImporter.Parse (xml, opt);
+
+			Assert.AreEqual (1, gens.Count);
+			Assert.AreEqual ("Example.Tests", gens [0].Namespace);
 		}
 	}
 }

--- a/tests/generator-Tests/expected.ji/Core_ClassParse/Mono.Android.projitems
+++ b/tests/generator-Tests/expected.ji/Core_ClassParse/Mono.Android.projitems
@@ -7,6 +7,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.Object.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.String.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Xamarin.Google.Composable.MyClass.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Xamarin.Test.Invalidnames.In.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Xamarin.Test.Invalidnames.InvalidNameMembers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)__NamespaceMapping__.cs" />

--- a/tests/generator-Tests/expected.ji/Core_ClassParse/Xamarin.Google.Composable.MyClass.cs
+++ b/tests/generator-Tests/expected.ji/Core_ClassParse/Xamarin.Google.Composable.MyClass.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using Java.Interop;
+
+namespace Xamarin.Google.Composable {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='com.com.google.compose']/class[@name='MyClass']"
+	[global::Java.Interop.JniTypeSignature ("com/com/google/compose/MyClass", GenerateJavaPeer=false)]
+	public partial class MyClass : global::Java.Lang.Object {
+		static readonly JniPeerMembers _members = new JniPeerMembers ("com/com/google/compose/MyClass", typeof (MyClass));
+
+		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		protected MyClass (ref JniObjectReference reference, JniObjectReferenceOptions options) : base (ref reference, options)
+		{
+		}
+
+	}
+}

--- a/tests/generator-Tests/expected.xaji/Core_ClassParse/Java.Interop.__TypeRegistrations.cs
+++ b/tests/generator-Tests/expected.xaji/Core_ClassParse/Java.Interop.__TypeRegistrations.cs
@@ -14,9 +14,11 @@ namespace Java.Interop {
 #endif // def MONODROID_TIMING
 			Java.Interop.TypeManager.RegisterPackages (
 					new string[]{
+						"com/com/google/compose",
 						"xamarin/test/invalidnames",
 					},
 					new Converter<string, Type>[]{
+						lookup_com_com_google_compose_package,
 						lookup_xamarin_test_invalidnames_package,
 					});
 #if MONODROID_TIMING
@@ -34,6 +36,18 @@ namespace Java.Interop {
 			if (managedType == null)
 				return null;
 			return Type.GetType (managedType);
+		}
+
+		static string[] package_com_com_google_compose_mappings;
+		static Type lookup_com_com_google_compose_package (string klass)
+		{
+			if (package_com_com_google_compose_mappings == null) {
+				package_com_com_google_compose_mappings = new string[]{
+					"com/com/google/compose/MyClass:Xamarin.Google.Composable.MyClass",
+				};
+			}
+
+			return Lookup (package_com_com_google_compose_mappings, klass);
 		}
 
 		static string[] package_xamarin_test_invalidnames_mappings;

--- a/tests/generator-Tests/expected.xaji/Core_ClassParse/Mono.Android.projitems
+++ b/tests/generator-Tests/expected.xaji/Core_ClassParse/Mono.Android.projitems
@@ -8,6 +8,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Java.Interop.__TypeRegistrations.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.Object.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Java.Lang.String.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Xamarin.Google.Composable.MyClass.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Xamarin.Test.Invalidnames.In.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Xamarin.Test.Invalidnames.InvalidNameMembers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)__NamespaceMapping__.cs" />

--- a/tests/generator-Tests/expected.xaji/Core_ClassParse/Xamarin.Google.Composable.MyClass.cs
+++ b/tests/generator-Tests/expected.xaji/Core_ClassParse/Xamarin.Google.Composable.MyClass.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Xamarin.Google.Composable {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='com.com.google.compose']/class[@name='MyClass']"
+	[global::Android.Runtime.Register ("com/com/google/compose/MyClass", DoNotGenerateAcw=true)]
+	public partial class MyClass : global::Java.Lang.Object {
+		static readonly JniPeerMembers _members = new XAPeerMembers ("com/com/google/compose/MyClass", typeof (MyClass));
+
+		internal static new IntPtr class_ref {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
+		public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+			get { return _members; }
+		}
+
+		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
+		protected override IntPtr ThresholdClass {
+			get { return _members.JniPeerType.PeerReference.Handle; }
+		}
+
+		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
+		[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
+		protected override global::System.Type ThresholdType {
+			get { return _members.ManagedPeerType; }
+		}
+
+		protected MyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+		{
+		}
+
+	}
+}

--- a/tests/generator-Tests/expected.xaji/Core_ClassParse/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/Core_ClassParse/__NamespaceMapping__.cs
@@ -2,6 +2,7 @@ using System;
 
 [assembly:global::Android.Runtime.NamespaceMapping (Java = "java.lang", Managed="Java.Lang")]
 [assembly:global::Android.Runtime.NamespaceMapping (Java = "xamarin.test.invalidnames", Managed="Xamarin.Test.Invalidnames")]
+[assembly:global::Android.Runtime.NamespaceMapping (Java = "com.com.google.compose", Managed="Xamarin.Google.Composable")]
 
 #if !NET
 namespace System.Runtime.Versioning {

--- a/tests/generator-Tests/expected/Core_ClassParse/Xamarin.Google.Composable.MyClass.cs
+++ b/tests/generator-Tests/expected/Core_ClassParse/Xamarin.Google.Composable.MyClass.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+
+namespace Xamarin.Google.Composable {
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='com.com.google.compose']/class[@name='MyClass']"
+	[global::Android.Runtime.Register ("com/com/google/compose/MyClass", DoNotGenerateAcw=true)]
+	public partial class MyClass : global::Java.Lang.Object {
+
+		internal static new IntPtr java_class_handle;
+		internal static new IntPtr class_ref {
+			get {
+				return JNIEnv.FindClass ("com/com/google/compose/MyClass", ref java_class_handle);
+			}
+		}
+
+		protected override IntPtr ThresholdClass {
+			get { return class_ref; }
+		}
+
+		protected override global::System.Type ThresholdType {
+			get { return typeof (MyClass); }
+		}
+
+		protected MyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+	}
+}

--- a/tests/generator-Tests/expected/Core_ClassParse/api.xml
+++ b/tests/generator-Tests/expected/Core_ClassParse/api.xml
@@ -22,5 +22,8 @@
     <class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="false" name="zzTop" static="false" visibility="public">
     </class>
   </package>
+  <package name="com.com.google.compose">
+    <class abstract="false" deprecated="not deprecated" extends="java.lang.Object" extends-generic-aware="java.lang.Object" final="false" name="MyClass" static="false" visibility="public" />
+  </package>
 </api>
 

--- a/tests/generator-Tests/expected/Core_ClassParse/metadata.xml
+++ b/tests/generator-Tests/expected/Core_ClassParse/metadata.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<metadata>
+  <ns-replace source="com." replacement="" />
+  <ns-replace source="com" replacement="Xamarin" />
+  <ns-replace source=".compose" replacement="Composable" />
+</metadata>

--- a/tools/generator/CodeGenerationOptions.cs
+++ b/tools/generator/CodeGenerationOptions.cs
@@ -80,6 +80,8 @@ namespace MonoDroid.Generation
 
 		public string NullForgivingOperator => SupportNullableReferenceTypes ? "!" : string.Empty;
 
+		public List<NamespaceTransform> NamespaceTransforms { get; } = new List<NamespaceTransform> ();
+
 		public string GetTypeReferenceName (Field field)
 		{
 			var name = GetOutputName (field.Symbol.FullName);
@@ -281,6 +283,17 @@ namespace MonoDroid.Generation
 
 				return s;
 			}
+		}
+
+		public string GetTransformedNamespace (string value)
+		{
+			if (!value.HasValue () || !NamespaceTransforms.Any ())
+				return value;
+
+			foreach (var nt in NamespaceTransforms)
+				value = nt.Apply (value);
+
+			return value;
 		}
 	}
 }

--- a/tools/generator/CodeGenerator.cs
+++ b/tools/generator/CodeGenerator.cs
@@ -176,8 +176,12 @@ namespace Xamarin.Android.Binder
 				return;
 
 			// Apply metadata fixups
-			foreach (var fixup in fixups)
-				api.ApplyFixupFile (fixup);
+			foreach (var fixup in fixups) {
+				if (FixupXmlDocument.Load (fixup) is FixupXmlDocument f) {
+					api.ApplyFixupFile (f);
+					opt.NamespaceTransforms.AddRange (f.GetNamespaceTransforms ());
+				}
+			}
 
 			api.ApiDocument.Save (apiXmlFile + ".fixed");
 

--- a/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
@@ -105,7 +105,7 @@ namespace MonoDroid.Generation
 
 		public static ClassGen CreateClass (XElement pkg, XElement elem, CodeGenerationOptions options)
 		{
-			var klass = new ClassGen (CreateGenBaseSupport (pkg, elem, false)) {
+			var klass = new ClassGen (CreateGenBaseSupport (pkg, elem, options, false)) {
 				BaseType = elem.XGetAttribute ("extends"),
 				FromXml = true,
 				IsAbstract = elem.XGetAttribute ("abstract") == "true",
@@ -234,7 +234,7 @@ namespace MonoDroid.Generation
 			return field;
 		}
 
-		public static GenBaseSupport CreateGenBaseSupport (XElement pkg, XElement elem, bool isInterface)
+		public static GenBaseSupport CreateGenBaseSupport (XElement pkg, XElement elem, CodeGenerationOptions opt, bool isInterface)
 		{
 			var support = new GenBaseSupport {
 				IsAcw = true,
@@ -258,7 +258,7 @@ namespace MonoDroid.Generation
 			if (pkg.Attribute ("managedName") != null)
 				support.Namespace = pkg.XGetAttribute ("managedName");
 			else
-				support.Namespace = StringRocks.PackageToPascalCase (support.PackageName);
+				support.Namespace = opt.GetTransformedNamespace (StringRocks.PackageToPascalCase (support.PackageName));
 
 			var tpn = elem.Element ("typeParameters");
 
@@ -302,7 +302,7 @@ namespace MonoDroid.Generation
 
 		public static InterfaceGen CreateInterface (XElement pkg, XElement elem, CodeGenerationOptions options)
 		{
-			var iface = new InterfaceGen (CreateGenBaseSupport (pkg, elem, true)) {
+			var iface = new InterfaceGen (CreateGenBaseSupport (pkg, elem, options, true)) {
 				ArgsType = elem.XGetAttribute ("argsType"),
 				HasManagedName = elem.Attribute ("managedName") != null,
 				NoAlternatives = elem.XGetAttribute ("no-alternatives") == "true",


### PR DESCRIPTION
Fixes: #727 

Today, when `generator` creates a .NET `namespace` from a Java `package`, it applies a simple pascal case transformation to make the namespace match established .NET naming standards.

For example: `package android.database` becomes `namespace Android.Database`.

However there are a few scenarios that this is not a good fit for.

(1) Words where Pascal case is not desired: `androidx` -> `AndroidX`
(2) Java package names are often longer than C# namespaces: `com.google.android.material.animation` -> `Google.Android.Material.Animation`.

Both of these scenarios can lead to many repeated `metadata` lines to fix:
```
<attr path="/api/package[@name='androidx.core.accessibilityservice']" name="managedName">AndroidX.Core.AccessibilityService</attr>
<attr path="/api/package[@name='androidx.core.app']" name="managedName">AndroidX.Core.App</attr>
<attr path="/api/package[@name='androidx.core.content']" name="managedName">AndroidX.Core.Content</attr>
<attr path="/api/package[@name='androidx.core.database']" name="managedName">AndroidX.Core.Database</attr>
<attr path="/api/package[@name='androidx.core.graphics']" name="managedName">AndroidX.Core.Graphics</attr>
<attr path="/api/package[@name='androidx.core.graphics.drawable']" name="managedName">AndroidX.Core.Graphics.Drawable</attr>
<attr path="/api/package[@name='androidx.core.hardware.display']" name="managedName">AndroidX.Core.Hardware.Display</attr>
<attr path="/api/package[@name='androidx.core.hardware.fingerprint']" name="managedName">AndroidX.Core.Hardware.Fingerprint</attr>
<attr path="/api/package[@name='androidx.core.internal']" name="managedName">AndroidX.Core.Internal</attr>
<attr path="/api/package[@name='androidx.core.internal.view']" name="managedName">AndroidX.Core.Internal.View</attr>
etc..
```

([Source](https://github.com/xamarin/AndroidX/blob/master/source/androidx.core/core/Transforms/Metadata.Namespaces.xml))

## Solution

To help these scenarios, we introduce a new metadata-specified item that would allow simple replacements.  (Note that `generator` accepts `<ns-replace>` in `metadata` files, though we will likely provide the MSBuild item specified in #727 as the preferred way for users to specify replacements.)

Examples:

```xml
<metadata>
  <ns-replace source='Androidx' replacement='AndroidX' />
  <ns-replace source='Com' replacement='' />
  <ns-replace source='Com.Google.' replacement='Google' />
</metadata>
```

## Implementation Notes

These replacements will *only* be run for `<package>` elements that do not specify a `@managedName` attribute.  If you use `@managedName` you are opting to provide the exact name, we will not process it further.

Unlike unused metadata, these replacement will not raise a warning if they are unused.

### Case Sensitivity

Replacements take place **_after_** the automatic Pascal case transform, but the compare is case-insensitive.

Thus, both of the following are equivalent:
```xml
<ns-replace source='Androidx' replacement='AndroidX' />
<ns-replace source='androidx' replacement='AndroidX' />
```

### Word Bounds

Replacements take place **_only_** on full words (namespace parts).

Thus,  
```xml
<ns-replace source='Com' replacement='' />
```

Matches `Com.Google.Library`, but not `Common.Google.Library` or `Google.Imaging.Dicom`.

Multiple full words can be used:

```xml
<ns-replace source='Com.Google' replacement='Google' />
<ns-replace source='Com.Androidx' replacement='Xamarin.AndroidX' />
```

### Word Position

The word part match can be constrained to the beginning or end of a namespace by appending a `.` or prepending a `.`, respectively.

```xml
<ns-replace source='Androidx.' replacement='Xamarin.AndroidX' />
```

matches `Androidx.Core`, but not `Square.OkHttp.Androidx`.

Similarly,

```xml
<ns-replace source='.Compose' replacement='ComposeUI' />
```

matches `Google.AndroidX.Compose`, but not `Google.Compose.Writer`.

Both prepending and appending a `.` makes it an exact match.

```xml
<ns-replace source='.Androidx.' replacement='Xamarin.AndroidX' />
```

matches `Androidx`, but not `Google.Androidx.Core`.

### Replacement Order

Replacements run in the order specified by the `metadata` file, however adding replacements to multiple `metadata` files may result in an unintended order.

Replacements are run sequentially, and multiple replacements may affect a single namespace.

```xml
<ns-replace source='Androidx' replacement='Xamarin.AndroidX' />
<ns-replace source='View' replacement='Views' />
```

changes `Androidx.View` to `Xamarin.AndroidX.Views`.