### PR TITLE
[Java.Interop] Place `JniEnvironment.g.cs` in `$(IntermediateOutputPath)` to support parallel builds.

### DIFF
--- a/src/Java.Interop/Java.Interop.targets
+++ b/src/Java.Interop/Java.Interop.targets
@@ -14,13 +14,13 @@
   <Target Name="BuildJniEnvironment_g_cs"
       BeforeTargets="BeforeCompile"
       Inputs="$(_JNIEnvGenPath)"
-      Outputs="Java.Interop/JniEnvironment.g.cs;$(IntermediateOutputPath)jni.c">
+      Outputs="$(IntermediateOutputPath)JniEnvironment.g.cs;$(IntermediateOutputPath)jni.c">
     <MakeDir Directories="$(IntermediateOutputPath)" />
     <Exec
-        Command="$(_RunJNIEnvGen) Java.Interop/JniEnvironment.g.cs $(IntermediateOutputPath)jni.c"
+        Command="$(_RunJNIEnvGen) $(IntermediateOutputPath)JniEnvironment.g.cs $(IntermediateOutputPath)jni.c"
     />
     <ItemGroup>
-      <Compile Include="$([System.IO.Path]::Combine('Java.Interop','JniEnvironment.g.cs'))" KeepDuplicates="false" />
+      <Compile Include="$(IntermediateOutputPath)JniEnvironment.g.cs" KeepDuplicates="false" />
     </ItemGroup>
   </Target>
   <Target Name="BuildInteropJar"


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6496140

Due to multitargeting of `Java.Interop.csproj` and parallel builds (no `-m:1`), we can write the file `Java.Interop/JniEnvironment.g.cs` twice in a build:

```
// net7.0
Command = /Users/builder/azdo/_work/1/s/xamarin-android/bin/Release/dotnet/dotnet "/Users/builder/azdo/_work/1/s/xamarin-android/external/Java.Interop/bin/BuildRelease-net7.0/jnienv-gen.dll" Java.Interop/JniEnvironment.g.cs obj/Release/net7.0/jni.c

// netstandard2.0
Command = mono "/Users/builder/azdo/_work/1/s/xamarin-android/external/Java.Interop/bin/BuildRelease/jnienv-gen.exe" Java.Interop/JniEnvironment.g.cs obj/Release/netstandard2.0/jni.c
```

As a race condition, this can cause the generation invocations to clobber each other, or to re-generate the file while the other is trying to compile with it:

```
/Users/builder/azdo/_work/1/s/xamarin-android/external/Java.Interop/src/Java.Interop/Java.Interop/JniEnvironment.g.cs(6926,21): error CS1027: #endif directive expected [/Users/builder/azdo/_work/1/s/xamarin-android/external/Java.Interop/src/Java.Interop/Java.Interop.csproj]
```

Fix this by moving the file to `$(IntermediateOutputPath)` so that each can have their own copy.