### PR TITLE
[generator] Add support for `[ObsoletedOSPlatform]`.

### DIFF
--- a/src/utils/XmlExtensions.cs
+++ b/src/utils/XmlExtensions.cs
@@ -20,5 +20,18 @@ namespace Xamarin.Android.Tools {
 			var attr = nav.GetAttribute (name, ns);
 			return attr != null ? attr.Trim () : null;
 		}
+
+		public static int? XGetAttributeAsIntOrNull (this XElement element, string name)
+		{
+			var attr = element.Attribute (name);
+
+			if (attr?.Value is null)
+				return null;
+
+			if (int.TryParse (attr.Value, out var val))
+				return val;
+
+			return null;
+		}
 	}
 }

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
@@ -532,6 +532,86 @@ namespace generatortests
 		}
 
 		[Test]
+		public void ObsoletedOSPlatformAttributeSupport ()
+		{
+			var xml = @"<api>
+			  <package name='java.lang' jni-name='java/lang'>
+			    <class abstract='false' deprecated='not deprecated' final='false' name='Object' static='false' visibility='public' jni-signature='Ljava/lang/Object;' />
+			  </package>
+			  <package name='com.xamarin.android' jni-name='com/xamarin/android'>
+			    <class abstract='false' deprecated='This is a class deprecated since 25!' extends='java.lang.Object' extends-generic-aware='java.lang.Object' jni-extends='Ljava/lang/Object;' final='false' name='MyClass' static='false' visibility='public' jni-signature='Lcom/xamarin/android/MyClass;' deprecated-since='25'>
+			      <field deprecated='This is a field deprecated since 25!' final='true' name='ACCEPT_HANDOVER' jni-signature='Ljava/lang/String;' static='true' transient='false' type='java.lang.String' type-generic-aware='java.lang.String' value='&quot;android.permission.ACCEPT_HANDOVER&quot;' visibility='public' volatile='false' deprecated-since='25'></field>
+			      <constructor deprecated='This is a constructor deprecated since 25!' final='false' name='MyClass' jni-signature='()V' bridge='false' static='false' type='com.xamarin.android.MyClass' synthetic='false' visibility='public' deprecated-since='25'></constructor>
+			      <method abstract='true' deprecated='This is a method deprecated since 25!' final='false' name='countAffectedRows' jni-signature='()I' bridge='false' native='false' return='int' jni-return='I' static='false' synchronized='false' synthetic='false' visibility='public' deprecated-since='25'></method>
+			      <method abstract='false' deprecated='This is a property getter deprecated since 25!' final='false' name='getCount' jni-signature='()I' bridge='false' native='false' return='int' jni-return='I' static='false' synchronized='false' synthetic='false' visibility='public' deprecated-since='25'></method>
+			      <method abstract='false' deprecated='This is a property setter deprecated since 25!' final='false' name='setCount' jni-signature='(I)V' bridge='false' native='false' return='void' jni-return='V' static='false' synchronized='false' synthetic='false' visibility='public' deprecated-since='25'>
+					<parameter name='count' type='int' jni-type='I'></parameter>
+				  </method>
+			    </class>
+			  </package>
+			</api>";
+
+			options.UseObsoletedOSPlatformAttributes = true;
+
+			var gens = ParseApiDefinition (xml);
+			var iface = gens.Single (g => g.Name == "MyClass");
+
+			generator.Context.ContextTypes.Push (iface);
+			generator.WriteType (iface, string.Empty, new GenerationInfo ("", "", "MyAssembly"));
+			generator.Context.ContextTypes.Pop ();
+
+			// Ensure [ObsoletedOSPlatform] was written
+			Assert.True (writer.ToString ().Contains ("[global::System.Runtime.Versioning.ObsoletedOSPlatform (\"android25.0\", @\"This is a class deprecated since 25!\")]"), writer.ToString ());
+			Assert.True (writer.ToString ().Contains ("[global::System.Runtime.Versioning.ObsoletedOSPlatform (\"android25.0\", @\"This is a field deprecated since 25!\")]"), writer.ToString ());
+			Assert.True (writer.ToString ().Contains ("[global::System.Runtime.Versioning.ObsoletedOSPlatform (\"android25.0\", @\"This is a constructor deprecated since 25!\")]"), writer.ToString ());
+			Assert.True (writer.ToString ().Contains ("[global::System.Runtime.Versioning.ObsoletedOSPlatform (\"android25.0\", @\"This is a method deprecated since 25!\")]"), writer.ToString ());
+			Assert.True (writer.ToString ().Contains ("[global::System.Runtime.Versioning.ObsoletedOSPlatform (\"android25.0\", @\"This is a property getter deprecated since 25! This is a property setter deprecated since 25!\")]"), writer.ToString ());
+		}
+
+		[Test]
+		public void ObsoletedOSPlatformAttributeUnneededSupport ()
+		{
+			var xml = @"<api>
+			  <package name='java.lang' jni-name='java/lang'>
+			    <class abstract='false' deprecated='not deprecated' final='false' name='Object' static='false' visibility='public' jni-signature='Ljava/lang/Object;' />
+			  </package>
+			  <package name='com.xamarin.android' jni-name='com/xamarin/android'>
+			    <class abstract='false' deprecated='This is a class deprecated since 19!' extends='java.lang.Object' extends-generic-aware='java.lang.Object' jni-extends='Ljava/lang/Object;' final='false' name='MyClass' static='false' visibility='public' jni-signature='Lcom/xamarin/android/MyClass;' deprecated-since='19'>
+			      <field deprecated='This is a field deprecated since 0!' final='true' name='ACCEPT_HANDOVER' jni-signature='Ljava/lang/String;' static='true' transient='false' type='java.lang.String' type-generic-aware='java.lang.String' value='&quot;android.permission.ACCEPT_HANDOVER&quot;' visibility='public' volatile='false' deprecated-since='0'></field>
+			      <constructor deprecated='This is a constructor deprecated since empty string!' final='false' name='MyClass' jni-signature='()V' bridge='false' static='false' type='com.xamarin.android.MyClass' synthetic='false' visibility='public' deprecated-since=''></constructor>
+			      <method abstract='true' deprecated='deprecated' final='false' name='countAffectedRows' jni-signature='()I' bridge='false' native='false' return='int' jni-return='I' static='false' synchronized='false' synthetic='false' visibility='public' deprecated-since='25'></method>
+			      <method abstract='true' deprecated='This method has an invalid deprecated-since!' final='false' name='countAffectedRows2' jni-signature='()I' bridge='false' native='false' return='int' jni-return='I' static='false' synchronized='false' synthetic='false' visibility='public' deprecated-since='foo'></method>
+			      <method abstract='false' deprecated='deprecated' final='false' name='getCount' jni-signature='()I' bridge='false' native='false' return='int' jni-return='I' static='false' synchronized='false' synthetic='false' visibility='public' deprecated-since='22'></method>
+			      <method abstract='false' deprecated='deprecated' final='false' name='setCount' jni-signature='(I)V' bridge='false' native='false' return='void' jni-return='V' static='false' synchronized='false' synthetic='false' visibility='public' deprecated-since='22'>
+					<parameter name='count' type='int' jni-type='I'></parameter>
+				  </method>
+			    </class>
+			  </package>
+			</api>";
+
+			options.UseObsoletedOSPlatformAttributes = true;
+
+			var gens = ParseApiDefinition (xml);
+			var iface = gens.Single (g => g.Name == "MyClass");
+
+			generator.Context.ContextTypes.Push (iface);
+			generator.WriteType (iface, string.Empty, new GenerationInfo ("", "", "MyAssembly"));
+			generator.Context.ContextTypes.Pop ();
+
+			// These should use [Obsolete] because they have always been obsolete in all currently supported versions (21+)
+			Assert.True (writer.ToString ().Contains ("[global::System.Obsolete (@\"This is a class deprecated since 19!\")]"), writer.ToString ());
+			Assert.True (writer.ToString ().Contains ("[global::System.Obsolete (@\"This is a field deprecated since 0!\")]"), writer.ToString ());
+			Assert.True (writer.ToString ().Contains ("[global::System.Obsolete (@\"This is a constructor deprecated since empty string!\")]"), writer.ToString ());
+
+			// This should not have a message because the default "deprecated" message isn't useful
+			Assert.True (writer.ToString ().Contains ("[global::System.Runtime.Versioning.ObsoletedOSPlatform (\"android25.0\")]"), writer.ToString ());
+			Assert.True (writer.ToString ().Contains ("[global::System.Runtime.Versioning.ObsoletedOSPlatform (\"android22.0\")]"), writer.ToString ());
+
+			// This should use [Obsolete] because the 'deprecated-since' attribute could not be parsed
+			Assert.True (writer.ToString ().Contains ("[global::System.Obsolete (@\"This method has an invalid deprecated-since!\")]"), writer.ToString ());
+		}
+
+		[Test]
 		[NonParallelizable]	// We are setting a static property on Report
 		public void WarnIfTypeNameMatchesNamespace ()
 		{

--- a/tools/generator/CodeGenerationOptions.cs
+++ b/tools/generator/CodeGenerationOptions.cs
@@ -66,6 +66,7 @@ namespace MonoDroid.Generation
 		public bool SupportNestedInterfaceTypes { get; set; }
 		public bool SupportNullableReferenceTypes { get; set; }
 		public bool UseShallowReferencedTypes { get; set; }
+		public bool UseObsoletedOSPlatformAttributes { get; set; }
 		public bool RemoveConstSugar => BuildingCoreAssembly;
 
 		bool? buildingCoreAssembly;

--- a/tools/generator/CodeGenerator.cs
+++ b/tools/generator/CodeGenerator.cs
@@ -83,6 +83,7 @@ namespace Xamarin.Android.Binder
 				SupportDefaultInterfaceMethods = options.SupportDefaultInterfaceMethods,
 				SupportNestedInterfaceTypes = options.SupportNestedInterfaceTypes,
 				SupportNullableReferenceTypes = options.SupportNullableReferenceTypes,
+				UseObsoletedOSPlatformAttributes = options.UseObsoletedOSPlatformAttributes,
 			};
 			var resolverCache       = new TypeDefinitionCache ();
 

