### PR TITLE
[generator] Fix xamarin-android/src/Mono.Android build

### DIFF
--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteMethodWithCharSequenceArrays.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteMethodWithCharSequenceArrays.txt
@@ -1,0 +1,41 @@
+// Metadata.xml XPath class reference: path="/api/package[@name='com.example']/class[@name='MyClass']"
+[global::Java.Interop.JniTypeSignature ("com/example/MyClass", GenerateJavaPeer=false)]
+public partial class MyClass : Java.Lang.Object {
+	static readonly JniPeerMembers _members = new JniPeerMembers ("com/example/MyClass", typeof (MyClass));
+
+	[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
+	[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
+	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+		get { return _members; }
+	}
+
+	protected MyClass (ref JniObjectReference reference, JniObjectReferenceOptions options) : base (ref reference, options)
+	{
+	}
+
+	// Metadata.xml XPath method reference: path="/api/package[@name='com.example']/class[@name='MyClass']/method[@name='echo' and count(parameter)=1 and parameter[1][@type='java.lang.CharSequence[]']]"
+	public virtual unsafe Java.Interop.JavaObjectArray<Java.Lang.ICharSequence>? Echo (Java.Interop.JavaObjectArray<Java.Lang.ICharSequence>? messages)
+	{
+		const string __id = "echo.([Ljava/lang/CharSequence;)[Ljava/lang/CharSequence;";
+		var native_messages = global::Java.Interop.JniEnvironment.Arrays.CreateMarshalObjectArray<global::Java.Lang.ICharSequence> (messages);
+		try {
+			JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+			__args [0] = new JniArgumentValue (native_messages);
+			var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, __args);
+			return global::Java.Interop.JniEnvironment.Runtime.ValueManager.GetValue<global::Java.Interop.JavaObjectArray<Java.Lang.ICharSequence>>(ref __rm, JniObjectReferenceOptions.CopyAndDispose);
+		} finally {
+			if (native_messages != null) {
+				native_messages.DisposeUnlessReferenced ();
+			}
+			global::System.GC.KeepAlive (messages);
+		}
+	}
+
+	public Java.Interop.JavaObjectArray<string>? Echo (Java.Interop.JavaObjectArray<string>? messages)
+	{
+		Java.Interop.JavaObjectArray<Java.Lang.ICharSequence>? __result = Echo (messages);
+		var __rsval = __result;
+		return __rsval;
+	}
+
+}

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteObjectField.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteObjectField.txt
@@ -1,0 +1,31 @@
+// Metadata.xml XPath class reference: path="/api/package[@name='java.code']/class[@name='MyClass']"
+[global::Java.Interop.JniTypeSignature ("java/code/MyClass", GenerateJavaPeer=false)]
+public partial class MyClass {
+
+	// Metadata.xml XPath field reference: path="/api/package[@name='java.code']/class[@name='MyClass']/field[@name='field']"
+	public java.code.Example? field {
+		get {
+			const string __id = "field.Ljava/code/Example;";
+
+			var __v = _members.InstanceFields.GetObjectValue (__id, this);
+			return global::Java.Interop.JniEnvironment.Runtime.ValueManager.GetValue<java.code.Example? >(ref __v, JniObjectReferenceOptions.Copy);
+		}
+		set {
+			const string __id = "field.Ljava/code/Example;";
+
+			try {
+				_members.InstanceFields.SetValue (__id, this, value?.PeerReference ?? default);
+
+			} finally {
+				GC.KeepAlive (value);
+			}
+		}
+	}
+
+	static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/MyClass", typeof (MyClass));
+
+	protected MyClass (ref JniObjectReference reference, JniObjectReferenceOptions options) : base (ref reference, options)
+	{
+	}
+
+}

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteMethodWithCharSequenceArrays.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteMethodWithCharSequenceArrays.txt
@@ -1,0 +1,81 @@
+// Metadata.xml XPath class reference: path="/api/package[@name='com.example']/class[@name='MyClass']"
+[global::Android.Runtime.Register ("com/example/MyClass", DoNotGenerateAcw=true)]
+public partial class MyClass : Java.Lang.Object {
+	static readonly JniPeerMembers _members = new XAPeerMembers ("com/example/MyClass", typeof (MyClass));
+
+	internal static new IntPtr class_ref {
+		get { return _members.JniPeerType.PeerReference.Handle; }
+	}
+
+	[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
+	[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
+	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+		get { return _members; }
+	}
+
+	[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
+	[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
+	protected override IntPtr ThresholdClass {
+		get { return _members.JniPeerType.PeerReference.Handle; }
+	}
+
+	[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
+	[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
+	protected override global::System.Type ThresholdType {
+		get { return _members.ManagedPeerType; }
+	}
+
+	protected MyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+	{
+	}
+
+	static Delegate? cb_echo_arrayLjava_lang_CharSequence_;
+#pragma warning disable 0169
+	static Delegate GetEcho_arrayLjava_lang_CharSequence_Handler ()
+	{
+		if (cb_echo_arrayLjava_lang_CharSequence_ == null)
+			cb_echo_arrayLjava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_L) n_Echo_arrayLjava_lang_CharSequence_);
+		return cb_echo_arrayLjava_lang_CharSequence_;
+	}
+
+	static IntPtr n_Echo_arrayLjava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_messages)
+	{
+		var __this = global::Java.Lang.Object.GetObject<Com.Example.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
+		var messages = (Java.Lang.ICharSequence[]?) JNIEnv.GetArray (native_messages, JniHandleOwnership.DoNotTransfer, typeof (Java.Lang.ICharSequence));
+		IntPtr __ret = JNIEnv.NewArray (__this.EchoFormatted (messages));
+		if (messages != null)
+			JNIEnv.CopyArray (messages, native_messages);
+		return __ret;
+	}
+#pragma warning restore 0169
+
+	// Metadata.xml XPath method reference: path="/api/package[@name='com.example']/class[@name='MyClass']/method[@name='echo' and count(parameter)=1 and parameter[1][@type='java.lang.CharSequence[]']]"
+	[Register ("echo", "([Ljava/lang/CharSequence;)[Ljava/lang/CharSequence;", "GetEcho_arrayLjava_lang_CharSequence_Handler")]
+	public virtual unsafe Java.Lang.ICharSequence[]? EchoFormatted (Java.Lang.ICharSequence[]? messages)
+	{
+		const string __id = "echo.([Ljava/lang/CharSequence;)[Ljava/lang/CharSequence;";
+		IntPtr native_messages = JNIEnv.NewArray (messages);
+		try {
+			JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+			__args [0] = new JniArgumentValue (native_messages);
+			var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, __args);
+			return (Java.Lang.ICharSequence[]?) JNIEnv.GetArray (__rm.Handle, JniHandleOwnership.TransferLocalRef, typeof (Java.Lang.ICharSequence));
+		} finally {
+			if (messages != null) {
+				JNIEnv.CopyArray (native_messages, messages);
+				JNIEnv.DeleteLocalRef (native_messages);
+			}
+			global::System.GC.KeepAlive (messages);
+		}
+	}
+
+	public string[]? Echo (string[]? messages)
+	{
+		var jlca_messages = CharSequence.ArrayFromStringArray (messages);
+		Java.Lang.ICharSequence[]? __result = EchoFormatted (jlca_messages);
+		var __rsval = CharSequence.ArrayToStringArray (__result);
+		if (jlca_messages != null) foreach (var s in jlca_messages) s?.Dispose ();
+		return __rsval;
+	}
+
+}

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteObjectField.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteObjectField.txt
@@ -1,0 +1,36 @@
+// Metadata.xml XPath class reference: path="/api/package[@name='java.code']/class[@name='MyClass']"
+[global::Android.Runtime.Register ("java/code/MyClass", DoNotGenerateAcw=true)]
+public partial class MyClass {
+
+	// Metadata.xml XPath field reference: path="/api/package[@name='java.code']/class[@name='MyClass']/field[@name='field']"
+	[Register ("field")]
+	public java.code.Example? field {
+		get {
+			const string __id = "field.Ljava/code/Example;";
+
+			var __v = _members.InstanceFields.GetObjectValue (__id, this);
+			return global::Java.Lang.Object.GetObject<java.code.Example> (__v.Handle, JniHandleOwnership.TransferLocalRef);
+		}
+		set {
+			const string __id = "field.Ljava/code/Example;";
+
+			IntPtr native_value = global::Android.Runtime.JNIEnv.ToLocalJniHandle (value);
+			try {
+				_members.InstanceFields.SetValue (__id, this, new JniObjectReference (native_value));
+			} finally {
+				global::Android.Runtime.JNIEnv.DeleteLocalRef (native_value);
+			}
+		}
+	}
+
+	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/MyClass", typeof (MyClass));
+
+	internal static IntPtr class_ref {
+		get { return _members.JniPeerType.PeerReference.Handle; }
+	}
+
+	protected MyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+	{
+	}
+
+}

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodWithCharSequenceArrays.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodWithCharSequenceArrays.txt
@@ -1,0 +1,81 @@
+// Metadata.xml XPath class reference: path="/api/package[@name='com.example']/class[@name='MyClass']"
+[global::Android.Runtime.Register ("com/example/MyClass", DoNotGenerateAcw=true)]
+public partial class MyClass : Java.Lang.Object {
+	static readonly JniPeerMembers _members = new XAPeerMembers ("com/example/MyClass", typeof (MyClass));
+
+	internal static new IntPtr class_ref {
+		get { return _members.JniPeerType.PeerReference.Handle; }
+	}
+
+	[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
+	[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
+	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
+		get { return _members; }
+	}
+
+	[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
+	[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
+	protected override IntPtr ThresholdClass {
+		get { return _members.JniPeerType.PeerReference.Handle; }
+	}
+
+	[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
+	[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
+	protected override global::System.Type ThresholdType {
+		get { return _members.ManagedPeerType; }
+	}
+
+	protected MyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+	{
+	}
+
+	static Delegate cb_echo_arrayLjava_lang_CharSequence_;
+#pragma warning disable 0169
+	static Delegate GetEcho_arrayLjava_lang_CharSequence_Handler ()
+	{
+		if (cb_echo_arrayLjava_lang_CharSequence_ == null)
+			cb_echo_arrayLjava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_L) n_Echo_arrayLjava_lang_CharSequence_);
+		return cb_echo_arrayLjava_lang_CharSequence_;
+	}
+
+	static IntPtr n_Echo_arrayLjava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_messages)
+	{
+		var __this = global::Java.Lang.Object.GetObject<Com.Example.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var messages = (Java.Lang.ICharSequence[]) JNIEnv.GetArray (native_messages, JniHandleOwnership.DoNotTransfer, typeof (Java.Lang.ICharSequence));
+		IntPtr __ret = JNIEnv.NewArray (__this.EchoFormatted (messages));
+		if (messages != null)
+			JNIEnv.CopyArray (messages, native_messages);
+		return __ret;
+	}
+#pragma warning restore 0169
+
+	// Metadata.xml XPath method reference: path="/api/package[@name='com.example']/class[@name='MyClass']/method[@name='echo' and count(parameter)=1 and parameter[1][@type='java.lang.CharSequence[]']]"
+	[Register ("echo", "([Ljava/lang/CharSequence;)[Ljava/lang/CharSequence;", "GetEcho_arrayLjava_lang_CharSequence_Handler")]
+	public virtual unsafe Java.Lang.ICharSequence[] EchoFormatted (Java.Lang.ICharSequence[] messages)
+	{
+		const string __id = "echo.([Ljava/lang/CharSequence;)[Ljava/lang/CharSequence;";
+		IntPtr native_messages = JNIEnv.NewArray (messages);
+		try {
+			JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+			__args [0] = new JniArgumentValue (native_messages);
+			var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, __args);
+			return (Java.Lang.ICharSequence[]) JNIEnv.GetArray (__rm.Handle, JniHandleOwnership.TransferLocalRef, typeof (Java.Lang.ICharSequence));
+		} finally {
+			if (messages != null) {
+				JNIEnv.CopyArray (native_messages, messages);
+				JNIEnv.DeleteLocalRef (native_messages);
+			}
+			global::System.GC.KeepAlive (messages);
+		}
+	}
+
+	public string[] Echo (string[] messages)
+	{
+		var jlca_messages = CharSequence.ArrayFromStringArray (messages);
+		Java.Lang.ICharSequence[] __result = EchoFormatted (jlca_messages);
+		var __rsval = CharSequence.ArrayToStringArray (__result);
+		if (jlca_messages != null) foreach (var s in jlca_messages) s?.Dispose ();
+		return __rsval;
+	}
+
+}

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteObjectField.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteObjectField.txt
@@ -1,0 +1,36 @@
+// Metadata.xml XPath class reference: path="/api/package[@name='java.code']/class[@name='MyClass']"
+[global::Android.Runtime.Register ("java/code/MyClass", DoNotGenerateAcw=true)]
+public partial class MyClass {
+
+	// Metadata.xml XPath field reference: path="/api/package[@name='java.code']/class[@name='MyClass']/field[@name='field']"
+	[Register ("field")]
+	public java.code.Example field {
+		get {
+			const string __id = "field.Ljava/code/Example;";
+
+			var __v = _members.InstanceFields.GetObjectValue (__id, this);
+			return global::Java.Lang.Object.GetObject<java.code.Example> (__v.Handle, JniHandleOwnership.TransferLocalRef);
+		}
+		set {
+			const string __id = "field.Ljava/code/Example;";
+
+			IntPtr native_value = global::Android.Runtime.JNIEnv.ToLocalJniHandle (value);
+			try {
+				_members.InstanceFields.SetValue (__id, this, new JniObjectReference (native_value));
+			} finally {
+				global::Android.Runtime.JNIEnv.DeleteLocalRef (native_value);
+			}
+		}
+	}
+
+	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/MyClass", typeof (MyClass));
+
+	internal static IntPtr class_ref {
+		get { return _members.JniPeerType.PeerReference.Handle; }
+	}
+
+	protected MyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+	{
+	}
+
+}

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteMethodWithCharSequenceArrays.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteMethodWithCharSequenceArrays.txt
@@ -1,0 +1,77 @@
+// Metadata.xml XPath class reference: path="/api/package[@name='com.example']/class[@name='MyClass']"
+[global::Android.Runtime.Register ("com/example/MyClass", DoNotGenerateAcw=true)]
+public partial class MyClass : Java.Lang.Object {
+
+	internal static new IntPtr java_class_handle;
+	internal static new IntPtr class_ref {
+		get {
+			return JNIEnv.FindClass ("com/example/MyClass", ref java_class_handle);
+		}
+	}
+
+	protected override IntPtr ThresholdClass {
+		get { return class_ref; }
+	}
+
+	protected override global::System.Type ThresholdType {
+		get { return typeof (MyClass); }
+	}
+
+	protected MyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+	static Delegate cb_echo_arrayLjava_lang_CharSequence_;
+#pragma warning disable 0169
+	static Delegate GetEcho_arrayLjava_lang_CharSequence_Handler ()
+	{
+		if (cb_echo_arrayLjava_lang_CharSequence_ == null)
+			cb_echo_arrayLjava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_L) n_Echo_arrayLjava_lang_CharSequence_);
+		return cb_echo_arrayLjava_lang_CharSequence_;
+	}
+
+	static IntPtr n_Echo_arrayLjava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_messages)
+	{
+		var __this = global::Java.Lang.Object.GetObject<Com.Example.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+		var messages = (Java.Lang.ICharSequence[]) JNIEnv.GetArray (native_messages, JniHandleOwnership.DoNotTransfer, typeof (Java.Lang.ICharSequence));
+		IntPtr __ret = JNIEnv.NewArray (__this.EchoFormatted (messages));
+		if (messages != null)
+			JNIEnv.CopyArray (messages, native_messages);
+		return __ret;
+	}
+#pragma warning restore 0169
+
+	static IntPtr id_echo_arrayLjava_lang_CharSequence_;
+	// Metadata.xml XPath method reference: path="/api/package[@name='com.example']/class[@name='MyClass']/method[@name='echo' and count(parameter)=1 and parameter[1][@type='java.lang.CharSequence[]']]"
+	[Register ("echo", "([Ljava/lang/CharSequence;)[Ljava/lang/CharSequence;", "GetEcho_arrayLjava_lang_CharSequence_Handler")]
+	public virtual unsafe Java.Lang.ICharSequence[] EchoFormatted (Java.Lang.ICharSequence[] messages)
+	{
+		if (id_echo_arrayLjava_lang_CharSequence_ == IntPtr.Zero)
+			id_echo_arrayLjava_lang_CharSequence_ = JNIEnv.GetMethodID (class_ref, "echo", "([Ljava/lang/CharSequence;)[Ljava/lang/CharSequence;");
+		IntPtr native_messages = JNIEnv.NewArray (messages);
+		try {
+			JValue* __args = stackalloc JValue [1];
+			__args [0] = new JValue (native_messages);
+
+			Java.Lang.ICharSequence[] __ret;
+			if (((object) this).GetType () == ThresholdType)
+				__ret = (Java.Lang.ICharSequence[]) JNIEnv.GetArray (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_echo_arrayLjava_lang_CharSequence_, __args), JniHandleOwnership.TransferLocalRef, typeof (Java.Lang.ICharSequence));
+			else
+				__ret = (Java.Lang.ICharSequence[]) JNIEnv.GetArray (JNIEnv.CallNonvirtualObjectMethod (((global::Java.Lang.Object) this).Handle, ThresholdClass, JNIEnv.GetMethodID (ThresholdClass, "echo", "([Ljava/lang/CharSequence;)[Ljava/lang/CharSequence;"), __args), JniHandleOwnership.TransferLocalRef, typeof (Java.Lang.ICharSequence));
+			return __ret;
+		} finally {
+			if (messages != null) {
+				JNIEnv.CopyArray (native_messages, messages);
+				JNIEnv.DeleteLocalRef (native_messages);
+			}
+		}
+	}
+
+	public string[] Echo (string[] messages)
+	{
+		var jlca_messages = CharSequence.ArrayFromStringArray(messages);
+		Java.Lang.ICharSequence[] __result = EchoFormatted (jlca_messages);
+		var __rsval = CharSequence.ArrayToStringArray (__result);
+		if (jlca_messages != null) foreach (var s in jlca_messages) s?.Dispose ();
+		return __rsval;
+	}
+
+}

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteObjectField.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XamarinAndroid/WriteObjectField.txt
@@ -1,0 +1,37 @@
+// Metadata.xml XPath class reference: path="/api/package[@name='java.code']/class[@name='MyClass']"
+[global::Android.Runtime.Register ("java/code/MyClass", DoNotGenerateAcw=true)]
+public partial class MyClass  {
+
+
+	static IntPtr field_jfieldId;
+
+	// Metadata.xml XPath field reference: path="/api/package[@name='java.code']/class[@name='MyClass']/field[@name='field']"
+	[Register ("field")]
+	public java.code.Example field {
+		get {
+			if (field_jfieldId == IntPtr.Zero)
+				field_jfieldId = JNIEnv.GetFieldID (class_ref, "field", "Ljava/code/Example;");
+			IntPtr __ret = JNIEnv.GetObjectField (((global::Java.Lang.Object) this).Handle, field_jfieldId);
+			return global::Java.Lang.Object.GetObject<java.code.Example> (__ret, JniHandleOwnership.TransferLocalRef);
+		}
+		set {
+			if (field_jfieldId == IntPtr.Zero)
+				field_jfieldId = JNIEnv.GetFieldID (class_ref, "field", "Ljava/code/Example;");
+			IntPtr native_value = JNIEnv.ToLocalJniHandle (value);
+			try {
+				JNIEnv.SetField (((global::Java.Lang.Object) this).Handle, field_jfieldId, native_value);
+			} finally {
+				JNIEnv.DeleteLocalRef (native_value);
+			}
+		}
+	}
+	internal static IntPtr java_class_handle;
+	internal static IntPtr class_ref {
+		get {
+			return JNIEnv.FindClass ("java/code/MyClass", ref java_class_handle);
+		}
+	}
+
+	protected MyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) {}
+
+}

