### PR TITLE
[Java.Interop] net6.0 is Version=v0.1.0.0

### DIFF
--- a/build-tools/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks.targets
+++ b/build-tools/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks.targets
@@ -113,7 +113,7 @@
     <PropertyGroup>
       <_NetToolVersion>$(GitBaseVersionMajor).$(GitBaseVersionMinor).$(GitBaseVersionPatch).$(GitCommits)</_NetToolVersion>
       <_OldToolVersion>0.2.$(GitBaseVersionPatch).$(GitCommits)</_OldToolVersion>
-      <_NetCoreLibVersion>$(GitBaseVersionMajor).$(GitBaseVersionMinor).0.0</_NetCoreLibVersion>
+      <_NetCoreLibVersion>0.1.0.0</_NetCoreLibVersion>
       <_OldCoreLibVersion>0.1.0.0</_OldCoreLibVersion>
       <_FileVersion>$(GitBaseVersionMajor).$(GitBaseVersionMinor).$(GitBaseVersionPatch).$(GitCommits)</_FileVersion>
     </PropertyGroup>


### PR DESCRIPTION
Context: cbd966686e2a3179cf3e6285990302c6b7afab21
Context: http://aka.ms/maui-schedule
Context: https://github.com/xamarin/xamarin-android-tools/commit/f0b3abdb7600bc47be8696bab2c170d849283f06

The hope with commit cbd96668 was that we could "fix" an oversight
in our ".NET 6 Story": `Java.Interop.dll` *should* have a version
which matches the .NET SDK version, or at least *doesn't* match the
"Classic" Xamarin.Android version, to better support future expected
API changes to `Java.Interop.dll`.

Unfortunately, this change didn't make it before .NET 6 went stable
in [2021-November][0], meaning the `net6.0-android` and
`net6.0-android31.0` target frameworks are "set in stone" to target
API-31.

My *hope* had been that we could implicitly "pull a mulligan",
fix the `Java.Interop.dll` assembly version in cbd96668, and make
`net6.0-android32.0` (API-32) the default for MAUI.

Unfortunately, as per xamarin/xamarin-android-tools@f0b3abdb:

> We do not yet have all of our proverbial ducks in a row to bump
> these Android SDK versions.

That remains the case: lots of moving parts means we won't be able to
make API-32 the default API level when MAUI ships.

This in turn means we have an ABI break: net6.0-android31.0 (the
default!) will want `Java.Interop.dll` v0.1.0.0, but current
.NET 6 Preview 13/14 is providing `Java.Interop.dll` v6.0.0.0.
This can only result in pain and suffering.

"Partially revert" cbd96668, and set `$(JINetCoreLibVersion)`=0.1.0.0.
This will cause `Java.Interop.dll` to be version 0.1.0.0, restoring
compatibility with net6.0-android31.0, removing pain & suffering.

TODO: when we start targeting .NET 7.0, we should revert *this*
commit, so that `$(JINetCoreLibVersion)` is once again

	<_NetCoreLibVersion>$(GitBaseVersionMajor).$(GitBaseVersionMinor).0.0</_NetCoreLibVersion>

i.e. 7.0.0.0, as `GitInfo.txt` will likewise be updated.

[0]: https://devblogs.microsoft.com/dotnet/announcing-net-6/