### PR TITLE
[Java.Base] Fix CS0108 Warnings

### DIFF
--- a/src/Java.Base-ref.cs
+++ b/src/Java.Base-ref.cs
@@ -81,7 +81,7 @@ namespace Java.IO
         [System.ComponentModel.EditorBrowsableAttribute(1)]
         [System.Diagnostics.DebuggerBrowsableAttribute(0)]
         public override Java.Interop.JniPeerMembers JniPeerMembers { get { throw null; } }
-        protected int Mark { get { throw null; } set { } }
+        protected int MarkedPosition { get { throw null; } set { } }
         protected int Pos { get { throw null; } set { } }
         [Java.Interop.JniMethodSignatureAttribute("read", "()I")]
         public override int Read() { throw null; }
@@ -511,7 +511,7 @@ namespace Java.IO
     public partial interface ICloseable : Java.Interop.IJavaPeerable, Java.Lang.IAutoCloseable, System.IDisposable
     {
         [Java.Interop.JniMethodSignatureAttribute("close", "()V")]
-        new void Close();
+        void Java.Lang.IAutoCloseable.Close();
     }
     [Java.Interop.JniTypeSignatureAttribute("java/io/DataInput", GenerateJavaPeer=false)]
     public partial interface IDataInput : Java.Interop.IJavaPeerable, System.IDisposable
@@ -693,7 +693,7 @@ namespace Java.IO
         [Java.Interop.JniMethodSignatureAttribute("available", "()I")]
         int Available();
         [Java.Interop.JniMethodSignatureAttribute("close", "()V")]
-        new void Close();
+        void Java.Lang.IAutoCloseable.Close();
         [Java.Interop.JniMethodSignatureAttribute("read", "()I")]
         int Read();
         [Java.Interop.JniMethodSignatureAttribute("read", "([B)I")]
@@ -770,16 +770,16 @@ namespace Java.IO
     [Java.Interop.JniTypeSignatureAttribute("java/io/ObjectOutput", GenerateJavaPeer=false)]
     public partial interface IObjectOutput : Java.Interop.IJavaPeerable, Java.IO.IDataOutput, Java.Lang.IAutoCloseable, System.IDisposable
     {
-        [Java.Interop.JniMethodSignatureAttribute("close", "()V")]
-        new void Close();
         [Java.Interop.JniMethodSignatureAttribute("flush", "()V")]
         void Flush();
         [Java.Interop.JniMethodSignatureAttribute("write", "([B)V")]
-        new void Write(Java.Interop.JavaSByteArray? p0);
+        void Java.IO.IDataOutput.Write(Java.Interop.JavaSByteArray? p0);
         [Java.Interop.JniMethodSignatureAttribute("write", "([BII)V")]
-        new void Write(Java.Interop.JavaSByteArray? p0, int p1, int p2);
+        void Java.IO.IDataOutput.Write(Java.Interop.JavaSByteArray? p0, int p1, int p2);
         [Java.Interop.JniMethodSignatureAttribute("write", "(I)V")]
-        new void Write(int p0);
+        void Java.IO.IDataOutput.Write(int p0);
+        [Java.Interop.JniMethodSignatureAttribute("close", "()V")]
+        void Java.Lang.IAutoCloseable.Close();
         [Java.Interop.JniMethodSignatureAttribute("writeObject", "(Ljava/lang/Object;)V")]
         void WriteObject(Java.Lang.Object? p0);
     }
@@ -6621,7 +6621,7 @@ namespace Java.Lang.Reflect
     public partial interface IAnnotatedArrayType : Java.Interop.IJavaPeerable, Java.Lang.Reflect.IAnnotatedElement, Java.Lang.Reflect.IAnnotatedType, System.IDisposable
     {
         Java.Lang.Reflect.IAnnotatedType? AnnotatedGenericComponentType { [Java.Interop.JniMethodSignatureAttribute("getAnnotatedGenericComponentType", "()Ljava/lang/reflect/AnnotatedType;")] get; }
-        new Java.Lang.Reflect.IAnnotatedType? AnnotatedOwnerType { [Java.Interop.JniMethodSignatureAttribute("getAnnotatedOwnerType", "()Ljava/lang/reflect/AnnotatedType;")] get; }
+        Java.Lang.Reflect.IAnnotatedType? Java.Lang.Reflect.IAnnotatedType.AnnotatedOwnerType { [Java.Interop.JniMethodSignatureAttribute("getAnnotatedOwnerType", "()Ljava/lang/reflect/AnnotatedType;")] get; }
     }
     [Java.Interop.JniTypeSignatureAttribute("java/lang/reflect/AnnotatedElement", GenerateJavaPeer=false)]
     public partial interface IAnnotatedElement : Java.Interop.IJavaPeerable, System.IDisposable
