### PR TITLE
[generator] Fix reserved keywords binary search

### DIFF
--- a/tests/generator-Tests/Unit-Tests/CodeGenerationOptionsTests.cs
+++ b/tests/generator-Tests/Unit-Tests/CodeGenerationOptionsTests.cs
@@ -1,4 +1,5 @@
-using System;
+using System.Collections.Generic;
+using System.Linq;
 using MonoDroid.Generation;
 using NUnit.Framework;
 
@@ -79,5 +80,17 @@ namespace generatortests
 
 			Assert.AreEqual ("uint", opt.GetTypeReferenceName (primitive_uint));
 		}
+
+		[Test, TestCaseSource (nameof (ReservedKeywords))]
+		[SetCulture ("cs-CZ")]
+		public void GetSafeIdentifierCultureInvariant (string keyword)
+		{
+			var opt = new CodeGenerationOptions { SupportNullableReferenceTypes = true };
+
+			Assert.AreEqual ($"{keyword}_", opt.GetSafeIdentifier (keyword));
+		}
+
+		private static IEnumerable<TestCaseData> ReservedKeywords
+			=> TypeNameUtilities.reserved_keywords.Select (keyword => new TestCaseData (keyword));
 	}
 }

--- a/tests/generator-Tests/Unit-Tests/CodeGenerationOptionsTests.cs
+++ b/tests/generator-Tests/Unit-Tests/CodeGenerationOptionsTests.cs
@@ -85,7 +85,7 @@ namespace generatortests
 		[SetCulture ("cs-CZ")]
 		public void GetSafeIdentifierCultureInvariant (string keyword)
 		{
-			var opt = new CodeGenerationOptions { SupportNullableReferenceTypes = true };
+			var opt = new CodeGenerationOptions ();
 
 			Assert.AreEqual ($"{keyword}_", opt.GetSafeIdentifier (keyword));
 		}

--- a/tests/generator-Tests/Unit-Tests/TypeNameUtilitiesTests.cs
+++ b/tests/generator-Tests/Unit-Tests/TypeNameUtilitiesTests.cs
@@ -1,4 +1,5 @@
-using System;
+using System.Collections.Generic;
+using System.Linq;
 using MonoDroid.Generation;
 using NUnit.Framework;
 
@@ -19,5 +20,17 @@ namespace generatortests
 			Assert.AreEqual ("byte_var", TypeNameUtilities.MangleName ("byte_var"));
 			Assert.AreEqual ("foo", TypeNameUtilities.MangleName ("foo"));
 		}
+
+		[Test, TestCaseSource (nameof (ReservedKeywords))]
+		[SetCulture ("cs-CZ")]
+		public void MangleNameCutlureInvariant (string keyword)
+		{
+			Assert.AreEqual ($"@{keyword}", TypeNameUtilities.MangleName (keyword));
+		}
+
+		private static IEnumerable<TestCaseData> ReservedKeywords
+			=> TypeNameUtilities.reserved_keywords
+				.Where (keyword => keyword != "event") // "event" is a special case which is mapped to "e" instead of "@event"
+				.Select (keyword => new TestCaseData (keyword));
 	}
 }

--- a/tools/generator/CodeGenerationOptions.cs
+++ b/tools/generator/CodeGenerationOptions.cs
@@ -267,7 +267,7 @@ namespace MonoDroid.Generation
 			// (ReturnValue.ToNative() takes an argument which could be either an expression or mere symbol.)
 			if (name [name.Length-1] != ')' && !name.Contains ('.') && !name.StartsWith ("@", StringComparison.Ordinal)) {
 				if (!IdentifierValidator.IsValidIdentifier (name) ||
-						Array.BinarySearch (TypeNameUtilities.reserved_keywords, name) >= 0) {
+						Array.BinarySearch (TypeNameUtilities.reserved_keywords, name, StringComparer.Ordinal) >= 0) {
 					name = name + "_";
 				}
 			}

--- a/tools/generator/Utilities/TypeNameUtilities.cs
+++ b/tools/generator/Utilities/TypeNameUtilities.cs
@@ -80,8 +80,8 @@ namespace MonoDroid.Generation
 		{
 			if (name == "event")
 				return "e";
-			
-			if (Array.BinarySearch (reserved_keywords, name) >= 0)
+
+			if (Array.BinarySearch (reserved_keywords, name, StringComparer.Ordinal) >= 0)
 				return "@" + name;
 
 			return name;


### PR DESCRIPTION
I was having trouble building Xamarin.Android on my PC because the generated C# code wouldn't compile. The identifiers `checked`, `decimal`, and `delegate` wheren't prefixed with `@`. I later found out that this was happening because Windows on my PC had Region format set to Czech. We have this weird _letter_ "ch" which is actually the 9th letter of our alphabet. Therefore, the `required_keywords` array isn't sorted correctly when the culture is `cs-CZ` since it contains the word `"checked"` and `Array.BinarySearch` wasn't working correctly for me because it utilized the default culture-specific string comparer. This PR explicitly sets the string comparer for binary search to `Ordinal` which solves the problem.