### PR TITLE
[generator] Refactor generation logic for applying [Obsolete] attributes.

### DIFF
--- a/tools/generator/SourceWriters/BoundClass.cs
+++ b/tools/generator/SourceWriters/BoundClass.cs
@@ -44,8 +44,7 @@ namespace generator.SourceWriters
 			klass.JavadocInfo?.AddJavadocs (Comments);
 			Comments.Add ($"// Metadata.xml XPath class reference: path=\"{klass.MetadataXPathReference}\"");
 
-			if (klass.IsDeprecated)
-				Attributes.Add (new ObsoleteAttr (klass.DeprecatedComment) { WriteAttributeSuffix = true });
+			SourceWriterExtensions.AddObsolete (Attributes, klass.DeprecatedComment, klass.IsDeprecated, writeAttributeSuffix: true);
 
 			SourceWriterExtensions.AddSupportedOSPlatform (Attributes, klass, opt);
 

--- a/tools/generator/SourceWriters/BoundConstructor.cs
+++ b/tools/generator/SourceWriters/BoundConstructor.cs
@@ -33,8 +33,7 @@ namespace generator.SourceWriters
 				Attributes.Add (new RegisterAttr (".ctor", constructor.JniSignature, string.Empty, additionalProperties: constructor.AdditionalAttributeString ()));
 			}
 
-			if (constructor.Deprecated != null)
-				Attributes.Add (new ObsoleteAttr (constructor.Deprecated.Replace ("\"", "\"\"")));
+			SourceWriterExtensions.AddObsolete (Attributes, constructor.Deprecated);
 
 			if (constructor.CustomAttributes != null)
 				Attributes.Add (new CustomAttr (constructor.CustomAttributes));

--- a/tools/generator/SourceWriters/BoundField.cs
+++ b/tools/generator/SourceWriters/BoundField.cs
@@ -30,8 +30,9 @@ namespace generator.SourceWriters
 
 			if (field.IsEnumified)
 				Attributes.Add (new GeneratedEnumAttr ());
-			if (field.IsDeprecated)
-				Attributes.Add (new ObsoleteAttr (field.DeprecatedComment, field.IsDeprecatedError) { NoAtSign = true, WriteEmptyString = true });
+
+			SourceWriterExtensions.AddObsolete (Attributes, field.DeprecatedComment, field.IsDeprecated, noAtSign: true, writeEmptyString: true, isError: field.IsDeprecatedError);
+
 			if (field.Annotation.HasValue ())
 				Attributes.Add (new CustomAttr (field.Annotation));
 

--- a/tools/generator/SourceWriters/BoundFieldAsProperty.cs
+++ b/tools/generator/SourceWriters/BoundFieldAsProperty.cs
@@ -47,8 +47,7 @@ namespace generator.SourceWriters
 				Attributes.Add (new RegisterAttr (field.JavaName, additionalProperties: field.AdditionalAttributeString ()));
 			}
 
-			if (field.IsDeprecated)
-				Attributes.Add (new ObsoleteAttr (field.DeprecatedComment, field.IsDeprecatedError) { NoAtSign = true });
+			SourceWriterExtensions.AddObsolete (Attributes, field.DeprecatedComment, field.IsDeprecated, noAtSign: true, isError: field.IsDeprecatedError);
 
 			SetVisibility (field.Visibility);
 			UseExplicitPrivateKeyword = true;

--- a/tools/generator/SourceWriters/BoundInterface.cs
+++ b/tools/generator/SourceWriters/BoundInterface.cs
@@ -43,8 +43,7 @@ namespace generator.SourceWriters
 			iface.JavadocInfo?.AddJavadocs (Comments);
 			Comments.Add ($"// Metadata.xml XPath interface reference: path=\"{iface.MetadataXPathReference}\"");
 
