### PR TITLE
[build] Use explicit netstandard2.0 protobuf ref

### DIFF
--- a/src/Xamarin.Android.Tools.Bytecode/Xamarin.Android.Tools.Bytecode.csproj
+++ b/src/Xamarin.Android.Tools.Bytecode/Xamarin.Android.Tools.Bytecode.csproj
@@ -18,7 +18,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="protobuf-net" />
+    <!-- Always reference the netstandard2.0 version of protobuf-net as it is a shared dependency. -->
+    <PackageReference Include="protobuf-net" ExcludeAssets="Compile" GeneratePathProperty="true" />
+    <Reference Include="protobuf-net">
+      <HintPath>$(PkgProtobuf-net)\lib\netstandard2.0\protobuf-net.dll</HintPath>
+    </Reference>
   </ItemGroup>
 
 </Project>

--- a/tools/java-source-utils/java-source-utils.csproj
+++ b/tools/java-source-utils/java-source-utils.csproj
@@ -1,13 +1,9 @@
 <Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
-    <TargetFrameworks>net472</TargetFrameworks>
+    <TargetFrameworks>$(DotNetTargetFramework)</TargetFrameworks>
     <OutputPath>$(UtilityOutputFullPath)</OutputPath>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" />
-  </ItemGroup>
 
   <ItemGroup>
     <CompileJava Include="src\main\**\*.java" />


### PR DESCRIPTION
Updates Xamarin.Android.Tools.Bytecode to always use the netstandard2.0
version of `protobuf-net`, as this is the version that ships in Xamarin
Android.

The TargetFramework of java-source-utils has also been updated to adjust
the output path of this project when building from Xamarin.Android.