### PR TITLE
[Directory.Build.props] Set a dummy PackageVersion to work around VS/NuGet issue

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,6 +8,15 @@
     <_OutputPath>$(MSBuildThisFileDirectory)bin\Build$(Configuration)\</_OutputPath>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <ProduceReferenceAssemblyInOutDir>true</ProduceReferenceAssemblyInOutDir>
+    
+    <!-- 
+      Workaround for https://github.com/NuGet/Home/issues/6461 (VSWin Only)
+      Even though we don't build NuGet packages, it still attempts to build the NuGet package name, which includes 
+      the assembly version if PackageVersion isn't specified. Because our assemblies have different versions
+      per-TFM, that causes a problem because the package can't have multiple versions in it.  
+      Set a dummy PackageVersion because we don't actually need it.
+    -->
+    <PackageVersion>1.0.0.0</PackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tools/generator/generator.slnf
+++ b/tools/generator/generator.slnf
@@ -2,11 +2,13 @@
   "solution": {
     "path": "..\\..\\Java.Interop.sln",
     "projects": [
+      "external\\xamarin-android-tools\\src\\Xamarin.Android.Tools.AndroidSdk\\Xamarin.Android.Tools.AndroidSdk.csproj",
       "src\\Java.Interop.Localization\\Java.Interop.Localization.csproj",
       "src\\Java.Interop.Tools.Cecil\\Java.Interop.Tools.Cecil.csproj",
       "src\\Java.Interop.Tools.Diagnostics\\Java.Interop.Tools.Diagnostics.csproj",
       "src\\Java.Interop.Tools.Generator\\Java.Interop.Tools.Generator.csproj",
       "src\\Java.Interop.Tools.JavaCallableWrappers\\Java.Interop.Tools.JavaCallableWrappers.csproj",
+      "src\\Java.Interop.Tools.JavaSource\\Java.Interop.Tools.JavaSource.csproj",
       "src\\Java.Interop.Tools.JavaTypeSystem\\Java.Interop.Tools.JavaTypeSystem.csproj",
       "src\\Xamarin.Android.Tools.AnnotationSupport\\Xamarin.Android.Tools.AnnotationSupport.csproj",
       "src\\Xamarin.Android.Tools.ApiXmlAdjuster\\Xamarin.Android.Tools.ApiXmlAdjuster.csproj",


### PR DESCRIPTION
Context: https://github.com/NuGet/Home/issues/6461

Trying to build `Java.Interop.csproj` in Visual Studio currently fails with several errors like:
```
Error NETSDK1005 Assets file 'C:\code\xamarin-android\external\Java.Interop\tools\generator\obj\project.assets.json' 
doesn't have a target for 'net6.0'. Ensure that restore has run and that you have included 'net6.0' in the 
TargetFrameworks for your project.
```

Even though we don't build NuGet packages, it still attempts to calculate the NuGet package name, which includes the assembly `$(Version)` if `$(PackageVersion)` isn't specified. Because our assemblies have different versions per-TFM, that causes a problem because the package can't have multiple versions in it.  

We can set a dummy `$(PackageVersion)` because we don't actually need it.

Also updates the `generator.slnf` for additional needed projects to build `generator`.