### PR TITLE
[generator] Handle Java class with base class set to itself.

### DIFF
--- a/src/Java.Interop.Tools.JavaTypeSystem/JavaModels/JavaClassModel.cs
+++ b/src/Java.Interop.Tools.JavaTypeSystem/JavaModels/JavaClassModel.cs
@@ -37,6 +37,13 @@ namespace Java.Interop.Tools.JavaTypeSystem.Models
 					throw;
 				}
 
+				// Apparently some Java obfuscator sets a class's base type to itself, which
+				// results in a stack overflow. Check for this case and remove the offending type.
+				if (BaseTypeReference.ReferencedType is JavaClassModel jcm && jcm == this) {
+					unresolvables.Add (new JavaUnresolvableModel (this, BaseTypeGeneric, UnresolvableType.InvalidBaseType));
+					throw new JavaTypeResolutionException (BaseTypeGeneric);
+				}
+
 				// We don't resolve reference-only types by default, so if our base class
 				// is a reference only type, we need to force it to resolve here. This will be
 				// needed later when we attempt to resolve base methods.

--- a/src/Java.Interop.Tools.JavaTypeSystem/Utilities/JavaUnresolvableModel.cs
+++ b/src/Java.Interop.Tools.JavaTypeSystem/Utilities/JavaUnresolvableModel.cs
@@ -25,6 +25,9 @@ namespace Java.Interop.Tools.JavaTypeSystem.Models
 					$"The type '{member?.DeclaringType.FullName}' was removed because the required {GetUnresolvableType ()} '{GetUnresolvable ()}' was removed because its name contains a dollar sign." :
 					$"The {GetUnresolvableType ()} '{GetUnresolvable ()}' was removed because its name contains a dollar sign.";
 
+			if (Type == UnresolvableType.InvalidBaseType)
+				return $"The {GetUnresolvableType ()} '{GetUnresolvable ()}' was removed because the base type '{MissingType}' is invalid.";
+
 			if (Unresolvable is JavaTypeModel)
 				return $"The {GetUnresolvableType ()} '{GetUnresolvable ()}' was removed because the Java {GetReason ()} '{MissingType}' could not be found.";
 
@@ -77,6 +80,7 @@ namespace Java.Interop.Tools.JavaTypeSystem.Models
 		ReturnType,
 		ParameterType,
 		BaseType,
-		ImplementsType
+		ImplementsType,
+		InvalidBaseType
 	}
 }

--- a/src/Java.Interop.Tools.JavaTypeSystem/Utilities/JavaUnresolvableModel.cs
+++ b/src/Java.Interop.Tools.JavaTypeSystem/Utilities/JavaUnresolvableModel.cs
@@ -81,6 +81,6 @@ namespace Java.Interop.Tools.JavaTypeSystem.Models
 		ParameterType,
 		BaseType,
 		ImplementsType,
-		InvalidBaseType
+		InvalidBaseType,
 	}
 }

--- a/tests/Java.Interop.Tools.JavaTypeSystem-Tests/JavaTypeCollectionTests.cs
+++ b/tests/Java.Interop.Tools.JavaTypeSystem-Tests/JavaTypeCollectionTests.cs
@@ -122,5 +122,30 @@ namespace Java.Interop.Tools.JavaTypeSystem.Tests
 			Assert.IsNotNull (t.Methods.SingleOrDefault (m => m.Name == "DoT"), "Method with generic T not found");
 			Assert.IsNotNull (t.Methods.SingleOrDefault (m => m.Name == "DoU"), "Method with generic U not found");
 		}
+
+		[Test]
+		public void InvalidBaseTypeResolution ()
+		{
+			var api = new JavaTypeCollection ();
+
+			// Create "my.ns" package
+			var my_ns = api.AddPackage ("my.ns", "my/ns");
+
+			// Create new "my.ns.MyObject" type with "my.ns.MyObject" as base type
+			var jlo = JavaApiTestHelper.CreateClass (my_ns, "MyObject", javaBaseType: "my.ns.MyObject", javaBaseTypeGeneric: "my.ns.MyObject");
+
+			api.AddType (jlo);
+
+			// Run the resolver
+			var results = api.ResolveCollection ();
+
+			// Ensure we marked it as unresolvable
+			Assert.AreEqual (1, results.Count);
+			Assert.AreEqual (1, results [0].Unresolvables.Count);
+			Assert.AreEqual ("The class '[Class] my.ns.MyObject' was removed because the base type 'my.ns.MyObject' is invalid.", results [0].Unresolvables [0].GetDisplayMessage ());
+
+			// Ensure we removed the type from the collection
+			Assert.AreEqual (0, api.TypesFlattened.Count);
+		}
 	}
 }


