### PR TITLE
[generator] Unsigned primitive types should not be nullable.

### DIFF
--- a/tests/generator-Tests/Unit-Tests/CodeGenerationOptionsTests.cs
+++ b/tests/generator-Tests/Unit-Tests/CodeGenerationOptionsTests.cs
@@ -57,15 +57,27 @@ namespace generatortests
 		{
 			var opt = new CodeGenerationOptions { SupportNullableReferenceTypes = true };
 
+			// System.Void isn't a valid return type, ensure it gets changed to void
 			var system_void = new ReturnValue (null, "void", "System.Void", false, false);
 			system_void.Validate (opt, null, null);
 
 			Assert.AreEqual ("void", opt.GetTypeReferenceName (system_void));
 
+			// Primitive types should not be nullable
 			var primitive_void = new ReturnValue (null, "void", "void", false, false);
 			primitive_void.Validate (opt, null, null);
 
 			Assert.AreEqual ("void", opt.GetTypeReferenceName (primitive_void));
+
+			var system_uint = new ReturnValue (null, "uint", "System.UInt32", false, false);
+			system_uint.Validate (opt, null, null);
+
+			Assert.AreEqual ("System.UInt32", opt.GetTypeReferenceName (system_uint));
+
+			var primitive_uint = new ReturnValue (null, "uint", "uint", false, false);
+			primitive_uint.Validate (opt, null, null);
+
+			Assert.AreEqual ("uint", opt.GetTypeReferenceName (primitive_uint));
 		}
 	}
 }

--- a/tools/generator/CodeGenerationOptions.cs
+++ b/tools/generator/CodeGenerationOptions.cs
@@ -157,6 +157,10 @@ namespace MonoDroid.Generation
 				case "char":
 				case "double":
 				case "short":
+				case "uint":
+				case "ushort":
+				case "ulong":
+				case "byte":
 				case "System.Boolean":
 				case "System.Byte":
 				case "System.Char":
@@ -166,6 +170,9 @@ namespace MonoDroid.Generation
 				case "System.Int64":
 				case "System.Single":
 				case "System.SByte":
+				case "System.UInt16":
+				case "System.UInt32":
+				case "System.UInt64":
 				case "System.Void":
 				case "Android.Graphics.Color":
 					return string.Empty;


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/issues/955

Primitive types are not nullable in Java, thus we do not default them to nullable when using NRT in `generator`.  However, when we added Kotlin's unsigned primitive types we did not special case them to not-nullable like the existing primitive types.

This causes compilation errors when trying to enable `nullable` when binding Kotlin stdlib:

```csharp
// Metadata.xml XPath method reference: path="/api/package[@name='kotlin.random']/class[@name='URandomKt']/method[@name='nextUInt-qCasIEU' and count(parameter)=2 and parameter[1][@type='kotlin.random.Random'] and parameter[2][@type='uint']]"
[Register ("nextUInt-qCasIEU", "(Lkotlin/random/Random;I)I", "")]
public static unsafe uint? NextUInt (global::Kotlin.Random.Random obj, uint? until)
{
	const string __id = "nextUInt-qCasIEU.(Lkotlin/random/Random;I)I";
	try {
		JniArgumentValue* __args = stackalloc JniArgumentValue [2];
		__args [0] = new JniArgumentValue ((obj == null) ? IntPtr.Zero : ((global::Java.Lang.Object) obj).Handle);
		__args [1] = new JniArgumentValue (until); // Error CS1503 Argument 1: cannot convert from 'uint?' to 'bool'
...
```

Add them to the primitive list in `generator` so they are not generated as nullable.