### PR TITLE
[generator] Process javadoc for nested types

### DIFF
--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/JavadocInfo.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/JavadocInfo.cs
@@ -257,9 +257,10 @@ namespace MonoDroid.Generation
 			// Example: "https://developer.android.com/reference/android/app/Application#registerOnProvideAssistDataListener(android.app.Application.OnProvideAssistDataListener)"
 			// Example: "https://developer.android.com/reference/android/animation/ObjectAnimator#ofFloat(T,%20android.util.Property%3CT,%20java.lang.Float%3E,%20float...)"
 
+			declaringJniType = declaringJniType.Replace ("$", ".");
 			var java    = new StringBuilder (declaringJniType)
-				.Replace ("/", ".")
-				.Replace ("$", ".");
+				.Replace ("/", ".");
+
 			var url     = new StringBuilder (prefix);
 			if (!prefix.EndsWith ("/", StringComparison.Ordinal)) {
 				url.Append ("/");

--- a/tools/generator/Java.Interop.Tools.Generator.Transformation/JavadocFixups.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Transformation/JavadocFixups.cs
@@ -46,6 +46,9 @@ namespace Java.Interop.Tools.Generator.Transformation
 
 			foreach (var type in gens) {
 				AddJavadoc (type, typeJavadocs, options.XmldocStyle);
+				foreach (var nested in type.NestedTypes) {
+					AddJavadoc (nested, typeJavadocs, options.XmldocStyle);
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes: https://github.com/xamarin/java.interop/issues/992

Looking at the latest set of API docs for [a nested type][0] I noticed
that we were missing a lot of content that should have been produced by
the Mono.Android build when translating Javadoc to C# doc comments.

After further investigation, we realized that we were not attempting to
process and translate Javadoc for _any_ nested types.  This has been
fixed by adding a missing Javadoc processing iteration over each types
nested type.

Additionally, Java documentation URLs for nested types have been fixed
by replacing '$' with '.' in both the URL and text for the URL.

[0]: https://github.com/xamarin/android-api-docs/blame/b4084443c0354661e2257eb698e03d3fe1d86f1b/docs/Mono.Android/en/Android.AccessibilityServices/AccessibilityButtonController%2BAccessibilityButtonCallback.xml#L25