### PR TITLE
[generator] Add support for @explicitInterface metadata.

### DIFF
--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
@@ -352,6 +352,156 @@ namespace generatortests
 
 			Assert.Pass ("WriteType did not NRE");
 		}
+
+		[Test]
+		public void ExplicitInterfaceMetadata_InterfaceMethod ()
+		{
+			var xml = @"<api>
+			  <package name='java.lang' jni-name='java/lang'>
+			    <class abstract='false' deprecated='not deprecated' final='false' name='Object' static='false' visibility='public' jni-signature='Ljava/lang/Object;' />
+			  </package>
+			  <package name='com.xamarin.android' jni-name='com/xamarin/android'>
+			    <interface abstract='false' deprecated='not deprecated' extends='java.lang.Object' extends-generic-aware='java.lang.Object' jni-extends='Ljava/lang/Object;' final='false' name='MyInterface' static='false' visibility='public' jni-signature='Lcom/xamarin/android/MyInterface;'>
+			      <method abstract='true' deprecated='not deprecated' final='false' name='countAffectedRows' jni-signature='()I' bridge='false' native='false' return='int' jni-return='I' static='false' synchronized='false' synthetic='false' visibility='public' explicitInterface='IRowCounter'></method>
+			    </interface>
+			  </package>
+			</api>";
+
+			var gens = ParseApiDefinition (xml);
+			var iface = gens.Single (g => g.Name == "IMyInterface");
+
+			generator.Context.ContextTypes.Push (iface);
+			generator.WriteType (iface, string.Empty, new GenerationInfo ("", "", "MyAssembly"));
+			generator.Context.ContextTypes.Pop ();
+
+			// Ensure explicit interface was written
+			Assert.True (writer.ToString ().Contains ("int IRowCounter.CountAffectedRows ("), $"was: `{writer}`");
+		}
+
+		[Test]
+		public void ExplicitInterfaceMetadata_InterfaceProperty ()
+		{
+			var xml = @"<api>
+			  <package name='java.lang' jni-name='java/lang'>
+			    <class abstract='false' deprecated='not deprecated' final='false' name='Object' static='false' visibility='public' jni-signature='Ljava/lang/Object;' />
+			  </package>
+			  <package name='com.xamarin.android' jni-name='com/xamarin/android'>
+			    <interface abstract='false' deprecated='not deprecated' extends='java.lang.Object' extends-generic-aware='java.lang.Object' jni-extends='Ljava/lang/Object;' final='false' name='MyInterface' static='false' visibility='public' jni-signature='Lcom/xamarin/android/MyInterface;'>
+			      <method abstract='true' deprecated='not deprecated' final='false' name='getAge' jni-signature='()I' bridge='false' native='false' return='int' jni-return='I' static='false' synchronized='false' synthetic='false' visibility='public' explicitInterface='IHasAge'></method>
+			    </interface>
+			  </package>
+			</api>";
+
+			var gens = ParseApiDefinition (xml);
+			var iface = gens.Single (g => g.Name == "IMyInterface");
+
+			generator.Context.ContextTypes.Push (iface);
+			generator.WriteType (iface, string.Empty, new GenerationInfo ("", "", "MyAssembly"));
+			generator.Context.ContextTypes.Pop ();
+
+			// Ensure explicit interface was written
+			Assert.True (writer.ToString ().Contains ("int IHasAge.Age {"), $"was: `{writer}`");
+		}
+
+		[Test]
+		public void ExplicitInterfaceMetadata_ClassMethod ()
+		{
+			var xml = @"<api>
+			  <package name='java.lang' jni-name='java/lang'>
+			    <class abstract='false' deprecated='not deprecated' final='false' name='Object' static='false' visibility='public' jni-signature='Ljava/lang/Object;' />
+			  </package>
+			  <package name='com.xamarin.android' jni-name='com/xamarin/android'>
+			    <class abstract='false' deprecated='not deprecated' extends='java.lang.Object' extends-generic-aware='java.lang.Object' jni-extends='Ljava/lang/Object;' final='false' name='MyClass' static='false' visibility='public' jni-signature='Lcom/xamarin/android/MyClass;'>
+			      <method abstract='false' deprecated='not deprecated' final='false' name='countAffectedRows' jni-signature='()I' bridge='false' native='false' return='int' jni-return='I' static='false' synchronized='false' synthetic='false' visibility='public' explicitInterface='IRowCounter'></method>
+			    </class>
+			  </package>
+			</api>";
+
+			var gens = ParseApiDefinition (xml);
+			var iface = gens.Single (g => g.Name == "MyClass");
+
+			generator.Context.ContextTypes.Push (iface);
+			generator.WriteType (iface, string.Empty, new GenerationInfo ("", "", "MyAssembly"));
+			generator.Context.ContextTypes.Pop ();
+
+			// Ensure explicit interface was written
+			Assert.True (writer.ToString ().Contains ("int IRowCounter.CountAffectedRows ("), $"was: `{writer}`");
+		}
+
+		[Test]
+		public void ExplicitInterfaceMetadata_ClassProperty ()
+		{
+			var xml = @"<api>
+			  <package name='java.lang' jni-name='java/lang'>
+			    <class abstract='false' deprecated='not deprecated' final='false' name='Object' static='false' visibility='public' jni-signature='Ljava/lang/Object;' />
+			  </package>
+			  <package name='com.xamarin.android' jni-name='com/xamarin/android'>
+			    <class abstract='false' deprecated='not deprecated' extends='java.lang.Object' extends-generic-aware='java.lang.Object' jni-extends='Ljava/lang/Object;' final='false' name='MyClass' static='false' visibility='public' jni-signature='Lcom/xamarin/android/MyClass;'>
+			      <method abstract='false' deprecated='not deprecated' final='false' name='getAge' jni-signature='()I' bridge='false' native='false' return='int' jni-return='I' static='false' synchronized='false' synthetic='false' visibility='public' explicitInterface='IHasAge'></method>
+			    </class>
+			  </package>
+			</api>";
+
+			var gens = ParseApiDefinition (xml);
+			var iface = gens.Single (g => g.Name == "MyClass");
+
+			generator.Context.ContextTypes.Push (iface);
+			generator.WriteType (iface, string.Empty, new GenerationInfo ("", "", "MyAssembly"));
+			generator.Context.ContextTypes.Pop ();
+
+			// Ensure explicit interface was written
+			Assert.True (writer.ToString ().Contains ("int IHasAge.Age {"), $"was: `{writer}`");
+		}
+
+		[Test]
+		public void ExplicitInterfaceMetadata_AbstractClassMethod ()
+		{
+			var xml = @"<api>
+			  <package name='java.lang' jni-name='java/lang'>
+			    <class abstract='false' deprecated='not deprecated' final='false' name='Object' static='false' visibility='public' jni-signature='Ljava/lang/Object;' />
+			  </package>
+			  <package name='com.xamarin.android' jni-name='com/xamarin/android'>
+			    <class abstract='false' deprecated='not deprecated' extends='java.lang.Object' extends-generic-aware='java.lang.Object' jni-extends='Ljava/lang/Object;' final='false' name='MyClass' static='false' visibility='public' jni-signature='Lcom/xamarin/android/MyClass;'>
+			      <method abstract='true' deprecated='not deprecated' final='false' name='countAffectedRows' jni-signature='()I' bridge='false' native='false' return='int' jni-return='I' static='false' synchronized='false' synthetic='false' visibility='public' explicitInterface='IRowCounter'></method>
+			    </class>
+			  </package>
+			</api>";
+
+			var gens = ParseApiDefinition (xml);
+			var iface = gens.Single (g => g.Name == "MyClass");
+
+			generator.Context.ContextTypes.Push (iface);
+			generator.WriteType (iface, string.Empty, new GenerationInfo ("", "", "MyAssembly"));
+			generator.Context.ContextTypes.Pop ();
+
+			// Ensure explicit interface was written
+			Assert.True (writer.ToString ().Contains ("abstract int IRowCounter.CountAffectedRows ("), $"was: `{writer}`");
+		}
+
+		[Test]
+		public void ExplicitInterfaceMetadata_AbstractClassProperty ()
+		{
+			var xml = @"<api>
+			  <package name='java.lang' jni-name='java/lang'>
+			    <class abstract='false' deprecated='not deprecated' final='false' name='Object' static='false' visibility='public' jni-signature='Ljava/lang/Object;' />
+			  </package>
+			  <package name='com.xamarin.android' jni-name='com/xamarin/android'>
+			    <class abstract='false' deprecated='not deprecated' extends='java.lang.Object' extends-generic-aware='java.lang.Object' jni-extends='Ljava/lang/Object;' final='false' name='MyClass' static='false' visibility='public' jni-signature='Lcom/xamarin/android/MyClass;'>
+			      <method abstract='true' deprecated='not deprecated' final='false' name='getAge' jni-signature='()I' bridge='false' native='false' return='int' jni-return='I' static='false' synchronized='false' synthetic='false' visibility='public' explicitInterface='IHasAge'></method>
+			    </class>
+			  </package>
+			</api>";
+
+			var gens = ParseApiDefinition (xml);
+			var iface = gens.Single (g => g.Name == "MyClass");
+
+			generator.Context.ContextTypes.Push (iface);
+			generator.WriteType (iface, string.Empty, new GenerationInfo ("", "", "MyAssembly"));
+			generator.Context.ContextTypes.Pop ();
+
+			// Ensure explicit interface was written
+			Assert.True (writer.ToString ().Contains ("abstract int IHasAge.Age {"), $"was: `{writer}`");
+		}
 	}
 
 	[TestFixture]

