### PR TITLE
[Java.Interop] optimize JniTypeManager.AssertSimpleReference()

### DIFF
--- a/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
@@ -116,7 +116,7 @@ namespace Java.Interop {
 			internal static void AssertSimpleReference (string jniSimpleReference, string argumentName = "jniSimpleReference")
 			{
 				if (string.IsNullOrEmpty (jniSimpleReference))
-					throw new ArgumentNullException (nameof (jniSimpleReference));
+					throw new ArgumentNullException (argumentName);
 				if (jniSimpleReference.IndexOf ('.') >= 0)
 					throw new ArgumentException ("JNI type names do not contain '.', they use '/'. Are you sure you're using a JNI type name?", argumentName);
 				switch (jniSimpleReference [0]) {

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
@@ -115,14 +115,20 @@ namespace Java.Interop {
 
 			internal static void AssertSimpleReference (string jniSimpleReference, string argumentName = "jniSimpleReference")
 			{
-				if (jniSimpleReference == null)
-					throw new ArgumentNullException (argumentName);
-				if (jniSimpleReference != null && jniSimpleReference.IndexOf (".", StringComparison.Ordinal) >= 0)
+				if (string.IsNullOrEmpty (jniSimpleReference))
+					throw new ArgumentNullException (nameof (jniSimpleReference));
+				if (jniSimpleReference.IndexOf ('.') >= 0)
 					throw new ArgumentException ("JNI type names do not contain '.', they use '/'. Are you sure you're using a JNI type name?", argumentName);
-				if (jniSimpleReference != null && jniSimpleReference.StartsWith ("[", StringComparison.Ordinal))
-					throw new ArgumentException ("Arrays cannot be present in simplified type references.", argumentName);
-				if (jniSimpleReference != null && jniSimpleReference.StartsWith ("L", StringComparison.Ordinal) && jniSimpleReference.EndsWith (";", StringComparison.Ordinal))
-					throw new ArgumentException ("JNI type references are not supported.", argumentName);
+				switch (jniSimpleReference [0]) {
+					case '[':
+						throw new ArgumentException ("Arrays cannot be present in simplified type references.", argumentName);
+					case 'L':
+						if (jniSimpleReference [jniSimpleReference.Length - 1] == ';')
+							throw new ArgumentException ("JNI type references are not supported.", argumentName);
+						break;
+					default:
+						break;
+				}
 			}
 
 			// NOTE: This method needs to be kept in sync with GetTypeSignatures()


### PR DESCRIPTION
We noticed `dotnet trace` output was showing:

    21.28ms (0.45%) java.interop!Java.Interop.JniRuntime.JniTypeManager.AssertSimpleReference(string,string)

This code path was introduced by a new feature in 1f27ab55.

For now, I think we can rewrite this to use the `char` overload of
`IndexOf`, as well as the regular indexer on `string`.

After these changes, I get a better time:

    1.21ms java.interop!Java.Interop.JniRuntime.JniTypeManager.AssertSimpleReference(string,string)

We may have just *moved* the location that ICU is loaded, but this
change is good regardless.