--- a/tools/generator/CodeGeneratorOptions.cs
+++ b/tools/generator/CodeGeneratorOptions.cs
@@ -53,6 +53,7 @@ namespace Xamarin.Android.Binder
 		public bool		    SupportNestedInterfaceTypes { get; set; }
 		public bool		    SupportNullableReferenceTypes { get; set; }
 		public bool		    UseLegacyJavaResolver { get; set; }
+		public bool			UseObsoletedOSPlatformAttributes { get; set; }
 
 		public XmldocStyle		    XmldocStyle { get; set; } = XmldocStyle.IntelliSense;
 
@@ -102,12 +103,13 @@ namespace Xamarin.Android.Binder
 					"SDK Platform {VERSION}/API level.",
 					v => opts.ApiLevel = v },
 				{ "lang-features=",
-					"For internal use. (Flags: interface-constants,default-interface-methods,nullable-reference-types)",
+					"For internal use. (Flags: interface-constants,default-interface-methods,nested-interface-types,nullable-reference-types,obsoleted-platform-attributes)",
 					v => {
 						opts.SupportInterfaceConstants = v?.Contains ("interface-constants") == true;
 						opts.SupportDefaultInterfaceMethods = v?.Contains ("default-interface-methods") == true;
 						opts.SupportNestedInterfaceTypes = v?.Contains ("nested-interface-types") == true;
 						opts.SupportNullableReferenceTypes = v?.Contains ("nullable-reference-types") == true;
+						opts.UseObsoletedOSPlatformAttributes = v?.Contains ("obsoleted-platform-attributes") == true;
 						}},
 				{ "preserve-enums",
 					"For internal use.",

--- a/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
@@ -155,6 +155,7 @@ namespace MonoDroid.Generation
 				ApiAvailableSince = declaringType.ApiAvailableSince,
 				CustomAttributes = elem.XGetAttribute ("customAttributes"),
 				Deprecated = elem.Deprecated (),
+				DeprecatedSince = elem.XGetAttributeAsIntOrNull ("deprecated-since"),
 				GenericArguments = elem.GenericArguments (),
 				Name = elem.XGetAttribute ("name"),
 				Visibility = elem.Visibility ()
@@ -200,6 +201,7 @@ namespace MonoDroid.Generation
 			var field = new Field {
 				ApiAvailableSince = declaringType.ApiAvailableSince,
 				DeprecatedComment = elem.XGetAttribute ("deprecated"),
+				DeprecatedSince = elem.XGetAttributeAsIntOrNull ("deprecated-since"),
 				IsAcw = true,
 				IsDeprecated = elem.XGetAttribute ("deprecated") != "not deprecated",
 				IsDeprecatedError = elem.XGetAttribute ("deprecated-error") == "true",
@@ -237,6 +239,7 @@ namespace MonoDroid.Generation
 		public static GenBaseSupport CreateGenBaseSupport (XElement pkg, XElement elem, CodeGenerationOptions opt, bool isInterface)
 		{
 			var support = new GenBaseSupport {
+				DeprecatedSince = elem.XGetAttributeAsIntOrNull ("deprecated-since"),
 				IsAcw = true,
 				IsDeprecated = elem.XGetAttribute ("deprecated") != "not deprecated",
 				IsGeneratable = true,
@@ -348,6 +351,7 @@ namespace MonoDroid.Generation
 				ArgsType = elem.Attribute ("argsType")?.Value,
 				CustomAttributes = elem.XGetAttribute ("customAttributes"),
 				Deprecated = elem.Deprecated (),
+				DeprecatedSince = elem.XGetAttributeAsIntOrNull ("deprecated-since"),
 				ExplicitInterface = elem.XGetAttribute ("explicitInterface"),
 				EventName = elem.Attribute ("eventName")?.Value,
 				GenerateAsyncWrapper = elem.Attribute ("generateAsyncWrapper") != null,

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Field.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Field.cs
@@ -9,6 +9,7 @@ namespace MonoDroid.Generation
 		public string Annotation { get; set; }
 		public int ApiAvailableSince { get; set; }
 		public string DeprecatedComment { get; set; }
+		public int? DeprecatedSince { get; set; }
 		public bool IsAcw { get; set; }
 		public bool IsDeprecated { get; set; }
 		public bool IsDeprecatedError { get; set; }

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
@@ -251,6 +251,8 @@ namespace MonoDroid.Generation
 
 		public string DeprecatedComment => support.DeprecatedComment;
 
+		public int? DeprecatedSince => support.DeprecatedSince;
+
 		IEnumerable<GenBase> Descendants (IList<GenBase> gens)
 		{
 			foreach (var directDescendants in gens.Where (x => x.BaseGen == this)) {

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBaseSupport.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBaseSupport.cs
@@ -7,6 +7,7 @@ namespace MonoDroid.Generation
 		public bool IsAcw { get; set; }
 		public bool IsDeprecated { get; set; }
 		public string DeprecatedComment { get; set; }
+		public int? DeprecatedSince { get; set; }
 		public bool IsGeneratable { get; set; }
 		public bool IsGeneric { get; set; }
 		public bool IsObfuscated { get; set; }

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/MethodBase.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/MethodBase.cs
@@ -18,6 +18,7 @@ namespace MonoDroid.Generation
 		public string AssemblyName { get; set; }
 		public GenBase DeclaringType { get; }
 		public string Deprecated { get; set; }
+		public int? DeprecatedSince { get; set; }
 		public GenericParameterDefinitionList GenericArguments { get; set; }
 		public bool IsAcw { get; set; }
 		public bool IsValid { get; private set; }

--- a/tools/generator/SourceWriters/Attributes/ObsoleteAttr.cs
+++ b/tools/generator/SourceWriters/Attributes/ObsoleteAttr.cs
@@ -14,21 +14,19 @@ namespace generator.SourceWriters
 
 		public ObsoleteAttr (string message = null, bool isError = false)
 		{
-			Message = message;
+			Message = message?.Replace ("\"", "\"\"").Trim ();
 			IsError = isError;
 		}
 
 		public override void WriteAttribute (CodeWriter writer)
 		{
-			var parts = new List<string> ();
+			var content = string.Empty;
 
-			if (Message != null)
-				parts.Add ($"@\"{Message}\"");
+			if (Message != null || IsError)
+				content += $"@\"{Message}\"";
 
 			if (IsError)
-				parts.Add ("error: true");
-
-			var content = string.Join (", ", parts.ToArray ());
+				content += ", error: true";
 
 			if (content.HasValue ())
 				writer.WriteLine ($"[global::System.Obsolete ({content})]");

--- a/tools/generator/SourceWriters/Attributes/ObsoletedOSPlatformAttr.cs
+++ b/tools/generator/SourceWriters/Attributes/ObsoletedOSPlatformAttr.cs
@@ -1,0 +1,25 @@
+using System;
+using Xamarin.SourceWriter;
+
+namespace generator.SourceWriters
+{
+	public class ObsoletedOSPlatformAttr : AttributeWriter
+	{
+		public string Message { get; set; }
+		public int Version { get; }
+
+		public ObsoletedOSPlatformAttr (string message, int version)
+		{
+			Message = message;
+			Version = version;
+		}
+
+		public override void WriteAttribute (CodeWriter writer)
+		{
+			if (Message.HasValue ())
+				writer.WriteLine ($"[global::System.Runtime.Versioning.ObsoletedOSPlatform (\"android{Version}.0\", @\"{Message.Replace ("\"", "\"\"")}\")]");
+			else
+				writer.WriteLine ($"[global::System.Runtime.Versioning.ObsoletedOSPlatform (\"android{Version}.0\")]");
+		}
+	}
+}

--- a/tools/generator/SourceWriters/BoundClass.cs
+++ b/tools/generator/SourceWriters/BoundClass.cs
@@ -44,7 +44,7 @@ namespace generator.SourceWriters
 			klass.JavadocInfo?.AddJavadocs (Comments);
 			Comments.Add ($"// Metadata.xml XPath class reference: path=\"{klass.MetadataXPathReference}\"");
 
-			SourceWriterExtensions.AddObsolete (Attributes, klass.DeprecatedComment, klass.IsDeprecated);
+			SourceWriterExtensions.AddObsolete (Attributes, klass.DeprecatedComment, opt, forceDeprecate: klass.IsDeprecated, deprecatedSince: klass.DeprecatedSince);
 
 			SourceWriterExtensions.AddSupportedOSPlatform (Attributes, klass, opt);
 

--- a/tools/generator/SourceWriters/BoundConstructor.cs
+++ b/tools/generator/SourceWriters/BoundConstructor.cs
@@ -33,7 +33,7 @@ namespace generator.SourceWriters
 				Attributes.Add (new RegisterAttr (".ctor", constructor.JniSignature, string.Empty, additionalProperties: constructor.AdditionalAttributeString ()));
 			}
 
-			SourceWriterExtensions.AddObsolete (Attributes, constructor.Deprecated);
+			SourceWriterExtensions.AddObsolete (Attributes, constructor.Deprecated, opt, deprecatedSince: constructor.DeprecatedSince);
 
 			if (constructor.CustomAttributes != null)
 				Attributes.Add (new CustomAttr (constructor.CustomAttributes));

--- a/tools/generator/SourceWriters/BoundField.cs
+++ b/tools/generator/SourceWriters/BoundField.cs
@@ -31,7 +31,7 @@ namespace generator.SourceWriters
 			if (field.IsEnumified)
 				Attributes.Add (new GeneratedEnumAttr ());
 
-			SourceWriterExtensions.AddObsolete (Attributes, field.DeprecatedComment, field.IsDeprecated, isError: field.IsDeprecatedError);
+			SourceWriterExtensions.AddObsolete (Attributes, field.DeprecatedComment, opt, field.IsDeprecated, isError: field.IsDeprecatedError, deprecatedSince: field.DeprecatedSince);
 
 			if (field.Annotation.HasValue ())
 				Attributes.Add (new CustomAttr (field.Annotation));

--- a/tools/generator/SourceWriters/BoundFieldAsProperty.cs
+++ b/tools/generator/SourceWriters/BoundFieldAsProperty.cs
@@ -47,7 +47,7 @@ namespace generator.SourceWriters
 				Attributes.Add (new RegisterAttr (field.JavaName, additionalProperties: field.AdditionalAttributeString ()));
 			}
 
-			SourceWriterExtensions.AddObsolete (Attributes, field.DeprecatedComment, field.IsDeprecated, isError: field.IsDeprecatedError);
+			SourceWriterExtensions.AddObsolete (Attributes, field.DeprecatedComment, opt, field.IsDeprecated, isError: field.IsDeprecatedError, deprecatedSince: field.DeprecatedSince);
 
 			SetVisibility (field.Visibility);
 			UseExplicitPrivateKeyword = true;

--- a/tools/generator/SourceWriters/BoundInterface.cs
+++ b/tools/generator/SourceWriters/BoundInterface.cs
@@ -43,7 +43,7 @@ namespace generator.SourceWriters
 			iface.JavadocInfo?.AddJavadocs (Comments);
 			Comments.Add ($"// Metadata.xml XPath interface reference: path=\"{iface.MetadataXPathReference}\"");
 
-			SourceWriterExtensions.AddObsolete (Attributes, iface.DeprecatedComment, iface.IsDeprecated);
+			SourceWriterExtensions.AddObsolete (Attributes, iface.DeprecatedComment, opt, iface.IsDeprecated, deprecatedSince: iface.DeprecatedSince);
 
 			if (!iface.IsConstSugar (opt)) {
 				var signature = string.IsNullOrWhiteSpace (iface.Namespace)

--- a/tools/generator/SourceWriters/BoundInterfaceMethodDeclaration.cs
+++ b/tools/generator/SourceWriters/BoundInterfaceMethodDeclaration.cs
@@ -34,7 +34,7 @@ namespace generator.SourceWriters
 			if (method.DeclaringType.IsGeneratable)
 				Comments.Add ($"// Metadata.xml XPath method reference: path=\"{method.GetMetadataXPathReference (method.DeclaringType)}\"");
 
-			SourceWriterExtensions.AddObsolete (Attributes, method.Deprecated);
+			SourceWriterExtensions.AddObsolete (Attributes, method.Deprecated, opt, deprecatedSince: method.DeprecatedSince);
 
 			if (method.IsReturnEnumified)
 				Attributes.Add (new GeneratedEnumAttr (true));

--- a/tools/generator/SourceWriters/BoundMethod.cs
+++ b/tools/generator/SourceWriters/BoundMethod.cs
@@ -74,7 +74,7 @@ namespace generator.SourceWriters
 			if (method.DeclaringType.IsGeneratable)
 				Comments.Add ($"// Metadata.xml XPath method reference: path=\"{method.GetMetadataXPathReference (method.DeclaringType)}\"");
 
-			SourceWriterExtensions.AddObsolete (Attributes, method.Deprecated);
+			SourceWriterExtensions.AddObsolete (Attributes, method.Deprecated, opt, deprecatedSince: method.DeprecatedSince);
 
 			if (method.IsReturnEnumified)
 				Attributes.Add (new GeneratedEnumAttr (true));

--- a/tools/generator/SourceWriters/BoundMethodAbstractDeclaration.cs
+++ b/tools/generator/SourceWriters/BoundMethodAbstractDeclaration.cs
@@ -53,7 +53,7 @@ namespace generator.SourceWriters
 			if (method.DeclaringType.IsGeneratable)
 				Comments.Add ($"// Metadata.xml XPath method reference: path=\"{method.GetMetadataXPathReference (method.DeclaringType)}\"");
 
-			SourceWriterExtensions.AddObsolete (Attributes, method.Deprecated);
+			SourceWriterExtensions.AddObsolete (Attributes, method.Deprecated, opt, deprecatedSince: method.DeprecatedSince);
 
 			SourceWriterExtensions.AddSupportedOSPlatform (Attributes, method, opt);
 

--- a/tools/generator/SourceWriters/BoundMethodExtensionStringOverload.cs
+++ b/tools/generator/SourceWriters/BoundMethodExtensionStringOverload.cs
@@ -26,7 +26,7 @@ namespace generator.SourceWriters
 			SetVisibility (method.Visibility);
 			ReturnType = new TypeReferenceWriter (opt.GetTypeReferenceName (method.RetVal).Replace ("Java.Lang.ICharSequence", "string").Replace ("global::string", "string"));
 
-			SourceWriterExtensions.AddObsolete (Attributes, method.Deprecated);
+			SourceWriterExtensions.AddObsolete (Attributes, method.Deprecated, opt, deprecatedSince: method.DeprecatedSince);
 
 			SourceWriterExtensions.AddSupportedOSPlatform (Attributes, method, opt);
 

--- a/tools/generator/SourceWriters/BoundMethodStringOverload.cs
+++ b/tools/generator/SourceWriters/BoundMethodStringOverload.cs
@@ -24,7 +24,7 @@ namespace generator.SourceWriters
 			SetVisibility (method.Visibility);
 			ReturnType = new TypeReferenceWriter (opt.GetTypeReferenceName (method.RetVal).Replace ("Java.Lang.ICharSequence", "string").Replace ("global::string", "string"));
 
-			SourceWriterExtensions.AddObsolete (Attributes, method.Deprecated);
+			SourceWriterExtensions.AddObsolete (Attributes, method.Deprecated, opt, deprecatedSince: method.DeprecatedSince);
 
 			SourceWriterExtensions.AddSupportedOSPlatform (Attributes, method, opt);
 

--- a/tools/generator/SourceWriters/BoundProperty.cs
+++ b/tools/generator/SourceWriters/BoundProperty.cs
@@ -75,7 +75,8 @@ namespace generator.SourceWriters
 			// Unlike [Register], [Obsolete] cannot be put on property accessors, so we can apply them only under limited condition...
 			if (property.Getter.Deprecated != null && (property.Setter == null || property.Setter.Deprecated != null)) {
 				var message = property.Getter.Deprecated.Trim () + (property.Setter != null && property.Setter.Deprecated != property.Getter.Deprecated ? " " + property.Setter.Deprecated.Trim () : null);
-				SourceWriterExtensions.AddObsolete (Attributes, message);
+				var since = property.Getter?.DeprecatedSince ?? property.Setter?.DeprecatedSince;
+				SourceWriterExtensions.AddObsolete (Attributes, message, opt, deprecatedSince: since);
 			}
 
 			SourceWriterExtensions.AddSupportedOSPlatform (Attributes, property.Getter, opt);

--- a/tools/generator/SourceWriters/InterfaceMemberAlternativeClass.cs
+++ b/tools/generator/SourceWriters/InterfaceMemberAlternativeClass.cs
@@ -42,7 +42,7 @@ namespace generator.SourceWriters
 			Attributes.Add (new RegisterAttr (iface.RawJniName, noAcw: true, additionalProperties: iface.AdditionalAttributeString ()) { AcwLast = true });
 
 			if (should_obsolete)
-				SourceWriterExtensions.AddObsolete (Attributes, $"Use the '{iface.FullName}' type. This class will be removed in a future release.");
+				SourceWriterExtensions.AddObsolete (Attributes, $"Use the '{iface.FullName}' type. This class will be removed in a future release.", opt);
 
 			Constructors.Add (new ConstructorWriter { Name = Name, IsInternal = true });
 
@@ -53,7 +53,7 @@ namespace generator.SourceWriters
 				Fields.Add (new PeerMembersField (opt, iface.RawJniName, Name, false));
 
 			if (!iface.HasManagedName && !opt.SupportInterfaceConstants)
-				sibling_classes.Add (new InterfaceConstsForwardClass (iface));
+				sibling_classes.Add (new InterfaceConstsForwardClass (iface, opt));
 		}
 
 		void AddMethods (InterfaceGen iface, bool shouldObsolete, CodeGenerationOptions opt)
@@ -171,7 +171,7 @@ namespace generator.SourceWriters
 
 	public class InterfaceConstsForwardClass : ClassWriter
 	{
-		public InterfaceConstsForwardClass (InterfaceGen iface)
+		public InterfaceConstsForwardClass (InterfaceGen iface, CodeGenerationOptions opt)
 		{
 			Name = iface.Name.Substring (1) + "Consts";
 			Inherits = iface.Name.Substring (1);
@@ -180,7 +180,7 @@ namespace generator.SourceWriters
 			IsAbstract = true;
 
 			Attributes.Add (new RegisterAttr (iface.RawJniName, noAcw: true, additionalProperties: iface.AdditionalAttributeString ()));
-			SourceWriterExtensions.AddObsolete (Attributes, $"Use the '{iface.Name.Substring (1)}' type. This type will be removed in a future release.", isError: true);
+			SourceWriterExtensions.AddObsolete (Attributes, $"Use the '{iface.Name.Substring (1)}' type. This type will be removed in a future release.", opt, isError: true);
 
 			Constructors.Add (new ConstructorWriter {
 				Name = Name,

--- a/tools/generator/SourceWriters/MethodCallback.cs
+++ b/tools/generator/SourceWriters/MethodCallback.cs
@@ -43,7 +43,7 @@ namespace generator.SourceWriters
 			IsStatic = true;
 			IsPrivate = method.IsInterfaceDefaultMethod;
 
-			SourceWriterExtensions.AddObsolete (Attributes, null, forceDeprecate: !string.IsNullOrWhiteSpace (method.Deprecated));
+			SourceWriterExtensions.AddObsolete (Attributes, null, opt, forceDeprecate: !string.IsNullOrWhiteSpace (method.Deprecated), deprecatedSince: method.DeprecatedSince);
 
 			SourceWriterExtensions.AddSupportedOSPlatform (Attributes, method, opt);
 
@@ -135,7 +135,7 @@ namespace generator.SourceWriters
 			IsStatic = true;
 			IsPrivate = method.IsInterfaceDefaultMethod;
 
-			SourceWriterExtensions.AddObsolete (Attributes, null, forceDeprecate: !string.IsNullOrWhiteSpace (method.Deprecated));
+			SourceWriterExtensions.AddObsolete (Attributes, null, opt, forceDeprecate: !string.IsNullOrWhiteSpace (method.Deprecated), deprecatedSince: method.DeprecatedSince);
 
 			SourceWriterExtensions.AddSupportedOSPlatform (Attributes, method, opt);
 		}


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/7234

Add support for a new `lang-features=obsoleted-platform-attributes` `generator` option.

When used, for API that was obsoleted in API levels greater than our .NET 7 minimum (API 21), we will generate .NET 7's new `[ObsoletedOSPlatform]` attribute *instead of* `[Obsolete]`:

```csharp
// New
[global::System.Runtime.Versioning.ObsoletedOSPlatform ("android22.0", @"This class is obsoleted in this android platform")]
public partial class CookieSpecParamBean : Org.Apache.Http.Params.HttpAbstractParamBean { ... }

// Previous
[global::System.Obsolete (@"This class is obsoleted in this android platform")]
public partial class CookieSpecParamBean : Org.Apache.Http.Params.HttpAbstractParamBean { ... }
```

This is useful for a .NET 7+ context because we always *compile* against a "latest" `Mono.Android`, even if you are *targeting* an earlier version.  For example, this causes the above class to throw an obsolete warning even if you are using `$(SupportedOSPlatformVersion)=21`.

Companion XA test PR: https://github.com/xamarin/xamarin-android/pull/7266