### PR TITLE
[Java.Base-Tests] Use $(UtilityOutputFullPath)/jcw-gen.dll

### DIFF
--- a/tests/Java.Base-Tests/Java.Base-Tests.targets
+++ b/tests/Java.Base-Tests/Java.Base-Tests.targets
@@ -19,7 +19,7 @@
       <_RefAsmDirs Include="@(ReferencePathWithRefAssemblies->'%(RootDir)%(Directory).'->Distinct())" />
     </ItemGroup>
     <PropertyGroup>
-      <_JcwGen>"$(ToolOutputFullPath)/jcw-gen.dll"</_JcwGen>
+      <_JcwGen>"$(UtilityOutputFullPath)/jcw-gen.dll"</_JcwGen>
       <_Target>--codegen-target JavaInterop1</_Target>
       <_Output>-o "$(IntermediateOutputPath)/java"</_Output>
       <_Libpath>@(_RefAsmDirs->'-L "%(Identity)"', ' ')</_Libpath>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/6984

While attempting to bump Java.Interop, the **nunit Java.Interop tests**
job is failing on Windows, because it can't find `jcw-gen.dll`:

	C:\a\_work\2\s\external\Java.Interop\tests\Java.Base-Tests\Java.Base-Tests.targets(27,5):
	error MSB3073: The command "C:\a\_work\2\s\bin\Release\dotnet\dotnet "C:\a\_work\2\s\external\Java.Interop\bin\Release-net6.0\/jcw-gen.dll" …"" exited with code 1.

The `jcw-gen.dll` invocation needs to use `$(UtilityOutputFullPath)`,
not `$(ToolOutputFullPath)`, as the `jcw-gen.dll` output path is
altered within xamarin/xamarin-android.  `$(UtilityOutputFullPath)`
allows customization by xamarin-android, not `$(ToolOutputFullPath)`.