--- a/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
@@ -348,6 +348,7 @@ namespace MonoDroid.Generation
 				ArgsType = elem.Attribute ("argsType")?.Value,
 				CustomAttributes = elem.XGetAttribute ("customAttributes"),
 				Deprecated = elem.Deprecated (),
+				ExplicitInterface = elem.XGetAttribute ("explicitInterface"),
 				EventName = elem.Attribute ("eventName")?.Value,
 				GenerateAsyncWrapper = elem.Attribute ("generateAsyncWrapper") != null,
 				GenerateDispatchingSetter = elem.Attribute ("generateDispatchingSetter") != null,

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Method.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Method.cs
@@ -33,6 +33,7 @@ namespace MonoDroid.Generation
 		public bool ReturnNotNull { get; set; }
 		public ReturnValue RetVal { get; set; }
 		public int SourceApiLevel { get; set; }
+		public string ExplicitInterface { get; set; }
 
 		// it used to be private though...
 		internal string AdjustedName => IsReturnCharSequence ? Name + "Formatted" : Name;

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Property.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Property.cs
@@ -58,5 +58,7 @@ namespace MonoDroid.Generation
 				}
 			}
 		}
+
+		public string ExplicitInterface => Getter?.ExplicitInterface ?? Setter?.ExplicitInterface;
 	}
 }