--- a/tests/generator-Tests/Unit-Tests/SupportTypes.cs
+++ b/tests/generator-Tests/Unit-Tests/SupportTypes.cs
@@ -266,6 +266,18 @@ namespace generatortests
 			return iface;
 		}
 
+		public static TestField CreateField (string fieldName, CodeGenerationOptions options, string fieldType, bool isStatic = false)
+		{
+			var field = new TestField (fieldType, fieldName);
+
+			if (isStatic)
+				field.SetStatic ();
+
+			field.Validate (options, null, new CodeGeneratorContext ());
+
+			return field;
+		}
+
 		public static TestInterface CreateInterface (string interfaceName, CodeGenerationOptions options)
 		{
 			var iface = CreateEmptyInterface (interfaceName);

--- a/tools/generator/SourceWriters/BoundFieldAsProperty.cs
+++ b/tools/generator/SourceWriters/BoundFieldAsProperty.cs
@@ -144,11 +144,13 @@ namespace generator.SourceWriters
 				if (opt.CodeGenerationTarget != CodeGenerationTarget.JavaInterop1 &&
 						field.SetParameters.HasCleanup &&
 						!have_prep) {
+					arg = native_arg;
 					writer.WriteLine ($"IntPtr {native_arg} = global::Android.Runtime.JNIEnv.ToLocalJniHandle (value);");
 				}
 			}
 
 			writer.WriteLine ("try {");
