### PR TITLE
[generator] Add `managedOverride` values `none` and `reabstract`.

### DIFF
--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
@@ -148,6 +148,56 @@ namespace generatortests
 		}
 
 		[Test]
+		public void ManagedOverrideMethod_None ()
+		{
+			var xml = @"<api>
+			  <package name='java.lang' jni-name='java/lang'>
+			    <class abstract='false' deprecated='not deprecated' final='false' name='Object' static='false' visibility='public' jni-signature='Ljava/lang/Object;' />
+			  </package>
+			  <package name='com.xamarin.android' jni-name='com/xamarin/android'>
+			    <class abstract='false' deprecated='not deprecated' extends='java.lang.Object' extends-generic-aware='java.lang.Object' jni-extends='Ljava/lang/Object;' final='false' name='MyClass' static='false' visibility='public' jni-signature='Lcom/xamarin/android/MyClass;'>
+			      <method abstract='false' deprecated='not deprecated' final='false' name='DoStuff' jni-signature='()I' bridge='false' native='false' return='int' jni-return='I' static='false' synchronized='false' synthetic='false' visibility='public' managedOverride='none'></method>
+			    </class>
+			  </package>
+			</api>";
+
+			var gens = ParseApiDefinition (xml);
+			var klass = gens.Single (g => g.Name == "MyClass");
+
+			generator.Context.ContextTypes.Push (klass);
+			generator.WriteType (klass, string.Empty, new GenerationInfo ("", "", "MyAssembly"));
+			generator.Context.ContextTypes.Pop ();
+
+			// This would contain 'virtual' if the 'managedOverride' was not working
+			Assert.True (writer.ToString ().Contains ("public unsafe int DoStuff ()"), $"was: `{writer}`");
+		}
+
+		[Test]
+		public void ManagedOverrideInterfaceMethod_Reabstract ()
+		{
+			var xml = @"<api>
+			  <package name='java.lang' jni-name='java/lang'>
+			    <class abstract='false' deprecated='not deprecated' final='false' name='Object' static='false' visibility='public' jni-signature='Ljava/lang/Object;' />
+			  </package>
+			  <package name='com.xamarin.android' jni-name='com/xamarin/android'>
+			    <interface abstract='false' deprecated='not deprecated' extends='java.lang.Object' extends-generic-aware='java.lang.Object' jni-extends='Ljava/lang/Object;' final='false' name='MyInterface' static='false' visibility='public' jni-signature='Lcom/xamarin/android/MyInterface;'>
+			      <method abstract='true' deprecated='not deprecated' final='false' name='DoStuff' jni-signature='()I' bridge='false' native='false' return='int' jni-return='I' static='false' synchronized='false' synthetic='false' visibility='public' managedOverride='reabstract'></method>
+			    </interface>
+			  </package>
+			</api>";
+
+			var gens = ParseApiDefinition (xml);
+			var iface = gens.Single (g => g.Name == "IMyInterface");
+
+			generator.Context.ContextTypes.Push (iface);
+			generator.WriteType (iface, string.Empty, new GenerationInfo ("", "", "MyAssembly"));
+			generator.Context.ContextTypes.Pop ();
+
+			// This would not contain 'abstract' if the 'managedOverride' was not working
+			Assert.True (writer.ToString ().Contains ("abstract int DoStuff ()"), $"was: `{writer}`");
+		}
+
+		[Test]
 		public void ManagedOverrideProperty_Virtual ()
 		{
 			var xml = @"<api>
@@ -193,6 +243,56 @@ namespace generatortests
 			generator.Context.ContextTypes.Pop ();
 
 			Assert.True (writer.ToString ().Contains ("public override unsafe int Name {"), $"was: `{writer.ToString ()}`");
+		}
+
+		[Test]
+		public void ManagedOverrideProperty_None ()
+		{
+			var xml = @"<api>
+			  <package name='java.lang' jni-name='java/lang'>
+			    <class abstract='false' deprecated='not deprecated' final='false' name='Object' static='false' visibility='public' jni-signature='Ljava/lang/Object;' />
+			  </package>
+			  <package name='com.xamarin.android' jni-name='com/xamarin/android'>
+			    <class abstract='false' deprecated='not deprecated' extends='java.lang.Object' extends-generic-aware='java.lang.Object' jni-extends='Ljava/lang/Object;' final='false' name='MyClass' static='false' visibility='public' jni-signature='Lcom/xamarin/android/MyClass;'>
+			      <method abstract='false' deprecated='not deprecated' final='false' name='getName' jni-signature='()I' bridge='false' native='false' return='int' jni-return='I' static='false' synchronized='false' synthetic='false' visibility='public' managedOverride='none'></method>
+			    </class>
+			  </package>
+			</api>";
+
+			var gens = ParseApiDefinition (xml);
+			var klass = gens.Single (g => g.Name == "MyClass");
+
+			generator.Context.ContextTypes.Push (klass);
+			generator.WriteType (klass, string.Empty, new GenerationInfo ("", "", "MyAssembly"));
+			generator.Context.ContextTypes.Pop ();
+
+			// This would contain 'virtual' if the 'managedOverride' was not working
+			Assert.True (writer.ToString ().Contains ("public unsafe int Name {"), $"was: `{writer}`");
+		}
+
+		[Test]
+		public void ManagedOverrideInterfaceProperty_Reabstract ()
+		{
+			var xml = @"<api>
+			  <package name='java.lang' jni-name='java/lang'>
+			    <class abstract='false' deprecated='not deprecated' final='false' name='Object' static='false' visibility='public' jni-signature='Ljava/lang/Object;' />
+			  </package>
+			  <package name='com.xamarin.android' jni-name='com/xamarin/android'>
+			    <interface abstract='false' deprecated='not deprecated' extends='java.lang.Object' extends-generic-aware='java.lang.Object' jni-extends='Ljava/lang/Object;' final='false' name='MyInterface' static='false' visibility='public' jni-signature='Lcom/xamarin/android/MyInterface;'>
+			      <method abstract='true' deprecated='not deprecated' final='false' name='getName' jni-signature='()I' bridge='false' native='false' return='int' jni-return='I' static='false' synchronized='false' synthetic='false' visibility='public' managedOverride='reabstract'></method>
+			    </interface>
+			  </package>
+			</api>";
+
+			var gens = ParseApiDefinition (xml);
+			var iface = gens.Single (g => g.Name == "IMyInterface");
+
+			generator.Context.ContextTypes.Push (iface);
+			generator.WriteType (iface, string.Empty, new GenerationInfo ("", "", "MyAssembly"));
+			generator.Context.ContextTypes.Pop ();
+
+			// This would not contain 'abstract' if the 'managedOverride' was not working
+			Assert.True (writer.ToString ().Contains ("abstract int Name {"), $"was: `{writer}`");
 		}
 
 		[Test]

