### PR TITLE
[generator] Fix <remove-attr> metadata.

### DIFF
--- a/src/Java.Interop.Tools.Generator/Metadata/FixupXmlDocument.cs
+++ b/src/Java.Interop.Tools.Generator/Metadata/FixupXmlDocument.cs
@@ -153,7 +153,7 @@ namespace Java.Interop.Tools.Generator
 						var matched = false;
 
 						foreach (var node in nodes) {
-							node.RemoveAttributes ();
+							node.Attributes (name).Remove ();
 							matched = true;
 						}
 						

--- a/tests/generator-Tests/Unit-Tests/FixupXmlDocumentTests.cs
+++ b/tests/generator-Tests/Unit-Tests/FixupXmlDocumentTests.cs
@@ -82,7 +82,19 @@ namespace generatortests
 
 			api.ApplyFixupFile (fixup);
 
-			Assert.AreEqual ("<api><package /><package name='java' jni-name='java' /></api>", api.ApiDocument.ToString (SaveOptions.DisableFormatting).Replace ('\"', '\''));
+			Assert.AreEqual ("<api><package jni-name='android' /><package name='java' jni-name='java' /></api>", api.ApiDocument.ToString (SaveOptions.DisableFormatting).Replace ('\"', '\''));
+		}
+
+		[Test]
+		public void RemoveNotFoundAttribute ()
+		{
+			// Attribute 'foo' doesn't exist on node
+			var api = GetXmlApiDocument ();
+			var fixup = GetFixupXmlDocument ("<remove-attr path=\"/api/package[@name='android']\" name='foo' />");
+
+			api.ApplyFixupFile (fixup);
+
+			Assert.AreEqual ("<api><package name='android' jni-name='android' /><package name='java' jni-name='java' /></api>", api.ApiDocument.ToString (SaveOptions.DisableFormatting).Replace ('\"', '\''));
 		}
 
 		[Test]


### PR DESCRIPTION
Fixes #976.

Given an `api.xml` element like:
```xml
<package name='my.package'>
  <class name='MyClass' api-since='29' />
</package>
```

You would expect to be able to remove the `api-since` attribute with this metadata:
```xml
<remove-attr path='/api/package[@name='my.package']/class[@name='MyClass']' name='api-since' />
```

However, even though `generator` reads the `name` attribute, it then proceeds to ignore it and remove *all* attributes on the matched node, resulting in:

```xml
<package name='my.package'>
  <class />
</package>
```

This seems unintuitive, and I'm not sure how this could ever be successfully used in a binding project, since leaving an empty `<class>`, etc. node causes `generator` to crash.

Fix `<remove-attr>` to work as expected.