### PR TITLE
[Java.Interop] use $(DebugType) portable

### DIFF
--- a/src/Java.Interop/Java.Interop-MonoAndroid.csproj
+++ b/src/Java.Interop/Java.Interop-MonoAndroid.csproj
@@ -26,7 +26,7 @@
   <Import Condition="Exists ('$(XAConfigPath)')" Project="$(XAConfigPath)" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\bin\Debug</OutputPath>
     <DefineConstants>DEBUG;INTEROP;FEATURE_JNIENVIRONMENT_JI_PINVOKES;FEATURE_JNIOBJECTREFERENCE_INTPTRS;INTERNAL_NULLABLE_ATTRIBUTES;$(JavaInteropDefineConstants)</DefineConstants>
@@ -39,7 +39,7 @@
     <JNIEnvGenPath>..\..\bin\BuildDebug</JNIEnvGenPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/6799

xamarin/xamarin-android#6799 is missing `Java.Interop.pdb` when
building in `Release` mode. I suspect this is due to `$(DebugType)`
set to `full`. This creates `Java.Interop.dll.mdb`!

The modern approach is to use `portable` for both `Debug` and
`Release` builds, so we should just use that.