+
 			writer.Write ($"\t_members.{indirect}.SetValue (__id{(field.IsStatic ? "" : ", this")}, ");
 
 			if (opt.CodeGenerationTarget == CodeGenerationTarget.JavaInterop1) {
@@ -161,7 +163,6 @@ namespace generator.SourceWriters
 			} else {
 				writer.WriteLine ($"{(invokeType != "Object" ? arg : "new JniObjectReference (" + arg + ")")});");
 			}
-			writer.WriteLine ();
 
 			writer.WriteLine ("} finally {");
 			writer.Indent ();

--- a/tools/generator/SourceWriters/Extensions/SourceWriterExtensions.cs
+++ b/tools/generator/SourceWriters/Extensions/SourceWriterExtensions.cs
@@ -367,7 +367,7 @@ namespace generator.SourceWriters
 				case "void":
 					break;
 				case "Java.Lang.ICharSequence[]":
-					writer.WriteLine ($"var __rsval = {opt.GetStringArrayToCharSequenceArrayMethodName ()} (__result);");
+					writer.WriteLine ("var __rsval = CharSequence.ArrayToStringArray (__result);");
 					break;
 				case "Java.Lang.ICharSequence":
 					writer.WriteLine ("var __rsval = __result?.ToString ();");


### PR DESCRIPTION
[generator] Fix xamarin-android/src/Mono.Android build

