### PR TITLE
[generator] Remove [Obsolete] style compatibility hacks.

### DIFF
--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteInterface.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteInterface.txt
@@ -20,7 +20,7 @@ public abstract class MyInterface : Java.Lang.Object {
 }
 
 [Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
-[global::System.Obsolete ("Use the 'MyInterface' type. This type will be removed in a future release.", error: true)]
+[global::System.Obsolete (@"Use the 'MyInterface' type. This type will be removed in a future release.", error: true)]
 public abstract class MyInterfaceConsts : MyInterface {
 	private MyInterfaceConsts ()
 	{

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/ObsoleteInterfaceAlternativeClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/ObsoleteInterfaceAlternativeClass.txt
@@ -1,5 +1,5 @@
 [Register ("com/xamarin/android/Parent", DoNotGenerateAcw=true)]
-[global::System.Obsolete ("Use the 'Com.Xamarin.Android.IParent' type. This class will be removed in a future release.")]
+[global::System.Obsolete (@"Use the 'Com.Xamarin.Android.IParent' type. This class will be removed in a future release.")]
 public abstract class Parent : Java.Lang.Object {
 	internal Parent ()
 	{
@@ -7,18 +7,18 @@ public abstract class Parent : Java.Lang.Object {
 
 	// Metadata.xml XPath field reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent']/field[@name='ACCEPT_HANDOVER']"
 	[Register ("ACCEPT_HANDOVER")]
-	[Obsolete ("Use 'Com.Xamarin.Android.IParent.AcceptHandover'. This class will be removed in a future release.")]
+	[global::System.Obsolete (@"Use 'Com.Xamarin.Android.IParent.AcceptHandover'. This class will be removed in a future release.")]
 	public const string AcceptHandover = (string) "android.permission.ACCEPT_HANDOVER";
 
 	// Metadata.xml XPath field reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent']/field[@name='ALREADY_OBSOLETE']"
 	[Register ("ALREADY_OBSOLETE")]
-	[Obsolete ("deprecated")]
+	[global::System.Obsolete (@"deprecated")]
 	public const string AlreadyObsolete = (string) "android.permission.ACCEPT_HANDOVER";
 
 
 	// Metadata.xml XPath field reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent']/field[@name='API_NAME']"
 	[Register ("API_NAME")]
-	[Obsolete ("Use 'Com.Xamarin.Android.IParent.ApiName'. This class will be removed in a future release.")]
+	[global::System.Obsolete (@"Use 'Com.Xamarin.Android.IParent.ApiName'. This class will be removed in a future release.")]
 	public static string ApiName {
 		get {
 			const string __id = "API_NAME.Ljava/lang/String;";
@@ -29,7 +29,7 @@ public abstract class Parent : Java.Lang.Object {
 	}
 
 	// Metadata.xml XPath method reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent']/method[@name='comparing' and count(parameter)=0]"
-	[Obsolete (@"Use 'Com.Xamarin.Android.IParent.Comparing'. This class will be removed in a future release.")]
+	[global::System.Obsolete (@"Use 'Com.Xamarin.Android.IParent.Comparing'. This class will be removed in a future release.")]
 	[Register ("comparing", "()I", "")]
 	public static unsafe int Comparing ()
 	{
@@ -42,7 +42,7 @@ public abstract class Parent : Java.Lang.Object {
 	}
 
 	// Metadata.xml XPath method reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent']/method[@name='comparingOld' and count(parameter)=0]"
-	[Obsolete (@"deprecated")]
+	[global::System.Obsolete (@"deprecated")]
 	[Register ("comparingOld", "()I", "")]
 	public static unsafe int ComparingOld ()
 	{
@@ -69,7 +69,7 @@ public partial interface IParent : IJavaObject, IJavaPeerable {
 
 	// Metadata.xml XPath field reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent']/field[@name='ALREADY_OBSOLETE']"
 	[Register ("ALREADY_OBSOLETE")]
-	[Obsolete ("deprecated")]
+	[global::System.Obsolete (@"deprecated")]
 	public const string AlreadyObsolete = (string) "android.permission.ACCEPT_HANDOVER";
 
 
@@ -97,7 +97,7 @@ public partial interface IParent : IJavaObject, IJavaPeerable {
 	}
 
 	// Metadata.xml XPath method reference: path="/api/package[@name='com.xamarin.android']/interface[@name='Parent']/method[@name='comparingOld' and count(parameter)=0]"
-	[Obsolete (@"deprecated")]
+	[global::System.Obsolete (@"deprecated")]
 	[Register ("comparingOld", "()I", "")]
 	public static unsafe int ComparingOld ()
 	{

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterface.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterface.txt
@@ -20,7 +20,7 @@ public abstract class MyInterface : Java.Lang.Object {
 }
 
 [Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
-[global::System.Obsolete ("Use the 'MyInterface' type. This type will be removed in a future release.", error: true)]
+[global::System.Obsolete (@"Use the 'MyInterface' type. This type will be removed in a future release.", error: true)]
 public abstract class MyInterfaceConsts : MyInterface {
 	private MyInterfaceConsts ()
 	{

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceFieldAsDimProperty.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceFieldAsDimProperty.txt
@@ -33,7 +33,7 @@ public abstract class MyInterface : Java.Lang.Object {
 }
 
 [Register ("com/xamarin/android/MyInterface", DoNotGenerateAcw=true)]
-[global::System.Obsolete ("Use the 'MyInterface' type. This type will be removed in a future release.", error: true)]
+[global::System.Obsolete (@"Use the 'MyInterface' type. This type will be removed in a future release.", error: true)]
 public abstract class MyInterfaceConsts : MyInterface {
 	private MyInterfaceConsts ()
 	{

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteStaticInterfaceMethod.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteStaticInterfaceMethod.txt
@@ -20,7 +20,7 @@ public abstract class MyInterface : Java.Lang.Object {
 }
 
 [Register ("java/code/IMyInterface", DoNotGenerateAcw=true)]
-[global::System.Obsolete ("Use the 'MyInterface' type. This type will be removed in a future release.", error: true)]
+[global::System.Obsolete (@"Use the 'MyInterface' type. This type will be removed in a future release.", error: true)]
 public abstract class MyInterfaceConsts : MyInterface {
 	private MyInterfaceConsts ()
 	{

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
@@ -528,7 +528,7 @@ namespace generatortests
 			generator.Context.ContextTypes.Pop ();
 
 			// Ensure [Obsolete] was written
-			Assert.True (writer.ToString ().Contains ("[Obsolete (@\"This is so old!\")]"), writer.ToString ());
+			Assert.True (writer.ToString ().Contains ("[global::System.Obsolete (@\"This is so old!\")]"), writer.ToString ());
 		}
 
 		[Test]

--- a/tests/generator-Tests/expected.ji/Constructors/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/Constructors/Xamarin.Test.SomeObject.cs
@@ -20,7 +20,7 @@ namespace Xamarin.Test {
 		}
 
 		// Metadata.xml XPath constructor reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/constructor[@name='SomeObject' and count(parameter)=0]"
-		[Obsolete (@"deprecated")]
+		[global::System.Obsolete (@"deprecated")]
 		public unsafe SomeObject () : base (ref *InvalidJniObjectReference, JniObjectReferenceOptions.None)
 		{
 			const string __id = "()V";

--- a/tests/generator-Tests/expected.ji/NormalMethods/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/NormalMethods/Xamarin.Test.SomeObject.cs
@@ -126,7 +126,7 @@ namespace Xamarin.Test {
 		}
 
 		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/method[@name='ObsoleteMethod' and count(parameter)=0]"
-		[Obsolete (@"Deprecated please use IntegerMethod instead")]
+		[global::System.Obsolete (@"Deprecated please use IntegerMethod instead")]
 		public virtual unsafe int ObsoleteMethod ()
 		{
 			const string __id = "ObsoleteMethod.()I";

--- a/tests/generator-Tests/expected.ji/StaticMethods/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/StaticMethods/Xamarin.Test.SomeObject.cs
@@ -44,7 +44,7 @@ namespace Xamarin.Test {
 		}
 
 		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/method[@name='Obsoletemethod' and count(parameter)=0]"
-		[Obsolete (@"Deprecated please use methodAsString")]
+		[global::System.Obsolete (@"Deprecated please use methodAsString")]
 		[global::Java.Interop.JniMethodSignature ("Obsoletemethod", "()Ljava/lang/String;")]
 		public static unsafe string Obsoletemethod ()
 		{

--- a/tests/generator-Tests/expected.xaji/Constructors/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.xaji/Constructors/Xamarin.Test.SomeObject.cs
@@ -38,7 +38,7 @@ namespace Xamarin.Test {
 
 		// Metadata.xml XPath constructor reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/constructor[@name='SomeObject' and count(parameter)=0]"
 		[Register (".ctor", "()V", "")]
-		[Obsolete (@"deprecated")]
+		[global::System.Obsolete (@"deprecated")]
 		public unsafe SomeObject () : base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 		{
 			const string __id = "()V";

--- a/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.SomeObject.cs
@@ -269,7 +269,7 @@ namespace Xamarin.Test {
 
 		static Delegate cb_ObsoleteMethod;
 #pragma warning disable 0169
-		[Obsolete]
+		[global::System.Obsolete]
 		static Delegate GetObsoleteMethodHandler ()
 		{
 			if (cb_ObsoleteMethod == null)
@@ -277,7 +277,7 @@ namespace Xamarin.Test {
 			return cb_ObsoleteMethod;
 		}
 
-		[Obsolete]
+		[global::System.Obsolete]
 		static int n_ObsoleteMethod (IntPtr jnienv, IntPtr native__this)
 		{
 			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
@@ -286,7 +286,7 @@ namespace Xamarin.Test {
 #pragma warning restore 0169
 
 		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/method[@name='ObsoleteMethod' and count(parameter)=0]"
-		[Obsolete (@"Deprecated please use IntegerMethod instead")]
+		[global::System.Obsolete (@"Deprecated please use IntegerMethod instead")]
 		[Register ("ObsoleteMethod", "()I", "GetObsoleteMethodHandler")]
 		public virtual unsafe int ObsoleteMethod ()
 		{

--- a/tests/generator-Tests/expected.xaji/StaticMethods/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.xaji/StaticMethods/Xamarin.Test.SomeObject.cs
@@ -61,7 +61,7 @@ namespace Xamarin.Test {
 		}
 
 		// Metadata.xml XPath method reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/method[@name='Obsoletemethod' and count(parameter)=0]"
-		[Obsolete (@"Deprecated please use methodAsString")]
+		[global::System.Obsolete (@"Deprecated please use methodAsString")]
 		[Register ("Obsoletemethod", "()Ljava/lang/String;", "")]
 		public static unsafe string Obsoletemethod ()
 		{

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.ITestInterface.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.ITestInterface.cs
@@ -32,7 +32,7 @@ namespace Test.ME {
 	}
 
 	[Register ("test/me/TestInterface", DoNotGenerateAcw=true)]
-	[global::System.Obsolete ("Use the 'TestInterface' type. This type will be removed in a future release.", error: true)]
+	[global::System.Obsolete (@"Use the 'TestInterface' type. This type will be removed in a future release.", error: true)]
 	public abstract class TestInterfaceConsts : TestInterface {
 		private TestInterfaceConsts ()
 		{

--- a/tools/generator/SourceWriters/Attributes/ObsoleteAttr.cs
+++ b/tools/generator/SourceWriters/Attributes/ObsoleteAttr.cs
@@ -11,10 +11,6 @@ namespace generator.SourceWriters
 	{
 		public string Message { get; set; }
 		public bool IsError { get; set; }
-		public bool NoAtSign { get; set; }		// TODO: Temporary to match unit tests
-		public bool WriteEmptyString { get; set; }      // TODO: Temporary to match unit tests
-		public bool WriteAttributeSuffix { get; set; }  // TODO: Temporary to match unit tests
-		public bool WriteGlobal { get; set; }           // TODO: Temporary to match unit tests
 
 		public ObsoleteAttr (string message = null, bool isError = false)
 		{
@@ -24,22 +20,20 @@ namespace generator.SourceWriters
 
 		public override void WriteAttribute (CodeWriter writer)
 		{
-			var attr_name = WriteAttributeSuffix ? "ObsoleteAttribute" : "Obsolete";
+			var parts = new List<string> ();
 
-			if (WriteGlobal)
-				attr_name = "global::System." + attr_name;
-
-			if (Message is null && !WriteEmptyString && !IsError) {
-				writer.WriteLine ($"[{attr_name}]");
-				return;
-			}
-
-			writer.Write ($"[{attr_name} ({(NoAtSign ? "" : "@")}\"{Message}\"");
+			if (Message != null)
+				parts.Add ($"@\"{Message}\"");
 
 			if (IsError)
-				writer.Write (", error: true");
+				parts.Add ("error: true");
 
-			writer.WriteLine (")]");
+			var content = string.Join (", ", parts.ToArray ());
+
+			if (content.HasValue ())
+				writer.WriteLine ($"[global::System.Obsolete ({content})]");
+			else
+				writer.WriteLine ("[global::System.Obsolete]");
 		}
 	}
 }

--- a/tools/generator/SourceWriters/BoundClass.cs
+++ b/tools/generator/SourceWriters/BoundClass.cs
@@ -44,7 +44,7 @@ namespace generator.SourceWriters
 			klass.JavadocInfo?.AddJavadocs (Comments);
 			Comments.Add ($"// Metadata.xml XPath class reference: path=\"{klass.MetadataXPathReference}\"");
 
-			SourceWriterExtensions.AddObsolete (Attributes, klass.DeprecatedComment, klass.IsDeprecated, writeAttributeSuffix: true);
+			SourceWriterExtensions.AddObsolete (Attributes, klass.DeprecatedComment, klass.IsDeprecated);
 
 			SourceWriterExtensions.AddSupportedOSPlatform (Attributes, klass, opt);
 

--- a/tools/generator/SourceWriters/BoundField.cs
+++ b/tools/generator/SourceWriters/BoundField.cs
@@ -31,7 +31,7 @@ namespace generator.SourceWriters
 			if (field.IsEnumified)
 				Attributes.Add (new GeneratedEnumAttr ());
 
-			SourceWriterExtensions.AddObsolete (Attributes, field.DeprecatedComment, field.IsDeprecated, noAtSign: true, writeEmptyString: true, isError: field.IsDeprecatedError);
+			SourceWriterExtensions.AddObsolete (Attributes, field.DeprecatedComment, field.IsDeprecated, isError: field.IsDeprecatedError);
 
 			if (field.Annotation.HasValue ())
 				Attributes.Add (new CustomAttr (field.Annotation));

--- a/tools/generator/SourceWriters/BoundFieldAsProperty.cs
+++ b/tools/generator/SourceWriters/BoundFieldAsProperty.cs
@@ -47,7 +47,7 @@ namespace generator.SourceWriters
 				Attributes.Add (new RegisterAttr (field.JavaName, additionalProperties: field.AdditionalAttributeString ()));
 			}
 
-			SourceWriterExtensions.AddObsolete (Attributes, field.DeprecatedComment, field.IsDeprecated, noAtSign: true, isError: field.IsDeprecatedError);
+			SourceWriterExtensions.AddObsolete (Attributes, field.DeprecatedComment, field.IsDeprecated, isError: field.IsDeprecatedError);
 
 			SetVisibility (field.Visibility);
 			UseExplicitPrivateKeyword = true;

--- a/tools/generator/SourceWriters/BoundInterface.cs
+++ b/tools/generator/SourceWriters/BoundInterface.cs
@@ -43,7 +43,7 @@ namespace generator.SourceWriters
 			iface.JavadocInfo?.AddJavadocs (Comments);
 			Comments.Add ($"// Metadata.xml XPath interface reference: path=\"{iface.MetadataXPathReference}\"");
 
-			SourceWriterExtensions.AddObsolete (Attributes, iface.DeprecatedComment, iface.IsDeprecated, writeAttributeSuffix: true, writeEmptyString: true);
+			SourceWriterExtensions.AddObsolete (Attributes, iface.DeprecatedComment, iface.IsDeprecated);
 
 			if (!iface.IsConstSugar (opt)) {
 				var signature = string.IsNullOrWhiteSpace (iface.Namespace)

--- a/tools/generator/SourceWriters/Extensions/SourceWriterExtensions.cs
+++ b/tools/generator/SourceWriters/Extensions/SourceWriterExtensions.cs
@@ -301,18 +301,13 @@ namespace generator.SourceWriters
 
 		}
 
-		public static void AddObsolete (List<AttributeWriter> attributes, string message, bool forceDeprecate = false, bool isError = false, bool noAtSign = false, bool writeEmptyString = false, bool writeAttributeSuffix = false, bool writeGlobal = false)
+		public static void AddObsolete (List<AttributeWriter> attributes, string message, bool forceDeprecate = false, bool isError = false)
 		{
 			// Bail if we're not obsolete
 			if ((!forceDeprecate && !message.HasValue ()) || message == "not deprecated")
 				return;
 
-			attributes.Add (new ObsoleteAttr (message: message?.Replace ("\"", "\"\"").Trim (), isError: isError) {
-				NoAtSign = noAtSign,
-				WriteAttributeSuffix = writeAttributeSuffix,
-				WriteEmptyString = writeEmptyString,
-				WriteGlobal = writeGlobal
-			});
+			attributes.Add (new ObsoleteAttr (message: message?.Replace ("\"", "\"\"").Trim (), isError: isError));
 		}
 
 		public static void WriteMethodInvokerBody (CodeWriter writer, Method method, CodeGenerationOptions opt, string contextThis)

--- a/tools/generator/SourceWriters/InterfaceMemberAlternativeClass.cs
+++ b/tools/generator/SourceWriters/InterfaceMemberAlternativeClass.cs
@@ -42,7 +42,7 @@ namespace generator.SourceWriters
 			Attributes.Add (new RegisterAttr (iface.RawJniName, noAcw: true, additionalProperties: iface.AdditionalAttributeString ()) { AcwLast = true });
 
 			if (should_obsolete)
-				Attributes.Add (new ObsoleteAttr ($"Use the '{iface.FullName}' type. This class will be removed in a future release.") { WriteGlobal = true, NoAtSign = true });
+				SourceWriterExtensions.AddObsolete (Attributes, $"Use the '{iface.FullName}' type. This class will be removed in a future release.");
 
 			Constructors.Add (new ConstructorWriter { Name = Name, IsInternal = true });
 
@@ -180,7 +180,7 @@ namespace generator.SourceWriters
 			IsAbstract = true;
 
 			Attributes.Add (new RegisterAttr (iface.RawJniName, noAcw: true, additionalProperties: iface.AdditionalAttributeString ()));
-			Attributes.Add (new ObsoleteAttr ($"Use the '{iface.Name.Substring (1)}' type. This type will be removed in a future release.", true) { NoAtSign = true, WriteGlobal = true });
+			SourceWriterExtensions.AddObsolete (Attributes, $"Use the '{iface.Name.Substring (1)}' type. This type will be removed in a future release.", isError: true);
 
 			Constructors.Add (new ConstructorWriter {
 				Name = Name,


### PR DESCRIPTION
Traditionally `generator` was inconsistent with the style in which it generated `[Obsolete]` attributes, such as:

```csharp
[Obsolete]
[Obsolete ("")]
[Obsolete (@"")]
[ObsoleteAttribute]
[global::System.Obsolete]
```

We wrote a temporary compatibility layer to preserve these differences when we [refactored](https://github.com/xamarin/java.interop/pull/674) `generator`.  This allowed us to do a source code level text compare against a large corpus of generated code (`Mono.Android`/AndroidX/GPS) to ensure there were no changes.

Now that we are passed this phase, we can remove these hacks and standardize on `[global::System.Obsolete]` and `[global::System.Obsolete (@"message")]`.

XA test build to ensure there were no actual changes via ApiCompat testing: https://github.com/xamarin/xamarin-android/pull/7253.