--- a/tools/generator/SourceWriters/BoundAbstractProperty.cs
+++ b/tools/generator/SourceWriters/BoundAbstractProperty.cs
@@ -19,6 +19,7 @@ namespace generator.SourceWriters
 		public BoundAbstractProperty (GenBase gen, Property property, CodeGenerationOptions opt)
 		{
 			Name = property.AdjustedName;
+			ExplicitInterfaceImplementation = property.ExplicitInterface;
 			PropertyType = new TypeReferenceWriter (opt.GetTypeReferenceName (property.Getter.RetVal));
 
 			SetVisibility (property.Getter.RetVal.IsGeneric ? "protected" : property.Getter.Visibility);

--- a/tools/generator/SourceWriters/BoundInterfaceMethodDeclaration.cs
+++ b/tools/generator/SourceWriters/BoundInterfaceMethodDeclaration.cs
@@ -22,6 +22,8 @@ namespace generator.SourceWriters
 			this.opt = opt;
 
 			Name = method.AdjustedName;
+			ExplicitInterfaceImplementation = method.ExplicitInterface;
+
 			ReturnType = new TypeReferenceWriter (opt.GetTypeReferenceName (method.RetVal));
 			IsDeclaration = true;
 

--- a/tools/generator/SourceWriters/BoundInterfacePropertyDeclaration.cs
+++ b/tools/generator/SourceWriters/BoundInterfacePropertyDeclaration.cs
@@ -16,6 +16,7 @@ namespace generator.SourceWriters
 		public BoundInterfacePropertyDeclaration (GenBase gen, Property property, string adapter, CodeGenerationOptions opt)
 		{
 			Name = property.AdjustedName;
+			ExplicitInterfaceImplementation = property.ExplicitInterface;
 
 			PropertyType = new TypeReferenceWriter (opt.GetTypeReferenceName (property));
 			IsAutoProperty = true;

--- a/tools/generator/SourceWriters/BoundMethod.cs
+++ b/tools/generator/SourceWriters/BoundMethod.cs
@@ -48,6 +48,10 @@ namespace generator.SourceWriters
 			if (is_explicit)
 				ExplicitInterfaceImplementation = GetDeclaringTypeOfExplicitInterfaceMethod (method.OverriddenInterfaceMethod);
 
+			// Allow user to override our explicit interface logic
+			if (method.ExplicitInterface.HasValue ())
+				ExplicitInterfaceImplementation = method.ExplicitInterface;
+
 			if ((IsVirtual || !IsOverride) && type.RequiresNew (method.AdjustedName, method))
 				IsShadow = true;
 

--- a/tools/generator/SourceWriters/BoundMethodAbstractDeclaration.cs
+++ b/tools/generator/SourceWriters/BoundMethodAbstractDeclaration.cs
@@ -36,6 +36,7 @@ namespace generator.SourceWriters
 			}
 
 			Name = method.AdjustedName;
+			ExplicitInterfaceImplementation = method.ExplicitInterface;
 
 			IsAbstract = true;
 			IsShadow = impl.RequiresNew (method.Name, method);

--- a/tools/generator/SourceWriters/BoundProperty.cs
+++ b/tools/generator/SourceWriters/BoundProperty.cs
@@ -19,6 +19,7 @@ namespace generator.SourceWriters
 		public BoundProperty (GenBase gen, Property property, CodeGenerationOptions opt, bool withCallbacks = true, bool forceOverride = false)
 		{
 			Name = property.AdjustedName;
+			ExplicitInterfaceImplementation = property.ExplicitInterface;
 			PropertyType = new TypeReferenceWriter (opt.GetTypeReferenceName (property.Getter.RetVal));
 
 			SetVisibility (gen is InterfaceGen ? string.Empty : property.Getter.IsAbstract && property.Getter.RetVal.IsGeneric ? "protected" : (property.Setter ?? property.Getter).Visibility);


### PR DESCRIPTION
Fixes https://github.com/xamarin/java.interop/issues/1005.

In order to fully support "reabstraction", we need to emit member names with explicit interface names.  

```csharp
public partial interface ICloseable : global::Java.Lang.IAutoCloseable {
    abstract void IAutoCloseable.Close ();
}
```

This isn't something we have enough information to figure out automatically, so we should allow it to be specified with metadata using a new `explicitInterface` attribute.

```xml
<attr path="/api/package[@name='java.io']/interface[@name='Closeable']/method[@name='Close']" name="explicitInterface">
    IAutoCloseable
</attr>
```

Note this is not really a concept that `generator` "understands", it will simply output whatever is specified in this attribute.  Thus the value is the *C#* interface name, not the *Java* interface name.

For properties, placing `explicitInterface` on either the `getXXX` or `setXXX` methods will work.  The getter value takes precedence if both are specified.

This is implemented for both `interface` and `class` members, should there be other use-cases that can benefit from it.