### PR TITLE
[Java.Interop-MonoAndroid.csproj] Add ProjectReference to 'jnienv-gen'.

### DIFF
--- a/src/Java.Interop/Java.Interop-MonoAndroid.csproj
+++ b/src/Java.Interop/Java.Interop-MonoAndroid.csproj
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup Condition=" '$(XAInstallPrefix)' != '' ">
+    <TargetFrameworkIdentifier>MonoAndroid</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
+    <TargetFrameworkRootPath>$(XAInstallPrefix)xbuild-frameworks</TargetFrameworkRootPath>
+  </PropertyGroup>
+  
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -113,5 +120,10 @@
     <None Include="Documentation\Java.Interop\IJavaPeerable.xml" />
     <None Include="Documentation\Java.Interop\JniManagedPeerStates.xml" />
     <None Include="Documentation\Java.Interop\JniEnvironment.References.xml" />
+    <ProjectReference Include="..\..\build-tools\jnienv-gen\jnienv-gen.csproj"
+        ReferenceOutputAssembly="false"
+        SkipGetTargetFrameworkProperties="True"
+        AdditionalProperties="TargetFramework=net472"
+    />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes a parallel build issue in Xamarin.Android by adding a project reference to `jnienv-gen.csproj` from `Java.Interop-MonoAndroid.csproj`.  This ensures `jnienv-gen.exe` is available when building `Java.Interop-MonoAndroid.csproj`.

`Java.Interop-MonoAndroid.csproj` is built via the `<MSBuild>` task and was previously called with global properties specifying `MonoAndroid1.0` target framework.  

```xml
    <PropertyGroup>
      <_GlobalProperties>
        JavaInteropProfile=Net45;
        XAInstallPrefix=$(XAInstallPrefix);
        TargetFrameworkIdentifier=MonoAndroid;
        TargetFrameworkVersion=v1.0;
        TargetFrameworkRootPath=$(XAInstallPrefix)xbuild-frameworks;
      </_GlobalProperties>
    </PropertyGroup>
    <MSBuild
        Projects="$(JavaInteropFullPath)\src\Java.Interop\Java.Interop-MonoAndroid.csproj"
        Properties="$(_GlobalProperties)"
    />
```

However these properties flow to the `jnienv-gen` build, causing it to build as `monoandroid10` instead of `net472`.  

Move the `TargetFramework*` global properties from `Mono.Android.targets` to regular properties in `Java.Interop-MonoAndroid.csproj` so they are not passed to `jnienv-gen.csproj`.

This project will now be called with:

```xml
      <_GlobalProperties>
        JavaInteropProfile=Net45;
        XAInstallPrefix=$(XAInstallPrefix);
      </_GlobalProperties>
```

XA Companion PR: https://github.com/xamarin/xamarin-android/pull/7068