### PR TITLE
Fix marshal method descriptors

### DIFF
--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/TypeDefinitionRocks.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/TypeDefinitionRocks.cs
@@ -189,6 +189,6 @@ namespace Java.Interop.Tools.Cecil {
 			return null;
 		}
 
-		public static string? CecilTypeNameToReflectionTypeName (string typeName) => typeName?.Replace ('/', '+');
+		public static string? CecilTypeNameToReflectionTypeName (string? typeName) => typeName?.Replace ('/', '+');
 	}
 }

--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/TypeDefinitionRocks.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/TypeDefinitionRocks.cs
@@ -143,7 +143,7 @@ namespace Java.Interop.Tools.Cecil {
 			return string.Format ("{0}, {1}",
 					// Cecil likes to use '/' as the nested type separator, while
 					// Reflection uses '+' as the nested type separator. Use Reflection.
-					type.FullName.Replace ('/', '+'),
+			                CecilTypeNameToReflectionTypeName (type.FullName),
 					type.GetPartialAssemblyName (resolver));
 		}
 
@@ -160,7 +160,7 @@ namespace Java.Interop.Tools.Cecil {
 			return string.Format ("{0}, {1}",
 					// Cecil likes to use '/' as the nested type separator, while
 					// Reflection uses '+' as the nested type separator. Use Reflection.
-					type.FullName.Replace ('/', '+'),
+			                CecilTypeNameToReflectionTypeName (type.FullName),
 					(def ?? type).Module.Assembly.Name.FullName);
 		}
 
@@ -188,5 +188,7 @@ namespace Java.Interop.Tools.Cecil {
 
 			return null;
 		}
+
+		public static string CecilTypeNameToReflectionTypeName (string typeName) => typeName.Replace ('/', '+');
 	}
 }

--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/TypeDefinitionRocks.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/TypeDefinitionRocks.cs
@@ -189,6 +189,6 @@ namespace Java.Interop.Tools.Cecil {
 			return null;
 		}
 
-		public static string CecilTypeNameToReflectionTypeName (string typeName) => typeName.Replace ('/', '+');
+		public static string? CecilTypeNameToReflectionTypeName (string typeName) => typeName?.Replace ('/', '+');
 	}
 }

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
@@ -34,9 +34,11 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 		public string JniSignature    { get; }
 		public string Connector       { get; }
 		public string ManagedTypeName { get; }
+		public string OriginalDescString  { get; }
 
-		public OverriddenMethodDescriptor (string javaPackageName, string methodDescription)
+		public OverriddenMethodDescriptor (string javaPackageName, string methodDescription, string fallbackManagedTypeName)
 		{
+			OriginalDescString = methodDescription;
 			JavaPackageName = javaPackageName;
 			string[] parts = methodDescription.Split (methodDescSplitChars, 4);
 
@@ -49,8 +51,12 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 			if (parts.Length > 2) {
 				Connector = parts[2];
 				if (parts.Length > 3) {
-					ManagedTypeName = parts[3];
+					ManagedTypeName = parts[3].Replace ('/', '+');
 				}
+			}
+
+			if (String.IsNullOrEmpty (ManagedTypeName)) {
+				ManagedTypeName = fallbackManagedTypeName;
 			}
 		}
 	}
@@ -529,7 +535,6 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 
 		public void Generate (TextWriter writer)
 		{
-			overriddenMethodDescriptors = new List<OverriddenMethodDescriptor> ();
 			if (!string.IsNullOrEmpty (package)) {
 				writer.WriteLine ("package " + package + ";");
 				writer.WriteLine ();
@@ -563,17 +568,6 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 				}
 
 			GenerateFooter (writer);
-
-			string javaTypeName = $"{package}.{name}";
-			AddOverridenMethods (methods);
-			AddOverridenMethods (ctors);
-
-			void AddOverridenMethods (List<Signature> list)
-			{
-				foreach (Signature sig in list) {
-					overriddenMethodDescriptors.Add (new OverriddenMethodDescriptor (javaTypeName, sig.Method));
-				}
-			}
 		}
 
 		public void Generate (string outputPath)
@@ -716,9 +710,17 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 
 		void GenerateRegisterType (TextWriter sw, JavaCallableWrapperGenerator self, string field)
 		{
+			if (overriddenMethodDescriptors == null) {
+				overriddenMethodDescriptors = new List<OverriddenMethodDescriptor> ();
+			}
+
 			sw.WriteLine ("\t\t{0} = ", field);
-			foreach (Signature method in self.methods)
+			string managedTypeName = self.type.GetPartialAssemblyQualifiedName (cache);
+			string javaTypeName = $"{package}.{name}";
+			foreach (Signature method in self.methods) {
 				sw.WriteLine ("\t\t\t\"{0}\\n\" +", method.Method);
+				overriddenMethodDescriptors.Add (new OverriddenMethodDescriptor (javaTypeName, method.Method, managedTypeName));
+			}
 			sw.WriteLine ("\t\t\t\"\";");
 			if (CannotRegisterInStaticConstructor (self.type))
 				return;
@@ -732,7 +734,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 					break;
 			}
 			sw.Write ("\t\t");
-			sw.WriteLine (format, self.type.GetPartialAssemblyQualifiedName (cache), self.name, field);
+			sw.WriteLine (format, managedTypeName, self.name, field);
 		}
 
 		void GenerateFooter (TextWriter sw)

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
@@ -51,7 +51,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 			if (parts.Length > 2) {
 				Connector = parts[2];
 				if (parts.Length > 3) {
-					ManagedTypeName = parts[3].Replace ('/', '+');
+					ManagedTypeName = TypeDefinitionRocks.CecilTypeNameToReflectionTypeName (parts[3]);
 				}
 			}
 


### PR DESCRIPTION
Context: fb94d598bddf7818d841914dd4f565cf5cd0bbac

fb94d598 added code to collect all overriden method descriptors in
a list, so that the future marshal methods code generator can generate
correct code for them.  However, not all gathered descriptors contained
name of the managed type which declares the overridden methods.  This
commit fixes the problem.