### PR DESCRIPTION
Fixes #1031 

There apparently exists a Java obfuscator that attempts to break tools by setting the base class of a class to itself.  This breaks us with a `StackOverflowException`:

```java
public class c5<BaseHandler> extends c5<BaseHandler> { ... }
```

```
Stack overflow: IP: 0x11ae88918, fault addr: 0x30d984fd8
Stacktrace:
      at Java.Interop.Tools.JavaTypeSystem.Models.JavaClassModel.PrepareGenericInheritanceMapping () [0x00038] in <9ad2a4b0fd014215b74d06fce5575b7a>:0
      <...>
      at Java.Interop.Tools.JavaTypeSystem.Models.JavaClassModel.get_GenericInheritanceMapping () [0x00000] in <9ad2a4b0fd014215b74d06fce5575b7a>:0
      at Java.Interop.Tools.JavaTypeSystem.Models.JavaMethodModel/<>c__DisplayClass47_0.<FindBaseMethod>b__0 (Java.Interop.Tools.JavaTypeSystem.Models.JavaMethodModel) [0x00018] in <9ad2a4b0fd014215b74d06fce5575b7a>:0
      at System.Linq.Enumerable.TryGetFirst<TSource_REF> (System.Collections.Generic.IEnumerable`1<TSource_REF>,System.Func`2<TSource_REF, bool>,bool&) [0x0003f] in <80f7dc36b4e24f4b86610a67568d2e19>:0
      at System.Linq.Enumerable.FirstOrDefault<TSource_REF> (System.Collections.Generic.IEnumerable`1<TSource_REF>,System.Func`2<TSource_REF, bool>) [0x00000] in <80f7dc36b4e24f4b86610a67568d2e19>:0
      at Java.Interop.Tools.JavaTypeSystem.Models.JavaMethodModel.FindBaseMethod (Java.Interop.Tools.JavaTypeSystem.Models.JavaClassModel) [0x00028] in <9ad2a4b0fd014215b74d06fce5575b7a>:0
      at Java.Interop.Tools.JavaTypeSystem.Models.JavaClassModel.ResolveBaseMembers () [0x0002d] in <9ad2a4b0fd014215b74d06fce5575b7a>:0
      at Java.Interop.Tools.JavaTypeSystem.Models.JavaTypeCollection.ResolveCollection (Java.Interop.Tools.JavaTypeSystem.TypeResolutionOptions) [0x001d1] in <9ad2a4b0fd014215b74d06fce5575b7a>:0
      at generator.JavaTypeResolutionFixups.Fixup (string,string,Java.Interop.Tools.Cecil.DirectoryAssemblyResolver,string[]) [0x00055] in <a593e50c39a04879937ed01eece67aa3>:0
      at Xamarin.Android.Binder.CodeGenerator.Run (Xamarin.Android.Binder.CodeGeneratorOptions,Java.Interop.Tools.Cecil.DirectoryAssemblyResolver) [0x00230] in <a593e50c39a04879937ed01eece67aa3>:0
      at Xamarin.Android.Binder.CodeGenerator.Run (Xamarin.Android.Binder.CodeGeneratorOptions) [0x0001b] in <a593e50c39a04879937ed01eece67aa3>:0
      at Xamarin.Android.Binder.CodeGenerator.Main (string[]) [0x0000e] in <a593e50c39a04879937ed01eece67aa3>:0
      at (wrapper runtime-invoke) <Module>.runtime_invoke_int_object (object,intptr,intptr,intptr) [0x0002a] in <a593e50c39a04879937ed01eece67aa3>:0
```

We can add a check for this scenario to prevent the `StackOverflowException` and instead remove the offending type.  This removal will be logged with other removals in the `java-resolution-report.log`:

```
The class '[Class] my.namespace.c5' was removed because the base type 'my.namespace.c5' is invalid.
```