--- a/tools/generator/SourceWriters/BoundInterfaceMethodDeclaration.cs
+++ b/tools/generator/SourceWriters/BoundInterfaceMethodDeclaration.cs
@@ -25,6 +25,10 @@ namespace generator.SourceWriters
 			ReturnType = new TypeReferenceWriter (opt.GetTypeReferenceName (method.RetVal));
 			IsDeclaration = true;
 
+			// Allow user to force adding the 'abstract' keyword for "reabstraction"
+			if (method.ManagedOverride?.ToLowerInvariant () == "reabstract")
+				IsAbstract = true;
+
 			if (method.DeclaringType.IsGeneratable)
 				Comments.Add ($"// Metadata.xml XPath method reference: path=\"{method.GetMetadataXPathReference (method.DeclaringType)}\"");
 			if (method.Deprecated != null)

--- a/tools/generator/SourceWriters/BoundInterfacePropertyDeclaration.cs
+++ b/tools/generator/SourceWriters/BoundInterfacePropertyDeclaration.cs
@@ -20,6 +20,10 @@ namespace generator.SourceWriters
 			PropertyType = new TypeReferenceWriter (opt.GetTypeReferenceName (property));
 			IsAutoProperty = true;
 
+			// Allow user to force adding the 'abstract' keyword for "reabstraction"
+			if ((property.Getter ?? property.Setter).ManagedOverride?.ToLowerInvariant () == "reabstract")
+				IsAbstract = true;
+
 			if (property.Getter != null) {
 				HasGet = true;
 

--- a/tools/generator/SourceWriters/BoundMethod.cs
+++ b/tools/generator/SourceWriters/BoundMethod.cs
@@ -58,6 +58,9 @@ namespace generator.SourceWriters
 			} else if (method.ManagedOverride?.ToLowerInvariant () == "override") {
 				IsVirtual = false;
 				IsOverride = true;
+			} else if (method.ManagedOverride?.ToLowerInvariant () == "none") {
+				IsVirtual = false;
+				IsOverride = false;
 			}
 
 			ReturnType = new TypeReferenceWriter (opt.GetTypeReferenceName (method.RetVal));

--- a/tools/generator/SourceWriters/BoundProperty.cs
+++ b/tools/generator/SourceWriters/BoundProperty.cs
@@ -66,6 +66,9 @@ namespace generator.SourceWriters
 			} else if (!forceOverride && (property.Getter ?? property.Setter).ManagedOverride?.ToLowerInvariant () == "override") {
 				IsVirtual = false;
 				IsOverride = true;
+			} else if (!forceOverride && (property.Getter ?? property.Setter).ManagedOverride?.ToLowerInvariant () == "none") {
+				IsVirtual = false;
+				IsOverride = false;
 			}
 
 			// Unlike [Register], [Obsolete] cannot be put on property accessors, so we can apply them only under limited condition...


### PR DESCRIPTION
Fixes #981 

Add support for the `managedOverride = none` value:

```xml
<attr path="//method[@name='example']" name="managedOverride">none</attr>
```

This value ensures that the member is not marked as `virtual` or `override`, useful for `sealed` classes.

```csharp
public sealed class MyClass {
    public void DoThing () => ...
}
```

---

Additionally add support for the `managedOverride = reabstract` value:

```xml
<attr path="//method[@name='example']" name="managedOverride">reabstract</attr>
```

This only affects interfaces, and allows an interface member to be "reabstracted":

```csharp
public partial interface IAnnotatedType {
    // Contains default interface method
    virtual IAnnotatedType? AnnotatedOwnerType => null;
}
public partial interface IAnnotatedArrayType : IAnnotatedType {
    // Contains *no* method body; re-abstracted
    abstract IAnnotatedType? IAnnotatedType.AnnotatedOwnerType {get;}
}
```