### PR TITLE
[Java.Interop-MonoAndroid.csproj] Set Version after Directory.Build.props

### DIFF
--- a/src/Java.Interop/Java.Interop-MonoAndroid.csproj
+++ b/src/Java.Interop/Java.Interop-MonoAndroid.csproj
@@ -17,10 +17,10 @@
     <LangVersion>8.0</LangVersion>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
-    <Version>0.1.0.0</Version>
   </PropertyGroup>
   <Import Project="..\..\Directory.Build.props" />
   <PropertyGroup>
+    <Version>0.1.0.0</Version>
     <XAConfigPath>..\..\bin\Build$(Configuration)\XAConfig.props</XAConfigPath>
   </PropertyGroup>
   <Import Condition="Exists ('$(XAConfigPath)')" Project="$(XAConfigPath)" />


### PR DESCRIPTION
We are setting `<Version>0.1.0.0</Version>` in `Java.Interop-MonoAndroid.csproj`, which is correct.  However immediately after that we `<Import Project="..\..\Directory.Build.props" />` which defaults projects to `<Version>$(JIUtilityVersion)</Version>`.

This commit reorders the `.csproj` to set the `<Version>` in the project *after* the import.