### PR TITLE
[build] set $(ProduceReferenceAssemblyInOutDir)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,6 +7,7 @@
     <TreatWarningsAsErrors Condition=" '$(Configuration)' == 'Release' And '$(MSBuildRuntimeType)' != 'Mono' ">true</TreatWarningsAsErrors>
     <_OutputPath>$(MSBuildThisFileDirectory)bin\Build$(Configuration)\</_OutputPath>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+    <ProduceReferenceAssemblyInOutDir>true</ProduceReferenceAssemblyInOutDir>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Context: https://docs.microsoft.com/dotnet/core/compatibility/sdk/6.0/write-reference-assemblies-to-obj
Context: https://github.com/dotnet/msbuild/issues/7355

Using the latest internal builds of Visual Studio, you hit the build
error when building xamarin-android:

    build-tools\create-packs\Directory.Build.targets(28,5): error MSB4018: The "CreateFrameworkListFile" task failed unexpectedly. [build-tools\create-packs\Microsoft.Android.Ref.proj]
    build-tools\create-packs\Directory.Build.targets(28,5): error MSB4018: System.IO.DirectoryNotFoundException: Could not find a part of the path 'external\Java.Interop\bin\Debug-net6.0\ref\Java.Interop.dll'.

This was a breaking change in MSBuild:

> Old behavior
> Since reference assemblies were added, the .NET SDK has written
> reference assemblies to the ref directory in the OutDir directory of
> the compilation.

> New behavior
> Now, reference assemblies are written to the refint directory of the
> IntermediateOutputPath directory by default, like many other
> intermediate artifacts.

> Reason for change
> Reference assemblies are generally not run-time assets, and so don't
> belong in the OutDir directory by default.

Since we *are* using the reference assembly as build output, I think
we *should* put the file in `bin`.

Let's set `$(ProduceReferenceAssemblyInOutDir)` to get the old behavior.

After this change goes in, we'll need other changes in
xamarin-android. We might also be able to use `$(TargetRefPath)` in
some way, but that isn't needed here.