-			if (iface.IsDeprecated)
-				Attributes.Add (new ObsoleteAttr (iface.DeprecatedComment) { WriteAttributeSuffix = true, WriteEmptyString = true });
+			SourceWriterExtensions.AddObsolete (Attributes, iface.DeprecatedComment, iface.IsDeprecated, writeAttributeSuffix: true, writeEmptyString: true);
 
 			if (!iface.IsConstSugar (opt)) {
 				var signature = string.IsNullOrWhiteSpace (iface.Namespace)

--- a/tools/generator/SourceWriters/BoundInterfaceMethodDeclaration.cs
+++ b/tools/generator/SourceWriters/BoundInterfaceMethodDeclaration.cs
@@ -33,8 +33,9 @@ namespace generator.SourceWriters
 
 			if (method.DeclaringType.IsGeneratable)
 				Comments.Add ($"// Metadata.xml XPath method reference: path=\"{method.GetMetadataXPathReference (method.DeclaringType)}\"");
-			if (method.Deprecated != null)
-				Attributes.Add (new ObsoleteAttr (method.Deprecated.Replace ("\"", "\"\"")));
+
+			SourceWriterExtensions.AddObsolete (Attributes, method.Deprecated);
+
 			if (method.IsReturnEnumified)
 				Attributes.Add (new GeneratedEnumAttr (true));
 			if (method.IsInterfaceDefaultMethod)

--- a/tools/generator/SourceWriters/BoundMethod.cs
+++ b/tools/generator/SourceWriters/BoundMethod.cs
@@ -74,8 +74,7 @@ namespace generator.SourceWriters
 			if (method.DeclaringType.IsGeneratable)
 				Comments.Add ($"// Metadata.xml XPath method reference: path=\"{method.GetMetadataXPathReference (method.DeclaringType)}\"");
 
-			if (method.Deprecated.HasValue ())
-				Attributes.Add (new ObsoleteAttr (method.Deprecated.Replace ("\"", "\"\"")));
+			SourceWriterExtensions.AddObsolete (Attributes, method.Deprecated);
 
 			if (method.IsReturnEnumified)
 				Attributes.Add (new GeneratedEnumAttr (true));

--- a/tools/generator/SourceWriters/BoundMethodAbstractDeclaration.cs
+++ b/tools/generator/SourceWriters/BoundMethodAbstractDeclaration.cs
@@ -53,8 +53,7 @@ namespace generator.SourceWriters
 			if (method.DeclaringType.IsGeneratable)
 				Comments.Add ($"// Metadata.xml XPath method reference: path=\"{method.GetMetadataXPathReference (method.DeclaringType)}\"");
 
-			if (method.Deprecated.HasValue ())
-				Attributes.Add (new ObsoleteAttr (method.Deprecated.Replace ("\"", "\"\"")));
+			SourceWriterExtensions.AddObsolete (Attributes, method.Deprecated);
 
 			SourceWriterExtensions.AddSupportedOSPlatform (Attributes, method, opt);
 

--- a/tools/generator/SourceWriters/BoundMethodExtensionStringOverload.cs
+++ b/tools/generator/SourceWriters/BoundMethodExtensionStringOverload.cs
@@ -26,8 +26,7 @@ namespace generator.SourceWriters
 			SetVisibility (method.Visibility);
 			ReturnType = new TypeReferenceWriter (opt.GetTypeReferenceName (method.RetVal).Replace ("Java.Lang.ICharSequence", "string").Replace ("global::string", "string"));
 
-			if (method.Deprecated != null)
-				Attributes.Add (new ObsoleteAttr (method.Deprecated.Replace ("\"", "\"\"").Trim ()));
+			SourceWriterExtensions.AddObsolete (Attributes, method.Deprecated);
 
 			SourceWriterExtensions.AddSupportedOSPlatform (Attributes, method, opt);
 

--- a/tools/generator/SourceWriters/BoundMethodStringOverload.cs
+++ b/tools/generator/SourceWriters/BoundMethodStringOverload.cs
@@ -24,8 +24,7 @@ namespace generator.SourceWriters
 			SetVisibility (method.Visibility);
 			ReturnType = new TypeReferenceWriter (opt.GetTypeReferenceName (method.RetVal).Replace ("Java.Lang.ICharSequence", "string").Replace ("global::string", "string"));
 
-			if (method.Deprecated != null)
-				Attributes.Add (new ObsoleteAttr (method.Deprecated.Replace ("\"", "\"\"").Trim ()));
+			SourceWriterExtensions.AddObsolete (Attributes, method.Deprecated);
 
 			SourceWriterExtensions.AddSupportedOSPlatform (Attributes, method, opt);
 

--- a/tools/generator/SourceWriters/BoundProperty.cs
+++ b/tools/generator/SourceWriters/BoundProperty.cs
@@ -73,8 +73,10 @@ namespace generator.SourceWriters
 			}
 
 			// Unlike [Register], [Obsolete] cannot be put on property accessors, so we can apply them only under limited condition...
