### PR TITLE
[Java.Interop.Tools.JavaSource] Parse <code/> tags

### DIFF
--- a/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/SourceJavadocToXmldocGrammar.HtmlBnfTerms.cs
+++ b/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/SourceJavadocToXmldocGrammar.HtmlBnfTerms.cs
@@ -35,6 +35,7 @@ namespace Java.Interop.Tools.JavaSource {
 						| FormCtrlDeclaration
 						*/
 						| InlineHyperLinkDeclaration
+						| CodeElementDeclaration
 						| grammar.InlineTagsTerms.AllInlineTerms
 						| UnknownHtmlElementStart
 						,
@@ -136,6 +137,12 @@ namespace Java.Interop.Tools.JavaSource {
 					var aElementValue = new XText (parseNode.ChildNodes [1].AstNode.ToString ());
 					parseNode.AstNode = aElementValue;
 				};
+
+				CodeElementDeclaration.Rule = CreateStartElement ("code", grammar) + InlineDeclarations + CreateEndElement ("code", grammar);
+				CodeElementDeclaration.AstConfig.NodeCreator = (context, parseNode) => {
+					var target = parseNode.ChildNodes [1].AstNode;
+					parseNode.AstNode = new XElement ("c", target);
+				};
 			}
 
 			static IEnumerable<XElement> GetParagraphs (ParseTreeNodeList children)
@@ -205,6 +212,7 @@ namespace Java.Interop.Tools.JavaSource {
 			public  readonly    NonTerminal PreBlockDeclaration         = new NonTerminal (nameof (PreBlockDeclaration), ConcatChildNodes);
 			public  readonly    NonTerminal InlineHyperLinkDeclaration  = new NonTerminal (nameof (InlineHyperLinkDeclaration), ConcatChildNodes);
 			public  readonly    NonTerminal IgnorableElementDeclaration = new NonTerminal (nameof (IgnorableElementDeclaration), ConcatChildNodes);
+			public  readonly    NonTerminal CodeElementDeclaration      = new NonTerminal (nameof (CodeElementDeclaration), ConcatChildNodes);
 
 			public  readonly    Terminal    InlineHyperLinkOpenTerm     = new RegexBasedTerminal ("<a href=", @"(?i)<a\s*href\s*=") {
 				AstConfig = new AstNodeConfig {

--- a/tests/Java.Interop.Tools.JavaSource-Tests/SourceJavadocToXmldocGrammar.HtmlBnfTermsTests.cs
+++ b/tests/Java.Interop.Tools.JavaSource-Tests/SourceJavadocToXmldocGrammar.HtmlBnfTermsTests.cs
@@ -67,5 +67,16 @@ namespace Java.Interop.Tools.JavaSource.Tests
 			Assert.AreEqual ("\"AutofillService.html#FieldClassification\"&gt;field classification",
 					r.Root.AstNode.ToString ());
 		}
+
+		[Test]
+		public void CodeElementDeclaration ()
+		{
+			var p = CreateParser (g => g.HtmlTerms.CodeElementDeclaration);
+
+			var r = p.Parse ("<code>input.position()</code>");
+			Assert.IsFalse (r.HasErrors (), DumpMessages (r, p));
+			Assert.AreEqual ("<c>input.position()</c>", r.Root.AstNode.ToString ());
+		}
+
 	}
 }

--- a/tests/Java.Interop.Tools.JavaSource-Tests/SourceJavadocToXmldocParserTests.cs
+++ b/tests/Java.Interop.Tools.JavaSource-Tests/SourceJavadocToXmldocParserTests.cs
@@ -146,14 +146,14 @@ more description here.</para>
 			new ParseResult {
 				Javadoc = "Something {@link #method}: description, \"<code>declaration</code>\" or \"<code>another declaration</code>\".\n\n@apiSince 1\n",
 				FullXml = @"<member>
-  <summary>Something <c>#method</c>: description, ""&lt;code&gt;declaration&lt;/code&gt;"" or ""&lt;code&gt;another declaration&lt;/code&gt;"".</summary>
+  <summary>Something <c>#method</c>: description, ""<c>declaration</c>"" or ""<c>another declaration</c>"".</summary>
   <remarks>
-    <para>Something <c>#method</c>: description, ""&lt;code&gt;declaration&lt;/code&gt;"" or ""&lt;code&gt;another declaration&lt;/code&gt;"".</para>
+    <para>Something <c>#method</c>: description, ""<c>declaration</c>"" or ""<c>another declaration</c>"".</para>
     <para>Added in API level 1.</para>
   </remarks>
 </member>",
 				IntelliSenseXml = @"<member>
-  <summary>Something <c>#method</c>: description, ""&lt;code&gt;declaration&lt;/code&gt;"" or ""&lt;code&gt;another declaration&lt;/code&gt;"".</summary>
+  <summary>Something <c>#method</c>: description, ""<c>declaration</c>"" or ""<c>another declaration</c>"".</summary>
 </member>",
 			},
 			new ParseResult {


### PR DESCRIPTION
Fixes: https://github.com/xamarin/java.interop/issues/1041

Translates `<code/>` tags into `<c/>` tags, which should clean up thousands of illegible `&lt;code&gt;foo&lt;/code&gt;` instances.