@@ -6648,7 +6648,7 @@ namespace Java.Lang.Reflect
     [Java.Interop.JniTypeSignatureAttribute("java/lang/reflect/AnnotatedParameterizedType", GenerateJavaPeer=false)]
     public partial interface IAnnotatedParameterizedType : Java.Interop.IJavaPeerable, Java.Lang.Reflect.IAnnotatedElement, Java.Lang.Reflect.IAnnotatedType, System.IDisposable
     {
-        new Java.Lang.Reflect.IAnnotatedType? AnnotatedOwnerType { [Java.Interop.JniMethodSignatureAttribute("getAnnotatedOwnerType", "()Ljava/lang/reflect/AnnotatedType;")] get; }
+        Java.Lang.Reflect.IAnnotatedType? Java.Lang.Reflect.IAnnotatedType.AnnotatedOwnerType { [Java.Interop.JniMethodSignatureAttribute("getAnnotatedOwnerType", "()Ljava/lang/reflect/AnnotatedType;")] get; }
         [Java.Interop.JniMethodSignatureAttribute("getAnnotatedActualTypeArguments", "()[Ljava/lang/reflect/AnnotatedType;")]
         Java.Interop.JavaObjectArray<Java.Lang.Reflect.IAnnotatedType>? GetAnnotatedActualTypeArguments();
     }