-			if (property.Getter.Deprecated != null && (property.Setter == null || property.Setter.Deprecated != null))
-				Attributes.Add (new ObsoleteAttr (property.Getter.Deprecated.Replace ("\"", "\"\"").Trim () + (property.Setter != null && property.Setter.Deprecated != property.Getter.Deprecated ? " " + property.Setter.Deprecated.Replace ("\"", "\"\"").Trim () : null)));
+			if (property.Getter.Deprecated != null && (property.Setter == null || property.Setter.Deprecated != null)) {
+				var message = property.Getter.Deprecated.Trim () + (property.Setter != null && property.Setter.Deprecated != property.Getter.Deprecated ? " " + property.Setter.Deprecated.Trim () : null);
+				SourceWriterExtensions.AddObsolete (Attributes, message);
+			}
 
 			SourceWriterExtensions.AddSupportedOSPlatform (Attributes, property.Getter, opt);
 

--- a/tools/generator/SourceWriters/Extensions/SourceWriterExtensions.cs
+++ b/tools/generator/SourceWriters/Extensions/SourceWriterExtensions.cs
@@ -301,6 +301,20 @@ namespace generator.SourceWriters
 
 		}
 
+		public static void AddObsolete (List<AttributeWriter> attributes, string message, bool forceDeprecate = false, bool isError = false, bool noAtSign = false, bool writeEmptyString = false, bool writeAttributeSuffix = false, bool writeGlobal = false)
+		{
+			// Bail if we're not obsolete
+			if ((!forceDeprecate && !message.HasValue ()) || message == "not deprecated")
+				return;
+
+			attributes.Add (new ObsoleteAttr (message: message?.Replace ("\"", "\"\"").Trim (), isError: isError) {
+				NoAtSign = noAtSign,
+				WriteAttributeSuffix = writeAttributeSuffix,
+				WriteEmptyString = writeEmptyString,
+				WriteGlobal = writeGlobal
+			});
+		}
+
 		public static void WriteMethodInvokerBody (CodeWriter writer, Method method, CodeGenerationOptions opt, string contextThis)
 		{
 			writer.WriteLine ($"if ({method.EscapedIdName} == IntPtr.Zero)");

--- a/tools/generator/SourceWriters/MethodCallback.cs
+++ b/tools/generator/SourceWriters/MethodCallback.cs
@@ -43,8 +43,7 @@ namespace generator.SourceWriters
 			IsStatic = true;
 			IsPrivate = method.IsInterfaceDefaultMethod;
 
-			if (!string.IsNullOrWhiteSpace (method.Deprecated))
-				Attributes.Add (new ObsoleteAttr ());
+			SourceWriterExtensions.AddObsolete (Attributes, null, forceDeprecate: !string.IsNullOrWhiteSpace (method.Deprecated));
 
 			SourceWriterExtensions.AddSupportedOSPlatform (Attributes, method, opt);
 
@@ -136,8 +135,7 @@ namespace generator.SourceWriters
 			IsStatic = true;
 			IsPrivate = method.IsInterfaceDefaultMethod;
 
-			if (!string.IsNullOrWhiteSpace (method.Deprecated))
-				Attributes.Add (new ObsoleteAttr ());
+			SourceWriterExtensions.AddObsolete (Attributes, null, forceDeprecate: !string.IsNullOrWhiteSpace (method.Deprecated));
 
 			SourceWriterExtensions.AddSupportedOSPlatform (Attributes, method, opt);
 		}


### PR DESCRIPTION
Refactor `generator` logic for applying `[Obsolete]` attributes to a single common method.  This method will later be extended to add support for [`[ObsoletedOSPlatform]`](https://github.com/xamarin/xamarin-android/issues/7234).

Doing this piece first and separately allows us to verify that the refactor does not break anything, as the existing logic is a bit tricky. A future PR will also remove the temporary hacks used to preserve stylistic compatibility for the large `generator` [refactor](https://github.com/xamarin/java.interop/pull/674).

Test XA bump to ensure no changes to ApiCompat: https://github.com/xamarin/xamarin-android/pull/7240.