### PR TITLE
[Xamarin.Android.Tools.Bytecode-Tests] Fix BuildClasses

### DIFF
--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.targets
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.targets
@@ -1,7 +1,7 @@
 <Project>
 
   <ItemGroup>
-    <TestJarNoParameters Include="java/java/util/Collection.java" />
+    <TestJarNoParameters Include="java/**/Collection.java" />
     <TestJarNoParameters Include="java/**/*NoParameters.java" />
     <TestJar Include="java\**\*.java" Exclude="@(TestJarNoParameters);java\android\annotation\NonNull.java" />
     <TestKotlinJar Include="kotlin\**\*.kt" />


### PR DESCRIPTION
The `BuildClasses` target runs on every rebuild:

	% dotnet build
	…
	Build succeeded.

	  "…/Java.Interop/Java.Interop.sln" (default target) (1:2) ->
	  "…/Java.Interop/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj" (default target) (16:14) ->
	  "…/Java.Interop/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj" (Build target) (16:15) ->
	  (BuildClasses target) ->
	    EXEC : warning : [options] bootstrap class path not set in conjunction with -source 8 […/Java.Interop/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj]
			  "…/Java.Interop/Java.Interop.sln" (default target) (1:2) ->
	  "…/Java.Interop/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj" (default target) (16:14) ->
	  "…/Java.Interop/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj" (Build target) (16:16) ->
	    EXEC : warning : [options] bootstrap class path not set in conjunction with -source 8 […/Java.Interop/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj]
			  "…/Java.Interop/Java.Interop.sln" (default target) (1:2) ->
	  "…/Java.Interop/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj" (default target) (16:14) ->
	  "…/Java.Interop/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj" (Build target) (16:15) ->
	    EXEC : warning : [options] bootstrap class path not set in conjunction with -source 8 […/Java.Interop/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj]
			  "…/Java.Interop/Java.Interop.sln" (default target) (1:2) ->
	  "…/Java.Interop/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj" (default target) (16:14) ->
	  "…/Java.Interop/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj" (Build target) (16:16) ->
	    EXEC : warning : [options] bootstrap class path not set in conjunction with -source 8 […/Java.Interop/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj]

	    4 Warning(s)
	    0 Error(s)

	% dotnet build
	# same as above; EXEC warnings from `BuildClasses` target

	% dotnet build
	# ad infinitum

The cause for the warnings -- and the repetitive `BuildClasses` target
execution -- is that the `@(_BuildClassOutputs)` item group is wrong;
from the Dignostic build log:

	Target "BuildClasses: (TargetId:301)" in file "…/Java.Interop/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.targets" from project "…/Java.Interop/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj" (target "BeforeCompile" depends on it):
	  Building target "BuildClasses" completely.
	  Output file "obj//Debug-net7.0/classes/Collection.class" does not exist.

`obj/Debug-net7.0/classes/Collection.class` doesn't exist because it
will *never* exist; the file created is *actually*
`obj/Debug-net7.0/classes/java/util/Collection.class`.
Note the "missing" `java/util` in the path.

The cause of the missing `java/util` is that `@(_BuildClassOutputs)`
uses `%(RecursiveDir)`, which only expands `**` wildcards, while
`Collection.java` comes from:

	<TestJarNoParameters Include="java/java/util/Collection.java" />

Note the *lack* of `**`.  Consequently, `%(RecursiveDir)` expanded as
the empty string, which is why `java/util` was "lost".

Fix this by introducing wildcards:

	<TestJarNoParameters Include="java/**/Collection.java" />

This fixes the repetitive `BuildClasses` execution:

	% dotnet build
	…
	    EXEC : warning : [options] bootstrap class path not set in conjunction with -source 8 […/Java.Interop/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj]

	% dotnet build
	% no `EXEC : warning` message