### PR TITLE
[marshal-methods] Add marshal methods classification code

### DIFF
--- a/src/Java.Interop.NamingCustomAttributes/Android.Runtime/RegisterAttribute.cs
+++ b/src/Java.Interop.NamingCustomAttributes/Android.Runtime/RegisterAttribute.cs
@@ -26,7 +26,7 @@ namespace Android.Runtime {
 		}
 
 		public RegisterAttribute (string name, string signature, string connector)
-			: this (name, originAttribute)
+			: this (name)
 		{
 			this.connector = connector;
 			this.signature = signature;

--- a/src/Java.Interop.NamingCustomAttributes/Android.Runtime/RegisterAttribute.cs
+++ b/src/Java.Interop.NamingCustomAttributes/Android.Runtime/RegisterAttribute.cs
@@ -1,5 +1,7 @@
 using System;
 
+using Mono.Cecil;
+
 namespace Android.Runtime {
 
 	[AttributeUsage (AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Field | AttributeTargets.Interface | AttributeTargets.Method | AttributeTargets.Property)]
@@ -12,17 +14,20 @@ namespace Android.Runtime {
 		string name;
 		string signature;
 
-		public RegisterAttribute (string name)
+		public RegisterAttribute (string name, CustomAttribute originAttribute)
 		{
 			this.name = name;
+			OriginAttribute = originAttribute;
 		}
 
-		public RegisterAttribute (string name, string signature, string connector)
-			: this (name)
+		public RegisterAttribute (string name, string signature, string connector, CustomAttribute originAttribute)
+			: this (name, originAttribute)
 		{
 			this.connector = connector;
 			this.signature = signature;
 		}
+
+		public CustomAttribute OriginAttribute { get; }
 
 		public string Connector {
 			get { return connector; }

--- a/src/Java.Interop.NamingCustomAttributes/Android.Runtime/RegisterAttribute.cs
+++ b/src/Java.Interop.NamingCustomAttributes/Android.Runtime/RegisterAttribute.cs
@@ -39,7 +39,8 @@ namespace Android.Runtime {
 		}
 
 		public CustomAttribute OriginAttribute { get; }
-#endif
+#endif  // HAVE_CECIL
+
 		public string Connector {
 			get { return connector; }
 			set { connector = value; }

--- a/src/Java.Interop.NamingCustomAttributes/Android.Runtime/RegisterAttribute.cs
+++ b/src/Java.Interop.NamingCustomAttributes/Android.Runtime/RegisterAttribute.cs
@@ -14,17 +14,28 @@ namespace Android.Runtime {
 		string name;
 		string signature;
 
-		public RegisterAttribute (string name, CustomAttribute originAttribute)
+		public RegisterAttribute (string name)
 		{
 			this.name = name;
+		}
+
+		public RegisterAttribute (string name, CustomAttribute originAttribute)
+			: this (name)
+		{
 			OriginAttribute = originAttribute;
 		}
 
-		public RegisterAttribute (string name, string signature, string connector, CustomAttribute originAttribute)
+		public RegisterAttribute (string name, string signature, string connector)
 			: this (name, originAttribute)
 		{
 			this.connector = connector;
 			this.signature = signature;
+		}
+
+		public RegisterAttribute (string name, string signature, string connector, CustomAttribute originAttribute)
+			: this (name, signature, connector)
+		{
+			OriginAttribute = originAttribute;
 		}
 
 		public CustomAttribute OriginAttribute { get; }

--- a/src/Java.Interop.NamingCustomAttributes/Android.Runtime/RegisterAttribute.cs
+++ b/src/Java.Interop.NamingCustomAttributes/Android.Runtime/RegisterAttribute.cs
@@ -19,17 +19,17 @@ namespace Android.Runtime {
 			this.name = name;
 		}
 
-		public RegisterAttribute (string name, CustomAttribute originAttribute)
-			: this (name)
-		{
-			OriginAttribute = originAttribute;
-		}
-
 		public RegisterAttribute (string name, string signature, string connector)
 			: this (name)
 		{
 			this.connector = connector;
 			this.signature = signature;
+		}
+#if HAVE_CECIL
+		public RegisterAttribute (string name, CustomAttribute originAttribute)
+			: this (name)
+		{
+			OriginAttribute = originAttribute;
 		}
 
 		public RegisterAttribute (string name, string signature, string connector, CustomAttribute originAttribute)
@@ -39,7 +39,7 @@ namespace Android.Runtime {
 		}
 
 		public CustomAttribute OriginAttribute { get; }
-
+#endif
 		public string Connector {
 			get { return connector; }
 			set { connector = value; }

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
@@ -27,7 +27,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 
 	public abstract class JavaCallableMethodClassifier
 	{
-		public abstract bool ShouldBeDynamicallyRegistered (MethodDefinition registeredMethod, MethodDefinition implementedMethod, CustomAttribute registerAttribute);
+		public abstract bool ShouldBeDynamicallyRegistered (TypeDefinition topType, MethodDefinition registeredMethod, MethodDefinition implementedMethod, CustomAttribute registerAttribute);
 	}
 
 	 public class JavaCallableWrapperGenerator {
@@ -442,7 +442,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 					if (attr.Name.Contains ("-impl") || (attr.Name.Length > 7 && attr.Name[attr.Name.Length - 8] == '-'))
 						Diagnostic.Error (4217, LookupSource (implementedMethod), Localization.Resources.JavaCallableWrappers_XA4217, attr.Name);
 
-					bool shouldBeDynamicallyRegistered = methodClassifier?.ShouldBeDynamicallyRegistered (registeredMethod, implementedMethod, attr.OriginAttribute) ?? true;
+					bool shouldBeDynamicallyRegistered = methodClassifier?.ShouldBeDynamicallyRegistered (type, registeredMethod, implementedMethod, attr.OriginAttribute) ?? true;
 					var msig = new Signature (implementedMethod, attr, shouldBeDynamicallyRegistered);
 					if (!registeredMethod.IsConstructor && !methods.Any (m => m.Name == msig.Name && m.Params == msig.Params))
 						methods.Add (msig);

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
@@ -531,7 +531,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 						continue;
 					}
 					needCtor = true;
-					writer.WriteLine ("\tstatic final String __md_{0}_methods;", i);
+					writer.WriteLine ("\tstatic final String __md_{0}_methods;", i + 1);
 				}
 			}
 

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
@@ -711,14 +711,13 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 
 		void GenerateRegisterType (TextWriter sw, JavaCallableWrapperGenerator self, string field)
 		{
-			string managedTypeName = self.type.GetPartialAssemblyQualifiedName (cache);
-			string javaTypeName = $"{package}.{name}";
-
 			if (!self.HasDynamicallyRegisteredMethods) {
 				return;
 			}
 
 			sw.WriteLine ("\t\t{0} = ", field);
+			string managedTypeName = self.type.GetPartialAssemblyQualifiedName (cache);
+			string javaTypeName = $"{package}.{name}";
 
 			foreach (Signature method in self.methods) {
 				if (method.IsDynamicallyRegistered) {

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
@@ -25,40 +25,9 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 		JavaInterop1,
 	}
 
-	public class OverriddenMethodDescriptor
+	public interface IJCWMethodClassifier
 	{
-		static readonly char[] methodDescSplitChars = new char[] { ':' };
-
-		public string JavaPackageName { get; }
-		public string NativeName      { get; }
-		public string JniSignature    { get; }
-		public string Connector       { get; }
-		public string ManagedTypeName { get; }
-		public string OriginalDescString  { get; }
-
-		public OverriddenMethodDescriptor (string javaPackageName, string methodDescription, string fallbackManagedTypeName)
-		{
-			OriginalDescString = methodDescription;
-			JavaPackageName = javaPackageName;
-			string[] parts = methodDescription.Split (methodDescSplitChars, 4);
-
-			if (parts.Length < 2) {
-				throw new InvalidOperationException ($"Unexpected format for method description. Expected at least 2 parts, got {parts.Length} from: '{methodDescription}'");
-			}
-
-			NativeName = parts[0];
-			JniSignature = parts[1];
-			if (parts.Length > 2) {
-				Connector = parts[2];
-				if (parts.Length > 3) {
-					ManagedTypeName = TypeDefinitionRocks.CecilTypeNameToReflectionTypeName (parts[3]);
-				}
-			}
-
-			if (String.IsNullOrEmpty (ManagedTypeName)) {
-				ManagedTypeName = fallbackManagedTypeName;
-			}
-		}
+		bool ShouldBeDynamicallyRegistered (MethodDefinition registeredMethod, MethodDefinition implementedMethod, CustomAttribute registerAttribute);
 	}
 
 	 public class JavaCallableWrapperGenerator {
@@ -95,21 +64,22 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 		List<Signature> methods = new List<Signature> ();
 		List<Signature> ctors   = new List<Signature> ();
 		List<JavaCallableWrapperGenerator> children;
-		List<OverriddenMethodDescriptor> overriddenMethodDescriptors;
+
 		readonly IMetadataResolver cache;
+		readonly IJCWMethodClassifier methodClassifier;
 
 		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
 		public JavaCallableWrapperGenerator (TypeDefinition type, Action<string, object []> log)
 			: this (type, null, log, resolver: null)
 		{ }
 
-		public JavaCallableWrapperGenerator (TypeDefinition type, Action<string, object[]> log, TypeDefinitionCache cache)
-			: this (type, log, (IMetadataResolver) cache)
+		public JavaCallableWrapperGenerator (TypeDefinition type, Action<string, object[]> log, TypeDefinitionCache cache, IJCWMethodClassifier methodClassifier = null)
+			: this (type, log, (IMetadataResolver) cache, methodClassifier)
 		{
 		}
 
-		public JavaCallableWrapperGenerator (TypeDefinition type, Action<string, object[]> log, IMetadataResolver resolver)
-			: this (type, null, log, resolver)
+		public JavaCallableWrapperGenerator (TypeDefinition type, Action<string, object[]> log, IMetadataResolver resolver, IJCWMethodClassifier methodClassifier = null)
+			: this (type, null, log, resolver, methodClassifier)
 		{
 			if (type.HasNestedTypes) {
 				children = new List<JavaCallableWrapperGenerator> ();
@@ -117,13 +87,14 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 			}
 		}
 
-		public  IList<OverriddenMethodDescriptor> OverriddenMethodDescriptors => overriddenMethodDescriptors;
 		public  string          ApplicationJavaClass            { get; set; }
 		public  JavaPeerStyle   CodeGenerationTarget            { get; set; }
 
 		public bool GenerateOnCreateOverrides { get; set; }
 
 		public bool HasExport { get; private set; }
+
+		public bool HasDynamicallyRegisteredMethods => methods.Any ((Signature sig) => sig.IsDynamicallyRegistered);
 
 		/// <summary>
 		/// The Java source code to be included in Instrumentation.onCreate
@@ -152,8 +123,9 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 			HasExport |= children.Any (t => t.HasExport);
 		}
 
-		JavaCallableWrapperGenerator (TypeDefinition type, string outerType, Action<string, object[]> log, IMetadataResolver resolver)
+		JavaCallableWrapperGenerator (TypeDefinition type, string outerType, Action<string, object[]> log, IMetadataResolver resolver, IJCWMethodClassifier methodClassifier = null)
 		{
+			this.methodClassifier = methodClassifier;
 			this.type = type;
 			this.log = log;
 			this.cache = resolver ?? new TypeDefinitionCache ();
@@ -366,12 +338,13 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 			// attr.Resolve ();
 			RegisterAttribute r = null;
 			if (attr.ConstructorArguments.Count == 1)
-				r = new RegisterAttribute ((string) attr.ConstructorArguments [0].Value);
+				r = new RegisterAttribute ((string) attr.ConstructorArguments [0].Value, attr);
 			else if (attr.ConstructorArguments.Count == 3)
 				r = new RegisterAttribute (
 						(string) attr.ConstructorArguments [0].Value,
 						(string) attr.ConstructorArguments [1].Value,
-						(string) attr.ConstructorArguments [2].Value);
+						(string) attr.ConstructorArguments [2].Value,
+						attr);
 			if (r != null) {
 				var v = attr.Properties.FirstOrDefault (p => p.Name == "DoNotGenerateAcw");
 				r.DoNotGenerateAcw = v.Name == null ? false : (bool) v.Argument.Value;
@@ -384,7 +357,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 			// attr.Resolve ();
 			RegisterAttribute r = null;
 			if (attr.ConstructorArguments.Count == 1)
-				r = new RegisterAttribute ((string) attr.ConstructorArguments [0].Value);
+				r = new RegisterAttribute ((string) attr.ConstructorArguments [0].Value, attr);
 			if (r != null) {
 				var v = attr.Properties.FirstOrDefault (p => p.Name == "GenerateJavaPeer");
 				if (v.Name == null) {
@@ -403,7 +376,8 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 			if (attr.ConstructorArguments.Count == 2)
 				r = new RegisterAttribute ((string) attr.ConstructorArguments [0].Value,
 					(string) attr.ConstructorArguments [1].Value,
-					"");
+				        "",
+				        attr);
 			return r;
 		}
 
@@ -467,7 +441,8 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 					if (attr.Name.Contains ("-impl") || (attr.Name.Length > 7 && attr.Name[attr.Name.Length - 8] == '-'))
 						Diagnostic.Error (4217, LookupSource (implementedMethod), Localization.Resources.JavaCallableWrappers_XA4217, attr.Name);
 
-					var msig = new Signature (implementedMethod, attr);
+					bool shouldBeDynamicallyRegistered = methodClassifier?.ShouldBeDynamicallyRegistered (registeredMethod, implementedMethod, attr.OriginAttribute) ?? false;
+					var msig = new Signature (implementedMethod, attr, shouldBeDynamicallyRegistered);
 					if (!registeredMethod.IsConstructor && !methods.Any (m => m.Name == msig.Name && m.Params == msig.Params))
 						methods.Add (msig);
 				}
@@ -542,21 +517,38 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 
 			GenerateHeader (writer);
 
-			writer.WriteLine ("/** @hide */");
-			writer.WriteLine ("\tpublic static final String __md_methods;");
-			if (children != null) {
-				foreach (var i in Enumerable.Range (1, children.Count))
-					writer.WriteLine ("\tstatic final String __md_{0}_methods;", i);
+			bool needCtor = false;
+			if (HasDynamicallyRegisteredMethods) {
+				needCtor = true;
+				writer.WriteLine ("/** @hide */");
+				writer.WriteLine ("\tpublic static final String __md_methods;");
 			}
-			writer.WriteLine ("\tstatic {");
-			GenerateRegisterType (writer, this, "__md_methods");
+
 			if (children != null) {
-				for (int i = 0; i < children.Count; ++i) {
-					string methods = string.Format ("__md_{0}_methods", i + 1);
-					GenerateRegisterType (writer, children [i], methods);
+				for (int i = 0; i < children.Count; i++) {
+					if (!children[i].HasDynamicallyRegisteredMethods) {
+						continue;
+					}
+					needCtor = true;
+					writer.WriteLine ("\tstatic final String __md_{0}_methods;", i);
 				}
 			}
-			writer.WriteLine ("\t}");
+
+			if (needCtor) {
+				writer.WriteLine ("\tstatic {");
+
+				if (HasDynamicallyRegisteredMethods) {
+					GenerateRegisterType (writer, this, "__md_methods");
+				}
+
+				if (children != null) {
+					for (int i = 0; i < children.Count; ++i) {
+						string methods = string.Format ("__md_{0}_methods", i + 1);
+						GenerateRegisterType (writer, children [i], methods);
+					}
+				}
+				writer.WriteLine ("\t}");
+			}
 
 			GenerateBody (writer);
 
@@ -710,16 +702,19 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 
 		void GenerateRegisterType (TextWriter sw, JavaCallableWrapperGenerator self, string field)
 		{
-			if (overriddenMethodDescriptors == null) {
-				overriddenMethodDescriptors = new List<OverriddenMethodDescriptor> ();
+			string managedTypeName = self.type.GetPartialAssemblyQualifiedName (cache);
+			string javaTypeName = $"{package}.{name}";
+
+			if (!self.HasDynamicallyRegisteredMethods) {
+				return;
 			}
 
 			sw.WriteLine ("\t\t{0} = ", field);
-			string managedTypeName = self.type.GetPartialAssemblyQualifiedName (cache);
-			string javaTypeName = $"{package}.{name}";
+
 			foreach (Signature method in self.methods) {
-				sw.WriteLine ("\t\t\t\"{0}\\n\" +", method.Method);
-				overriddenMethodDescriptors.Add (new OverriddenMethodDescriptor (javaTypeName, method.Method, managedTypeName));
+				if (method.IsDynamicallyRegistered) {
+					sw.WriteLine ("\t\t\t\"{0}\\n\" +", method.Method);
+				}
 			}
 			sw.WriteLine ("\t\t\t\"\";");
 			if (CannotRegisterInStaticConstructor (self.type))
@@ -772,12 +767,13 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 
 		class Signature {
 
-			public Signature (MethodDefinition method, RegisterAttribute register) : this (method, register, null, null) {}
+			public Signature (MethodDefinition method, RegisterAttribute register, bool shouldBeDynamicallyRegistered = true) : this (method, register, null, null, shouldBeDynamicallyRegistered) {}
 
-			public Signature (MethodDefinition method, RegisterAttribute register, string managedParameters, string outerType)
+			public Signature (MethodDefinition method, RegisterAttribute register, string managedParameters, string outerType, bool shouldBeDynamicallyRegistered = true)
 				: this (register.Name, register.Signature, register.Connector, managedParameters, outerType, null)
 			{
 				Annotations = JavaCallableWrapperGenerator.GetAnnotationsString ("\t", method.CustomAttributes);
+				IsDynamicallyRegistered = shouldBeDynamicallyRegistered;
 			}
 
 			public Signature (MethodDefinition method, ExportAttribute export, IMetadataResolver cache)
@@ -880,6 +876,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 			public readonly string Method;
 			public readonly bool IsExport;
 			public readonly bool IsStatic;
+			public readonly bool IsDynamicallyRegistered = true;
 			public readonly string [] ThrownTypeNames;
 			public readonly string Annotations;
 		}

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
@@ -70,15 +70,23 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 
 		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
 		public JavaCallableWrapperGenerator (TypeDefinition type, Action<string, object []> log)
-			: this (type, null, log, resolver: null)
+			: this (type, log, resolver: null, methodClassifier: null)
 		{ }
 
-		public JavaCallableWrapperGenerator (TypeDefinition type, Action<string, object[]> log, TypeDefinitionCache cache, JavaCallableMethodClassifier methodClassifier = null)
+		public JavaCallableWrapperGenerator (TypeDefinition type, Action<string, object[]> log, TypeDefinitionCache cache)
+			: this (type, log, (IMetadataResolver) cache, methodClassifier: null)
+		{ }
+
+		public JavaCallableWrapperGenerator (TypeDefinition type, Action<string, object[]> log, TypeDefinitionCache cache, JavaCallableMethodClassifier methodClassifier)
 			: this (type, log, (IMetadataResolver) cache, methodClassifier)
 		{
 		}
 
-		public JavaCallableWrapperGenerator (TypeDefinition type, Action<string, object[]> log, IMetadataResolver resolver, JavaCallableMethodClassifier methodClassifier = null)
+		public JavaCallableWrapperGenerator (TypeDefinition type, Action<string, object[]> log, IMetadataResolver resolver)
+			: this (type, log, resolver, methodClassifier: null)
+		{ }
+
+		public JavaCallableWrapperGenerator (TypeDefinition type, Action<string, object[]> log, IMetadataResolver resolver, JavaCallableMethodClassifier methodClassifier)
 			: this (type, null, log, resolver, methodClassifier)
 		{
 			if (type.HasNestedTypes) {

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
@@ -441,7 +441,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 					if (attr.Name.Contains ("-impl") || (attr.Name.Length > 7 && attr.Name[attr.Name.Length - 8] == '-'))
 						Diagnostic.Error (4217, LookupSource (implementedMethod), Localization.Resources.JavaCallableWrappers_XA4217, attr.Name);
 
-					bool shouldBeDynamicallyRegistered = methodClassifier?.ShouldBeDynamicallyRegistered (registeredMethod, implementedMethod, attr.OriginAttribute) ?? false;
+					bool shouldBeDynamicallyRegistered = methodClassifier?.ShouldBeDynamicallyRegistered (registeredMethod, implementedMethod, attr.OriginAttribute) ?? true;
 					var msig = new Signature (implementedMethod, attr, shouldBeDynamicallyRegistered);
 					if (!registeredMethod.IsConstructor && !methods.Any (m => m.Name == msig.Name && m.Params == msig.Params))
 						methods.Add (msig);

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
@@ -25,9 +25,9 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 		JavaInterop1,
 	}
 
-	public interface IJCWMethodClassifier
+	public abstract class JavaCallableMethodClassifier
 	{
-		bool ShouldBeDynamicallyRegistered (MethodDefinition registeredMethod, MethodDefinition implementedMethod, CustomAttribute registerAttribute);
+		public abstract bool ShouldBeDynamicallyRegistered (MethodDefinition registeredMethod, MethodDefinition implementedMethod, CustomAttribute registerAttribute);
 	}
 
 	 public class JavaCallableWrapperGenerator {
@@ -66,19 +66,19 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 		List<JavaCallableWrapperGenerator> children;
 
 		readonly IMetadataResolver cache;
-		readonly IJCWMethodClassifier methodClassifier;
+		readonly JavaCallableMethodClassifier methodClassifier;
 
 		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
 		public JavaCallableWrapperGenerator (TypeDefinition type, Action<string, object []> log)
 			: this (type, null, log, resolver: null)
 		{ }
 
-		public JavaCallableWrapperGenerator (TypeDefinition type, Action<string, object[]> log, TypeDefinitionCache cache, IJCWMethodClassifier methodClassifier = null)
+		public JavaCallableWrapperGenerator (TypeDefinition type, Action<string, object[]> log, TypeDefinitionCache cache, JavaCallableMethodClassifier methodClassifier = null)
 			: this (type, log, (IMetadataResolver) cache, methodClassifier)
 		{
 		}
 
-		public JavaCallableWrapperGenerator (TypeDefinition type, Action<string, object[]> log, IMetadataResolver resolver, IJCWMethodClassifier methodClassifier = null)
+		public JavaCallableWrapperGenerator (TypeDefinition type, Action<string, object[]> log, IMetadataResolver resolver, JavaCallableMethodClassifier methodClassifier = null)
 			: this (type, null, log, resolver, methodClassifier)
 		{
 			if (type.HasNestedTypes) {
@@ -124,7 +124,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 			HasExport |= children.Any (t => t.HasExport);
 		}
 
-		JavaCallableWrapperGenerator (TypeDefinition type, string outerType, Action<string, object[]> log, IMetadataResolver resolver, IJCWMethodClassifier methodClassifier = null)
+		JavaCallableWrapperGenerator (TypeDefinition type, string outerType, Action<string, object[]> log, IMetadataResolver resolver, JavaCallableMethodClassifier methodClassifier = null)
 		{
 			this.methodClassifier = methodClassifier;
 			this.type = type;

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
@@ -94,7 +94,8 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 
 		public bool HasExport { get; private set; }
 
-		public bool HasDynamicallyRegisteredMethods => methods.Any ((Signature sig) => sig.IsDynamicallyRegistered);
+		// If there are no methods, we need to generate "empty" registration because of backward compatibility
+		public bool HasDynamicallyRegisteredMethods => methods.Count == 0 || methods.Any ((Signature sig) => sig.IsDynamicallyRegistered);
 
 		/// <summary>
 		/// The Java source code to be included in Instrumentation.onCreate


### PR DESCRIPTION
Add code which classifies methods selected by `JavaCallableWrapperGenerator`
and decides whether they are to be registered dynamically or using the
future native code marshal methods.

If a type `JavaCallableWrapperGenerator` is processing is found to not
have any dynamically registered methods, then the code to register them
is no longer generated.