### PR TITLE
[generator] Mark abstract methods as [Obsolete] if needed.

### DIFF
--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
@@ -502,6 +502,31 @@ namespace generatortests
 			// Ensure explicit interface was written
 			Assert.True (writer.ToString ().Contains ("abstract int IHasAge.Age {"), $"was: `{writer}`");
 		}
+
+		[Test]
+		public void ObsoleteBoundMethodAbstractDeclaration ()
+		{
+			var xml = @"<api>
+			  <package name='java.lang' jni-name='java/lang'>
+			    <class abstract='false' deprecated='not deprecated' final='false' name='Object' static='false' visibility='public' jni-signature='Ljava/lang/Object;' />
+			  </package>
+			  <package name='com.xamarin.android' jni-name='com/xamarin/android'>
+			    <class abstract='false' deprecated='not deprecated' extends='java.lang.Object' extends-generic-aware='java.lang.Object' jni-extends='Ljava/lang/Object;' final='false' name='MyClass' static='false' visibility='public' jni-signature='Lcom/xamarin/android/MyClass;'>
+			      <method abstract='true' deprecated='This is so old!' final='false' name='countAffectedRows' jni-signature='()I' bridge='false' native='false' return='int' jni-return='I' static='false' synchronized='false' synthetic='false' visibility='public'></method>
+			    </class>
+			  </package>
+			</api>";
+
+			var gens = ParseApiDefinition (xml);
+			var iface = gens.Single (g => g.Name == "MyClass");
+
+			generator.Context.ContextTypes.Push (iface);
+			generator.WriteType (iface, string.Empty, new GenerationInfo ("", "", "MyAssembly"));
+			generator.Context.ContextTypes.Pop ();
+
+			// Ensure [Obsolete] was written
+			Assert.True (writer.ToString ().Contains ("[Obsolete (@\"This is so old!\")]"), writer.ToString ());
+		}
 	}
 
 	[TestFixture]

--- a/tools/generator/SourceWriters/BoundMethodAbstractDeclaration.cs
+++ b/tools/generator/SourceWriters/BoundMethodAbstractDeclaration.cs
@@ -53,10 +53,8 @@ namespace generator.SourceWriters
 			if (method.DeclaringType.IsGeneratable)
 				Comments.Add ($"// Metadata.xml XPath method reference: path=\"{method.GetMetadataXPathReference (method.DeclaringType)}\"");
 
-			// TODO: shouldn't `[Obsolete]` be added for *all* CodeGenerationTargets?
-			if (opt.CodeGenerationTarget == CodeGenerationTarget.JavaInterop1 && method.Deprecated.HasValue ()) {
+			if (method.Deprecated.HasValue ())
 				Attributes.Add (new ObsoleteAttr (method.Deprecated.Replace ("\"", "\"\"")));
-			}
 
 			SourceWriterExtensions.AddSupportedOSPlatform (Attributes, method, opt);
 


### PR DESCRIPTION
Fixes: https://github.com/xamarin/java.interop/issues/969

If you have a Java `abstract` method which is deprecated:

```java
public abstract class Example {
    @Deprecated
    public abstract void m();
}
```

then the C# binding is *not* `[Obsolete]`, *and* the `*Invoker` override *is* `[Obsolete]`:

```csharp
// Binding
public abstract partial class Example : Java.Lang.Object {
    [Register (…)]
    public abstract void M();
}

internal partial class ExampleInvoker : Example {
    [Obsolete]
    public override void M() => …
}
```

This state of affairs results in a [CS0809 warning](https://docs.microsoft.com/en-us/dotnet/csharp/misc/cs0809):

```
Error CS0809: Obsolete member 'ExampleInvoker.M()' overrides non-obsolete member 'Example.M()'
```

Expand the fix from https://github.com/xamarin/java.interop/pull/968 to apply to `XAJavaInterop1` code generation.