### PR TITLE
[generator] Add string cast to prevent CS1503.

### DIFF
--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteInterfaceMethodInvokers.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteInterfaceMethodInvokers.txt
@@ -21,7 +21,7 @@ public unsafe int GetCountForKey (string key)
 {
 	if (id_GetCountForKey_Ljava_lang_String_ == IntPtr.Zero)
 		id_GetCountForKey_Ljava_lang_String_ = JNIEnv.GetMethodID (class_ref, "GetCountForKey", "(Ljava/lang/String;)I");
-	IntPtr native_key = JNIEnv.NewString (key);
+	IntPtr native_key = JNIEnv.NewString ((string)key);
 	JValue* __args = stackalloc JValue [1];
 	__args [0] = new JValue (native_key);
 	var __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_GetCountForKey_Ljava_lang_String_, __args);

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteInterfaceMethodInvokersWithSkips.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteInterfaceMethodInvokersWithSkips.txt
@@ -21,7 +21,7 @@ public unsafe int GetCountForKey (string key)
 {
 	if (id_GetCountForKey_Ljava_lang_String_ == IntPtr.Zero)
 		id_GetCountForKey_Ljava_lang_String_ = JNIEnv.GetMethodID (class_ref, "GetCountForKey", "(Ljava/lang/String;)I");
-	IntPtr native_key = JNIEnv.NewString (key);
+	IntPtr native_key = JNIEnv.NewString ((string)key);
 	JValue* __args = stackalloc JValue [1];
 	__args [0] = new JValue (native_key);
 	var __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_GetCountForKey_Ljava_lang_String_, __args);

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteInterfacePropertyInvokers.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteInterfacePropertyInvokers.txt
@@ -91,7 +91,7 @@ public unsafe string Key {
 	set {
 		if (id_set_Key_Ljava_lang_String_ == IntPtr.Zero)
 			id_set_Key_Ljava_lang_String_ = JNIEnv.GetMethodID (class_ref, "set_Key", "(Ljava/lang/String;)V");
-		IntPtr native_value = JNIEnv.NewString (value);
+		IntPtr native_value = JNIEnv.NewString ((string)value);
 		JValue* __args = stackalloc JValue [1];
 		__args [0] = new JValue (native_value);
 		JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_set_Key_Ljava_lang_String_, __args);

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteInterfacePropertyInvokersWithSkips.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteInterfacePropertyInvokersWithSkips.txt
@@ -42,7 +42,7 @@ public unsafe string Key {
 	set {
 		if (id_set_Key_Ljava_lang_String_ == IntPtr.Zero)
 			id_set_Key_Ljava_lang_String_ = JNIEnv.GetMethodID (class_ref, "set_Key", "(Ljava/lang/String;)V");
-		IntPtr native_value = JNIEnv.NewString (value);
+		IntPtr native_value = JNIEnv.NewString ((string)value);
 		JValue* __args = stackalloc JValue [1];
 		__args [0] = new JValue (native_value);
 		JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_set_Key_Ljava_lang_String_, __args);

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteClass.txt
@@ -37,7 +37,7 @@ public partial class MyClass {
 		if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
 			return;
 
-		IntPtr native_p0 = JNIEnv.NewString (p0);
+		IntPtr native_p0 = JNIEnv.NewString ((string?)p0);
 		try {
 			JniArgumentValue* __args = stackalloc JniArgumentValue [1];
 			__args [0] = new JniArgumentValue (native_p0);
@@ -153,7 +153,7 @@ public partial class MyClass {
 		[Register ("set_Key", "(Ljava/lang/String;)V", "Getset_Key_Ljava_lang_String_Handler")]
 		set {
 			const string __id = "set_Key.(Ljava/lang/String;)V";
-			IntPtr native_value = JNIEnv.NewString (value);
+			IntPtr native_value = JNIEnv.NewString ((string?)value);
 			try {
 				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
 				__args [0] = new JniArgumentValue (native_value);
@@ -253,7 +253,7 @@ public partial class MyClass {
 	public virtual unsafe int GetCountForKey (string? key)
 	{
 		const string __id = "GetCountForKey.(Ljava/lang/String;)I";
-		IntPtr native_key = JNIEnv.NewString (key);
+		IntPtr native_key = JNIEnv.NewString ((string?)key);
 		try {
 			JniArgumentValue* __args = stackalloc JniArgumentValue [1];
 			__args [0] = new JniArgumentValue (native_key);

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteInterface.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteInterface.txt
@@ -223,7 +223,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		set {
 			if (id_set_Key_Ljava_lang_String_ == IntPtr.Zero)
 				id_set_Key_Ljava_lang_String_ = JNIEnv.GetMethodID (class_ref, "set_Key", "(Ljava/lang/String;)V");
-			IntPtr native_value = JNIEnv.NewString (value);
+			IntPtr native_value = JNIEnv.NewString ((string?)value);
 			JValue* __args = stackalloc JValue [1];
 			__args [0] = new JValue (native_value);
 			JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_set_Key_Ljava_lang_String_, __args);
@@ -303,7 +303,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	{
 		if (id_GetCountForKey_Ljava_lang_String_ == IntPtr.Zero)
 			id_GetCountForKey_Ljava_lang_String_ = JNIEnv.GetMethodID (class_ref, "GetCountForKey", "(Ljava/lang/String;)I");
-		IntPtr native_key = JNIEnv.NewString (key);
+		IntPtr native_key = JNIEnv.NewString ((string?)key);
 		JValue* __args = stackalloc JValue [1];
 		__args [0] = new JValue (native_key);
 		var __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_GetCountForKey_Ljava_lang_String_, __args);

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClass.txt
@@ -37,7 +37,7 @@ public partial class MyClass {
 		if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
 			return;
 
-		IntPtr native_p0 = JNIEnv.NewString (p0);
+		IntPtr native_p0 = JNIEnv.NewString ((string)p0);
 		try {
 			JniArgumentValue* __args = stackalloc JniArgumentValue [1];
 			__args [0] = new JniArgumentValue (native_p0);
@@ -153,7 +153,7 @@ public partial class MyClass {
 		[Register ("set_Key", "(Ljava/lang/String;)V", "Getset_Key_Ljava_lang_String_Handler")]
 		set {
 			const string __id = "set_Key.(Ljava/lang/String;)V";
-			IntPtr native_value = JNIEnv.NewString (value);
+			IntPtr native_value = JNIEnv.NewString ((string)value);
 			try {
 				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
 				__args [0] = new JniArgumentValue (native_value);
@@ -253,7 +253,7 @@ public partial class MyClass {
 	public virtual unsafe int GetCountForKey (string key)
 	{
 		const string __id = "GetCountForKey.(Ljava/lang/String;)I";
-		IntPtr native_key = JNIEnv.NewString (key);
+		IntPtr native_key = JNIEnv.NewString ((string)key);
 		try {
 			JniArgumentValue* __args = stackalloc JniArgumentValue [1];
 			__args [0] = new JniArgumentValue (native_key);

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterface.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterface.txt
@@ -223,7 +223,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		set {
 			if (id_set_Key_Ljava_lang_String_ == IntPtr.Zero)
 				id_set_Key_Ljava_lang_String_ = JNIEnv.GetMethodID (class_ref, "set_Key", "(Ljava/lang/String;)V");
-			IntPtr native_value = JNIEnv.NewString (value);
+			IntPtr native_value = JNIEnv.NewString ((string)value);
 			JValue* __args = stackalloc JValue [1];
 			__args [0] = new JValue (native_value);
 			JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_set_Key_Ljava_lang_String_, __args);
@@ -303,7 +303,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	{
 		if (id_GetCountForKey_Ljava_lang_String_ == IntPtr.Zero)
 			id_GetCountForKey_Ljava_lang_String_ = JNIEnv.GetMethodID (class_ref, "GetCountForKey", "(Ljava/lang/String;)I");
-		IntPtr native_key = JNIEnv.NewString (key);
+		IntPtr native_key = JNIEnv.NewString ((string)key);
 		JValue* __args = stackalloc JValue [1];
 		__args [0] = new JValue (native_key);
 		var __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_GetCountForKey_Ljava_lang_String_, __args);

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteClass.txt
@@ -48,7 +48,7 @@ public partial class MyClass  {
 		if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
 			return;
 
-		IntPtr native_p0 = JNIEnv.NewString (p0);
+		IntPtr native_p0 = JNIEnv.NewString ((string)p0);
 		try {
 			JValue* __args = stackalloc JValue [1];
 			__args [0] = new JValue (native_p0);
@@ -193,7 +193,7 @@ public partial class MyClass  {
 		set {
 			if (id_set_Key_Ljava_lang_String_ == IntPtr.Zero)
 				id_set_Key_Ljava_lang_String_ = JNIEnv.GetMethodID (class_ref, "set_Key", "(Ljava/lang/String;)V");
-			IntPtr native_value = JNIEnv.NewString (value);
+			IntPtr native_value = JNIEnv.NewString ((string)value);
 			try {
 				JValue* __args = stackalloc JValue [1];
 				__args [0] = new JValue (native_value);
@@ -299,7 +299,7 @@ public partial class MyClass  {
 	{
 		if (id_GetCountForKey_Ljava_lang_String_ == IntPtr.Zero)
 			id_GetCountForKey_Ljava_lang_String_ = JNIEnv.GetMethodID (class_ref, "GetCountForKey", "(Ljava/lang/String;)I");
-		IntPtr native_key = JNIEnv.NewString (key);
+		IntPtr native_key = JNIEnv.NewString ((string)key);
 		try {
 			JValue* __args = stackalloc JValue [1];
 			__args [0] = new JValue (native_key);

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteClassConstructors.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteClassConstructors.txt
@@ -37,7 +37,7 @@ static IntPtr id_ctor_Ljava_lang_String_;
 	if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
 		return;
 
-	IntPtr native_p0 = JNIEnv.NewString (p0);
+	IntPtr native_p0 = JNIEnv.NewString ((string)p0);
 	try {
 		JValue* __args = stackalloc JValue [1];
 		__args [0] = new JValue (native_p0);

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteClassMethods.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteClassMethods.txt
@@ -23,7 +23,7 @@ public virtual unsafe int GetCountForKey (string key)
 {
 	if (id_GetCountForKey_Ljava_lang_String_ == IntPtr.Zero)
 		id_GetCountForKey_Ljava_lang_String_ = JNIEnv.GetMethodID (class_ref, "GetCountForKey", "(Ljava/lang/String;)I");
-	IntPtr native_key = JNIEnv.NewString (key);
+	IntPtr native_key = JNIEnv.NewString ((string)key);
 	try {
 		JValue* __args = stackalloc JValue [1];
 		__args [0] = new JValue (native_key);

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteClassProperties.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteClassProperties.txt
@@ -120,7 +120,7 @@ public virtual unsafe string Key {
 	set {
 		if (id_set_Key_Ljava_lang_String_ == IntPtr.Zero)
 			id_set_Key_Ljava_lang_String_ = JNIEnv.GetMethodID (class_ref, "set_Key", "(Ljava/lang/String;)V");
-		IntPtr native_value = JNIEnv.NewString (value);
+		IntPtr native_value = JNIEnv.NewString ((string)value);
 		try {
 			JValue* __args = stackalloc JValue [1];
 			__args [0] = new JValue (native_value);

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteFieldSetBody.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteFieldSetBody.txt
@@ -1,6 +1,6 @@
 if (bar_jfieldId == IntPtr.Zero)
 	bar_jfieldId = JNIEnv.GetFieldID (class_ref, "bar", "Ljava/lang/String;");
-IntPtr native_value = JNIEnv.NewString (value);
+IntPtr native_value = JNIEnv.NewString ((string)value);
 try {
 	JNIEnv.SetField (((global::Java.Lang.Object) this).Handle, bar_jfieldId, native_value);
 } finally {

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteFieldString.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteFieldString.txt
@@ -12,7 +12,7 @@ public string bar {
 	set {
 		if (bar_jfieldId == IntPtr.Zero)
 			bar_jfieldId = JNIEnv.GetFieldID (class_ref, "bar", "Ljava/lang/String;");
-		IntPtr native_value = JNIEnv.NewString (value);
+		IntPtr native_value = JNIEnv.NewString ((string)value);
 		try {
 			JNIEnv.SetField (((global::Java.Lang.Object) this).Handle, bar_jfieldId, native_value);
 		} finally {

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteInterface.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteInterface.txt
@@ -205,7 +205,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		set {
 			if (id_set_Key_Ljava_lang_String_ == IntPtr.Zero)
 				id_set_Key_Ljava_lang_String_ = JNIEnv.GetMethodID (class_ref, "set_Key", "(Ljava/lang/String;)V");
-			IntPtr native_value = JNIEnv.NewString (value);
+			IntPtr native_value = JNIEnv.NewString ((string)value);
 			JValue* __args = stackalloc JValue [1];
 			__args [0] = new JValue (native_value);
 			JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_set_Key_Ljava_lang_String_, __args);
@@ -285,7 +285,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	{
 		if (id_GetCountForKey_Ljava_lang_String_ == IntPtr.Zero)
 			id_GetCountForKey_Ljava_lang_String_ = JNIEnv.GetMethodID (class_ref, "GetCountForKey", "(Ljava/lang/String;)I");
-		IntPtr native_key = JNIEnv.NewString (key);
+		IntPtr native_key = JNIEnv.NewString ((string)key);
 		JValue* __args = stackalloc JValue [1];
 		__args [0] = new JValue (native_key);
 		var __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_GetCountForKey_Ljava_lang_String_, __args);

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteInterfaceInvoker.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteInterfaceInvoker.txt
@@ -134,7 +134,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		set {
 			if (id_set_Key_Ljava_lang_String_ == IntPtr.Zero)
 				id_set_Key_Ljava_lang_String_ = JNIEnv.GetMethodID (class_ref, "set_Key", "(Ljava/lang/String;)V");
-			IntPtr native_value = JNIEnv.NewString (value);
+			IntPtr native_value = JNIEnv.NewString ((string)value);
 			JValue* __args = stackalloc JValue [1];
 			__args [0] = new JValue (native_value);
 			JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_set_Key_Ljava_lang_String_, __args);
@@ -214,7 +214,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	{
 		if (id_GetCountForKey_Ljava_lang_String_ == IntPtr.Zero)
 			id_GetCountForKey_Ljava_lang_String_ = JNIEnv.GetMethodID (class_ref, "GetCountForKey", "(Ljava/lang/String;)I");
-		IntPtr native_key = JNIEnv.NewString (key);
+		IntPtr native_key = JNIEnv.NewString ((string)key);
 		JValue* __args = stackalloc JValue [1];
 		__args [0] = new JValue (native_key);
 		var __ret = JNIEnv.CallIntMethod (((global::Java.Lang.Object) this).Handle, id_GetCountForKey_Ljava_lang_String_, __args);

--- a/tests/generator-Tests/expected.xaji/CSharpKeywords/Xamarin.Test.CSharpKeywords.cs
+++ b/tests/generator-Tests/expected.xaji/CSharpKeywords/Xamarin.Test.CSharpKeywords.cs
@@ -71,7 +71,7 @@ namespace Xamarin.Test {
 		public static unsafe string UseThis (string this_)
 		{
 			const string __id = "useThis.(Ljava/lang/String;)Ljava/lang/String;";
-			IntPtr native_this = JNIEnv.NewString (this_);
+			IntPtr native_this = JNIEnv.NewString ((string)this_);
 			try {
 				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
 				__args [0] = new JniArgumentValue (native_this);

--- a/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.FrameworkMediaCrypto.cs
+++ b/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.FrameworkMediaCrypto.cs
@@ -58,7 +58,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 		public unsafe bool RequiresSecureDecoderComponent (string p0)
 		{
 			const string __id = "requiresSecureDecoderComponent.(Ljava/lang/String;)Z";
-			IntPtr native_p0 = JNIEnv.NewString (p0);
+			IntPtr native_p0 = JNIEnv.NewString ((string)p0);
 			try {
 				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
 				__args [0] = new JniArgumentValue (native_p0);

--- a/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaCrypto.cs
+++ b/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaCrypto.cs
@@ -92,7 +92,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 		{
 			if (id_requiresSecureDecoderComponent_Ljava_lang_String_ == IntPtr.Zero)
 				id_requiresSecureDecoderComponent_Ljava_lang_String_ = JNIEnv.GetMethodID (class_ref, "requiresSecureDecoderComponent", "(Ljava/lang/String;)Z");
-			IntPtr native_p0 = JNIEnv.NewString (p0);
+			IntPtr native_p0 = JNIEnv.NewString ((string)p0);
 			JValue* __args = stackalloc JValue [1];
 			__args [0] = new JValue (native_p0);
 			var __ret = JNIEnv.CallBooleanMethod (((global::Java.Lang.Object) this).Handle, id_requiresSecureDecoderComponent_Ljava_lang_String_, __args);

--- a/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.SomeObject.cs
@@ -254,7 +254,7 @@ namespace Xamarin.Test {
 		public virtual unsafe void VoidMethodWithParams (string astring, int anint, global::Java.Lang.Object anObject)
 		{
 			const string __id = "VoidMethodWithParams.(Ljava/lang/String;ILjava/lang/Object;)V";
-			IntPtr native_astring = JNIEnv.NewString (astring);
+			IntPtr native_astring = JNIEnv.NewString ((string)astring);
 			try {
 				JniArgumentValue* __args = stackalloc JniArgumentValue [3];
 				__args [0] = new JniArgumentValue (native_astring);

--- a/tests/generator-Tests/expected.xaji/NormalProperties/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.xaji/NormalProperties/Xamarin.Test.SomeObject.cs
@@ -250,7 +250,7 @@ namespace Xamarin.Test {
 			[Register ("setSomeString", "(Ljava/lang/String;)V", "GetSetSomeString_Ljava_lang_String_Handler")]
 			set {
 				const string __id = "setSomeString.(Ljava/lang/String;)V";
-				IntPtr native_value = JNIEnv.NewString (value);
+				IntPtr native_value = JNIEnv.NewString ((string)value);
 				try {
 					JniArgumentValue* __args = stackalloc JniArgumentValue [1];
 					__args [0] = new JniArgumentValue (native_value);

--- a/tests/generator-Tests/expected.xaji/StaticProperties/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.xaji/StaticProperties/Xamarin.Test.SomeObject.cs
@@ -75,7 +75,7 @@ namespace Xamarin.Test {
 			[Register ("setSomeString", "(Ljava/lang/String;)V", "")]
 			set {
 				const string __id = "setSomeString.(Ljava/lang/String;)V";
-				IntPtr native_value = JNIEnv.NewString (value);
+				IntPtr native_value = JNIEnv.NewString ((string)value);
 				try {
 					JniArgumentValue* __args = stackalloc JniArgumentValue [1];
 					__args [0] = new JniArgumentValue (native_value);

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericStringPropertyImplementation.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericStringPropertyImplementation.cs
@@ -101,7 +101,7 @@ namespace Test.ME {
 			[Register ("SetObject", "(Ljava/lang/String;)V", "GetSetObject_Ljava_lang_String_Handler")]
 			set {
 				const string __id = "SetObject.(Ljava/lang/String;)V";
-				IntPtr native_value = JNIEnv.NewString (value);
+				IntPtr native_value = JNIEnv.NewString ((string)value);
 				try {
 					JniArgumentValue* __args = stackalloc JniArgumentValue [1];
 					__args [0] = new JniArgumentValue (native_value);

--- a/tests/generator-Tests/expected/CSharpKeywords/Xamarin.Test.CSharpKeywords.cs
+++ b/tests/generator-Tests/expected/CSharpKeywords/Xamarin.Test.CSharpKeywords.cs
@@ -67,7 +67,7 @@ namespace Xamarin.Test {
 		{
 			if (id_useThis_Ljava_lang_String_ == IntPtr.Zero)
 				id_useThis_Ljava_lang_String_ = JNIEnv.GetStaticMethodID (class_ref, "useThis", "(Ljava/lang/String;)Ljava/lang/String;");
-			IntPtr native_this = JNIEnv.NewString (this_);
+			IntPtr native_this = JNIEnv.NewString ((string)this_);
 			try {
 				JValue* __args = stackalloc JValue [1];
 				__args [0] = new JValue (native_this);

--- a/tests/generator-Tests/expected/NormalMethods/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected/NormalMethods/Xamarin.Test.SomeObject.cs
@@ -286,7 +286,7 @@ namespace Xamarin.Test {
 		{
 			if (id_VoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object_ == IntPtr.Zero)
 				id_VoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object_ = JNIEnv.GetMethodID (class_ref, "VoidMethodWithParams", "(Ljava/lang/String;ILjava/lang/Object;)V");
-			IntPtr native_astring = JNIEnv.NewString (astring);
+			IntPtr native_astring = JNIEnv.NewString ((string)astring);
 			try {
 				JValue* __args = stackalloc JValue [3];
 				__args [0] = new JValue (native_astring);

--- a/tests/generator-Tests/expected/NormalProperties/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected/NormalProperties/Xamarin.Test.SomeObject.cs
@@ -227,7 +227,7 @@ namespace Xamarin.Test {
 			set {
 				if (id_setSomeString_Ljava_lang_String_ == IntPtr.Zero)
 					id_setSomeString_Ljava_lang_String_ = JNIEnv.GetMethodID (class_ref, "setSomeString", "(Ljava/lang/String;)V");
-				IntPtr native_value = JNIEnv.NewString (value);
+				IntPtr native_value = JNIEnv.NewString ((string)value);
 				try {
 					JValue* __args = stackalloc JValue [1];
 					__args [0] = new JValue (native_value);

--- a/tests/generator-Tests/expected/StaticProperties/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected/StaticProperties/Xamarin.Test.SomeObject.cs
@@ -70,7 +70,7 @@ namespace Xamarin.Test {
 			set {
 				if (id_setSomeString_Ljava_lang_String_ == IntPtr.Zero)
 					id_setSomeString_Ljava_lang_String_ = JNIEnv.GetStaticMethodID (class_ref, "setSomeString", "(Ljava/lang/String;)V");
-				IntPtr native_value = JNIEnv.NewString (value);
+				IntPtr native_value = JNIEnv.NewString ((string)value);
 				try {
 					JValue* __args = stackalloc JValue [1];
 					__args [0] = new JValue (native_value);

--- a/tests/generator-Tests/expected/TestInterface/Test.ME.GenericStringPropertyImplementation.cs
+++ b/tests/generator-Tests/expected/TestInterface/Test.ME.GenericStringPropertyImplementation.cs
@@ -108,7 +108,7 @@ namespace Test.ME {
 			set {
 				if (id_SetObject_Ljava_lang_String_ == IntPtr.Zero)
 					id_SetObject_Ljava_lang_String_ = JNIEnv.GetMethodID (class_ref, "SetObject", "(Ljava/lang/String;)V");
-				IntPtr native_value = JNIEnv.NewString (value);
+				IntPtr native_value = JNIEnv.NewString ((string)value);
 				try {
 					JValue* __args = stackalloc JValue [1];
 					__args [0] = new JValue (native_value);

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/StringSymbol.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Symbols/StringSymbol.cs
@@ -123,7 +123,7 @@ namespace MonoDroid.Generation {
 				};
 			}
 			return new[]{
-				$"IntPtr {native_name} = JNIEnv.NewString ({managed_name});",
+				$"IntPtr {native_name} = JNIEnv.NewString ((string{opt.NullableOperator}){managed_name});",
 			};
 		}
 


### PR DESCRIPTION
Fixes: #967 
Context: https://github.com/xamarin/AndroidX/pull/512

If you need to change a `string` to JLO for a method parameter, the generated code produces a CS1503 error because it generates this code:
```csharp
// Metadata.xml XPath method reference: path="/api/package[@name='androidx.activity.result.contract']/class[@name='ActivityResultContracts.RequestPermission']/method[@name='createIntent' and count(parameter)=2 and parameter[1][@type='android.content.Context'] and parameter[2][@type='java.lang.String']]"
[Register ("createIntent", "(Landroid/content/Context;Ljava/lang/String;)Landroid/content/Intent;", "")]
public override unsafe global::Android.Content.Intent CreateIntent (global::Android.Content.Context context, global::Java.Lang.Object input)
{
	const string __id = "createIntent.(Landroid/content/Context;Ljava/lang/String;)Landroid/content/Intent;";
	IntPtr native_input = JNIEnv.NewString (input);
	try {
		JniArgumentValue* __args = stackalloc JniArgumentValue [2];
		__args [0] = new JniArgumentValue ((context == null) ? IntPtr.Zero : ((global::Java.Lang.Object) context).Handle);
		__args [1] = new JniArgumentValue (native_input);
		var __rm = _members.InstanceMethods.InvokeAbstractObjectMethod (__id, this, __args);
		return global::Java.Lang.Object.GetObject<global::Android.Content.Intent> (__rm.Handle, JniHandleOwnership.TransferLocalRef);
	} finally {
		JNIEnv.DeleteLocalRef (native_input);
		global::System.GC.KeepAlive (context);
		global::System.GC.KeepAlive (input);
	}
}
```

This produces:
```
Error CS1503 Argument 1: cannot convert from 'Java.Lang.Object' to 'string?'
```

For this line:
```csharp
  IntPtr native_input = JNIEnv.NewString (input);
```

Although there is a cast from JLO to `string`, the cast is explicit, meaning we need to use this:
```csharp
  IntPtr native_input = JNIEnv.NewString ((string?)input);
```

The solution is to add the explicit `(string?)` cast in `generator`.