@@ -6661,14 +6661,14 @@ namespace Java.Lang.Reflect
     [Java.Interop.JniTypeSignatureAttribute("java/lang/reflect/AnnotatedTypeVariable", GenerateJavaPeer=false)]
     public partial interface IAnnotatedTypeVariable : Java.Interop.IJavaPeerable, Java.Lang.Reflect.IAnnotatedElement, Java.Lang.Reflect.IAnnotatedType, System.IDisposable
     {
-        new Java.Lang.Reflect.IAnnotatedType? AnnotatedOwnerType { [Java.Interop.JniMethodSignatureAttribute("getAnnotatedOwnerType", "()Ljava/lang/reflect/AnnotatedType;")] get; }
+        Java.Lang.Reflect.IAnnotatedType? Java.Lang.Reflect.IAnnotatedType.AnnotatedOwnerType { [Java.Interop.JniMethodSignatureAttribute("getAnnotatedOwnerType", "()Ljava/lang/reflect/AnnotatedType;")] get; }
         [Java.Interop.JniMethodSignatureAttribute("getAnnotatedBounds", "()[Ljava/lang/reflect/AnnotatedType;")]
         Java.Interop.JavaObjectArray<Java.Lang.Reflect.IAnnotatedType>? GetAnnotatedBounds();
     }
     [Java.Interop.JniTypeSignatureAttribute("java/lang/reflect/AnnotatedWildcardType", GenerateJavaPeer=false)]
     public partial interface IAnnotatedWildcardType : Java.Interop.IJavaPeerable, Java.Lang.Reflect.IAnnotatedElement, Java.Lang.Reflect.IAnnotatedType, System.IDisposable
     {
-        new Java.Lang.Reflect.IAnnotatedType? AnnotatedOwnerType { [Java.Interop.JniMethodSignatureAttribute("getAnnotatedOwnerType", "()Ljava/lang/reflect/AnnotatedType;")] get; }
+        Java.Lang.Reflect.IAnnotatedType? Java.Lang.Reflect.IAnnotatedType.AnnotatedOwnerType { [Java.Interop.JniMethodSignatureAttribute("getAnnotatedOwnerType", "()Ljava/lang/reflect/AnnotatedType;")] get; }
         [Java.Interop.JniMethodSignatureAttribute("getAnnotatedLowerBounds", "()[Ljava/lang/reflect/AnnotatedType;")]
         Java.Interop.JavaObjectArray<Java.Lang.Reflect.IAnnotatedType>? GetAnnotatedLowerBounds();
         [Java.Interop.JniMethodSignatureAttribute("getAnnotatedUpperBounds", "()[Ljava/lang/reflect/AnnotatedType;")]

--- a/src/Java.Base/Java.Base.csproj
+++ b/src/Java.Base/Java.Base.csproj
@@ -4,8 +4,7 @@
     <TargetFramework>$(DotNetTargetFramework)</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
-    <!-- TODO: CS0108 is due to e.g. interfaces re-abstracting default interface methods -->
-    <NoWarn>$(NoWarn);8764;CS0108</NoWarn>
+    <NoWarn>$(NoWarn);8764</NoWarn>
   </PropertyGroup>
 
   <Import Project="..\..\TargetFrameworkDependentValues.props" />

--- a/src/Java.Base/Transforms/Metadata.xml
+++ b/src/Java.Base/Transforms/Metadata.xml
@@ -12,6 +12,46 @@
   <!-- warning CS0672: Member 'Enum.JavaFinalize()' overrides obsolete member 'Object.JavaFinalize()'. Add the Obsolete attribute to 'Enum.JavaFinalize()'. -->
   <attr path="/api/package[@name='java.lang']/class[@name='Enum']/method[@name='finalize' and count(parameter)=0]" name="deprecated">deprecated</attr>
 
+  <!-- warning CS0108: 'MEMBER' hides inherited member 'MEMBER'. Use the new keyword if hiding was intended. -->
+  <attr path="/api/package[@name='java.io']/class[
+        @name='ByteArrayInputStream'
+      ]/field[@name='mark']"
+      name="managedName">MarkedPosition</attr>
+  <attr path="/api/package[@name='java.lang.reflect']/interface[
+        @name='AnnotatedArrayType'
+        or @name='AnnotatedParameterizedType'
+        or @name='AnnotatedTypeVariable'
+        or @name='AnnotatedWildcardType'
+      ]/method[@name='getAnnotatedOwnerType' and count(parameter)=0]"
+      name="managedOverride">reabstract</attr>
+  <attr path="/api/package[@name='java.lang.reflect']/interface[
+        @name='AnnotatedArrayType'
+        or @name='AnnotatedParameterizedType'
+        or @name='AnnotatedTypeVariable'
+        or @name='AnnotatedWildcardType'
+      ]/method[@name='getAnnotatedOwnerType' and count(parameter)=0]"
+      name="explicitInterface">IAnnotatedType</attr>
+  <attr path="/api/package[@name='java.io']/interface[
+        @name='Closeable'
+        or @name='ObjectInput'
+        or @name='ObjectOutput'
+      ]/method[@name='close' and count(parameter)=0]"
+      name="managedOverride">reabstract</attr>
+  <attr path="/api/package[@name='java.io']/interface[
+        @name='Closeable'
+        or @name='ObjectInput'
+        or @name='ObjectOutput'
+      ]/method[@name='close' and count(parameter)=0]"
+      name="explicitInterface">Java.Lang.IAutoCloseable</attr>
+  <attr path="/api/package[@name='java.io']/interface[
+        @name='ObjectOutput'
+      ]/method[@name='write']"
+      name="managedOverride">reabstract</attr>
+  <attr path="/api/package[@name='java.io']/interface[
+        @name='ObjectOutput'
+      ]/method[@name='write']"
+      name="explicitInterface">IDataOutput</attr>
+
   <!-- AbstractStringBuilder is package-private; fixity fix -->
   <remove-node path="//api/package[@name='java.lang']/class[@name='AbstractStringBuilder']" />
 


### PR DESCRIPTION
Context: a65d6fb4d79041c959435c15dc3dcf5331e5d715
Context: 22d5687bc5c572ea0eadbd1a23f02f424af782d1
Context: fadbb82c3b8ab7979c19e9f139bdf2589e47549e

Commit a65d6fb4 added [warning CS0108][0] to `$(NoWarn)`, as there
was no way to fix this warning on `IAnnotatedArrayType`.

With commits 22d5687b and fadbb82c, it is now possible to fix the
CS0108 warning on `IAnnotatedArrayType`, among others.

Remove CS0108 from `$(NoWarn)`, and use `Metadata.xml` to fix/avoid
the constructs which caused the CS0108 warnings.

One CS0108 which *isn't* fixed by [reabstraction][1] of
Interface Default Members is for the
[`java.io.ByteArrayInputStream.mark`][2] field, which has the same
name -- and thus hides -- the [`InputStream.mark()` method][3].
This isn't a problem for Java -- context disambiguates between field
access and a method invocation -- but in C# the easier solution is to
use Metadata to rename `ByteArrayInputStream.mark` to
`ByteArrayInputStream.MarkedPosition`, which fixes the CS0108.

[0]: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs0108
[1]: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-8.0/default-interface-methods#reabstraction
[2]: https://developer.android.com/reference/java/io/ByteArrayInputStream#mark
[3]: https://developer.android.com/reference/java/io/InputStream#mark(int)