### PR TITLE
[Xamarin.Android.Tools.Bytecode] Extend api xml doc type detection

### DIFF
--- a/src/Xamarin.Android.Tools.Bytecode/JavaDocumentScraper.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/JavaDocumentScraper.cs
@@ -374,7 +374,8 @@ namespace Xamarin.Android.Tools.Bytecode
 					rawXML = new string (buf, 0, len).Trim ();
 				}
 				if (rawXML.IndexOf ("<api", StringComparison.Ordinal) >= 0 &&
-						rawXML.IndexOf ("<package", StringComparison.Ordinal) >= 0)
+						(rawXML.IndexOf ("<package", StringComparison.Ordinal) >= 0 ||
+						rawXML.IndexOf ("<javadoc-metadata", StringComparison.Ordinal) >= 0))
 					kind = JavaDocletType._ApiXml;
 				else if (rawXML.StartsWith ("package", StringComparison.Ordinal) ||
 						rawXML.StartsWith (";", StringComparison.Ordinal)) {

--- a/src/Xamarin.Android.Tools.Bytecode/JavaDocumentScraper.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/JavaDocumentScraper.cs
@@ -375,7 +375,7 @@ namespace Xamarin.Android.Tools.Bytecode
 				}
 				if (rawXML.IndexOf ("<api", StringComparison.Ordinal) >= 0 &&
 						(rawXML.IndexOf ("<package", StringComparison.Ordinal) >= 0 ||
-						rawXML.IndexOf ("<javadoc-metadata", StringComparison.Ordinal) >= 0))
+						 rawXML.IndexOf ("<javadoc-metadata", StringComparison.Ordinal) >= 0))
 					kind = JavaDocletType._ApiXml;
 				else if (rawXML.StartsWith ("package", StringComparison.Ordinal) ||
 						rawXML.StartsWith (";", StringComparison.Ordinal)) {


### PR DESCRIPTION

Context: https://github.com/xamarin/xamarin-android/pull/6662

The `@(JavaSourceJar)` item supports the following metadata:

    <JavaSourceJar Include="javasourcejartest-sources.jar" >
      <CopyrightFile>$(MSBuildThisFileDirectory)javadoc-copyright.xml</CopyrightFile>
      <UrlPrefix>https://developer.android.com/reference</UrlPrefix>
      <UrlStyle>developer.android.com/reference@2020-Nov</UrlStyle>
      <DocRootUrl>https://developer.android.com</DocRootUrl>
    </JavaSourceJar>

If a copyright file is provided which contains more than 500 characters
the type of the documentation file will not be correctly identified.
This results in the following build error:

    Task "ClassParse" (TaskId:143)
      Task Parameter:ToolPath=C:\Users\cloudtest\android-toolchain\dotnet\packs\Microsoft.Android.Sdk.Windows\31.0.200-ci.pr.gh6662.38\tools (TaskId:143)
      Task Parameter:OutputFile=obj\Debug\api.xml.class-parse (TaskId:143)
      Task Parameter:SourceJars=javasourcejartest.jar (TaskId:143)
      Task Parameter:
          DocumentationPaths=
              obj\Debug\javadoc-javasourcejartest-sources-C93909CC4CF9CB39.xml
                      CopyrightFile=C:\a\_work\1\a\TestRelease\01-25_05.25.10\temp\JavaSourceJar\javadoc-copyright.xml
                      DocRootUrl=https://developer.android.com
                      Hash=C93909CC4CF9CB39
                      OriginalItemSpec=javasourcejartest-sources.jar
                      UrlPrefix=https://developer.android.com/reference
                      UrlStyle=developer.android.com/reference@2020-Nov (TaskId:143)
      Using: dotnet C:\Users\cloudtest\android-toolchain\dotnet\packs\Microsoft.Android.Sdk.Windows\31.0.200-ci.pr.gh6662.38\tools\class-parse.dll (TaskId:143)
      [class-parse] response file: obj\Debug\class-parse.rsp (TaskId:143)
      --o="obj\Debug\api.xml.class-parse" (TaskId:143)
      --docspath="obj\Debug\javadoc-javasourcejartest-sources-C93909CC4CF9CB39.xml" (TaskId:143)
      "javasourcejartest.jar" (TaskId:143)
      dotnet C:\Users\cloudtest\android-toolchain\dotnet\packs\Microsoft.Android.Sdk.Windows\31.0.200-ci.pr.gh6662.38\tools\class-parse.dll @obj\Debug\class-parse.rsp  (TaskId:143)
      Unhandled exception. System.Exception: Directory 'obj\Debug\javadoc-javasourcejartest-sources-C93909CC4CF9CB39.xml' does not exist (TaskId:143)
         at Xamarin.Android.Tools.Bytecode.AndroidDocScraper..ctor(String dir, String patternHead, String resetPatternHead, String parameterPairSplitter, Boolean continuousParamLines, String openMethod, String paramSep, String closeMethod, String postCloseMethodParens) in /Users/builder/azdo/_work/1/s/xamarin-android/external/Java.Interop/src/Xamarin.Android.Tools.Bytecode/JavaDocumentScraper.cs:line 165 (TaskId:143)
         at Xamarin.Android.Tools.Bytecode.AndroidDocScraper..ctor(String dir, String patternHead, String resetPatternHead, String parameterPairSplitter, Boolean continuousParamLines) in /Users/builder/azdo/_work/1/s/xamarin-android/external/Java.Interop/src/Xamarin.Android.Tools.Bytecode/JavaDocumentScraper.cs:line 147 (TaskId:143)
         at Xamarin.Android.Tools.Bytecode.DroidDocScraper..ctor(String dir) in /Users/builder/azdo/_work/1/s/xamarin-android/external/Java.Interop/src/Xamarin.Android.Tools.Bytecode/JavaDocumentScraper.cs:line 41 (TaskId:143)
         at Xamarin.Android.Tools.Bytecode.ClassPath.CreateDocScraper(String src) in /Users/builder/azdo/_work/1/s/xamarin-android/external/Java.Interop/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs:line 274 (TaskId:143)
         at Xamarin.Android.Tools.Bytecode.ClassPath.FixupParametersFromDocs(XElement api, String path) in /Users/builder/azdo/_work/1/s/xamarin-android/external/Java.Interop/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs:line 285 (TaskId:143)
         at Xamarin.Android.Tools.Bytecode.ClassPath.FixupParametersFromDocs(XElement api) in /Users/builder/azdo/_work/1/s/xamarin-android/external/Java.Interop/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs:line 266 (TaskId:143)
         at Xamarin.Android.Tools.Bytecode.ClassPath.ToXElement() in /Users/builder/azdo/_work/1/s/xamarin-android/external/Java.Interop/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs:line 360 (TaskId:143)
         at Xamarin.Android.Tools.Bytecode.ClassPath.SaveXmlDescription(TextWriter textWriter) in /Users/builder/azdo/_work/1/s/xamarin-android/external/Java.Interop/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs:line 379 (TaskId:143)
         at Xamarin.Android.Tools.App.Main(String[] args) in /Users/builder/azdo/_work/1/s/xamarin-android/external/Java.Interop/tools/class-parse/Program.cs:line 94 (TaskId:143)

Fix the `JavaDocletType._ApiXml` doc type detection in such cases by
also checking for the `<javadoc-metadata>` element that is created by
`java-source-utils.jar`
