### PR TITLE
Update azure-pipelines.yaml

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -21,7 +21,7 @@ variables:
   RunningOnCI: true
   Build.Configuration: Release
   MaxJdkVersion: 8
-  DotNetCoreVersion: 6.0.x
+  DotNetCoreVersion: 6.0.202
   1ESWindowsPool: AzurePipelines-EO
   1ESWindowsImage: AzurePipelinesWindows2022compliant
   1ESMacPool: Azure Pipelines


### PR DESCRIPTION
Mono uses the .NET 6 reference libraries to build the `net6.0` binaries with its `msbuild`.  This works for .NET 6 `6.0.202`, however when .NET 6 is upgraded to `6.0.300` it now fails with:

```
/Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/Microsoft.Common.CurrentVersion.targets(1232,5): error MSB3971: The reference assemblies for ".NETFramework,Version=v6.0" were not found. You might be using an older .NET SDK to target .NET 5.0 or higher. Update Visual Studio and/or your .NET SDK.
```

Pin our .NET 6 to the working version for now so we can continue to build successfully on CI.