### PR TITLE
[Java.Interop.Tools.Expressions] Add Java.Interop.Tools.Expressions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -72,7 +72,6 @@
     <_JavacSourceOptions>-source $(JavacSourceVersion) -target $(JavacTargetVersion) $(_BootClassPath)</_JavacSourceOptions>
   </PropertyGroup>
   <PropertyGroup>
-    <_XamarinAndroidCecilPath Condition=" '$(CecilSourceDirectory)' != '' And Exists('$(UtilityOutputFullPath)Xamarin.Android.Cecil.dll') ">$(UtilityOutputFullPath)Xamarin.Android.Cecil.dll</_XamarinAndroidCecilPath>
     <XamarinAndroidToolsFullPath>$([System.IO.Path]::GetFullPath ('$(XamarinAndroidToolsDirectory)'))</XamarinAndroidToolsFullPath>
   </PropertyGroup>
 

--- a/Java.Interop.sln
+++ b/Java.Interop.sln
@@ -109,6 +109,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Java.Base", "src\Java.Base\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Java.Base-Tests", "tests\Java.Base-Tests\Java.Base-Tests.csproj", "{CB05E11B-B96F-4179-A4E9-5D6BDE29A8FC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Java.Interop.Tools.Expressions", "src\Java.Interop.Tools.Expressions\Java.Interop.Tools.Expressions.csproj", "{1A0262FE-3CDB-4AF2-AAD8-65C59524FE8A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Java.Interop.Tools.Expressions-Tests", "tests\Java.Interop.Tools.Expressions-Tests\Java.Interop.Tools.Expressions-Tests.csproj", "{211BAA88-66B1-41B2-88B2-530DBD8DF702}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Java.Interop.NamingCustomAttributes\Java.Interop.NamingCustomAttributes.projitems*{58b564a1-570d-4da2-b02d-25bddb1a9f4f}*SharedItemsImports = 5
@@ -308,6 +312,14 @@ Global
 		{CB05E11B-B96F-4179-A4E9-5D6BDE29A8FC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CB05E11B-B96F-4179-A4E9-5D6BDE29A8FC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CB05E11B-B96F-4179-A4E9-5D6BDE29A8FC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1A0262FE-3CDB-4AF2-AAD8-65C59524FE8A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1A0262FE-3CDB-4AF2-AAD8-65C59524FE8A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1A0262FE-3CDB-4AF2-AAD8-65C59524FE8A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1A0262FE-3CDB-4AF2-AAD8-65C59524FE8A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{211BAA88-66B1-41B2-88B2-530DBD8DF702}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{211BAA88-66B1-41B2-88B2-530DBD8DF702}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{211BAA88-66B1-41B2-88B2-530DBD8DF702}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{211BAA88-66B1-41B2-88B2-530DBD8DF702}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -360,6 +372,8 @@ Global
 		{11942DE9-AEC2-4B95-87AB-CA707C37643D} = {271C9F30-F679-4793-942B-0D9527CB3E2F}
 		{30DCECA5-16FD-4FD0-883C-E5E83B11565D} = {0998E45F-8BCE-4791-A944-962CD54E2D80}
 		{CB05E11B-B96F-4179-A4E9-5D6BDE29A8FC} = {271C9F30-F679-4793-942B-0D9527CB3E2F}
+		{1A0262FE-3CDB-4AF2-AAD8-65C59524FE8A} = {0998E45F-8BCE-4791-A944-962CD54E2D80}
+		{211BAA88-66B1-41B2-88B2-530DBD8DF702} = {271C9F30-F679-4793-942B-0D9527CB3E2F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {29204E0C-382A-49A0-A814-AD7FBF9774A5}

--- a/TargetFrameworkDependentValues.props
+++ b/TargetFrameworkDependentValues.props
@@ -12,6 +12,7 @@
     <TestOutputFullPath>$(MSBuildThisFileDirectory)bin\Test$(Configuration)-$(TargetFramework.ToLowerInvariant())\</TestOutputFullPath>
     <UtilityOutputFullPath Condition=" '$(UtilityOutputFullPathCoreApps)' != '' ">$(UtilityOutputFullPathCoreApps)</UtilityOutputFullPath>
     <UtilityOutputFullPath Condition=" '$(UtilityOutputFullPathCoreApps)' == '' ">$(ToolOutputFullPath)</UtilityOutputFullPath>
+    <_XamarinAndroidCecilPath Condition=" '$(CecilSourceDirectory)' != '' And Exists('$(UtilityOutputFullPathCoreApps)Xamarin.Android.Cecil.dll') ">$(UtilityOutputFullPathCoreApps)Xamarin.Android.Cecil.dll</_XamarinAndroidCecilPath>
     <RollForward>Major</RollForward>
     <JIUtilityVersion>$(JINetToolVersion)</JIUtilityVersion>
     <JICoreLibVersion>$(JINetCoreLibVersion)</JICoreLibVersion>
@@ -23,6 +24,7 @@
     <ToolOutputFullPath>$(MSBuildThisFileDirectory)bin\$(Configuration)\</ToolOutputFullPath>
     <TestOutputFullPath>$(MSBuildThisFileDirectory)bin\Test$(Configuration)\</TestOutputFullPath>
     <UtilityOutputFullPath Condition=" '$(UtilityOutputFullPath)' == '' ">$(ToolOutputFullPath)</UtilityOutputFullPath>
+    <_XamarinAndroidCecilPath Condition=" '$(CecilSourceDirectory)' != '' And Exists('$(UtilityOutputFullPath)Xamarin.Android.Cecil.dll') ">$(UtilityOutputFullPath)Xamarin.Android.Cecil.dll</_XamarinAndroidCecilPath>
     <JIUtilityVersion>$(JIOldToolVersion)</JIUtilityVersion>
     <JICoreLibVersion>$(JIOldCoreLibVersion)</JICoreLibVersion>
   </PropertyGroup>

--- a/build-tools/automation/templates/core-tests.yaml
+++ b/build-tools/automation/templates/core-tests.yaml
@@ -105,10 +105,28 @@ steps:
 
 - task: DotNetCoreCLI@2
   displayName: 'Tests: Java.Interop.Export'
-  condition: eq('${{ parameters.runNativeTests }}', 'true')
+  condition: or(eq('${{ parameters.runNativeDotnetTests }}', 'true'), eq('${{ parameters.runNativeTests }}', 'true'))
   inputs:
     command: test
     testRunTitle: Java.Interop.Export (${{ parameters.platformName }})
+    arguments: bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Export-Tests.dll
+  continueOnError: true
+
+- task: DotNetCoreCLI@2
+  displayName: 'jnimarshalmethod-gen Java.Interop.Export-Tests.dll'
+  condition: or(eq('${{ parameters.runNativeDotnetTests }}', 'true'), eq('${{ parameters.runNativeTests }}', 'true'))
+  inputs:
+    command: custom
+    custom: bin/$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/jnimarshalmethod-gen.dll
+    arguments: bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Export-Tests.dll -v -v --keeptemp -o bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)
+  continueOnError: true
+
+- task: DotNetCoreCLI@2
+  displayName: 'Tests: Java.Interop.Export w/ jnimarshalmethod-gen!'
+  condition: or(eq('${{ parameters.runNativeDotnetTests }}', 'true'), eq('${{ parameters.runNativeTests }}', 'true'))
+  inputs:
+    command: test
+    testRunTitle: Java.Interop.Export (jnimarshalmethod-gen + ${{ parameters.platformName }})
     arguments: bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Export-Tests.dll
   continueOnError: true
 

--- a/src/Java.Base-ref.cs
+++ b/src/Java.Base-ref.cs
@@ -6408,7 +6408,7 @@ namespace Java.Lang.Reflect
     {
         protected AccessibleObject() { }
         protected AccessibleObject(ref Java.Interop.JniObjectReference reference, Java.Interop.JniObjectReferenceOptions options) { }
-        public virtual bool Accessible { get { throw null; } set { } }
+        public virtual bool Accessible { [System.ObsoleteAttribute("deprecated")] get { throw null; } set { } }
         [System.ComponentModel.EditorBrowsableAttribute(1)]
         [System.Diagnostics.DebuggerBrowsableAttribute(0)]
         public override Java.Interop.JniPeerMembers JniPeerMembers { get { throw null; } }

--- a/src/Java.Interop.Export/Java.Interop.Export.csproj
+++ b/src/Java.Interop.Export/Java.Interop.Export.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;$(DotNetTargetFramework)</TargetFrameworks>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <ProjectGuid>{B501D075-6183-4E1D-92C9-F7B5002475B1}</ProjectGuid>
     <Nullable>enable</Nullable>
     <SignAssembly>true</SignAssembly>

--- a/src/Java.Interop.Export/Java.Interop/MarshalMemberBuilder.cs
+++ b/src/Java.Interop.Export/Java.Interop/MarshalMemberBuilder.cs
@@ -278,7 +278,7 @@ namespace Java.Interop {
 						typeof (object),
 						typeof (IntPtr)
 					};
-					marshalDelegateTypes = new ();
+					marshalDelegateTypes = new (StringComparer.Ordinal);
 				}
 				if (marshalDelegateTypes!.TryGetValue (name, out var type)) {
 					return type;

--- a/src/Java.Interop.Tools.Expressions/Java.Interop.Tools.Expressions.csproj
+++ b/src/Java.Interop.Tools.Expressions/Java.Interop.Tools.Expressions.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DotNetTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <Import Project="..\..\TargetFrameworkDependentValues.props" />
+
+  <PropertyGroup>
+    <OutputPath>$(UtilityOutputFullPath)</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+  </ItemGroup>
+
+  <Import Project="..\..\build-tools\scripts\cecil.projitems" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Java.Interop\Java.Interop.csproj" />
+    <ProjectReference Include="..\..\src\Java.Interop.Tools.Cecil\Java.Interop.Tools.Cecil.csproj" />
+    <ProjectReference Include="..\..\src\Java.Interop.Tools.Diagnostics\Java.Interop.Tools.Diagnostics.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Java.Interop.Tools.Expressions/Java.Interop.Tools.Expressions/CecilCompilerExpressionVisitor.cs
+++ b/src/Java.Interop.Tools.Expressions/Java.Interop.Tools.Expressions/CecilCompilerExpressionVisitor.cs
@@ -1,0 +1,827 @@
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Linq.Expressions;
+
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+namespace Java.Interop.Tools.Expressions;
+
+class CecilCompilerExpressionVisitor : ExpressionVisitor
+{
+	public CecilCompilerExpressionVisitor (AssemblyDefinition declaringAssembly, MethodBody body, VariableDefinitions variables, Action<TraceLevel, string> logger)
+	{
+		this.assemblyDef    = declaringAssembly;
+		this.body           = body;
+		this.variables      = variables;
+		il                  = body.GetILProcessor ();
+		Logger              = logger;
+	}
+
+	AssemblyDefinition                          assemblyDef;
+	MethodBody                                  body;
+	ILProcessor                                 il;
+	VariableDefinitions                         variables;
+	Dictionary<LabelTarget, List<Instruction>>  returnFixups    = new ();
+	Action<TraceLevel, string>                  Logger;
+
+	/// <summary>
+	/// Dispatches the expression to one of the more specialized visit methods in this class.
+	/// </summary>
+	/// <param name="node">The expression to visit.</param>
+	/// <returns>The modified expression, if it or any subexpression was modified;
+	/// otherwise, returns the original expression.</returns>
+	[return: NotNullIfNotNull("node")]
+	public override Expression? Visit (
+			Expression? node)
+	{
+		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.Visit [{node?.NodeType.ToString () ?? "<null>"}]: {node}");
+		return base.Visit (node);
+	}
+
+	/// <summary>
+	/// Visits the children of the <see cref="BinaryExpression"/>.
+	/// </summary>
+	/// <param name="node">The expression to visit.</param>
+	/// <returns>The modified expression, if it or any subexpression was modified;
+	/// otherwise, returns the original expression.</returns>
+	protected override Expression VisitBinary (
+			BinaryExpression node)
+	{
+		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.VisitBinary: {node} [{node.NodeType}]");
+		switch (node.NodeType) {
+		case ExpressionType.Assign:
+			var target  = node.Left as ParameterExpression;
+			if (target == null) {
+				Logger (TraceLevel.Verbose, $"# jonp: don't know where to assign `{node.Left}`!");
+				return base.VisitBinary (node);
+			}
+			Logger (TraceLevel.Verbose, $"# jonp: target={target}; target.Type={target.Type}; requires-&? {InstanceInvokeRequiresAddress (target.Type)}");
+			if (InstanceInvokeRequiresAddress (target.Type) && node.Right is NewExpression n) {
+				variables [target].LoadAddress (il);
+				Visit (node.Right);
+			} else {
+				Visit (node.Right);
+				variables [target].Store (il);
+			}
+			break;
+		case ExpressionType.Equal:
+			Visit (node.Left);
+			Visit (node.Right);
+			il.Emit (OpCodes.Ceq);
+			break;
+		default:
+			Logger (TraceLevel.Verbose, $"# jonp: don't know how to emit binary expr {node.NodeType}!");
+			base.VisitBinary (node);
+			break;
+		}
+		return node;
+	}
+
+	static bool InstanceInvokeRequiresAddress (Type type) => type.IsValueType && !type.IsPrimitive;
+
+	/// <summary>
+	/// Visits the children of the <see cref="BlockExpression"/>.
+	/// </summary>
+	/// <param name="node">The expression to visit.</param>
+	/// <returns>The modified expression, if it or any subexpression was modified;
+	/// otherwise, returns the original expression.</returns>
+	protected override Expression VisitBlock (
+			BlockExpression node)
+	{
+		// Base method also visits parameter nodes after body; we don't want that.
+		// https://cs.github.com/dotnet/runtime/blob/9df6ea21007319967975dc9985413bb6518287da/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionVisitor.cs#L214
+		// return base.VisitBlock (node);
+		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.VisitBlock: {node}");
+		foreach (var e in node.Expressions) {
+			Visit (e);
+		}
+		return node;
+	}
+
+	/// <summary>
+	/// Visits the children of the <see cref="ConditionalExpression"/>.
+	/// </summary>
+	/// <param name="node">The expression to visit.</param>
+	/// <returns>The modified expression, if it or any subexpression was modified;
+	/// otherwise, returns the original expression.</returns>
+	protected override Expression VisitConditional (
+			ConditionalExpression node)
+	{
+		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.VisitConditional: {node}");
+		Visit (node.Test);
+		var startFalse = il.Create (OpCodes.Nop);
+		var endBranch  = il.Create (OpCodes.Nop);
+		il.Emit (OpCodes.Brfalse, startFalse);
+		Visit (node.IfTrue);
+		il.Emit (OpCodes.Br, endBranch);
+		il.Append (startFalse);
+		Visit (node.IfFalse);
+		il.Append (endBranch);
+		return node;
+		// return base.VisitConditional (node);
+	}
+
+	/// <summary>
+	/// Visits the <see cref="ConstantExpression"/>.
+	/// </summary>
+	/// <param name="node">The expression to visit.</param>
+	/// <returns>The modified expression, if it or any subexpression was modified;
+	/// otherwise, returns the original expression.</returns>
+	protected override Expression VisitConstant (
+			ConstantExpression node)
+	{
+		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.VisitConstant: {node}");
+		switch (Type.GetTypeCode (node.Type)) {
+			case TypeCode.String:
+				il.Emit (OpCodes.Ldstr, (string?) node.Value);
+				break;
+			case TypeCode.Boolean:
+				if ((bool) node.Value!) {
+					il.Emit (OpCodes.Ldc_I4_1);
+				} else {
+					il.Emit (OpCodes.Ldc_I4_0);
+				}
+				break;
+			case TypeCode.Char:
+				il.Emit (OpCodes.Ldc_I4, (char) node.Value!);
+				break;
+			case TypeCode.SByte:
+				il.Emit (OpCodes.Ldc_I4_S, (sbyte) node.Value!);
+				break;
+			case TypeCode.Byte:
+				il.Emit (OpCodes.Ldc_I4, (byte) node.Value!);
+				break;
+			case TypeCode.Int16:
+				il.Emit (OpCodes.Ldc_I4, (short) node.Value!);
+				break;
+			case TypeCode.Int32:
+				il.Emit (OpCodes.Ldc_I4, (int) node.Value!);
+				break;
+			case TypeCode.Int64:
+				il.Emit (OpCodes.Ldc_I8, (long) node.Value!);
+				break;
+			case TypeCode.Single:
+				il.Emit (OpCodes.Ldc_R4, (float) node.Value!);
+				break;
+			case TypeCode.Double:
+				il.Emit (OpCodes.Ldc_R8, (double) node.Value!);
+				break;
+			case TypeCode.UInt16:
+				il.Emit (OpCodes.Ldc_I4, (short) node.Value!);
+				break;
+			case TypeCode.UInt32:
+				il.Emit (OpCodes.Ldc_I4, (int) node.Value!);
+				break;
+			case TypeCode.UInt64:
+				il.Emit (OpCodes.Ldc_I8, (int) node.Value!);
+				break;
+			case TypeCode.Object:
+				if (node.Type == typeof (Type)) {
+					Logger (TraceLevel.Verbose, $"# jonp: TODO load type {node.Value}");
+					break;
+				} else if (node.Value == null) {
+					Logger (TraceLevel.Verbose, $"# jonp: TODO ldnull {node.Value}");
+					il.Emit (OpCodes.Ldnull);
+					break;
+				}
+				goto default;
+			default:
+				Logger (TraceLevel.Verbose, $"# jonp: don't know how to deal with constant with value `{node}` NodeType `{node.NodeType}` Type `{node.Type}` typecode {Type.GetTypeCode (node.Type)}");
+				break;
+				// throw new NotSupportedException ();
+		}
+		return node;
+	}
+
+	/// <summary>
+	/// Visits the <see cref="DebugInfoExpression"/>.
+	/// </summary>
+	/// <param name="node">The expression to visit.</param>
+	/// <returns>The modified expression, if it or any subexpression was modified;
+	/// otherwise, returns the original expression.</returns>
+	protected override  Expression VisitDebugInfo (
+			DebugInfoExpression node)
+	{
+		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.VisitDebugInfo: {node}");
+		return base.VisitDebugInfo (node);
+	}
+
+	/// <summary>
+	/// Visits the <see cref="DefaultExpression"/>.
+	/// </summary>
+	/// <param name="node">The expression to visit.</param>
+	/// <returns>The modified expression, if it or any subexpression was modified;
+	/// otherwise, returns the original expression.</returns>
+	protected override Expression VisitDefault (
+			DefaultExpression node)
+	{
+		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.VisitDefault: {node}");
+		return base.VisitDefault (node);
+	}
+
+	/// <summary>
+	/// Visits the children of the extension expression.
+	/// </summary>
+	/// <param name="node">The expression to visit.</param>
+	/// <returns>The modified expression, if it or any subexpression was modified;
+	/// otherwise, returns the original expression.</returns>
+	/// <remarks>
+	/// This can be overridden to visit or rewrite specific extension nodes.
+	/// If it is not overridden, this method will call <see cref="Expression.VisitChildren"/>,
+	/// which gives the node a chance to walk its children. By default,
+	/// <see cref="Expression.VisitChildren"/> will try to reduce the node.
+	/// </remarks>
+	protected override Expression VisitExtension (
+			Expression node)
+	{
+		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.VisitExtension: {node}");
+		return base.VisitExtension (node);
+	}
+
+	/// <summary>
+	/// Visits the children of the <see cref="GotoExpression"/>.
+	/// </summary>
+	/// <param name="node">The expression to visit.</param>
+	/// <returns>The modified expression, if it or any subexpression was modified;
+	/// otherwise, returns the original expression.</returns>
+	protected override Expression VisitGoto (
+			GotoExpression node)
+	{
+		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.VisitGoto: {node}");
+		if (node.Kind != GotoExpressionKind.Return || node.Type == typeof (void)) {
+			return base.VisitGoto (node);
+		}
+		Visit (node.Value);
+		variables.ReturnValue?.Store (il);
+		il.Emit (OpCodes.Ret);
+		List<Instruction> fixups    = GetFixupsForLabelTarget (node.Target);
+		fixups.Add (il.Body.Instructions.Last ());
+		Logger (TraceLevel.Verbose, $"# jonp: adding fixup for goto `{node}` at index {il.Body.Instructions.Count-1}");
+		return node;
+	}
+
+	/// <summary>
+	/// Visits the children of the <see cref="InvocationExpression"/>.
+	/// </summary>
+	/// <param name="node">The expression to visit.</param>
+	/// <returns>The modified expression, if it or any subexpression was modified;
+	/// otherwise, returns the original expression.</returns>
+	protected override Expression VisitInvocation (
+			InvocationExpression node)
+	{
+		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.VisitInvocation: {node}");
+		return base.VisitInvocation (node);
+	}
+
+	/// <summary>
+	/// Visits the <see cref="LabelTarget"/>.
+	/// </summary>
+	/// <param name="node">The expression to visit.</param>
+	/// <returns>The modified expression, if it or any subexpression was modified;
+	/// otherwise, returns the original expression.</returns>
+	[return: NotNullIfNotNull("node")]
+	protected override LabelTarget? VisitLabelTarget (
+			LabelTarget? node)
+	{
+		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.VisitLabelTarget: {node}");
+		if (node != null) {
+			il.Emit (OpCodes.Nop);
+			GetFixupsForLabelTarget (node).Add (il.Body.Instructions.Last ());
+		}
+		return base.VisitLabelTarget (node);
+	}
+
+	List<Instruction> GetFixupsForLabelTarget (LabelTarget target)
+	{
+		List<Instruction>? fixups;
+		if (!returnFixups.TryGetValue (target, out fixups)) {
+			returnFixups.Add (target, fixups = new ());
+		}
+		return fixups;
+	}
+
+	/// <summary>
+	/// Visits the children of the <see cref="LabelExpression"/>.
+	/// </summary>
+	/// <param name="node">The expression to visit.</param>
+	/// <returns>The modified expression, if it or any subexpression was modified;
+	/// otherwise, returns the original expression.</returns>
+	protected override Expression VisitLabel (
+			LabelExpression node)
+	{
+		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.VisitLabel: {node}");
+		var target = il.Body.Instructions.Last ();
+		if (returnFixups.TryGetValue (node.Target, out var fixups)) {
+			foreach (var replace in fixups) {
+				Logger (TraceLevel.Verbose, $"# jonp: VisitLabel: replacing instruction `{replace}` w/ `leave {target}");
+				Debug.Assert (replace.OpCode == OpCodes.Ret || replace.OpCode == OpCodes.Nop);
+				replace.OpCode = OpCodes.Leave;
+				replace.Operand = target;
+			}
+		}
+		return base.VisitLabel (node);
+	}
+
+	/// <summary>
+	/// Visits the children of the <see cref="Expression{T}"/>.
+	/// </summary>
+	/// <typeparam name="T">The type of the delegate.</typeparam>
+	/// <param name="node">The expression to visit.</param>
+	/// <returns>The modified expression, if it or any subexpression was modified;
+	/// otherwise, returns the original expression.</returns>
+	protected override Expression VisitLambda<T>(Expression<T> node)
+	{
+		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.VisitLambda: {node}");
+		return Visit (node.Body);
+		// Base method also visits parameter nodes after body; we don't want that.
+		// return base.VisitLambda (node);
+	}
+
+	/// <summary>
+	/// Visits the children of the <see cref="LoopExpression"/>.
+	/// </summary>
+	/// <param name="node">The expression to visit.</param>
+	/// <returns>The modified expression, if it or any subexpression was modified;
+	/// otherwise, returns the original expression.</returns>
+	protected override Expression VisitLoop (
+			LoopExpression node)
+	{
+		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.VisitLoop: {node}");
+		return base.VisitLoop (node);
+	}
+
+	/// <summary>
+	/// Visits the children of the <see cref="MemberExpression"/>.
+	/// </summary>
+	/// <param name="node">The expression to visit.</param>
+	/// <returns>The modified expression, if it or any subexpression was modified;
+	/// otherwise, returns the original expression.</returns>
+	protected override Expression VisitMember (
+			MemberExpression node)
+	{
+		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.VisitMember: {node}");
+		base.VisitMember (node);
+		switch (node.Member.MemberType) {
+		case System.Reflection.MemberTypes.Field:
+			var field = (System.Reflection.FieldInfo) node.Member;
+			il.Emit (
+					field.IsStatic ? OpCodes.Ldsfld : OpCodes.Ldfld,
+					assemblyDef.MainModule.ImportReference (field));
+			break;
+		case System.Reflection.MemberTypes.Property:
+			var property    = (System.Reflection.PropertyInfo) node.Member;
+			var getter      = property.GetGetMethod ();
+			il.Emit (GetCallOpCode (getter!), assemblyDef.MainModule.ImportReference (getter));
+			break;
+		default:
+			throw new NotSupportedException ($"How do I visit `{node.Member.MemberType}`? {node}");
+		}
+		return node;
+	}
+
+	/// <summary>
+	/// Visits the children of the <see cref="IndexExpression"/>.
+	/// </summary>
+	/// <param name="node">The expression to visit.</param>
+	/// <returns>The modified expression, if it or any subexpression was modified;
+	/// otherwise, returns the original expression.</returns>
+	protected override Expression VisitIndex (
+			IndexExpression node)
+	{
+		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.VisitIndex: {node}");
+		return base.VisitIndex (node);
+	}
+
+	/// <summary>
+	/// Visits the children of the <see cref="MethodCallExpression"/>.
+	/// </summary>
+	/// <param name="node">The expression to visit.</param>
+	/// <returns>The modified expression, if it or any subexpression was modified;
+	/// otherwise, returns the original expression.</returns>
+	protected override Expression VisitMethodCall (
+			MethodCallExpression node)
+	{
+		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.VisitMethodCall: {node}; node.Object={node.Object}");
+		// We need to special-case `node.Object` handling
+		// https://github.com/dotnet/runtime/blob/edd23fcb1b350cb1a53fa409200da55e9c33e99e/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionVisitor.cs#L403-L413
+
+		if (node.Object is ParameterExpression target) {
+			if (InstanceInvokeRequiresAddress (target.Type)) {
+				variables [target].LoadAddress (il);
+			} else {
+				variables [target].Load (il);
+			}
+		} else {
+			Visit (node.Object);
+		}
+		foreach (var a in node.Arguments) {
+			Visit (a);
+		}
+		il.Emit (GetCallOpCode (node.Method), assemblyDef.MainModule.ImportReference (node.Method));
+
+		return node;
+	}
+
+	OpCode GetCallOpCode (global::System.Reflection.MethodBase method)
+	{
+		if (method.IsStatic || (method.DeclaringType?.IsValueType ?? false))
+			return OpCodes.Call;
+		return OpCodes.Callvirt;
+	}
+
+	void EmitConsoleWriteLine (ILProcessor il, string message)
+	{
+		Action<string> cwl = Console.WriteLine;
+		il.Emit (OpCodes.Ldstr, message);
+		il.Emit (OpCodes.Call, assemblyDef.MainModule.ImportReference (cwl.Method));
+	}
+
+	/// <summary>
+	/// Visits the children of the <see cref="NewArrayExpression"/>.
+	/// </summary>
+	/// <param name="node">The expression to visit.</param>
+	/// <returns>The modified expression, if it or any subexpression was modified;
+	/// otherwise, returns the original expression.</returns>
+	protected override Expression VisitNewArray (
+			NewArrayExpression node)
+	{
+		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.VisitNewArray: {node}");
+		return base.VisitNewArray (node);
+	}
+
+	/// <summary>
+	/// Visits the children of the <see cref="NewExpression"/>.
+	/// </summary>
+	/// <param name="node">The expression to visit.</param>
+	/// <returns>The modified expression, if it or any subexpression was modified;
+	/// otherwise, returns the original expression.</returns>
+	protected override Expression VisitNew (
+			NewExpression node)
+	{
+		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.VisitNew: {node}");
+		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.VisitNew: ctor={node.Constructor} {node.Constructor != null}");
+		base.VisitNew (node);
+		if (node.Constructor == null && node.Type.IsValueType) {
+			il.Emit (OpCodes.Initobj,   assemblyDef.MainModule.ImportReference (node.Type));
+		} else {
+			il.Emit (OpCodes.Call,      assemblyDef.MainModule.ImportReference (node.Constructor));
+		}
+		return node;
+	}
+
+	/// <summary>
+	/// Visits the <see cref="ParameterExpression"/>.
+	/// </summary>
+	/// <param name="node">The expression to visit.</param>
+	/// <returns>The modified expression, if it or any subexpression was modified;
+	/// otherwise, returns the original expression.</returns>
+	protected override Expression VisitParameter (
+			ParameterExpression node)
+	{
+		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.VisitParameter: {(node.Type.IsByRef ? "&" : "")}{node}");
+
+		if (node.Type.IsByRef) {
+			variables [node].LoadAddress (il);
+		} else {
+			variables [node].Load (il);
+		}
+		
+		return node;
+	}
+
+	/// <summary>
+	/// Visits the children of the <see cref="RuntimeVariablesExpression"/>.
+	/// </summary>
+	/// <param name="node">The expression to visit.</param>
+	/// <returns>The modified expression, if it or any subexpression was modified;
+	/// otherwise, returns the original expression.</returns>
+	protected override Expression VisitRuntimeVariables (
+			RuntimeVariablesExpression node)
+	{
+		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.VisitRuntimeVariables: {node}");
+		return base.VisitRuntimeVariables (node);
+	}
+
+	/// <summary>
+	/// Visits the children of the <see cref="SwitchCase"/>.
+	/// </summary>
+	/// <param name="node">The expression to visit.</param>
+	/// <returns>The modified expression, if it or any subexpression was modified;
+	/// otherwise, returns the original expression.</returns>
+	protected override SwitchCase VisitSwitchCase (
+			SwitchCase node)
+	{
+		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.VisitSwitchCase: {node}");
+		return base.VisitSwitchCase (node);
+	}
+
+	/// <summary>
+	/// Visits the children of the <see cref="SwitchExpression"/>.
+	/// </summary>
+	/// <param name="node">The expression to visit.</param>
+	/// <returns>The modified expression, if it or any subexpression was modified;
+	/// otherwise, returns the original expression.</returns>
+	protected override Expression VisitSwitch (
+			SwitchExpression node)
+	{
+		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.VisitSwitch: {node}");
+		return base.VisitSwitch (node);
+	}
+
+	/// <summary>
+	/// Visits the children of the <see cref="CatchBlock"/>.
+	/// </summary>
+	/// <param name="node">The expression to visit.</param>
+	/// <returns>The modified expression, if it or any subexpression was modified;
+	/// otherwise, returns the original expression.</returns>
+	protected override CatchBlock VisitCatchBlock (
+			CatchBlock node)
+	{
+		// On entry, IL stream should assume that there is an Exception type on the evaluation stack.
+
+		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.VisitCatchBlock: {node}");
+
+		var startCatchBlock     = il.Body.Instructions.Count;
+		var handlerDef          = new ExceptionHandler (ExceptionHandlerType.Catch) {
+			TryStart        = TryStart,
+		};
+		body.ExceptionHandlers.Add (handlerDef);
+
+		if (node.Filter != null) {
+			EmitCatchFilter (node);
+			handlerDef.HandlerType  = ExceptionHandlerType.Filter;
+			handlerDef.FilterStart  = il.Body.Instructions [startCatchBlock];
+			startCatchBlock         = il.Body.Instructions.Count;
+		} else if (node.Test != null) {
+			handlerDef.CatchType        = assemblyDef.MainModule.ImportReference (node.Test);
+		}
+
+		if (node.Variable != null) {
+			il.Emit (OpCodes.Castclass, assemblyDef.MainModule.ImportReference (node.Variable.Type));
+			variables [node.Variable!].Store (il);
+		} else {
+			il.Emit (OpCodes.Pop);
+		}
+
+		Visit (node.Body);
+		EmitLeave ();
+
+		handlerDef.HandlerStart = il.Body.Instructions [startCatchBlock];
+
+		return node;
+	}
+
+	void EmitCatchFilter (CatchBlock node)
+	{
+		Instruction? fixupStartFilter   = null;
+		Instruction? fixupEndFilter     = null;
+
+		if (node.Test != null) {
+			il.Emit (OpCodes.Isinst, assemblyDef.MainModule.ImportReference (node.Test));
+			il.Emit (OpCodes.Dup);
+			il.Emit (OpCodes.Brtrue_S,  il.Body.Instructions.Last ());
+			fixupStartFilter    = il.Body.Instructions.Last ();
+			il.Emit (OpCodes.Pop);
+			il.Emit (OpCodes.Ldc_I4_0);
+			il.Emit (OpCodes.Br_S,      il.Body.Instructions.Last ());
+			fixupEndFilter      = il.Body.Instructions.Last ();
+		}
+
+		if (node.Variable != null) {
+			variables [node.Variable!].Store (il);
+		} else {
+			il.Emit (OpCodes.Pop);
+		}
+
+		if (fixupStartFilter != null) {
+			fixupStartFilter.Operand    = il.Body.Instructions.Last ();
+		}
+
+		Visit (node.Filter);
+
+		// node.Filter is assumed to leave a "boolean" on the eval stack; convert to an int
+		il.Emit (OpCodes.Ldc_I4_0);
+		il.Emit (OpCodes.Cgt_Un);
+
+		il.Emit (OpCodes.Endfilter);
+
+		if (fixupEndFilter != null) {
+			fixupEndFilter.Operand      = il.Body.Instructions.Last ();
+		}
+	}
+
+	Instruction?        TryStart;
+	List<Instruction>?  FixupLeaveOffsets;
+
+
+	/// <summary>
+	/// Visits the children of the <see cref="TryExpression"/>.
+	/// </summary>
+	/// <param name="node">The expression to visit.</param>
+	/// <returns>The modified expression, if it or any subexpression was modified;
+	/// otherwise, returns the original expression.</returns>
+	protected override Expression VisitTry (
+			TryExpression node)
+	{
+		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.VisitTry: {node}");
+
+		var prevTryStart        = TryStart;
+		var pFixupLeaveOffsets  = FixupLeaveOffsets;
+		try {
+			var startTryBlock   = il.Body.Instructions.Count;
+			FixupLeaveOffsets   = new ();
+
+			Visit (node.Body);
+			EmitLeave ();
+			TryStart            = il.Body.Instructions [startTryBlock];
+
+			Visit (node.Handlers, VisitCatchBlock);
+
+			if (node.Finally != null) {
+				var startFinallyBlock   = il.Body.Instructions.Count;
+				Visit (node.Finally);
+				il.Emit (OpCodes.Endfinally);
+
+				var finallyDef = new ExceptionHandler (ExceptionHandlerType.Finally) {
+					TryStart        = TryStart,
+					HandlerStart    = il.Body.Instructions [startFinallyBlock],
+				};
+				body.ExceptionHandlers.Add (finallyDef);
+			}
+
+			// Visit (node.Fault);
+
+			// ECMA 335 Partition X § 19 Exception Handling
+			//  HandlerBlock ::= `handler` Label to Label
+			// Handler range is from first label ***prior to*** second (emphasis @jonpryor)
+			// Therefore we need to append `NOP` to the IL stream so that the fixupTarget is
+			// one-past-the-end, as nothing afterward has yet been emitted.
+
+			il.Emit (OpCodes.Nop);
+			var fixupTarget = il.Body.Instructions.Last ();
+
+			for (int i = 0; i < (body.ExceptionHandlers.Count-1); ++i) {
+				var c = body.ExceptionHandlers [i];
+				var n = body.ExceptionHandlers [i+1];
+				c.TryEnd        = c.FilterStart ?? c.HandlerStart;
+				c.HandlerEnd    = n.FilterStart ?? n.HandlerStart;
+			}
+			if (body.ExceptionHandlers.Count > 0) {
+				var f           = body.ExceptionHandlers [body.ExceptionHandlers.Count-1];
+				f.TryEnd        = f.HandlerStart;
+				f.HandlerEnd    = fixupTarget;
+			}
+			foreach (var fixup in FixupLeaveOffsets) {
+				fixup.Operand   = fixupTarget;
+			}
+		}
+		finally {
+			TryStart            = prevTryStart;
+			FixupLeaveOffsets   = pFixupLeaveOffsets;
+		}
+
+		return node;
+	}
+
+	void EmitLeave ()
+	{
+		// keep in sync w/ VisitGoto()
+		// Prevent multiple `leave OFFSET`s in the output
+		if (il.Body.Instructions.Last ().OpCode.Code != Code.Ret) {
+			il.Emit (OpCodes.Leave, il.Body.Instructions.Last ());
+			FixupLeaveOffsets!.Add (il.Body.Instructions.Last ());
+		}
+	}
+
+	/// <summary>
+	/// Visits the children of the <see cref="TypeBinaryExpression"/>.
+	/// </summary>
+	/// <param name="node">The expression to visit.</param>
+	/// <returns>The modified expression, if it or any subexpression was modified;
+	/// otherwise, returns the original expression.</returns>
+	protected override Expression VisitTypeBinary (
+			TypeBinaryExpression node)
+	{
+		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.VisitTypeBinary: {node}");
+		return base.VisitTypeBinary (node);
+	}
+
+	/// <summary>
+	/// Visits the children of the <see cref="UnaryExpression"/>.
+	/// </summary>
+	/// <param name="node">The expression to visit.</param>
+	/// <returns>The modified expression, if it or any subexpression was modified;
+	/// otherwise, returns the original expression.</returns>
+	protected override Expression VisitUnary (
+			UnaryExpression node)
+	{
+		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.VisitUnary: {node}");
+		return base.VisitUnary (node);
+	}
+
+	/// <summary>
+	/// Visits the children of the <see cref="MemberInitExpression"/>.
+	/// </summary>
+	/// <param name="node">The expression to visit.</param>
+	/// <returns>The modified expression, if it or any subexpression was modified;
+	/// otherwise, returns the original expression.</returns>
+	protected override Expression VisitMemberInit (
+			MemberInitExpression node)
+	{
+		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.VisitMemberInit: {node}");
+		return base.VisitMemberInit (node);
+	}
+
+	/// <summary>
+	/// Visits the children of the <see cref="ListInitExpression"/>.
+	/// </summary>
+	/// <param name="node">The expression to visit.</param>
+	/// <returns>The modified expression, if it or any subexpression was modified;
+	/// otherwise, returns the original expression.</returns>
+	protected override Expression VisitListInit (
+			ListInitExpression node)
+	{
+		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.VisitListInit: {node}");
+		return base.VisitListInit (node);
+	}
+
+	/// <summary>
+	/// Visits the children of the <see cref="ElementInit"/>.
+	/// </summary>
+	/// <param name="node">The expression to visit.</param>
+	/// <returns>The modified expression, if it or any subexpression was modified;
+	/// otherwise, returns the original expression.</returns>
+	protected override ElementInit VisitElementInit (
+			ElementInit node)
+	{
+		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.VisitElementInit: {node}");
+		return base.VisitElementInit (node);
+	}
+
+	/// <summary>
+	/// Visits the children of the <see cref="MemberBinding"/>.
+	/// </summary>
+	/// <param name="node">The expression to visit.</param>
+	/// <returns>The modified expression, if it or any subexpression was modified;
+	/// otherwise, returns the original expression.</returns>
+	protected override MemberBinding VisitMemberBinding (
+			MemberBinding node)
+	{
+		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.VisitMemberBinding: {node}");
+		return base.VisitMemberBinding (node);
+	}
+
+	/// <summary>
+	/// Visits the children of the <see cref="MemberAssignment"/>.
+	/// </summary>
+	/// <param name="node">The expression to visit.</param>
+	/// <returns>The modified expression, if it or any subexpression was modified;
+	/// otherwise, returns the original expression.</returns>
+	protected override MemberAssignment VisitMemberAssignment (
+			MemberAssignment node)
+	{
+		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.VisitMemberAssignment: {node}");
+		return base.VisitMemberAssignment (node);
+	}
+
+	/// <summary>
+	/// Visits the children of the <see cref="MemberMemberBinding"/>.
+	/// </summary>
+	/// <param name="node">The expression to visit.</param>
+	/// <returns>The modified expression, if it or any subexpression was modified;
+	/// otherwise, returns the original expression.</returns>
+	protected override MemberMemberBinding VisitMemberMemberBinding (
+			MemberMemberBinding node)
+	{
+		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.VisitMemberMemberBinding: {node}");
+		return base.VisitMemberMemberBinding (node);
+	}
+
+	/// <summary>
+	/// Visits the children of the <see cref="MemberListBinding"/>.
+	/// </summary>
+	/// <param name="node">The expression to visit.</param>
+	/// <returns>The modified expression, if it or any subexpression was modified;
+	/// otherwise, returns the original expression.</returns>
+	protected override MemberListBinding VisitMemberListBinding (
+			MemberListBinding node)
+	{
+		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.VisitMemberListBinding: {node}");
+		return base.VisitMemberListBinding (node);
+	}
+
+	/// <summary>
+	/// Visits the children of the <see cref="DynamicExpression" />.
+	/// </summary>
+	/// <param name="node">The expression to visit.</param>
+	/// <returns>The modified expression, if it or any subexpression was modified;
+	/// otherwise, returns the original expression.</returns>
+	protected override Expression VisitDynamic (
+			DynamicExpression node)
+	{
+		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.VisitDynamic: {node}");
+		return base.VisitDynamic (node);
+	}
+}

--- a/src/Java.Interop.Tools.Expressions/Java.Interop.Tools.Expressions/CecilCompilerExpressionVisitor.cs
+++ b/src/Java.Interop.Tools.Expressions/Java.Interop.Tools.Expressions/CecilCompilerExpressionVisitor.cs
@@ -295,8 +295,7 @@ class CecilCompilerExpressionVisitor : ExpressionVisitor
 
 	List<Instruction> GetFixupsForLabelTarget (LabelTarget target)
 	{
-		List<Instruction>? fixups;
-		if (!returnFixups.TryGetValue (target, out fixups)) {
+		if (!returnFixups.TryGetValue (target, out List<Instruction>? fixups)) {
 			returnFixups.Add (target, fixups = new ());
 		}
 		return fixups;
@@ -313,7 +312,7 @@ class CecilCompilerExpressionVisitor : ExpressionVisitor
 	{
 		Logger (TraceLevel.Verbose, $"# jonp: CecilCompilerExpressionVisitor.VisitLabel: {node}");
 		var target = il.Body.Instructions.Last ();
-		if (returnFixups.TryGetValue (node.Target, out var fixups)) {
+		if (returnFixups.TryGetValue (node.Target, out List<Instruction>? fixups)) {
 			foreach (var replace in fixups) {
 				Logger (TraceLevel.Verbose, $"# jonp: VisitLabel: replacing instruction `{replace}` w/ `leave {target}");
 				Debug.Assert (replace.OpCode == OpCodes.Ret || replace.OpCode == OpCodes.Nop);

--- a/src/Java.Interop.Tools.Expressions/Java.Interop.Tools.Expressions/ExpressionAssemblyBuilder.cs
+++ b/src/Java.Interop.Tools.Expressions/Java.Interop.Tools.Expressions/ExpressionAssemblyBuilder.cs
@@ -1,0 +1,452 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq.Expressions;
+using System.Text;
+
+using Java.Interop;
+using Java.Interop.Tools.Diagnostics;
+
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using static System.Formats.Asn1.AsnWriter;
+
+namespace Java.Interop.Tools.Expressions;
+
+public class ExpressionAssemblyBuilder {
+
+	public ExpressionAssemblyBuilder (AssemblyDefinition declaringAssemblyDefinition, Action<TraceLevel, string>? logger = null)
+	{
+		DeclaringAssemblyDefinition     = declaringAssemblyDefinition;
+		Logger                          = logger ?? Diagnostic.CreateConsoleLogger ();
+	}
+
+	public  AssemblyDefinition              DeclaringAssemblyDefinition     {get;}
+	public  Action<TraceLevel, string>      Logger                          {get;}
+	public  bool                            KeepTemporaryFiles              {get; set;}
+
+	public MethodDefinition Compile (LambdaExpression expression)
+	{
+		var mmDef   = CreateMethodDefinition (DeclaringAssemblyDefinition, expression);
+		var decls   = new VariableDefinitions (DeclaringAssemblyDefinition, mmDef, expression, Logger);
+		var mmBody  = mmDef.Body;
+		var il      = mmBody.GetILProcessor ();
+		var v       = new CecilCompilerExpressionVisitor (DeclaringAssemblyDefinition, mmBody, decls, Logger);
+		v.Visit (expression);
+
+		if (expression.ReturnType != null && expression.ReturnType != typeof (void) && decls.ReturnValue == null) {
+			Logger (TraceLevel.Error, $"# jonp: validation error: expression has a return type but we didn't find a return value! expression={expression}");
+		}
+
+		decls.ReturnValue?.Load (il);
+		il.Emit (OpCodes.Ret);
+
+		return mmDef;
+	}
+
+	static MethodDefinition CreateMethodDefinition (AssemblyDefinition declaringAssembly, LambdaExpression expression)
+	{
+		var mmDef = new MethodDefinition (
+			name:       "@CHANGE-ME@",
+			attributes: Mono.Cecil.MethodAttributes.Static | Mono.Cecil.MethodAttributes.Private | Mono.Cecil.MethodAttributes.HideBySig,
+			returnType: declaringAssembly.MainModule.ImportReference (expression.ReturnType)
+		) {
+			Body = {
+				InitLocals      = true,
+			},
+		};
+		return mmDef;
+	}
+
+	public MethodDefinition CreateRegistrationMethod (IList<ExpressionMethodRegistration> methods)
+	{
+		var registrations = new MethodDefinition (
+			name:       "__RegisterNativeMembers",
+			attributes: MethodAttributes.Static | MethodAttributes.Private | MethodAttributes.HideBySig,
+			returnType: DeclaringAssemblyDefinition.MainModule.TypeSystem.Void
+		) {
+			Body = {
+				InitLocals      = true,
+			},
+		};
+
+		var ctor    = typeof (JniAddNativeMethodRegistrationAttribute).GetConstructor (Type.EmptyTypes);
+		var attr    = new CustomAttribute (DeclaringAssemblyDefinition.MainModule.ImportReference (ctor));
+		registrations.CustomAttributes.Add (attr);
+
+		var args    = new ParameterDefinition ("args", default, DeclaringAssemblyDefinition.MainModule.ImportReference (typeof (JniNativeMethodRegistrationArguments)));
+		registrations.Parameters.Add (args);
+
+		var arrayType   = DeclaringAssemblyDefinition.MainModule.ImportReference (typeof (JniNativeMethodRegistration []));
+
+		var array   = new VariableDefinition (arrayType);
+		registrations.Body.Variables.Add (array);
+
+		var il = registrations.Body.GetILProcessor ();
+		EmitConsoleWriteLine (il, $"# jonp: called __RegisterNativeMembers w/ {methods.Count} methods to register.");
+		il.Emit (OpCodes.Ldc_I4, methods.Count);
+		il.Emit (OpCodes.Newarr, DeclaringAssemblyDefinition.MainModule.ImportReference (arrayType.GetElementType ()));
+		// il.Emit (OpCodes.Stloc_0);
+
+		var JniNativeMethodRegistration_ctor    = typeof (JniNativeMethodRegistration).GetConstructor (new [] { typeof (string), typeof (string), typeof (Delegate) });
+		var jnmr_ctor                           = DeclaringAssemblyDefinition.MainModule.ImportReference (JniNativeMethodRegistration_ctor);
+
+		for (int i = 0; i < methods.Count; i++) {
+			var delegateCtor = GetMarshalMethodDelegateCtor (methods [i].MarshalMethodDefinition);
+
+			// il.Emit (OpCodes.Ldloc_0);      // args
+			il.Emit (OpCodes.Dup);      // args
+			il.Emit (OpCodes.Ldc_I4, i);    // index of `args` to set
+
+			// new JniNativeMethodRegistration (JniName, JniSignature, new _JniMarshal_PP… (MarshalMethodDefinition))
+			il.Emit (OpCodes.Ldstr,         methods [i].JniName);
+			il.Emit (OpCodes.Ldstr,         methods [i].JniSignature);
+			il.Emit (OpCodes.Ldnull);
+			il.Emit (OpCodes.Ldftn,         methods [i].MarshalMethodDefinition);
+			il.Emit (OpCodes.Newobj,        delegateCtor);
+			il.Emit (OpCodes.Newobj,        jnmr_ctor);
+
+			il.Emit (OpCodes.Stelem_Any,	arrayType.GetElementType ());   // args [i] = new JniNativeMethodRegistration (…)
+		}
+
+		il.Emit (OpCodes.Stloc_0);
+
+		Action<IEnumerable<JniNativeMethodRegistration>> addRegistrations = new JniNativeMethodRegistrationArguments ().AddRegistrations;
+		il.Emit (OpCodes.Ldarga_S, args);
+		il.Emit (OpCodes.Ldloc_0);
+		il.Emit (OpCodes.Call, DeclaringAssemblyDefinition.MainModule.ImportReference (addRegistrations.Method));
+		il.Emit (OpCodes.Ret);
+
+
+		return registrations;
+	}
+
+	void EmitConsoleWriteLine (ILProcessor il, string message)
+	{
+		Action<string> cwl = Console.WriteLine;
+		il.Emit (OpCodes.Ldstr, message);
+		il.Emit (OpCodes.Call,  DeclaringAssemblyDefinition.MainModule.ImportReference (cwl.Method));
+	}
+
+	// Keep in sync w/ MarshalMemberBuilder.GetMarshalerType()
+	MethodReference GetMarshalMethodDelegateCtor (MethodDefinition method)
+	{
+		// Too many parameters; does a `_JniMarshal_*` type exist in the type's declaring assembly?
+		var delegateName    = GetMarshalMethodDelegateName (method.Parameters, method.ReturnType);
+
+		var delegateDef = DeclaringAssemblyDefinition.MainModule.GetType (delegateName.ToString ());
+		if (delegateDef == null) {
+			delegateDef     = CreateMarshalMethodDelegateType (delegateName, method.Parameters, method.ReturnType);
+			DeclaringAssemblyDefinition.MainModule.Types.Add (delegateDef);
+		}
+		return delegateDef.Methods.First (m => m.Name == ".ctor");
+	}
+
+	string GetMarshalMethodDelegateName (IList<ParameterDefinition> parameters, TypeReference returnType)
+	{
+		// Too many parameters; does a `_JniMarshal_*` type exist in the type's declaring assembly?
+		var delegateName    = new StringBuilder ();
+		delegateName.Append ("_JniMarshal_PP");
+
+		for (int i = 2; i < parameters.Count; i++) {
+			delegateName.Append (GetJniMarshalDelegateParameterIdentifier (parameters [i].ParameterType));
+		}
+		delegateName.Append ("_");
+		delegateName.Append (GetJniMarshalDelegateParameterIdentifier (returnType));
+
+		return delegateName.ToString ();
+	}
+
+	char GetJniMarshalDelegateParameterIdentifier (TypeReference type)
+	{
+		switch (type?.FullName) {
+			case "System.Boolean":  return 'Z';
+			case "System.Byte":     return 'B';
+			case "System.SByte":    return 'B';
+			case "System.Char":     return 'C';
+			case "System.Int16":    return 'S';
+			case "System.UInt16":   return 's';
+			case "System.Int32":    return 'I';
+			case "System.UInt32":   return 'i';
+			case "System.Int64":    return 'J';
+			case "System.UInt64":   return 'j';
+			case "System.Single":   return 'F';
+			case "System.Double":   return 'D';
+			case null:
+			case "System.Void":     return 'V';
+			default:                return 'L';
+		}
+	}
+
+	public TypeDefinition CreateMarshalMethodDelegateType (string delegateName, IList<ParameterDefinition> parameters, TypeReference returnType)
+	{
+		var delegateDef = new TypeDefinition (
+				@namespace: "",
+				name:       delegateName,
+				attributes: TypeAttributes.Class | TypeAttributes.NotPublic | TypeAttributes.Sealed | TypeAttributes.AnsiClass | TypeAttributes.AutoClass
+		);
+		delegateDef.BaseType = DeclaringAssemblyDefinition.MainModule.ImportReference (typeof (MulticastDelegate));
+
+		var delegateCtor = new MethodDefinition (
+				name:       ".ctor",
+				attributes: MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName,
+				returnType: DeclaringAssemblyDefinition.MainModule.TypeSystem.Void
+		);
+		delegateCtor.ImplAttributes     = MethodImplAttributes.Runtime | MethodImplAttributes.Managed;
+		delegateCtor.Parameters.Add (new ParameterDefinition ("object", default, DeclaringAssemblyDefinition.MainModule.TypeSystem.Object));
+		delegateCtor.Parameters.Add (new ParameterDefinition ("method", default, DeclaringAssemblyDefinition.MainModule.TypeSystem.IntPtr));
+		delegateDef.Methods.Add (delegateCtor);
+
+		var invoke = new MethodDefinition (
+				name: "Invoke",
+				attributes: MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.NewSlot | MethodAttributes.Virtual,
+				returnType: returnType
+		);
+		invoke.ImplAttributes   = MethodImplAttributes.Runtime | MethodImplAttributes.Managed;
+		foreach (var p in parameters) {
+			invoke.Parameters.Add (new ParameterDefinition (p.Name, p.Attributes, p.ParameterType));
+		}
+		delegateDef.Methods.Add (invoke);
+
+		return delegateDef;
+	}
+
+
+	public void Write (string path)
+	{
+		Logger (TraceLevel.Verbose, $"# jonp: ExpressionAssemblyBuilder.Write to path={path}");
+		var module = DeclaringAssemblyDefinition.MainModule;
+
+		var c       = new MemoryStream ();
+		DeclaringAssemblyDefinition.Write (c);
+		c.Position  = 0;
+
+		if (KeepTemporaryFiles) {
+			using var intermediate = File.Create (path + ".cecil");
+			c.WriteTo (intermediate);
+			c.Position  = 0;
+		}
+
+		Logger (TraceLevel.Verbose, $"# jonp: ---");
+
+		var rp = new ReaderParameters {
+			InMemory    = true,
+			ReadSymbols = false,
+			ReadWrite   = false,
+			ReadingMode = ReadingMode.Immediate,
+		};
+		var newAsm              = AssemblyDefinition.ReadAssembly (c, rp);
+		module                  = newAsm.MainModule;
+		var systemRuntimeRef    = module.AssemblyReferences.FirstOrDefault (r => r.Name == "System.Runtime");
+		var privateCorelibRef   = module.AssemblyReferences.FirstOrDefault (r => r.Name == "System.Private.CoreLib");
+
+		if (systemRuntimeRef == null && privateCorelibRef != null) {
+			systemRuntimeRef    = GetSystemRuntimeReference ();
+			module.AssemblyReferences.Add (systemRuntimeRef);
+		}
+
+		var selfRef             = module.AssemblyReferences.FirstOrDefault (r => r.Name == newAsm.Name.Name);
+		foreach (var member in module.GetMemberReferences ()) {
+			Logger (TraceLevel.Verbose, $"# jonp: looking at ref for member: [{member.DeclaringType.Scope?.Name}]{member}");
+			if (member.DeclaringType.Scope == privateCorelibRef) {
+				Logger (TraceLevel.Verbose, $"# jonp: Fixing scope ref for member: {member}");
+				member.DeclaringType.Scope = systemRuntimeRef;
+				continue;
+			}
+			if (member.DeclaringType.Scope == selfRef) {
+				Logger (TraceLevel.Verbose, $"# jonp: Fixing scope self ref for member: {member}");
+				member.DeclaringType.Scope = null;
+				continue;
+			}
+		}
+		foreach (var type in module.GetTypeReferences ()) {
+			Logger (TraceLevel.Verbose, $"# jonp: looking at ref for type: [{type.Scope}]{type}");
+			if (type.Scope == privateCorelibRef) {
+				Logger (TraceLevel.Verbose, $"# jonp: Fixing scope ref for type: {type}");
+				type.Scope = systemRuntimeRef;
+				continue;
+			}
+			if (type.Scope == selfRef) {
+				Logger (TraceLevel.Verbose, $"# jonp: Fixing scope self ref for type: {type}");
+				type.Scope = null;
+				continue;
+			}
+		}
+		module.AssemblyReferences.Remove (privateCorelibRef);
+		if (selfRef != null) {
+			module.AssemblyReferences.Remove (selfRef);
+		}
+		newAsm.Write (path);
+	}
+
+	static AssemblyNameReference GetSystemRuntimeReference ()
+	{
+		var privateCorelibDir   = Path.GetDirectoryName (typeof (object).Assembly.Location) ??
+			throw new NotSupportedException ("Cannot find directory of `System.Private.CoreLib.dll`!");
+		var systemRuntimePath   = Path.Combine (privateCorelibDir, "System.Runtime.dll");
+		if (!File.Exists (systemRuntimePath)) {
+			throw new NotSupportedException ($"Could not find `System.Runtime.dll`; looked at `{systemRuntimePath}`.");
+		}
+		var rp                  = new ReaderParameters {
+			InMemory        = false,
+			ReadSymbols     = false,
+			ReadWrite       = false,
+			ReadingMode     = ReadingMode.Deferred,
+		};
+		using var systemRuntime = AssemblyDefinition.ReadAssembly (systemRuntimePath, rp);
+		var nameDef             = systemRuntime.Name;
+		return new AssemblyNameReference (nameDef.Name, nameDef.Version) {
+			HashAlgorithm   = nameDef.HashAlgorithm,
+			PublicKeyToken  = nameDef.PublicKeyToken,
+		};
+	}
+}
+
+sealed class VariableInfo {
+	public VariableInfo (Action<ILProcessor> load, Action<ILProcessor> loadAddress, Action<ILProcessor> store)
+	{
+		Load            = load;
+		LoadAddress     = loadAddress;
+		Store           = store;
+	}
+
+	public  readonly    Action<ILProcessor> Load;
+	public  readonly    Action<ILProcessor> LoadAddress;
+	public  readonly    Action<ILProcessor> Store;
+}
+
+sealed class VariableDefinitions {
+
+	Dictionary<ParameterExpression, VariableInfo>   variables = new ();
+	Action<TraceLevel, string>                      Logger;
+
+	public VariableDefinitions (AssemblyDefinition declaringAssembly, MethodDefinition declaringMethod, LambdaExpression expression, Action<TraceLevel, string> logger)
+	{
+		Logger  = logger;
+		for (int i = 0; i < expression.Parameters.Count; ++i) {
+			var c = expression.Parameters [i];
+			var d = new ParameterDefinition (c.Name, default, declaringAssembly.MainModule.ImportReference (c.Type));
+			declaringMethod.Parameters.Add (d);
+
+			VariableInfo v;
+
+			switch (i) {
+			case 0:
+				v = new VariableInfo (il => il.Emit (OpCodes.Ldarg_0),  il => il.Emit (OpCodes.Ldarga, 0),  il => il.Emit (OpCodes.Starg, 0));
+				break;
+			case 1:
+				v = new VariableInfo (il => il.Emit (OpCodes.Ldarg_1),  il => il.Emit (OpCodes.Ldarga, 1),  il => il.Emit (OpCodes.Starg, 1));
+				break;
+			case 2:
+				v = new VariableInfo (il => il.Emit (OpCodes.Ldarg_2),  il => il.Emit (OpCodes.Ldarga, 2),  il => il.Emit (OpCodes.Starg, 2));
+				break;
+			case 3:
+				v = new VariableInfo (il => il.Emit (OpCodes.Ldarg_3),  il => il.Emit (OpCodes.Ldarga, 3),  il => il.Emit (OpCodes.Starg, 3));
+				break;
+			default:
+				int x = i;
+				v = new VariableInfo (il => il.Emit (OpCodes.Ldarg, x), il => il.Emit (OpCodes.Ldarga, x),  il => il.Emit (OpCodes.Starg, x));
+				break;
+			}
+			variables [c] = v;
+		}
+		FillVariables (declaringAssembly, declaringMethod, expression);
+	}
+
+	public VariableInfo? ReturnValue {get; private set;}
+
+	public VariableInfo this [ParameterExpression e] {
+		get => variables [e];
+	}
+
+	void FillVariables (
+			AssemblyDefinition declaringAssembly,
+			MethodDefinition declaringMethod,
+			Expression e)
+	{
+		var variableVisitor = new VariableExpressionVisitor (variables.Keys, Logger);
+		variableVisitor.Visit (e);
+
+		Console.WriteLine ($"# jonp: filling {variableVisitor.Variables.Count} variables");
+		for (int i = 0; i < variableVisitor.Variables.Count; ++i) {
+			var c = variableVisitor.Variables [i];
+			var d = new VariableDefinition (declaringAssembly.MainModule.ImportReference (c.Type));
+			declaringMethod.Body.Variables.Add (d);
+
+			VariableInfo v;
+
+			switch (i) {
+			case 0:
+				v = new VariableInfo (il => il.Emit (OpCodes.Ldloc_0),  il => il.Emit (OpCodes.Ldloca, 0),  il => il.Emit (OpCodes.Stloc_0));
+				break;
+			case 1:
+				v = new VariableInfo (il => il.Emit (OpCodes.Ldloc_1),  il => il.Emit (OpCodes.Ldloca, 1),  il => il.Emit (OpCodes.Stloc_1));
+				break;
+			case 2:
+				v = new VariableInfo (il => il.Emit (OpCodes.Ldloc_2),  il => il.Emit (OpCodes.Ldloca, 2),  il => il.Emit (OpCodes.Stloc_2));
+				break;
+			case 3:
+				v = new VariableInfo (il => il.Emit (OpCodes.Ldloc_3),  il => il.Emit (OpCodes.Ldloca, 3),  il => il.Emit (OpCodes.Stloc_3));
+				break;
+			default:
+				var x = i;
+				v = new VariableInfo (il => il.Emit (OpCodes.Ldloc, x),	il => il.Emit (OpCodes.Ldloca, x),  il => il.Emit (OpCodes.Stloc, x));
+				break;
+			}
+			variables [c] = v;
+			if (c == variableVisitor.ReturnValue) {
+				ReturnValue = v;
+			}
+			Console.WriteLine ($"# jonp: FillVariables: local var {c.Name} is index {i}");
+		}
+	}
+}
+
+class VariableExpressionVisitor : ExpressionVisitor {
+
+	public VariableExpressionVisitor (ICollection<ParameterExpression> arguments, Action<TraceLevel, string> logger)
+	{
+		Arguments   = arguments;
+		Logger      = logger;
+	}
+
+	ICollection<ParameterExpression>    Arguments;
+	Action<TraceLevel, string>          Logger;
+
+	public  List<ParameterExpression>       Variables        = new ();
+	public  ParameterExpression?            ReturnValue;
+
+	protected override Expression VisitGoto (
+			GotoExpression node)
+	{
+		Logger (TraceLevel.Verbose, $"# jonp: VariableExpressionVisitor.Goto: {node}; node.Kind={node.Kind}; node.Type={node.Type}");
+		if (node.Kind != GotoExpressionKind.Return) {
+			return base.VisitGoto (node);
+		}
+		if (ReturnValue != null) {
+			return base.VisitGoto (node);
+		}
+		Logger (TraceLevel.Verbose, $"# jonp: VariableExpressionVisitor.Goto: node.Target={node.Target} node.Value={node.Value}");
+		if (node.Value is ParameterExpression rv) {
+			ReturnValue    = rv;
+			return base.VisitGoto (node);
+		}
+		if (node.Type == typeof (void)) {
+			return base.VisitGoto (node);
+		}
+		var p = Expression.Parameter (node.Type, "__goto.Return.Temporary");
+		Variables.Add (p);
+		ReturnValue = p;
+		Logger (TraceLevel.Verbose, $"# jonp: VariableExpressionVisitor.Goto: setting ReturnValue={p}");
+		return base.VisitGoto (node);
+	}
+
+	protected override Expression VisitParameter (
+			ParameterExpression node)
+	{
+		if (!Arguments.Contains (node) && !Variables.Contains (node)) {
+			Variables.Add (node);
+		}
+		return node;
+	}
+}

--- a/src/Java.Interop.Tools.Expressions/Java.Interop.Tools.Expressions/ExpressionAssemblyBuilder.cs
+++ b/src/Java.Interop.Tools.Expressions/Java.Interop.Tools.Expressions/ExpressionAssemblyBuilder.cs
@@ -367,7 +367,7 @@ sealed class VariableDefinitions {
 		var variableVisitor = new VariableExpressionVisitor (variables.Keys, Logger);
 		variableVisitor.Visit (e);
 
-		Console.WriteLine ($"# jonp: filling {variableVisitor.Variables.Count} variables");
+		Logger (TraceLevel.Verbose, $"# jonp: filling {variableVisitor.Variables.Count} variables");
 		for (int i = 0; i < variableVisitor.Variables.Count; ++i) {
 			var c = variableVisitor.Variables [i];
 			var d = new VariableDefinition (declaringAssembly.MainModule.ImportReference (c.Type));
@@ -397,7 +397,7 @@ sealed class VariableDefinitions {
 			if (c == variableVisitor.ReturnValue) {
 				ReturnValue = v;
 			}
-			Console.WriteLine ($"# jonp: FillVariables: local var {c.Name} is index {i}");
+			Logger (TraceLevel.Verbose, $"# jonp: FillVariables: local var {c.Name} is index {i}");
 		}
 	}
 }

--- a/src/Java.Interop.Tools.Expressions/Java.Interop.Tools.Expressions/ExpressionMethodRegistration.cs
+++ b/src/Java.Interop.Tools.Expressions/Java.Interop.Tools.Expressions/ExpressionMethodRegistration.cs
@@ -1,0 +1,9 @@
+using System;
+
+using Mono.Cecil;
+
+namespace Java.Interop.Tools.Expressions;
+
+public record ExpressionMethodRegistration (string JniName, string JniSignature, MethodDefinition MarshalMethodDefinition)
+{
+}

--- a/tests/Java.Interop.Tools.Expressions-Tests/Java.Interop.Tools.Expressions-Tests.csproj
+++ b/tests/Java.Interop.Tools.Expressions-Tests/Java.Interop.Tools.Expressions-Tests.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DotNetTargetFramework)</TargetFramework>
+    <RootNamespace>Java.Interop.Tools.ExpressionsTests</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\TargetFrameworkDependentValues.props" />
+
+  <PropertyGroup>
+    <OutputPath>$(TestOutputFullPath)</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+  </ItemGroup>
+
+  <!--
+  <Import Project="..\..\build-tools\scripts\cecil.projitems" />
+  -->
+  <ItemGroup>
+    <PackageReference Include="Mono.Cecil" Version="0.11.4" />
+    <PackageReference Include="Mono.Linq.Expressions" />
+  </ItemGroup>
+
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Java.Interop.Tools.Expressions\Java.Interop.Tools.Expressions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Java.Interop.Tools.Expressions-Tests/Java.Interop.Tools.ExpressionsTests/ExpressionAssemblyBuilderTests.cs
+++ b/tests/Java.Interop.Tools.Expressions-Tests/Java.Interop.Tools.ExpressionsTests/ExpressionAssemblyBuilderTests.cs
@@ -1,0 +1,444 @@
+namespace Java.Interop.Tools.ExpressionsTests;
+
+using System.IO;
+using System.Linq.Expressions;
+using System.Text;
+
+using Java.Interop.Tools.Diagnostics;
+using Java.Interop.Tools.Expressions;
+
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+using Mono.Linq.Expressions;
+
+[TestFixture]
+public class ExpressionAssemblyBuilderTests
+{
+	static  readonly    string      AssemblyModuleBaseName;
+
+	static ExpressionAssemblyBuilderTests ()
+	{
+		AssemblyModuleBaseName  = typeof (ExpressionAssemblyBuilderTests).Assembly.GetName ().Name +
+			"-" +
+			nameof (ExpressionAssemblyBuilderTests);
+	}
+
+	ExpressionAssemblyBuilder?      ExpressionAssemblyBuilder;
+	AssemblyDefinition?             AssemblyDefinition;
+	TypeDefinition?                 TypeDefinition;
+
+	[OneTimeSetUp]
+	public void InitializeTestEnvironment ()
+	{
+		var moduleParams   = new ModuleParameters {
+			Kind                            = ModuleKind.Dll,
+		};
+		AssemblyDefinition = AssemblyDefinition.CreateAssembly (
+				assemblyName:   new AssemblyNameDefinition (AssemblyModuleBaseName, new Version (0, 0, 0, 0)),
+				moduleName:     AssemblyModuleBaseName + ".dll",
+				parameters:     moduleParams
+		);
+		TypeDefinition     = new TypeDefinition (
+				@namespace: "Example",
+				name:       "Output",
+				attributes: TypeAttributes.Public | TypeAttributes.Sealed
+		);
+		TypeDefinition.BaseType     = AssemblyDefinition.MainModule.ImportReference (typeof (object));
+		AssemblyDefinition.MainModule.Types.Add (TypeDefinition);
+
+		ExpressionAssemblyBuilder   = new ExpressionAssemblyBuilder (AssemblyDefinition) {
+			KeepTemporaryFiles  = true,
+		};
+	}
+
+	[OneTimeTearDown]
+	public void TearDownTestEnvironment ()
+	{
+		var path = Path.GetDirectoryName (typeof (ExpressionAssemblyBuilderTests).Assembly.Location)
+			?? throw new InvalidOperationException ("`typeof (ExpressionAssemblyBuilderTests).Assembly.Location` is null?!");
+		ExpressionAssemblyBuilder!.Write (Path.Combine (path, AssemblyModuleBaseName + ".dll"));
+	}
+
+	void AddMethod (MethodDefinition method, [System.Runtime.CompilerServices.CallerMemberName] string methodName = "")
+	{
+		method.Name     = methodName;
+		method.IsPublic = true;
+		TypeDefinition!.Methods.Add (method);
+	}
+
+	[Test]
+	public void CreateMarshalMethodDelegateType ()
+	{
+		var t = ExpressionAssemblyBuilder!.CreateMarshalMethodDelegateType (
+				"_Jonp_Demo",
+				new [] {
+					new ParameterDefinition ("jnienv",  default,    AssemblyDefinition!.MainModule.TypeSystem.IntPtr),
+					new ParameterDefinition ("klass",   default,    AssemblyDefinition!.MainModule.TypeSystem.IntPtr),
+					new ParameterDefinition ("value",   default,    AssemblyDefinition!.MainModule.TypeSystem.Int32),
+				},
+				AssemblyDefinition.MainModule.TypeSystem.IntPtr
+		);
+		AssemblyDefinition.MainModule.Types.Add (t);
+	}
+
+	[Test]
+	public void Compile_MethodCall ()
+	{
+		Expression<Action> e = () => Console.WriteLine ("constant");
+		var m = ExpressionAssemblyBuilder!.Compile (e);
+
+		AddMethod (m);
+
+		var expected = new[]{
+			"Instruction_0000: ldstr \"constant\"",
+			"Instruction_0001: call System.Void System.Console::WriteLine(System.String)",
+			"Instruction_0002: ret",
+		};
+		var actual = m.Body.Instructions;
+		Assert.AreEqual (expected.Length, actual.Count);
+		for (int i = 0; i < expected.Length; ++i) {
+			Assert.AreEqual (expected [i], GetDescription (actual, i));
+		}
+	}
+
+	[Test]
+	public void Compile_Condition_1 ()
+	{
+		Expression<Func<int, int, bool>> e = (a, b) => a == b;
+		var m = ExpressionAssemblyBuilder!.Compile (e);
+
+		AddMethod (m);
+
+		var expected = new[]{
+			"Instruction_0000: ldarg.0",
+			"Instruction_0001: ldarg.1",
+			"Instruction_0002: ceq",
+			"Instruction_0003: ret",
+		};
+		var actual = m.Body.Instructions;
+		Assert.AreEqual (expected.Length, actual.Count);
+		for (int i = 0; i < expected.Length; ++i) {
+			Assert.AreEqual (expected [i], GetDescription (actual, i));
+		}
+	}
+
+	[Test]
+	public void Compile_Condition_2 ()
+	{
+		Expression<Func<int, int, int>> e = (a, b) => a == b ? 1 : 2;
+		var m = ExpressionAssemblyBuilder!.Compile (e);
+
+		AddMethod (m);
+
+		// Alas, branch targets d
+		var expected = new[]{
+			"Instruction_0000: ldarg.0",
+			"Instruction_0001: ldarg.1",
+			"Instruction_0002: ceq",
+			"Instruction_0003: brfalse Instruction_0006",
+			"Instruction_0004: ldc.i4 1",
+			"Instruction_0005: br Instruction_0008",
+			"Instruction_0006: nop",
+			"Instruction_0007: ldc.i4 2",
+			"Instruction_0008: nop",
+			"Instruction_0009: ret",
+		};
+		var actual = m.Body.Instructions;
+		Assert.AreEqual (expected.Length, actual.Count);
+		for (int i = 0; i < expected.Length; ++i) {
+			Assert.AreEqual (expected [i], GetDescription (actual, i));
+		}
+	}
+
+	[Test]
+	public void Compile_TryCatchFinally ()
+	{
+		var exit        = Expression.Label (typeof (int), "__exit");
+		var tryBlock    = Expression.Block (typeof (int),
+				E<Action>(() => Console.WriteLine ("try")).Body,
+				Expression.Return (target: exit, value: Expression.Constant (1), type: typeof (int))
+		);
+		var finallyBlock = E<Action>(() => Console.WriteLine ("finally")).Body;
+		var catchLog0   = E<Action<Exception>>(e => Console.WriteLine ("filtered"));
+		var catchFilt0  = Expression.Equal (
+			Expression.Constant (null, typeof (Exception)),
+			Expression.Property (catchLog0.Parameters [0], "InnerException"));
+		var catchBlock0 = Expression.Block (typeof (int),
+				catchLog0.Body,
+				Expression.Return (target: exit, value: Expression.Constant (3), type: typeof (int))
+		);
+		var catchLog1   = E<Action<Exception>>(e => Console.WriteLine (e.ToString ()));
+		var catchBlock1 = Expression.Block (typeof (int),
+				catchLog1.Body,
+				Expression.Return (target: exit, value: Expression.Constant (4), type: typeof (int))
+		);
+		var block = new List<Expression> {
+			Expression.TryCatchFinally (
+				body:       tryBlock,
+				@finally:   finallyBlock,
+				handlers:   new[]{
+					Expression.Catch (catchLog0.Parameters[0], catchBlock0, catchFilt0),
+					Expression.Catch (catchLog1.Parameters[0], catchBlock1),
+				}
+			),
+			Expression.Label (exit, Expression.Default (typeof (int))),
+		};
+		var e = Expression.Lambda (
+				delegateType:   typeof (Func<int>),
+				body:           Expression.Block (variables: Array.Empty<ParameterExpression>(), expressions: block),
+				name:           nameof (Compile_TryCatchFinally),
+				tailCall:       false,
+				parameters:     Array.Empty<ParameterExpression>()
+		);
+
+		Assert.AreEqual (1, ((Func<int>) e.Compile ())());
+
+		var expectedCsharp = @"int Compile_TryCatchFinally()
+{
+	try
+	{
+		Console.WriteLine(""try"");
+		return 1;
+	}
+	catch (Exception e) if (null == e.InnerException)
+	{
+		Console.WriteLine(""filtered"");
+		return 3;
+	}
+	catch (Exception e)
+	{
+		Console.WriteLine(e.ToString());
+		return 4;
+	}
+	finally
+	{
+		Console.WriteLine(""finally"");
+	}
+}";
+		Console.WriteLine ($"# jonp: expression tree as C#:");
+		Console.WriteLine (e.ToCSharpCode ());
+		Assert.AreEqual (expectedCsharp, e.ToCSharpCode ());
+
+		var m = ExpressionAssemblyBuilder!.Compile (e);
+
+		AddMethod (m);
+		DumpInstructions (m);
+
+		// Alas, branch targets d
+		var expected = new[]{
+		// .try
+			"Instruction_0000: ldstr \"try\"",
+			"Instruction_0001: call System.Void System.Console::WriteLine(System.String)",
+			"Instruction_0002: ldc.i4 1",
+			"Instruction_0003: stloc.0",
+			"Instruction_0004: leave Instruction_0025",
+		// }
+		// filter {
+			"Instruction_0005: isinst System.Exception",
+			"Instruction_0006: dup",
+			"Instruction_0007: brtrue.s Instruction_000b",
+			"Instruction_0008: pop",
+			"Instruction_0009: ldc.i4.0",
+			"Instruction_000a: br.s Instruction_0012",
+			"Instruction_000b: stloc.1",
+			"Instruction_000c: ldnull",
+			"Instruction_000d: ldloc.1",
+			"Instruction_000e: callvirt System.Exception System.Exception::get_InnerException()",
+			"Instruction_000f: ceq",
+			"Instruction_0010: ldc.i4.0",
+			"Instruction_0011: cgt.un",
+			"Instruction_0012: endfilter",
+		// }
+		// { // handler
+			"Instruction_0013: castclass System.Exception",
+			"Instruction_0014: stloc.1",
+			"Instruction_0015: ldstr \"filtered\"",
+			"Instruction_0016: call System.Void System.Console::WriteLine(System.String)",
+			"Instruction_0017: ldc.i4 3",
+			"Instruction_0018: stloc.0",
+			"Instruction_0019: leave Instruction_0025",
+		// }
+		// catch class System.Exception {
+			"Instruction_001a: castclass System.Exception",
+			"Instruction_001b: stloc.2",
+			"Instruction_001c: ldloc.2",
+			"Instruction_001d: callvirt System.String System.Object::ToString()",
+			"Instruction_001e: call System.Void System.Console::WriteLine(System.String)",
+			"Instruction_001f: ldc.i4 4",
+			"Instruction_0020: stloc.0",
+			"Instruction_0021: leave Instruction_0025",
+		// }
+		// finally {
+			"Instruction_0022: ldstr \"finally\"",
+			"Instruction_0023: call System.Void System.Console::WriteLine(System.String)",
+			"Instruction_0024: endfinally",
+		// }
+			"Instruction_0025: nop",
+			"Instruction_0026: nop",
+			"Instruction_0027: ldloc.0",
+			"Instruction_0028: ret",
+		};
+		var actual = m.Body.Instructions;
+		Assert.AreEqual (expected.Length, actual.Count);
+		for (int i = 0; i < expected.Length; ++i) {
+			Assert.AreEqual (expected [i], GetDescription (actual, i));
+		}
+	}
+
+	static Expression<TDelegate> E<TDelegate>(Expression<TDelegate> e)
+		where TDelegate : Delegate
+	{
+		return e;
+	}
+
+
+	static void DumpInstructions (MethodDefinition method)
+	{
+		var body = method.Body;
+		var instructions = body.Instructions;
+		if (body.HasExceptionHandlers) {
+			foreach (var h in method.Body.ExceptionHandlers) {
+				Console.Error.WriteLine ($"// Handler: {h.HandlerType}");
+				Console.Error.WriteLine( $"// \t" +
+					$"  CatchType=`{h.CatchType}`");
+				Console.Error.WriteLine ($"// \t" +
+					$"  TryStart=`{GetDescription (body.Instructions, body.Instructions.IndexOf (h.TryStart))}` TryEnd=`{GetDescription (body.Instructions, body.Instructions.IndexOf (h.TryEnd))}`");
+				Console.Error.WriteLine ($"// \t" +
+					$"  FilterStart=`{GetDescription (body.Instructions, body.Instructions.IndexOf (h.FilterStart))}`");
+				Console.Error.WriteLine ($"// \t" +
+					$"  HandlerStart=`{GetDescription (body.Instructions, body.Instructions.IndexOf (h.HandlerStart))}` HandlerEnd=`{GetDescription (body.Instructions, body.Instructions.IndexOf (h.HandlerEnd))}`");
+				Console.Error.WriteLine($"");
+			}
+		}
+		int indent = 0;
+		for (int i = 0; i < instructions.Count; ++i) {
+			var instruction = instructions [i];
+			DumpStartHandler (ref indent, body, instructions, i);
+			Console.Error.WriteLine ("{0}{1,-40}\t; {2}",
+					new string (' ', indent*2),
+					GetDescription (instructions, i),
+					instructions[i].ToString ());
+			DumpEndHandler (ref indent, body, instructions, i);
+		}
+	}
+
+	static void DumpStartHandler (ref int indent, MethodBody body, Mono.Collections.Generic.Collection<Instruction> instructions, int i)
+	{
+		var instruction = instructions [i];
+		if (!body.HasExceptionHandlers) {
+			return;
+		}
+		if (body.ExceptionHandlers.Any (e => e.TryStart == instruction)) {
+			Console.Error.WriteLine ($"{new string (' ', indent*2)}.try {{");
+			indent++;
+			return;
+		}
+		var f = body.ExceptionHandlers.FirstOrDefault (e => e.FilterStart == instruction);
+		if (f != null) {
+			Console.Error.WriteLine ($"{new string(' ', indent*2)}filter {{");
+			indent++;
+			return;
+
+		}
+		var h = body.ExceptionHandlers.FirstOrDefault (e => e.HandlerStart == instruction);
+		if (h != null) {
+			switch (h.HandlerType) {
+			case ExceptionHandlerType.Finally:
+				Console.Error.WriteLine ($"{new string (' ', indent*2)}finally {{");
+				break;
+			case ExceptionHandlerType.Catch:
+				Console.Error.WriteLine ($"{new string (' ', indent*2)}catch class {h.CatchType.FullName} {{");
+				break;
+			case ExceptionHandlerType.Filter:
+				Console.Error.WriteLine ($"{new string(' ', indent * 2)}{{ // handler");
+				break;
+			case ExceptionHandlerType.Fault:
+			default:
+				Console.Error.WriteLine ($"{new string (' ', indent*2)}{h.HandlerType} {{");
+				break;
+			}
+			indent++;
+			return;
+		}
+	}
+
+	static void DumpEndHandler (ref int indent, MethodBody body, Mono.Collections.Generic.Collection<Instruction> instructions, int i)
+	{
+		if (!body.HasExceptionHandlers) {
+			return;
+		}
+		if ((i + 1) >= instructions.Count) {
+			// End of instruction stream; clean up indentatino
+			if (indent == 0)
+				return;
+			indent--;
+			Console.Error.WriteLine ($"{new string (' ', indent)}}}");
+			return;
+		}
+		// Handler range is from first label ***prior to*** second (emphasis @jonpryor)
+		// Thus, look at *next* instruction.
+		var instruction = instructions[i+1];
+		if (body.ExceptionHandlers.Any (e => e.TryStart == instruction || e.FilterStart == instruction || e.HandlerStart == instruction ||
+				e.TryEnd == instruction || e.HandlerEnd== instruction)) {
+			indent--;
+			Console.Error.WriteLine ($"{new string (' ', indent)}}}");
+		}
+	}
+
+	// Cribbed with changes from `Instruction.ToString()`:
+	// https://github.com/dotnet/cecil/blob/e069cd8d25d5b61b0e28fe65e75959c20af7aa80/Mono.Cecil.Cil/Instruction.cs#L95-L134
+	//
+	// Don't want to use `Instruction.ToString()` as `Instruction.Offset` isn't updated until after
+	// `AssemblyDefinition.Write()`, and checking for `brfalse IL_0000` is not helpful.
+	static string GetDescription (IList<Instruction> instructions, int index)
+	{
+		if (index < 0) {
+			return "";
+		}
+		var instruction = instructions [index];
+		var description = new StringBuilder ();
+
+		AppendLabel (index)
+			.Append (": ")
+			.Append (instruction.OpCode.Name);
+
+		if (instruction.Operand == null) {
+			return description.ToString ();
+		}
+
+		description.Append (" ");
+
+		switch (instruction.OpCode.OperandType) {
+		case OperandType.ShortInlineBrTarget:
+		case OperandType.InlineBrTarget:
+			AppendLabel (instructions.IndexOf ((Instruction) instruction.Operand));
+			break;
+		case OperandType.InlineSwitch:
+			var labels = (Instruction []) instruction.Operand;
+			for (int i = 0; i < labels.Length; i++) {
+				if (i > 0)
+					description.Append (',');
+
+				AppendLabel (instructions.IndexOf (labels [i]));
+			}
+			break;
+		case OperandType.InlineString:
+			description.Append ('\"');
+			description.Append (instruction.Operand);
+			description.Append ('\"');
+			break;
+		default:
+			description.Append (instruction.Operand);
+			break;
+		}
+
+		return description.ToString ();
+
+		StringBuilder AppendLabel (int i)
+		{
+			return description.Append ("Instruction_")
+				.AppendFormat ("{0:x4}", i);
+		}
+	}
+}

--- a/tests/Java.Interop.Tools.Expressions-Tests/Usings.cs
+++ b/tests/Java.Interop.Tools.Expressions-Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using NUnit.Framework;

--- a/tools/jnimarshalmethod-gen/Xamarin.Android.Tools.JniMarshalMethodGenerator.csproj
+++ b/tools/jnimarshalmethod-gen/Xamarin.Android.Tools.JniMarshalMethodGenerator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>$(DotNetTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>8.0</LangVersion>
     <AssemblyName>jnimarshalmethod-gen</AssemblyName>
@@ -13,6 +13,7 @@
 
   <PropertyGroup>
     <OutputPath>$(UtilityOutputFullPath)</OutputPath>
+    <_DumpRegisterNativeMembers>True</_DumpRegisterNativeMembers>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(_DumpRegisterNativeMembers)' == 'True' ">
@@ -35,6 +36,7 @@
     <ProjectReference Include="..\..\src\Java.Interop\Java.Interop.csproj" />
     <ProjectReference Include="..\..\src\Java.Runtime.Environment\Java.Runtime.Environment.csproj" />
     <ProjectReference Include="..\..\src\Java.Interop.Tools.Cecil\Java.Interop.Tools.Cecil.csproj" />
+    <ProjectReference Include="..\..\src\Java.Interop.Tools.Expressions\Java.Interop.Tools.Expressions.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes: https://github.com/xamarin/java.interop/issues/616

Context: https://github.com/xamarin/java.interop/issues/14
Context: ff4053cb1e966ebec1c16f97211b9ded936f2707
Context: da5d1b8103bb90f156b93ebac9caa16cfc85764e
Context: 4787e0179b349ab5ee0d0dd03d08b694acea4971
Context: 41ba34856ab119ea6e22ab103320180143fdf03d

Remember `jnimarshalmethod-gen` (176240d2)?  And it's crazy idea to
use the `System.Linq.Expressions`-based custom marshaling
infrastructure (ff4053cb, da5d1b81) to generate JNI marshal methods
at build/packaging time.  And how we had to back burner it because
it depended upon `System.Reflection.Emit` being able to write
assemblies to disk, which is a feature that never made it to
.NET Core, and is still lacking as of .NET 7?

Add `src/Java.Interop.Tools.Expressions`, which contains code which
uses Mono.Cecil to compile `Expression<T>` expressions to IL.

Then update `jnimarshalmethod-gen` to use it!

~~ Usage ~~

	% dotnet bin/Debug-net7.0/jnimarshalmethod-gen.dll \
	  bin/TestDebug-net7.0/Java.Interop.Export-Tests.dll \
	  -v -v --keeptemp \
	  --jvm /Library/Java/JavaVirtualMachines/microsoft-11.jdk/Contents/Home/lib/jli/libjli.dylib \
	  -o _x \
	  -L bin/TestDebug-net7.0 \
	  -L /usr/local/share/dotnet/shared/Microsoft.NETCore.App/7.0.0

First param is assembly to process; `Java.Interop.Export-Tests.dll`
is handy because that's what the `run-test-jnimarshal` target in
`Makefile` processed.

  * `-v -v` is *really* verbose output

  * `--keeptemp` is keep temporary files, in this case
    `_x/Java.Interop.Export-Tests.dll.cecil`.

  * `--jvm PATH` is the path to the JVM library to load+use.

  * `-o DIR` is where to place output files; this will create
    `_x/Java.Interop.Export-Tests.dll`.

  * `-L DIR` adds `DIR` to library resolution paths; this adds
    `bin/TestDebug/net7.0` (dependencies of
    `Java.Interop.Export-Tests.dll`) and
    `Microsoft.NETCore.App/7.0.0-rc.1.22422.12` (net7 libs).

By default the directories containing input assemblies and the
directory containing `System.Private.CoreLib.dll` are part of the
default `-L` list.

When running in-tree, e.g. AzDO pipeline execution, `--jvm PATH`
will attempt to read the path in `bin/Build*/JdkInfo.props`
a'la `TestJVM` (002dea4a).  This allows an in-place update in
`core-tests.yaml` which does:

	dotnet bin/Debug-net7.0/jnimarshalmethod-gen.dll \
	  bin/TestDebug-net7.0/Java.Interop.Export-Tests.dll \
	  -v -v --keeptemp -o bin/TestDebug-net7.0

~~ Using `jnimarshalmethod-gen` output ~~

What does `jnimarshalmethod-gen` *do*?

	% ikdasm bin/TestDebug-net7.0/Java.Interop.Export-Tests.dll > beg.il
	% ikdasm _x/Java.Interop.Export-Tests.dll > end.il
	% git diff --no-index beg.il end.il
	# https://gist.github.com/jonpryor/b8233444f2e51043732bea922f6afc81

is a ~1KB diff which shows, paraphrasing greatly:

	public partial class ExportTest {
	    partial class '__<$>_jni_marshal_methods' {
	        static IntPtr funcIJavaObject (IntPtr jnienv, IntPtr this) => …
	        // …
	        [JniAddNativeMethodRegistration]
	        static void __RegisterNativeMembers (JniNativeMethodRegistrationArguments args) => …
	    }
	}
	internal delegate long _JniMarshal_PP_L (IntPtr jnienv, IntPtr self);
	// …

wherein `ExportTest._<$>_jni_marshal_methods` and the `_JniMarshal*`
delegate types are added to the assembly.

This also unblocks the desire stated in 4787e017:

> For `Java.Base`, @jonpryor wants to support the custom marshaling
> infrastructure introduced in 77a6bf86.  This would allow types to
> participate in JNI marshal method ("connector method") generation
> *at runtime*, allowing specialization based on the current set of
> types and assemblies.

What can we do with this `jnimarshalmethod-gen` output?  Use it!

First, make sure the tests work:

	% dotnet test --logger "console;verbosity=detailed" bin/TestDebug-net7.0/Java.Interop.Export-Tests.dll
	…
	Passed!  - Failed:     0, Passed:    17, Skipped:     0, Total:    17, Duration: 103 ms - Java.Interop.Export-Tests.dll (net7.0)

Then update/replace the unit test assembly with
`jnimarshalmethod-gen` output:

	% \cp _x/Java.Interop.Export-Tests.dll bin/TestDebug-net7.0
	% dotnet test --logger "console;verbosity=detailed" bin/TestDebug-net7.0/Java.Interop.Export-Tests.dll
	…
	Total tests: 17
	     Passed: 17

`core-tests.yaml` has been updated to do this.

~~ One-Off Tests ~~

One-off tests: ensure that the generated assembly can be decompiled:

	% ikdasm  bin/TestDebug-net7.0/Java.Interop.Tools.Expressions-Tests-ExpressionAssemblyBuilderTests.dll
	% monodis bin/TestDebug-net7.0/Java.Interop.Tools.Expressions-Tests-ExpressionAssemblyBuilderTests.dll

	% ikdasm  _x/Java.Interop.Export-Tests.dll
	% monodis _x/Java.Interop.Export-Tests.dll
	# which currently fails :-()

Re-enable most of `Java.Interop.Export-Tests.dll` for .NET 7;
see 41ba3485, which disabled those tests.

To verify the generated IL, use the [dotnet-ilverify][0] tool:

	dotnet tool install --global dotnet-ilverify

Usage of which is "weird":

	$HOME/.dotnet/tools/ilverify _x/Java.Interop.Export-Tests.dll \
	  --tokens --system-module System.Private.CoreLib \
	  -r 'bin/TestDebug-net7.0/*.dll' \
	  -r '/usr/local/share/dotnet/shared/Microsoft.NETCore.App/7.0.0/*.dll'
	All Classes and Methods in /Volumes/Xamarin-Work/src/xamarin/Java.Interop/_x/Java.Interop.Export-Tests.dll Verified.
	# no errors!

where:

  * `--tokens`: Include metadata tokens in error messages.
  * `--system-module NAME`: set the "System module name".  Defaults
    to `mscorlib`, which is wrong for .NET 5+, so this must be set to
    `System.Private.CoreLib` (no `.dll` suffix!).
  * `-r FILE-GLOB`: Where to resolve assembly references for the
    input assembly.  Fortunately file globs are supported…

~~ Removing `System.Private.CoreLib` ~~

`System.Private.CoreLib.dll` is *private*; it's not part of the
public assembly surface area, so you can't use
`csc -r:System.Private.CoreLib …` and expect it to work.  This makes
things interesting because *at runtime* everything "important" is in
`System.Private.CoreLib.dll`, like `System.Object`.

Specifically, if we do the "obvious" thing and do:

	newTypeDefinition.BaseType = assemblyDefinition.MainModule
	    .ImportReference (typeof (object));

you're gonna have a bad type, because the resulting IL for
`newTypeDefinition` will have a base class of
`[System.Private.CoreLib]System.Object`, which isn't usable.

Fix this by:

 1. Writing the assembly to a `Stream`.
 2. Reading the `Stream` from (1)
 3. Fixing all member references and assembly references so that
    `System.Private.CoreLib` is not referenced.

If `jnimarshalmethod-gen.dll --keeptemp` is used, then a `.cecil`
file is created with the contents of (1).

Additionally, and unexpectedly -- [jbevain/cecil#895][1] -- Mono.Cecil
adds a reference to the assembly being modified.  Remove the declaring
assembly from `AssemblyReferences`.

[0]: https://www.nuget.org/packages/dotnet-ilverify
[1]: https://github.com/jbevain/cecil/issues/895
