### PR TITLE
[Javadoc] Merge return values on bound properties

### DIFF
--- a/tools/generator/SourceWriters/BoundProperty.cs
+++ b/tools/generator/SourceWriters/BoundProperty.cs
@@ -179,6 +179,7 @@ namespace generator.SourceWriters
 
 				MergeSummary (memberDocs, setterDocs);
 				MergeRemarks (memberDocs, setterDocs);
+				MergeReturns (memberDocs, setterDocs);
 
 				memberDocs.Add (setterDocs.Nodes ());
 			}
@@ -221,6 +222,21 @@ namespace generator.SourceWriters
 				toContent.AddFirst (new XElement ("para", "Property getter documentation:"));
 				toContent.Add (new XElement ("para", "Property setter documentation:"));
 				toContent.Add (fromContent.Nodes ());
+			}
+		}
+
+		static void MergeReturns (XElement mergeInto, XElement mergeFrom)
+		{
+			var toContent = mergeInto.Element ("returns");
+			var fromContent = mergeFrom.Element ("returns");
+
+			if (toContent != null && fromContent != null) {
+				if (toContent.Value == fromContent.Value) {
+					fromContent.Remove ();
+				} else {
+					toContent.Add (" ");
+					toContent.Add (fromContent.Nodes ());
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Context: https://developer.android.com/reference/android/animation/Keyframe#setInterpolator(android.animation.TimeInterpolator)

The Java source for `Keyframe.setInterpolator` incidentally includes a
`@return` tag, even though the return type is void:

```java
    /**
     * Sets the optional interpolator for this Keyframe. A value of <code>null</code> indicates
     * that there is no interpolation, which is the same as linear interpolation.
     *
     * @return The optional interpolator for this Keyframe.
     */
    public void setInterpolator(TimeInterpolator interpolator) {
        mInterpolator = interpolator;
    }
```

This causes us to generate multiple `<returns>` C# doc comment tags on
the `Android.Animation.Keyframe.Interpolator` property, as the setter
and getter both include the same `@return` tag:

```csharp
    /// <summary>Gets the optional interpolator for this Keyframe. -or- Sets the optional interpolator for this Keyframe.</summary>
    /// ...
    /// <returns>The optional interpolator for this Keyframe.</returns>
    /// <returns>The optional interpolator for this Keyframe.</returns>
    public virtual unsafe Android.Animation.ITimeInterpolator? Interpolator {
```

The `mdoc.exe` tool does not handle this well, and will continously
append a `<value>` element on this property every time the tool runs
against our improperly formatted C# doc comments:

```xml
    <Docs>
      <summary>Gets the optional interpolator for this Keyframe. -or- Sets the optional interpolator for this Keyframe.</summary>
      <value>The optional interpolator for this Keyframe.</value>
      <value>The optional interpolator for this Keyframe.</value>
      <value>The optional interpolator for this Keyframe.</value>
      ...
      <since version="Added in API level 11" />
    </Docs>
```

Fix this by attempting to merge `returns` elements for property getters
and setters.