Context: a65d6fb4d79041c959435c15dc3dcf5331e5d715
Context: https://github.com/xamarin/xamarin-android/pull/6939

xamarin/xamarin-android#6939 attempted to bump to 05eddd9a, which
promptly broke the build of src/Mono.Android, e.g.
`src/Mono.Android/obj/Debug/net6.0/android-32/mcw/Android.Widget.GridLayout.cs`:

	/*       */ partial class GridLayout {
	/*       */     partial class partial class LayoutParams {
	/*       */         [Register ("rowSpec")]
	/*       */         public Android.Widget.GridLayout.Spec? RowSpec {
	/*       */             get {
	/*       */                 const string __id = "rowSpec.Landroid/widget/GridLayout$Spec;";
	/*       */                 var __v = _members.InstanceFields.GetObjectValue (__id, this);
	/*       */                 return global::Java.Lang.Object.GetObject<Android.Widget.GridLayout.Spec> (__v.Handle, JniHandleOwnership.TransferLocalRef);
	/*       */             }
	/*       */             set {
	/*       */                 const string __id = "rowSpec.Landroid/widget/GridLayout$Spec;";
	/*       */                 IntPtr native_value = global::Android.Runtime.JNIEnv.ToLocalJniHandle (value);
	/*       */                 try {
	/* L 239 */                     _members.InstanceFields.SetValue (__id, this, new JniObjectReference (value));
	/*       */                 } finally {
	/* L 242 */                     global::Android.Runtime.JNIEnv.DeleteLocalRef (value);
	/*       */                 }
	/*       */             }
	/*       */         }
	/*       */     }
	/*       */ }

due to compilation errors:

	src/Mono.Android/obj/Debug/net6.0/android-32/mcw/Android.Widget.GridLayout.cs(239,77):
	  error CS1503: Argument 1: cannot convert from 'Android.Widget.GridLayout.Spec' to 'System.IntPtr'
	src/Mono.Android/obj/Debug/net6.0/android-32/mcw/Android.Widget.GridLayout.cs(242,54):
	  error CS1503: Argument 1: cannot convert from 'Android.Widget.GridLayout.Spec' to 'System.IntPtr'

This was caused by `BoundFieldAsProperty.cs` not appropriately
setting `arg` to `native_arg`, so that the correct variable would be
cleaned up in the `finally` block.

There was another set of errors:

	src/Mono.Android/obj/Release/net6.0/android-32/mcw/Android.Widget.ArrayAdapter.cs(525,53):
	  error CS1503: Argument 1: cannot convert from 'Java.Lang.ICharSequence[]' to 'string[]?'

which was also caused by a65d6fb4 mis-refactoring
`SourceWriterExtensions.cs`, and overlooking the entire existence of
the `CharSequence.ArrayToStringArray()` method (oops).

Update `generator` so that xamarin-android once again builds, and add
unit tests to hit these particular code paths.
