### PR TITLE
Add `$schema` to `cgmanifest.json`

### DIFF
--- a/tools/java-source-utils/CGManifest.json
+++ b/tools/java-source-utils/CGManifest.json
@@ -1,26 +1,27 @@
 {
-    "Registrations": [
-        {
-            "Component": {
-                "Type": "maven",
-                "Maven": {
-                    "GroupId": "com.github.javaparser",
-                    "ArtifactId": "javaparser-core",
-                    "Version": "3.16.1"
-                }
-            },
-            "DevelopmentDependency":false
-        },
-        {
-            "Component": {
-                "Type": "maven",
-                "Maven": {
-                    "GroupId": "com.github.javaparser",
-                    "ArtifactId": "javaparser-symbol-solver-core",
-                    "Version": "3.16.1"
-                }
-            },
-            "DevelopmentDependency":false
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
+    {
+      "Component": {
+        "Type": "maven",
+        "Maven": {
+          "GroupId": "com.github.javaparser",
+          "ArtifactId": "javaparser-core",
+          "Version": "3.16.1"
         }
-    ]
+      },
+      "DevelopmentDependency": false
+    },
+    {
+      "Component": {
+        "Type": "maven",
+        "Maven": {
+          "GroupId": "com.github.javaparser",
+          "ArtifactId": "javaparser-symbol-solver-core",
+          "Version": "3.16.1"
+        }
+      },
+      "DevelopmentDependency": false
+    }
+  ]
 }

--- a/tools/java-source-utils/CGManifest.json
+++ b/tools/java-source-utils/CGManifest.json
@@ -1,27 +1,28 @@
 {
-  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
-  "Registrations": [
-    {
-      "Component": {
-        "Type": "maven",
-        "Maven": {
-          "GroupId": "com.github.javaparser",
-          "ArtifactId": "javaparser-core",
-          "Version": "3.16.1"
+    "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+    "version": 1,
+    "registrations": [
+        {
+            "component": {
+                "type": "maven",
+                "maven": {
+                    "groupId": "com.github.javaparser",
+                    "artifactId": "javaparser-core",
+                    "version": "3.16.1"
+                }
+            },
+            "developmentDependency":false
+        },
+        {
+            "component": {
+                "type": "maven",
+                "maven": {
+                    "groupId": "com.github.javaparser",
+                    "artifactId": "javaparser-symbol-solver-core",
+                    "version": "3.16.1"
+                }
+            },
+            "developmentDependency":false
         }
-      },
-      "DevelopmentDependency": false
-    },
-    {
-      "Component": {
-        "Type": "maven",
-        "Maven": {
-          "GroupId": "com.github.javaparser",
-          "ArtifactId": "javaparser-symbol-solver-core",
-          "Version": "3.16.1"
-        }
-      },
-      "DevelopmentDependency": false
-    }
-  ]
+    ]
 }


### PR DESCRIPTION
This pull request adds the JSON schema for `cgmanifest.json`.

## FAQ

### Why?

A JSON schema helps you to ensure that your `cgmanifest.json` file is valid.
JSON schema validation is a build-in feature in most modern IDEs like Visual Studio and Visual Studio Code.
Most modern IDEs also provide code-completion for JSON schemas.

### How can I validate my `cgmanifest.json` file?

Most modern IDEs like Visual Studio and Visual Studio Code have a built-in feature to validate JSON files.
You can also use [this small script](https://github.com/JamieMagee/verify-cgmanifest) to validate your `cgmanifest.json` file.

### Why does it suggest camel case for the properties?

Component Detection is able to read camel case and pascal case properties.
However, the JSON schema doesn't have a case-insensitive mode.
We therefore suggest camel case as it's the most common format for JSON.

### Why is the diff so large?

To deserialize the `cgmanifest.json` file, we use [`JSON.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
However, to serialize the JSON again we use [`prettier`](https://prettier.io/).
We found that, in general, it gave smaller diffs than the default [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) function.