### PR TITLE
[generator] Avoid C#11 delegate cache overhead.

### DIFF
--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteDuplicateInterfaceEventArgs.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteDuplicateInterfaceEventArgs.txt
@@ -71,7 +71,7 @@ internal partial class AnimatorListenerInvoker : global::Java.Lang.Object, Anima
 	static Delegate GetOnAnimationEnd_IHandler ()
 	{
 		if (cb_OnAnimationEnd_I == null)
-			cb_OnAnimationEnd_I = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPI_Z) n_OnAnimationEnd_I);
+			cb_OnAnimationEnd_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_Z (n_OnAnimationEnd_I));
 		return cb_OnAnimationEnd_I;
 	}
 
@@ -97,7 +97,7 @@ internal partial class AnimatorListenerInvoker : global::Java.Lang.Object, Anima
 	static Delegate GetOnAnimationEnd_IIHandler ()
 	{
 		if (cb_OnAnimationEnd_II == null)
-			cb_OnAnimationEnd_II = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPII_Z) n_OnAnimationEnd_II);
+			cb_OnAnimationEnd_II = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPII_Z (n_OnAnimationEnd_II));
 		return cb_OnAnimationEnd_II;
 	}
 

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteInterfaceRedeclaredDefaultMethod.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteInterfaceRedeclaredDefaultMethod.txt
@@ -4,42 +4,49 @@ public partial interface IMyInterface2 : java.code.IMyInterface {
 	// Metadata.xml XPath method reference: path="/api/package[@name='java.code']/interface[@name='IMyInterface']/method[@name='DoSomething' and count(parameter)=0]"
 	[Register ("DoSomething", "()V", "GetDoSomethingHandler:java.code.IMyInterface2Invoker, MyAssembly")]
 	void DoSomething ();
-	
+
 }
+
 [global::Android.Runtime.Register ("java/code/IMyInterface2", DoNotGenerateAcw=true)]
 internal partial class IMyInterface2Invoker : global::Java.Lang.Object, IMyInterface2 {
-	static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/IMyInterface2", typeof (IMyInterface2Invoker));
-	
+	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface2", typeof (IMyInterface2Invoker));
+
 	static IntPtr java_class_ref {
 		get { return _members.JniPeerType.PeerReference.Handle; }
 	}
-	
+
+	[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
+	[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 	public override global::Java.Interop.JniPeerMembers JniPeerMembers {
 		get { return _members; }
 	}
-	
+
+	[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
+	[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 	protected override IntPtr ThresholdClass {
 		get { return class_ref; }
 	}
-	
+
+	[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]
+	[global::System.ComponentModel.EditorBrowsable (global::System.ComponentModel.EditorBrowsableState.Never)]
 	protected override global::System.Type ThresholdType {
 		get { return _members.ManagedPeerType; }
 	}
-	
+
 	IntPtr class_ref;
-	
+
 	public static IMyInterface2 GetObject (IntPtr handle, JniHandleOwnership transfer)
 	{
 		return global::Java.Lang.Object.GetObject<IMyInterface2> (handle, transfer);
 	}
-	
+
 	static IntPtr Validate (IntPtr handle)
 	{
 		if (!JNIEnv.IsInstanceOf (handle, java_class_ref))
-			throw new InvalidCastException (string.Format ("Unable to convert instance of type '{0}' to type '{1}'.", JNIEnv.GetClassNameFromInstance (handle), "java.code.IMyInterface2"));
+			throw new InvalidCastException ($"Unable to convert instance of type '{JNIEnv.GetClassNameFromInstance (handle)}' to type 'java.code.IMyInterface2'.");
 		return handle;
 	}
-	
+
 	protected override void Dispose (bool disposing)
 	{
 		if (this.class_ref != IntPtr.Zero)
@@ -47,28 +54,30 @@ internal partial class IMyInterface2Invoker : global::Java.Lang.Object, IMyInter
 		this.class_ref = IntPtr.Zero;
 		base.Dispose (disposing);
 	}
-	
+
 	public IMyInterface2Invoker (IntPtr handle, JniHandleOwnership transfer) : base (Validate (handle), transfer)
 	{
 		IntPtr local_ref = JNIEnv.GetObjectClass (((global::Java.Lang.Object) this).Handle);
 		this.class_ref = JNIEnv.NewGlobalRef (local_ref);
 		JNIEnv.DeleteLocalRef (local_ref);
 	}
-	
+
 	static Delegate cb_DoSomething;
-	#pragma warning disable 0169
+#pragma warning disable 0169
 	static Delegate GetDoSomethingHandler ()
 	{
 		if (cb_DoSomething == null)
-			cb_DoSomething = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_V) n_DoSomething);
+			cb_DoSomething = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_DoSomething));
 		return cb_DoSomething;
 	}
+
 	static void n_DoSomething (IntPtr jnienv, IntPtr native__this)
 	{
 		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 		__this.DoSomething ();
 	}
-	#pragma warning restore 0169
+#pragma warning restore 0169
+
 	IntPtr id_DoSomething;
 	public unsafe void DoSomething ()
 	{
@@ -76,5 +85,5 @@ internal partial class IMyInterface2Invoker : global::Java.Lang.Object, IMyInter
 			id_DoSomething = JNIEnv.GetMethodID (class_ref, "DoSomething", "()V");
 		JNIEnv.CallVoidMethod (((global::Java.Lang.Object) this).Handle, id_DoSomething);
 	}
-	
+
 }

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteClass.txt
@@ -54,7 +54,7 @@ public partial class MyClass {
 	static Delegate Getget_CountHandler ()
 	{
 		if (cb_get_Count == null)
-			cb_get_Count = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_I) n_get_Count);
+			cb_get_Count = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_Count));
 		return cb_get_Count;
 	}
 
@@ -70,7 +70,7 @@ public partial class MyClass {
 	static Delegate Getset_Count_IHandler ()
 	{
 		if (cb_set_Count_I == null)
-			cb_set_Count_I = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPI_V) n_set_Count_I);
+			cb_set_Count_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_set_Count_I));
 		return cb_set_Count_I;
 	}
 
@@ -110,7 +110,7 @@ public partial class MyClass {
 	static Delegate Getget_KeyHandler ()
 	{
 		if (cb_get_Key == null)
-			cb_get_Key = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_L) n_get_Key);
+			cb_get_Key = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_get_Key));
 		return cb_get_Key;
 	}
 
@@ -126,7 +126,7 @@ public partial class MyClass {
 	static Delegate Getset_Key_Ljava_lang_String_Handler ()
 	{
 		if (cb_set_Key_Ljava_lang_String_ == null)
-			cb_set_Key_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_V) n_set_Key_Ljava_lang_String_);
+			cb_set_Key_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_set_Key_Ljava_lang_String_));
 		return cb_set_Key_Ljava_lang_String_;
 	}
 
@@ -193,7 +193,7 @@ public partial class MyClass {
 	static Delegate Getget_AbstractCountHandler ()
 	{
 		if (cb_get_AbstractCount == null)
-			cb_get_AbstractCount = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_I) n_get_AbstractCount);
+			cb_get_AbstractCount = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_AbstractCount));
 		return cb_get_AbstractCount;
 	}
 
@@ -209,7 +209,7 @@ public partial class MyClass {
 	static Delegate Getset_AbstractCount_IHandler ()
 	{
 		if (cb_set_AbstractCount_I == null)
-			cb_set_AbstractCount_I = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPI_V) n_set_AbstractCount_I);
+			cb_set_AbstractCount_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_set_AbstractCount_I));
 		return cb_set_AbstractCount_I;
 	}
 
@@ -235,7 +235,7 @@ public partial class MyClass {
 	static Delegate GetGetCountForKey_Ljava_lang_String_Handler ()
 	{
 		if (cb_GetCountForKey_Ljava_lang_String_ == null)
-			cb_GetCountForKey_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_I) n_GetCountForKey_Ljava_lang_String_);
+			cb_GetCountForKey_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetCountForKey_Ljava_lang_String_));
 		return cb_GetCountForKey_Ljava_lang_String_;
 	}
 
@@ -269,7 +269,7 @@ public partial class MyClass {
 	static Delegate GetKeyHandler ()
 	{
 		if (cb_Key == null)
-			cb_Key = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_L) n_Key);
+			cb_Key = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_Key));
 		return cb_Key;
 	}
 
@@ -308,7 +308,7 @@ public partial class MyClass {
 	static Delegate GetAbstractMethodHandler ()
 	{
 		if (cb_AbstractMethod == null)
-			cb_AbstractMethod = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_V) n_AbstractMethod);
+			cb_AbstractMethod = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_AbstractMethod));
 		return cb_AbstractMethod;
 	}
 

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteInterface.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteInterface.txt
@@ -135,7 +135,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static Delegate Getget_CountHandler ()
 	{
 		if (cb_get_Count == null)
-			cb_get_Count = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_I) n_get_Count);
+			cb_get_Count = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_Count));
 		return cb_get_Count;
 	}
 
@@ -151,7 +151,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static Delegate Getset_Count_IHandler ()
 	{
 		if (cb_set_Count_I == null)
-			cb_set_Count_I = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPI_V) n_set_Count_I);
+			cb_set_Count_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_set_Count_I));
 		return cb_set_Count_I;
 	}
 
@@ -184,7 +184,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static Delegate Getget_KeyHandler ()
 	{
 		if (cb_get_Key == null)
-			cb_get_Key = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_L) n_get_Key);
+			cb_get_Key = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_get_Key));
 		return cb_get_Key;
 	}
 
@@ -200,7 +200,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static Delegate Getset_Key_Ljava_lang_String_Handler ()
 	{
 		if (cb_set_Key_Ljava_lang_String_ == null)
-			cb_set_Key_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_V) n_set_Key_Ljava_lang_String_);
+			cb_set_Key_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_set_Key_Ljava_lang_String_));
 		return cb_set_Key_Ljava_lang_String_;
 	}
 
@@ -236,7 +236,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static Delegate Getget_AbstractCountHandler ()
 	{
 		if (cb_get_AbstractCount == null)
-			cb_get_AbstractCount = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_I) n_get_AbstractCount);
+			cb_get_AbstractCount = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_AbstractCount));
 		return cb_get_AbstractCount;
 	}
 
@@ -252,7 +252,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static Delegate Getset_AbstractCount_IHandler ()
 	{
 		if (cb_set_AbstractCount_I == null)
-			cb_set_AbstractCount_I = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPI_V) n_set_AbstractCount_I);
+			cb_set_AbstractCount_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_set_AbstractCount_I));
 		return cb_set_AbstractCount_I;
 	}
 
@@ -285,7 +285,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static Delegate GetGetCountForKey_Ljava_lang_String_Handler ()
 	{
 		if (cb_GetCountForKey_Ljava_lang_String_ == null)
-			cb_GetCountForKey_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_I) n_GetCountForKey_Ljava_lang_String_);
+			cb_GetCountForKey_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetCountForKey_Ljava_lang_String_));
 		return cb_GetCountForKey_Ljava_lang_String_;
 	}
 
@@ -316,7 +316,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static Delegate GetKeyHandler ()
 	{
 		if (cb_Key == null)
-			cb_Key = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_L) n_Key);
+			cb_Key = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_Key));
 		return cb_Key;
 	}
 
@@ -340,7 +340,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static Delegate GetAbstractMethodHandler ()
 	{
 		if (cb_AbstractMethod == null)
-			cb_AbstractMethod = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_V) n_AbstractMethod);
+			cb_AbstractMethod = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_AbstractMethod));
 		return cb_AbstractMethod;
 	}
 

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteMethodWithCharSequenceArrays.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteMethodWithCharSequenceArrays.txt
@@ -34,7 +34,7 @@ public partial class MyClass : Java.Lang.Object {
 	static Delegate GetEcho_arrayLjava_lang_CharSequence_Handler ()
 	{
 		if (cb_echo_arrayLjava_lang_CharSequence_ == null)
-			cb_echo_arrayLjava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_L) n_Echo_arrayLjava_lang_CharSequence_);
+			cb_echo_arrayLjava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_L (n_Echo_arrayLjava_lang_CharSequence_));
 		return cb_echo_arrayLjava_lang_CharSequence_;
 	}
 

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClass.txt
@@ -54,7 +54,7 @@ public partial class MyClass {
 	static Delegate Getget_CountHandler ()
 	{
 		if (cb_get_Count == null)
-			cb_get_Count = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_I) n_get_Count);
+			cb_get_Count = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_Count));
 		return cb_get_Count;
 	}
 
@@ -70,7 +70,7 @@ public partial class MyClass {
 	static Delegate Getset_Count_IHandler ()
 	{
 		if (cb_set_Count_I == null)
-			cb_set_Count_I = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPI_V) n_set_Count_I);
+			cb_set_Count_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_set_Count_I));
 		return cb_set_Count_I;
 	}
 
@@ -110,7 +110,7 @@ public partial class MyClass {
 	static Delegate Getget_KeyHandler ()
 	{
 		if (cb_get_Key == null)
-			cb_get_Key = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_L) n_get_Key);
+			cb_get_Key = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_get_Key));
 		return cb_get_Key;
 	}
 
@@ -126,7 +126,7 @@ public partial class MyClass {
 	static Delegate Getset_Key_Ljava_lang_String_Handler ()
 	{
 		if (cb_set_Key_Ljava_lang_String_ == null)
-			cb_set_Key_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_V) n_set_Key_Ljava_lang_String_);
+			cb_set_Key_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_set_Key_Ljava_lang_String_));
 		return cb_set_Key_Ljava_lang_String_;
 	}
 
@@ -193,7 +193,7 @@ public partial class MyClass {
 	static Delegate Getget_AbstractCountHandler ()
 	{
 		if (cb_get_AbstractCount == null)
-			cb_get_AbstractCount = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_I) n_get_AbstractCount);
+			cb_get_AbstractCount = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_AbstractCount));
 		return cb_get_AbstractCount;
 	}
 
@@ -209,7 +209,7 @@ public partial class MyClass {
 	static Delegate Getset_AbstractCount_IHandler ()
 	{
 		if (cb_set_AbstractCount_I == null)
-			cb_set_AbstractCount_I = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPI_V) n_set_AbstractCount_I);
+			cb_set_AbstractCount_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_set_AbstractCount_I));
 		return cb_set_AbstractCount_I;
 	}
 
@@ -235,7 +235,7 @@ public partial class MyClass {
 	static Delegate GetGetCountForKey_Ljava_lang_String_Handler ()
 	{
 		if (cb_GetCountForKey_Ljava_lang_String_ == null)
-			cb_GetCountForKey_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_I) n_GetCountForKey_Ljava_lang_String_);
+			cb_GetCountForKey_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetCountForKey_Ljava_lang_String_));
 		return cb_GetCountForKey_Ljava_lang_String_;
 	}
 
@@ -269,7 +269,7 @@ public partial class MyClass {
 	static Delegate GetKeyHandler ()
 	{
 		if (cb_Key == null)
-			cb_Key = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_L) n_Key);
+			cb_Key = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_Key));
 		return cb_Key;
 	}
 
@@ -308,7 +308,7 @@ public partial class MyClass {
 	static Delegate GetAbstractMethodHandler ()
 	{
 		if (cb_AbstractMethod == null)
-			cb_AbstractMethod = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_V) n_AbstractMethod);
+			cb_AbstractMethod = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_AbstractMethod));
 		return cb_AbstractMethod;
 	}
 

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteDefaultInterfaceMethodInvoker.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteDefaultInterfaceMethodInvoker.txt
@@ -12,7 +12,7 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 	private static Delegate GetDoDefaultHandler ()
 	{
 		if (cb_DoDefault == null)
-			cb_DoDefault = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_V) n_DoDefault);
+			cb_DoDefault = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_DoDefault));
 		return cb_DoDefault;
 	}
 
@@ -96,7 +96,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static Delegate GetDoDeclarationHandler ()
 	{
 		if (cb_DoDeclaration == null)
-			cb_DoDeclaration = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_V) n_DoDeclaration);
+			cb_DoDeclaration = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_DoDeclaration));
 		return cb_DoDeclaration;
 	}
 

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterface.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterface.txt
@@ -135,7 +135,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static Delegate Getget_CountHandler ()
 	{
 		if (cb_get_Count == null)
-			cb_get_Count = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_I) n_get_Count);
+			cb_get_Count = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_Count));
 		return cb_get_Count;
 	}
 
@@ -151,7 +151,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static Delegate Getset_Count_IHandler ()
 	{
 		if (cb_set_Count_I == null)
-			cb_set_Count_I = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPI_V) n_set_Count_I);
+			cb_set_Count_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_set_Count_I));
 		return cb_set_Count_I;
 	}
 
@@ -184,7 +184,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static Delegate Getget_KeyHandler ()
 	{
 		if (cb_get_Key == null)
-			cb_get_Key = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_L) n_get_Key);
+			cb_get_Key = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_get_Key));
 		return cb_get_Key;
 	}
 
@@ -200,7 +200,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static Delegate Getset_Key_Ljava_lang_String_Handler ()
 	{
 		if (cb_set_Key_Ljava_lang_String_ == null)
-			cb_set_Key_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_V) n_set_Key_Ljava_lang_String_);
+			cb_set_Key_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_set_Key_Ljava_lang_String_));
 		return cb_set_Key_Ljava_lang_String_;
 	}
 
@@ -236,7 +236,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static Delegate Getget_AbstractCountHandler ()
 	{
 		if (cb_get_AbstractCount == null)
-			cb_get_AbstractCount = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_I) n_get_AbstractCount);
+			cb_get_AbstractCount = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_AbstractCount));
 		return cb_get_AbstractCount;
 	}
 
@@ -252,7 +252,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static Delegate Getset_AbstractCount_IHandler ()
 	{
 		if (cb_set_AbstractCount_I == null)
-			cb_set_AbstractCount_I = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPI_V) n_set_AbstractCount_I);
+			cb_set_AbstractCount_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_set_AbstractCount_I));
 		return cb_set_AbstractCount_I;
 	}
 
@@ -285,7 +285,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static Delegate GetGetCountForKey_Ljava_lang_String_Handler ()
 	{
 		if (cb_GetCountForKey_Ljava_lang_String_ == null)
-			cb_GetCountForKey_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_I) n_GetCountForKey_Ljava_lang_String_);
+			cb_GetCountForKey_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetCountForKey_Ljava_lang_String_));
 		return cb_GetCountForKey_Ljava_lang_String_;
 	}
 
@@ -316,7 +316,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static Delegate GetKeyHandler ()
 	{
 		if (cb_Key == null)
-			cb_Key = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_L) n_Key);
+			cb_Key = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_Key));
 		return cb_Key;
 	}
 
@@ -340,7 +340,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static Delegate GetAbstractMethodHandler ()
 	{
 		if (cb_AbstractMethod == null)
-			cb_AbstractMethod = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_V) n_AbstractMethod);
+			cb_AbstractMethod = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_AbstractMethod));
 		return cb_AbstractMethod;
 	}
 

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultMethod.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultMethod.txt
@@ -8,7 +8,7 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 	private static Delegate GetDoSomethingHandler ()
 	{
 		if (cb_DoSomething == null)
-			cb_DoSomething = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_V) n_DoSomething);
+			cb_DoSomething = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_DoSomething));
 		return cb_DoSomething;
 	}
 

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultProperty.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultProperty.txt
@@ -8,7 +8,7 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 	private static Delegate Getget_ValueHandler ()
 	{
 		if (cb_get_Value == null)
-			cb_get_Value = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_I) n_get_Value);
+			cb_get_Value = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_Value));
 		return cb_get_Value;
 	}
 
@@ -24,7 +24,7 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 	private static Delegate Getset_Value_IHandler ()
 	{
 		if (cb_set_Value_I == null)
-			cb_set_Value_I = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPI_V) n_set_Value_I);
+			cb_set_Value_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_set_Value_I));
 		return cb_set_Value_I;
 	}
 

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultPropertyGetterOnly.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultPropertyGetterOnly.txt
@@ -8,7 +8,7 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 	private static Delegate Getget_ValueHandler ()
 	{
 		if (cb_get_Value == null)
-			cb_get_Value = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_I) n_get_Value);
+			cb_get_Value = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_Value));
 		return cb_get_Value;
 	}
 

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceRedeclaredDefaultMethod.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceRedeclaredDefaultMethod.txt
@@ -67,7 +67,7 @@ internal partial class IMyInterface2Invoker : global::Java.Lang.Object, IMyInter
 	static Delegate GetDoSomethingHandler ()
 	{
 		if (cb_DoSomething == null)
-			cb_DoSomething = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_V) n_DoSomething);
+			cb_DoSomething = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_DoSomething));
 		return cb_DoSomething;
 	}
 

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodWithCharSequenceArrays.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodWithCharSequenceArrays.txt
@@ -34,7 +34,7 @@ public partial class MyClass : Java.Lang.Object {
 	static Delegate GetEcho_arrayLjava_lang_CharSequence_Handler ()
 	{
 		if (cb_echo_arrayLjava_lang_CharSequence_ == null)
-			cb_echo_arrayLjava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_L) n_Echo_arrayLjava_lang_CharSequence_);
+			cb_echo_arrayLjava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_L (n_Echo_arrayLjava_lang_CharSequence_));
 		return cb_echo_arrayLjava_lang_CharSequence_;
 	}
 

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceClass.txt
@@ -102,7 +102,7 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 	static Delegate GetGetBarHandler ()
 	{
 		if (cb_getBar == null)
-			cb_getBar = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_I) n_GetBar);
+			cb_getBar = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_GetBar));
 		return cb_getBar;
 	}
 

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceTypes.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceTypes.txt
@@ -78,7 +78,7 @@ public partial interface IParent : IJavaObject, IJavaPeerable {
 		static Delegate GetGetBarHandler ()
 		{
 			if (cb_getBar == null)
-				cb_getBar = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_I) n_GetBar);
+				cb_getBar = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_GetBar));
 			return cb_getBar;
 		}
 
@@ -162,7 +162,7 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 	static Delegate GetGetBarHandler ()
 	{
 		if (cb_getBar == null)
-			cb_getBar = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_I) n_GetBar);
+			cb_getBar = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_GetBar));
 		return cb_getBar;
 	}
 

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteUnnestedInterfaceTypes.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteUnnestedInterfaceTypes.txt
@@ -69,7 +69,7 @@ internal partial class IParentChildInvoker : global::Java.Lang.Object, IParentCh
 	static Delegate GetGetBarHandler ()
 	{
 		if (cb_getBar == null)
-			cb_getBar = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_I) n_GetBar);
+			cb_getBar = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_GetBar));
 		return cb_getBar;
 	}
 
@@ -162,7 +162,7 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 	static Delegate GetGetBarHandler ()
 	{
 		if (cb_getBar == null)
-			cb_getBar = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_I) n_GetBar);
+			cb_getBar = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_GetBar));
 		return cb_getBar;
 	}
 

--- a/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.BasePublicClass.cs
+++ b/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.BasePublicClass.cs
@@ -51,7 +51,7 @@ namespace Xamarin.Test {
 		static Delegate GetBaseMethodHandler ()
 		{
 			if (cb_baseMethod == null)
-				cb_baseMethod = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_V) n_BaseMethod);
+				cb_baseMethod = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_BaseMethod));
 			return cb_baseMethod;
 		}
 

--- a/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.ExtendPublicClass.cs
+++ b/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.ExtendPublicClass.cs
@@ -68,7 +68,7 @@ namespace Xamarin.Test {
 		static Delegate GetFooHandler ()
 		{
 			if (cb_foo == null)
-				cb_foo = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_V) n_Foo);
+				cb_foo = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Foo));
 			return cb_foo;
 		}
 

--- a/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.IExtendedInterface.cs
+++ b/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.IExtendedInterface.cs
@@ -78,7 +78,7 @@ namespace Xamarin.Test {
 		static Delegate GetExtendedMethodHandler ()
 		{
 			if (cb_extendedMethod == null)
-				cb_extendedMethod = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_V) n_ExtendedMethod);
+				cb_extendedMethod = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_ExtendedMethod));
 			return cb_extendedMethod;
 		}
 
@@ -102,7 +102,7 @@ namespace Xamarin.Test {
 		static Delegate GetBaseMethodHandler ()
 		{
 			if (cb_baseMethod == null)
-				cb_baseMethod = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_V) n_BaseMethod);
+				cb_baseMethod = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_BaseMethod));
 			return cb_baseMethod;
 		}
 

--- a/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.PublicClass.cs
+++ b/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.PublicClass.cs
@@ -87,7 +87,7 @@ namespace Xamarin.Test {
 			static Delegate GetFooHandler ()
 			{
 				if (cb_foo == null)
-					cb_foo = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_V) n_Foo);
+					cb_foo = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Foo));
 				return cb_foo;
 			}
 
@@ -158,7 +158,7 @@ namespace Xamarin.Test {
 		static Delegate GetFooHandler ()
 		{
 			if (cb_foo == null)
-				cb_foo = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_V) n_Foo);
+				cb_foo = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Foo));
 			return cb_foo;
 		}
 

--- a/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.TestClass.cs
+++ b/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.TestClass.cs
@@ -68,7 +68,7 @@ namespace Xamarin.Test {
 		static Delegate GetBaseMethodHandler ()
 		{
 			if (cb_baseMethod == null)
-				cb_baseMethod = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_V) n_BaseMethod);
+				cb_baseMethod = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_BaseMethod));
 			return cb_baseMethod;
 		}
 

--- a/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.AbsSpinner.cs
+++ b/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.AbsSpinner.cs
@@ -51,7 +51,7 @@ namespace Xamarin.Test {
 		static Delegate GetGetAdapterHandler ()
 		{
 			if (cb_getAdapter == null)
-				cb_getAdapter = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_L) n_GetAdapter);
+				cb_getAdapter = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetAdapter));
 			return cb_getAdapter;
 		}
 
@@ -67,7 +67,7 @@ namespace Xamarin.Test {
 		static Delegate GetSetAdapter_Lxamarin_test_SpinnerAdapter_Handler ()
 		{
 			if (cb_setAdapter_Lxamarin_test_SpinnerAdapter_ == null)
-				cb_setAdapter_Lxamarin_test_SpinnerAdapter_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_V) n_SetAdapter_Lxamarin_test_SpinnerAdapter_);
+				cb_setAdapter_Lxamarin_test_SpinnerAdapter_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetAdapter_Lxamarin_test_SpinnerAdapter_));
 			return cb_setAdapter_Lxamarin_test_SpinnerAdapter_;
 		}
 

--- a/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.AdapterView.cs
+++ b/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.AdapterView.cs
@@ -52,7 +52,7 @@ namespace Xamarin.Test {
 		static Delegate GetGetAdapterHandler ()
 		{
 			if (cb_getAdapter == null)
-				cb_getAdapter = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_L) n_GetAdapter);
+				cb_getAdapter = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetAdapter));
 			return cb_getAdapter;
 		}
 
@@ -68,7 +68,7 @@ namespace Xamarin.Test {
 		static Delegate GetSetAdapter_Lxamarin_test_Adapter_Handler ()
 		{
 			if (cb_setAdapter_Lxamarin_test_Adapter_ == null)
-				cb_setAdapter_Lxamarin_test_Adapter_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_V) n_SetAdapter_Lxamarin_test_Adapter_);
+				cb_setAdapter_Lxamarin_test_Adapter_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetAdapter_Lxamarin_test_Adapter_));
 			return cb_setAdapter_Lxamarin_test_Adapter_;
 		}
 

--- a/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.GenericReturnObject.cs
+++ b/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.GenericReturnObject.cs
@@ -51,7 +51,7 @@ namespace Xamarin.Test {
 		static Delegate GetGenericReturnHandler ()
 		{
 			if (cb_GenericReturn == null)
-				cb_GenericReturn = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_L) n_GenericReturn);
+				cb_GenericReturn = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GenericReturn));
 			return cb_GenericReturn;
 		}
 

--- a/tests/generator-Tests/expected.xaji/Android.Graphics.Color/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.xaji/Android.Graphics.Color/Xamarin.Test.SomeObject.cs
@@ -71,7 +71,7 @@ namespace Xamarin.Test {
 		static Delegate GetGetSomeColorHandler ()
 		{
 			if (cb_getSomeColor == null)
-				cb_getSomeColor = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_I) n_GetSomeColor);
+				cb_getSomeColor = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_GetSomeColor));
 			return cb_getSomeColor;
 		}
 
@@ -87,7 +87,7 @@ namespace Xamarin.Test {
 		static Delegate GetSetSomeColor_IHandler ()
 		{
 			if (cb_setSomeColor_I == null)
-				cb_setSomeColor_I = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPI_V) n_SetSomeColor_I);
+				cb_setSomeColor_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_SetSomeColor_I));
 			return cb_setSomeColor_I;
 		}
 

--- a/tests/generator-Tests/expected.xaji/CSharpKeywords/Java.Lang.Throwable.cs
+++ b/tests/generator-Tests/expected.xaji/CSharpKeywords/Java.Lang.Throwable.cs
@@ -29,7 +29,7 @@ namespace Java.Lang {
 		static Delegate GetGetMessageHandler ()
 		{
 			if (cb_getMessage == null)
-				cb_getMessage = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_L) n_GetMessage);
+				cb_getMessage = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetMessage));
 			return cb_getMessage;
 		}
 

--- a/tests/generator-Tests/expected.xaji/CSharpKeywords/Xamarin.Test.CSharpKeywords.cs
+++ b/tests/generator-Tests/expected.xaji/CSharpKeywords/Xamarin.Test.CSharpKeywords.cs
@@ -51,7 +51,7 @@ namespace Xamarin.Test {
 		static Delegate GetUsePartial_IHandler ()
 		{
 			if (cb_usePartial_I == null)
-				cb_usePartial_I = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPI_L) n_UsePartial_I);
+				cb_usePartial_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_L (n_UsePartial_I));
 			return cb_usePartial_I;
 		}
 

--- a/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.ISpannable.cs
+++ b/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.ISpannable.cs
@@ -70,7 +70,7 @@ namespace Android.Text {
 		static Delegate GetGetSpanFlags_Ljava_lang_Object_Handler ()
 		{
 			if (cb_getSpanFlags_Ljava_lang_Object_ == null)
-				cb_getSpanFlags_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_I) n_GetSpanFlags_Ljava_lang_Object_);
+				cb_getSpanFlags_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetSpanFlags_Ljava_lang_Object_));
 			return cb_getSpanFlags_Ljava_lang_Object_;
 		}
 

--- a/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.ISpanned.cs
+++ b/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.ISpanned.cs
@@ -75,7 +75,7 @@ namespace Android.Text {
 		static Delegate GetGetSpanFlags_Ljava_lang_Object_Handler ()
 		{
 			if (cb_getSpanFlags_Ljava_lang_Object_ == null)
-				cb_getSpanFlags_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_I) n_GetSpanFlags_Ljava_lang_Object_);
+				cb_getSpanFlags_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetSpanFlags_Ljava_lang_Object_));
 			return cb_getSpanFlags_Ljava_lang_Object_;
 		}
 

--- a/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.SpannableString.cs
+++ b/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.SpannableString.cs
@@ -94,7 +94,7 @@ namespace Android.Text {
 		static Delegate GetGetSpanFlags_Ljava_lang_Object_Handler ()
 		{
 			if (cb_getSpanFlags_Ljava_lang_Object_ == null)
-				cb_getSpanFlags_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_I) n_GetSpanFlags_Ljava_lang_Object_);
+				cb_getSpanFlags_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetSpanFlags_Ljava_lang_Object_));
 			return cb_getSpanFlags_Ljava_lang_Object_;
 		}
 

--- a/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.SpannableStringInternal.cs
+++ b/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.SpannableStringInternal.cs
@@ -51,7 +51,7 @@ namespace Android.Text {
 		static Delegate GetGetSpanFlags_Ljava_lang_Object_Handler ()
 		{
 			if (cb_getSpanFlags_Ljava_lang_Object_ == null)
-				cb_getSpanFlags_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_I) n_GetSpanFlags_Ljava_lang_Object_);
+				cb_getSpanFlags_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetSpanFlags_Ljava_lang_Object_));
 			return cb_getSpanFlags_Ljava_lang_Object_;
 		}
 

--- a/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Views.View.cs
+++ b/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Views.View.cs
@@ -87,7 +87,7 @@ namespace Android.Views {
 			static Delegate GetOnClick_Landroid_view_View_Handler ()
 			{
 				if (cb_onClick_Landroid_view_View_ == null)
-					cb_onClick_Landroid_view_View_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_V) n_OnClick_Landroid_view_View_);
+					cb_onClick_Landroid_view_View_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_OnClick_Landroid_view_View_));
 				return cb_onClick_Landroid_view_View_;
 			}
 
@@ -169,7 +169,7 @@ namespace Android.Views {
 		static Delegate GetSetOnClickListener_Landroid_view_View_OnClickListener_Handler ()
 		{
 			if (cb_setOnClickListener_Landroid_view_View_OnClickListener_ == null)
-				cb_setOnClickListener_Landroid_view_View_OnClickListener_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_V) n_SetOnClickListener_Landroid_view_View_OnClickListener_);
+				cb_setOnClickListener_Landroid_view_View_OnClickListener_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetOnClickListener_Landroid_view_View_OnClickListener_));
 			return cb_setOnClickListener_Landroid_view_View_OnClickListener_;
 		}
 
@@ -200,7 +200,7 @@ namespace Android.Views {
 		static Delegate GetSetOn123Listener_Landroid_view_View_OnClickListener_Handler ()
 		{
 			if (cb_setOn123Listener_Landroid_view_View_OnClickListener_ == null)
-				cb_setOn123Listener_Landroid_view_View_OnClickListener_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_V) n_SetOn123Listener_Landroid_view_View_OnClickListener_);
+				cb_setOn123Listener_Landroid_view_View_OnClickListener_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetOn123Listener_Landroid_view_View_OnClickListener_));
 			return cb_setOn123Listener_Landroid_view_View_OnClickListener_;
 		}
 
@@ -231,7 +231,7 @@ namespace Android.Views {
 		static Delegate GetAddTouchables_Ljava_util_ArrayList_Handler ()
 		{
 			if (cb_addTouchables_Ljava_util_ArrayList_ == null)
-				cb_addTouchables_Ljava_util_ArrayList_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_V) n_AddTouchables_Ljava_util_ArrayList_);
+				cb_addTouchables_Ljava_util_ArrayList_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_AddTouchables_Ljava_util_ArrayList_));
 			return cb_addTouchables_Ljava_util_ArrayList_;
 		}
 

--- a/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaCrypto.cs
+++ b/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaCrypto.cs
@@ -74,7 +74,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 		static Delegate GetRequiresSecureDecoderComponent_Ljava_lang_String_Handler ()
 		{
 			if (cb_requiresSecureDecoderComponent_Ljava_lang_String_ == null)
-				cb_requiresSecureDecoderComponent_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_Z) n_RequiresSecureDecoderComponent_Ljava_lang_String_);
+				cb_requiresSecureDecoderComponent_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_Z (n_RequiresSecureDecoderComponent_Ljava_lang_String_));
 			return cb_requiresSecureDecoderComponent_Ljava_lang_String_;
 		}
 

--- a/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
+++ b/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
@@ -75,7 +75,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 		static Delegate GetOnEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayBHandler ()
 		{
 			if (cb_onEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB == null)
-				cb_onEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPLLIIL_V) n_OnEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB);
+				cb_onEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPLLIIL_V (n_OnEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB));
 			return cb_onEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB;
 		}
 
@@ -261,7 +261,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 		static Delegate GetSetOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_Handler ()
 		{
 			if (cb_setOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_ == null)
-				cb_setOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_V) n_SetOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_);
+				cb_setOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_));
 			return cb_setOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_;
 		}
 

--- a/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.II1.cs
+++ b/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.II1.cs
@@ -74,7 +74,7 @@ namespace Xamarin.Test {
 		static Delegate GetCloseHandler ()
 		{
 			if (cb_close == null)
-				cb_close = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_V) n_Close);
+				cb_close = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Close));
 			return cb_close;
 		}
 

--- a/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.II2.cs
+++ b/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.II2.cs
@@ -74,7 +74,7 @@ namespace Xamarin.Test {
 		static Delegate GetCloseHandler ()
 		{
 			if (cb_close == null)
-				cb_close = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_V) n_Close);
+				cb_close = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Close));
 			return cb_close;
 		}
 

--- a/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.SomeObject.cs
@@ -51,7 +51,7 @@ namespace Xamarin.Test {
 		static Delegate GetCloseHandler ()
 		{
 			if (cb_close == null)
-				cb_close = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_V) n_Close);
+				cb_close = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Close));
 			return cb_close;
 		}
 

--- a/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.SomeObject2.cs
+++ b/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.SomeObject2.cs
@@ -51,7 +51,7 @@ namespace Xamarin.Test {
 		static Delegate GetIrrelevantHandler ()
 		{
 			if (cb_irrelevant == null)
-				cb_irrelevant = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_V) n_Irrelevant);
+				cb_irrelevant = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Irrelevant));
 			return cb_irrelevant;
 		}
 
@@ -78,7 +78,7 @@ namespace Xamarin.Test {
 		static Delegate GetCloseHandler ()
 		{
 			if (cb_close == null)
-				cb_close = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_V) n_Close);
+				cb_close = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Close));
 			return cb_close;
 		}
 

--- a/tests/generator-Tests/expected.xaji/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
+++ b/tests/generator-Tests/expected.xaji/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
@@ -90,7 +90,7 @@ namespace Xamarin.Test {
 				static Delegate GetBuild_IHandler ()
 				{
 					if (cb_build_I == null)
-						cb_build_I = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPI_L) n_Build_I);
+						cb_build_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_L (n_Build_I));
 					return cb_build_I;
 				}
 

--- a/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.A.cs
+++ b/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.A.cs
@@ -55,7 +55,7 @@ namespace Xamarin.Test {
 			static Delegate GetSetCustomDimension_IHandler ()
 			{
 				if (cb_setCustomDimension_I == null)
-					cb_setCustomDimension_I = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPI_L) n_SetCustomDimension_I);
+					cb_setCustomDimension_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_L (n_SetCustomDimension_I));
 				return cb_setCustomDimension_I;
 			}
 
@@ -115,7 +115,7 @@ namespace Xamarin.Test {
 		static Delegate GetGetHandleHandler ()
 		{
 			if (cb_getHandle == null)
-				cb_getHandle = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_I) n_GetHandle);
+				cb_getHandle = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_GetHandle));
 			return cb_getHandle;
 		}
 

--- a/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.C.cs
+++ b/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.C.cs
@@ -52,7 +52,7 @@ namespace Xamarin.Test {
 		static Delegate GetSetCustomDimension_IHandler ()
 		{
 			if (cb_setCustomDimension_I == null)
-				cb_setCustomDimension_I = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPI_L) n_SetCustomDimension_I);
+				cb_setCustomDimension_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_L (n_SetCustomDimension_I));
 			return cb_setCustomDimension_I;
 		}
 

--- a/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.SomeObject.cs
@@ -71,7 +71,7 @@ namespace Xamarin.Test {
 		static Delegate GetGetTypeHandler ()
 		{
 			if (cb_getType == null)
-				cb_getType = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_L) n_GetType);
+				cb_getType = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetType));
 			return cb_getType;
 		}
 
@@ -99,7 +99,7 @@ namespace Xamarin.Test {
 		static Delegate GetHandle_Ljava_lang_Object_Ljava_lang_Throwable_Handler ()
 		{
 			if (cb_handle_Ljava_lang_Object_Ljava_lang_Throwable_ == null)
-				cb_handle_Ljava_lang_Object_Ljava_lang_Throwable_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPLL_I) n_Handle_Ljava_lang_Object_Ljava_lang_Throwable_);
+				cb_handle_Ljava_lang_Object_Ljava_lang_Throwable_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPLL_I (n_Handle_Ljava_lang_Object_Ljava_lang_Throwable_));
 			return cb_handle_Ljava_lang_Object_Ljava_lang_Throwable_;
 		}
 
@@ -135,7 +135,7 @@ namespace Xamarin.Test {
 		static Delegate GetIntegerMethodHandler ()
 		{
 			if (cb_IntegerMethod == null)
-				cb_IntegerMethod = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_I) n_IntegerMethod);
+				cb_IntegerMethod = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_IntegerMethod));
 			return cb_IntegerMethod;
 		}
 
@@ -163,7 +163,7 @@ namespace Xamarin.Test {
 		static Delegate GetVoidMethodHandler ()
 		{
 			if (cb_VoidMethod == null)
-				cb_VoidMethod = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_V) n_VoidMethod);
+				cb_VoidMethod = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_VoidMethod));
 			return cb_VoidMethod;
 		}
 
@@ -190,7 +190,7 @@ namespace Xamarin.Test {
 		static Delegate GetStringMethodHandler ()
 		{
 			if (cb_StringMethod == null)
-				cb_StringMethod = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_L) n_StringMethod);
+				cb_StringMethod = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_StringMethod));
 			return cb_StringMethod;
 		}
 
@@ -218,7 +218,7 @@ namespace Xamarin.Test {
 		static Delegate GetObjectMethodHandler ()
 		{
 			if (cb_ObjectMethod == null)
-				cb_ObjectMethod = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_L) n_ObjectMethod);
+				cb_ObjectMethod = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_ObjectMethod));
 			return cb_ObjectMethod;
 		}
 
@@ -246,7 +246,7 @@ namespace Xamarin.Test {
 		static Delegate GetVoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object_Handler ()
 		{
 			if (cb_VoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object_ == null)
-				cb_VoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPLIL_V) n_VoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object_);
+				cb_VoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPLIL_V (n_VoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object_));
 			return cb_VoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object_;
 		}
 
@@ -283,7 +283,7 @@ namespace Xamarin.Test {
 		static Delegate GetObsoleteMethodHandler ()
 		{
 			if (cb_ObsoleteMethod == null)
-				cb_ObsoleteMethod = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_I) n_ObsoleteMethod);
+				cb_ObsoleteMethod = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_ObsoleteMethod));
 			return cb_ObsoleteMethod;
 		}
 
@@ -313,7 +313,7 @@ namespace Xamarin.Test {
 		static Delegate GetArrayListTest_Ljava_util_ArrayList_Handler ()
 		{
 			if (cb_ArrayListTest_Ljava_util_ArrayList_ == null)
-				cb_ArrayListTest_Ljava_util_ArrayList_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_V) n_ArrayListTest_Ljava_util_ArrayList_);
+				cb_ArrayListTest_Ljava_util_ArrayList_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_ArrayListTest_Ljava_util_ArrayList_));
 			return cb_ArrayListTest_Ljava_util_ArrayList_;
 		}
 

--- a/tests/generator-Tests/expected.xaji/NormalProperties/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.xaji/NormalProperties/Xamarin.Test.SomeObject.cs
@@ -51,7 +51,7 @@ namespace Xamarin.Test {
 		static Delegate GetGetSomeIntegerHandler ()
 		{
 			if (cb_getSomeInteger == null)
-				cb_getSomeInteger = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_I) n_GetSomeInteger);
+				cb_getSomeInteger = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_GetSomeInteger));
 			return cb_getSomeInteger;
 		}
 
@@ -67,7 +67,7 @@ namespace Xamarin.Test {
 		static Delegate GetSetSomeInteger_IHandler ()
 		{
 			if (cb_setSomeInteger_I == null)
-				cb_setSomeInteger_I = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPI_V) n_SetSomeInteger_I);
+				cb_setSomeInteger_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_SetSomeInteger_I));
 			return cb_setSomeInteger_I;
 		}
 
@@ -93,7 +93,7 @@ namespace Xamarin.Test {
 		static Delegate GetGetSomeObjectPropertyHandler ()
 		{
 			if (cb_getSomeObjectProperty == null)
-				cb_getSomeObjectProperty = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_L) n_GetSomeObjectProperty);
+				cb_getSomeObjectProperty = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetSomeObjectProperty));
 			return cb_getSomeObjectProperty;
 		}
 
@@ -109,7 +109,7 @@ namespace Xamarin.Test {
 		static Delegate GetSetSomeObjectProperty_Ljava_lang_Object_Handler ()
 		{
 			if (cb_setSomeObjectProperty_Ljava_lang_Object_ == null)
-				cb_setSomeObjectProperty_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_V) n_SetSomeObjectProperty_Ljava_lang_Object_);
+				cb_setSomeObjectProperty_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetSomeObjectProperty_Ljava_lang_Object_));
 			return cb_setSomeObjectProperty_Ljava_lang_Object_;
 		}
 
@@ -136,7 +136,7 @@ namespace Xamarin.Test {
 		static Delegate GetGetSomeStringHandler ()
 		{
 			if (cb_getSomeString == null)
-				cb_getSomeString = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_L) n_GetSomeString);
+				cb_getSomeString = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetSomeString));
 			return cb_getSomeString;
 		}
 
@@ -152,7 +152,7 @@ namespace Xamarin.Test {
 		static Delegate GetSetSomeString_Ljava_lang_String_Handler ()
 		{
 			if (cb_setSomeString_Ljava_lang_String_ == null)
-				cb_setSomeString_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_V) n_SetSomeString_Ljava_lang_String_);
+				cb_setSomeString_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetSomeString_Ljava_lang_String_));
 			return cb_setSomeString_Ljava_lang_String_;
 		}
 

--- a/tests/generator-Tests/expected.xaji/ParameterXPath/Xamarin.Test.A.cs
+++ b/tests/generator-Tests/expected.xaji/ParameterXPath/Xamarin.Test.A.cs
@@ -52,7 +52,7 @@ namespace Xamarin.Test {
 		static Delegate GetSetA_Ljava_lang_Object_Handler ()
 		{
 			if (cb_setA_Ljava_lang_Object_ == null)
-				cb_setA_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_V) n_SetA_Ljava_lang_Object_);
+				cb_setA_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetA_Ljava_lang_Object_));
 			return cb_setA_Ljava_lang_Object_;
 		}
 
@@ -85,7 +85,7 @@ namespace Xamarin.Test {
 		static Delegate GetListTest_Ljava_util_List_Handler ()
 		{
 			if (cb_listTest_Ljava_util_List_ == null)
-				cb_listTest_Ljava_util_List_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_V) n_ListTest_Ljava_util_List_);
+				cb_listTest_Ljava_util_List_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_ListTest_Ljava_util_List_));
 			return cb_listTest_Ljava_util_List_;
 		}
 

--- a/tests/generator-Tests/expected.xaji/Streams/Java.IO.FilterOutputStream.cs
+++ b/tests/generator-Tests/expected.xaji/Streams/Java.IO.FilterOutputStream.cs
@@ -73,7 +73,7 @@ namespace Java.IO {
 		static Delegate GetWrite_IHandler ()
 		{
 			if (cb_write_I == null)
-				cb_write_I = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPI_V) n_Write_I);
+				cb_write_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_Write_I));
 			return cb_write_I;
 		}
 

--- a/tests/generator-Tests/expected.xaji/Streams/Java.IO.IOException.cs
+++ b/tests/generator-Tests/expected.xaji/Streams/Java.IO.IOException.cs
@@ -51,7 +51,7 @@ namespace Java.IO {
 		static Delegate GetPrintStackTraceHandler ()
 		{
 			if (cb_printStackTrace == null)
-				cb_printStackTrace = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_V) n_PrintStackTrace);
+				cb_printStackTrace = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_PrintStackTrace));
 			return cb_printStackTrace;
 		}
 

--- a/tests/generator-Tests/expected.xaji/Streams/Java.IO.InputStream.cs
+++ b/tests/generator-Tests/expected.xaji/Streams/Java.IO.InputStream.cs
@@ -68,7 +68,7 @@ namespace Java.IO {
 		static Delegate GetAvailableHandler ()
 		{
 			if (cb_available == null)
-				cb_available = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_I) n_Available);
+				cb_available = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_Available));
 			return cb_available;
 		}
 
@@ -96,7 +96,7 @@ namespace Java.IO {
 		static Delegate GetCloseHandler ()
 		{
 			if (cb_close == null)
-				cb_close = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_V) n_Close);
+				cb_close = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Close));
 			return cb_close;
 		}
 
@@ -123,7 +123,7 @@ namespace Java.IO {
 		static Delegate GetMark_IHandler ()
 		{
 			if (cb_mark_I == null)
-				cb_mark_I = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPI_V) n_Mark_I);
+				cb_mark_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_Mark_I));
 			return cb_mark_I;
 		}
 
@@ -152,7 +152,7 @@ namespace Java.IO {
 		static Delegate GetMarkSupportedHandler ()
 		{
 			if (cb_markSupported == null)
-				cb_markSupported = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_Z) n_MarkSupported);
+				cb_markSupported = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_Z (n_MarkSupported));
 			return cb_markSupported;
 		}
 
@@ -180,7 +180,7 @@ namespace Java.IO {
 		static Delegate GetReadHandler ()
 		{
 			if (cb_read == null)
-				cb_read = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_I) n_Read);
+				cb_read = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_Read));
 			return cb_read;
 		}
 
@@ -200,7 +200,7 @@ namespace Java.IO {
 		static Delegate GetRead_arrayBHandler ()
 		{
 			if (cb_read_arrayB == null)
-				cb_read_arrayB = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_I) n_Read_arrayB);
+				cb_read_arrayB = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_Read_arrayB));
 			return cb_read_arrayB;
 		}
 
@@ -240,7 +240,7 @@ namespace Java.IO {
 		static Delegate GetRead_arrayBIIHandler ()
 		{
 			if (cb_read_arrayBII == null)
-				cb_read_arrayBII = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPLII_I) n_Read_arrayBII);
+				cb_read_arrayBII = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPLII_I (n_Read_arrayBII));
 			return cb_read_arrayBII;
 		}
 
@@ -282,7 +282,7 @@ namespace Java.IO {
 		static Delegate GetResetHandler ()
 		{
 			if (cb_reset == null)
-				cb_reset = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_V) n_Reset);
+				cb_reset = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Reset));
 			return cb_reset;
 		}
 
@@ -309,7 +309,7 @@ namespace Java.IO {
 		static Delegate GetSkip_JHandler ()
 		{
 			if (cb_skip_J == null)
-				cb_skip_J = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPJ_J) n_Skip_J);
+				cb_skip_J = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPJ_J (n_Skip_J));
 			return cb_skip_J;
 		}
 

--- a/tests/generator-Tests/expected.xaji/Streams/Java.IO.OutputStream.cs
+++ b/tests/generator-Tests/expected.xaji/Streams/Java.IO.OutputStream.cs
@@ -68,7 +68,7 @@ namespace Java.IO {
 		static Delegate GetCloseHandler ()
 		{
 			if (cb_close == null)
-				cb_close = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_V) n_Close);
+				cb_close = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Close));
 			return cb_close;
 		}
 
@@ -95,7 +95,7 @@ namespace Java.IO {
 		static Delegate GetFlushHandler ()
 		{
 			if (cb_flush == null)
-				cb_flush = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_V) n_Flush);
+				cb_flush = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Flush));
 			return cb_flush;
 		}
 
@@ -122,7 +122,7 @@ namespace Java.IO {
 		static Delegate GetWrite_arrayBHandler ()
 		{
 			if (cb_write_arrayB == null)
-				cb_write_arrayB = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_V) n_Write_arrayB);
+				cb_write_arrayB = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_Write_arrayB));
 			return cb_write_arrayB;
 		}
 
@@ -160,7 +160,7 @@ namespace Java.IO {
 		static Delegate GetWrite_arrayBIIHandler ()
 		{
 			if (cb_write_arrayBII == null)
-				cb_write_arrayBII = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPLII_V) n_Write_arrayBII);
+				cb_write_arrayBII = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPLII_V (n_Write_arrayBII));
 			return cb_write_arrayBII;
 		}
 
@@ -200,7 +200,7 @@ namespace Java.IO {
 		static Delegate GetWrite_IHandler ()
 		{
 			if (cb_write_I == null)
-				cb_write_I = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPI_V) n_Write_I);
+				cb_write_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_Write_I));
 			return cb_write_I;
 		}
 

--- a/tests/generator-Tests/expected.xaji/Streams/Java.Lang.Throwable.cs
+++ b/tests/generator-Tests/expected.xaji/Streams/Java.Lang.Throwable.cs
@@ -29,7 +29,7 @@ namespace Java.Lang {
 		static Delegate GetGetMessageHandler ()
 		{
 			if (cb_getMessage == null)
-				cb_getMessage = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_L) n_GetMessage);
+				cb_getMessage = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetMessage));
 			return cb_getMessage;
 		}
 

--- a/tests/generator-Tests/expected.xaji/TestInterface/ClassWithoutNamespace.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/ClassWithoutNamespace.cs
@@ -66,7 +66,7 @@ public abstract partial class ClassWithoutNamespace : global::Java.Lang.Object, 
 	static Delegate GetFooHandler ()
 	{
 		if (cb_Foo == null)
-			cb_Foo = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_V) n_Foo);
+			cb_Foo = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Foo));
 		return cb_Foo;
 	}
 

--- a/tests/generator-Tests/expected.xaji/TestInterface/IInterfaceWithoutNamespace.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/IInterfaceWithoutNamespace.cs
@@ -72,7 +72,7 @@ internal partial class IInterfaceWithoutNamespaceInvoker : global::Java.Lang.Obj
 	static Delegate GetFooHandler ()
 	{
 		if (cb_Foo == null)
-			cb_Foo = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_V) n_Foo);
+			cb_Foo = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Foo));
 		return cb_Foo;
 	}
 

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericImplementation.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericImplementation.cs
@@ -68,7 +68,7 @@ namespace Test.ME {
 		static Delegate GetSetObject_arrayBHandler ()
 		{
 			if (cb_SetObject_arrayB == null)
-				cb_SetObject_arrayB = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_V) n_SetObject_arrayB);
+				cb_SetObject_arrayB = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetObject_arrayB));
 			return cb_SetObject_arrayB;
 		}
 

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericObjectPropertyImplementation.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericObjectPropertyImplementation.cs
@@ -68,7 +68,7 @@ namespace Test.ME {
 		static Delegate GetGetObjectHandler ()
 		{
 			if (cb_getObject == null)
-				cb_getObject = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_L) n_GetObject);
+				cb_getObject = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetObject));
 			return cb_getObject;
 		}
 
@@ -84,7 +84,7 @@ namespace Test.ME {
 		static Delegate GetSetObject_Ljava_lang_Object_Handler ()
 		{
 			if (cb_setObject_Ljava_lang_Object_ == null)
-				cb_setObject_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_V) n_SetObject_Ljava_lang_Object_);
+				cb_setObject_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetObject_Ljava_lang_Object_));
 			return cb_setObject_Ljava_lang_Object_;
 		}
 

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericStringImplementation.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericStringImplementation.cs
@@ -68,7 +68,7 @@ namespace Test.ME {
 		static Delegate GetSetObject_arrayLjava_lang_String_Handler ()
 		{
 			if (cb_SetObject_arrayLjava_lang_String_ == null)
-				cb_SetObject_arrayLjava_lang_String_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_V) n_SetObject_arrayLjava_lang_String_);
+				cb_SetObject_arrayLjava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetObject_arrayLjava_lang_String_));
 			return cb_SetObject_arrayLjava_lang_String_;
 		}
 

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericStringPropertyImplementation.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericStringPropertyImplementation.cs
@@ -68,7 +68,7 @@ namespace Test.ME {
 		static Delegate GetGetObjectHandler ()
 		{
 			if (cb_getObject == null)
-				cb_getObject = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_L) n_GetObject);
+				cb_getObject = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetObject));
 			return cb_getObject;
 		}
 
@@ -84,7 +84,7 @@ namespace Test.ME {
 		static Delegate GetSetObject_Ljava_lang_String_Handler ()
 		{
 			if (cb_SetObject_Ljava_lang_String_ == null)
-				cb_SetObject_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_V) n_SetObject_Ljava_lang_String_);
+				cb_SetObject_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetObject_Ljava_lang_String_));
 			return cb_SetObject_Ljava_lang_String_;
 		}
 

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.IGenericInterface.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.IGenericInterface.cs
@@ -75,7 +75,7 @@ namespace Test.ME {
 		static Delegate GetSetObject_Ljava_lang_Object_Handler ()
 		{
 			if (cb_SetObject_Ljava_lang_Object_ == null)
-				cb_SetObject_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_V) n_SetObject_Ljava_lang_Object_);
+				cb_SetObject_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetObject_Ljava_lang_Object_));
 			return cb_SetObject_Ljava_lang_Object_;
 		}
 

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.IGenericPropertyInterface.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.IGenericPropertyInterface.cs
@@ -81,7 +81,7 @@ namespace Test.ME {
 		static Delegate GetGetObjectHandler ()
 		{
 			if (cb_getObject == null)
-				cb_getObject = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_L) n_GetObject);
+				cb_getObject = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetObject));
 			return cb_getObject;
 		}
 
@@ -97,7 +97,7 @@ namespace Test.ME {
 		static Delegate GetSetObject_Ljava_lang_Object_Handler ()
 		{
 			if (cb_setObject_Ljava_lang_Object_ == null)
-				cb_setObject_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_V) n_SetObject_Ljava_lang_Object_);
+				cb_setObject_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetObject_Ljava_lang_Object_));
 			return cb_setObject_Ljava_lang_Object_;
 		}
 

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.ITestInterface.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.ITestInterface.cs
@@ -136,7 +136,7 @@ namespace Test.ME {
 		static Delegate GetGetSpanFlags_Ljava_lang_Object_Handler ()
 		{
 			if (cb_getSpanFlags_Ljava_lang_Object_ == null)
-				cb_getSpanFlags_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_I) n_GetSpanFlags_Ljava_lang_Object_);
+				cb_getSpanFlags_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetSpanFlags_Ljava_lang_Object_));
 			return cb_getSpanFlags_Ljava_lang_Object_;
 		}
 
@@ -165,7 +165,7 @@ namespace Test.ME {
 		static Delegate GetAppend_Ljava_lang_CharSequence_Handler ()
 		{
 			if (cb_append_Ljava_lang_CharSequence_ == null)
-				cb_append_Ljava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_V) n_Append_Ljava_lang_CharSequence_);
+				cb_append_Ljava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_Append_Ljava_lang_CharSequence_));
 			return cb_append_Ljava_lang_CharSequence_;
 		}
 
@@ -194,7 +194,7 @@ namespace Test.ME {
 		static Delegate GetIdentity_Ljava_lang_CharSequence_Handler ()
 		{
 			if (cb_identity_Ljava_lang_CharSequence_ == null)
-				cb_identity_Ljava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_L) n_Identity_Ljava_lang_CharSequence_);
+				cb_identity_Ljava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_L (n_Identity_Ljava_lang_CharSequence_));
 			return cb_identity_Ljava_lang_CharSequence_;
 		}
 

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.TestInterfaceImplementation.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.TestInterfaceImplementation.cs
@@ -89,7 +89,7 @@ namespace Test.ME {
 		static Delegate GetGetSpanFlags_Ljava_lang_Object_Handler ()
 		{
 			if (cb_getSpanFlags_Ljava_lang_Object_ == null)
-				cb_getSpanFlags_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_I) n_GetSpanFlags_Ljava_lang_Object_);
+				cb_getSpanFlags_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetSpanFlags_Ljava_lang_Object_));
 			return cb_getSpanFlags_Ljava_lang_Object_;
 		}
 
@@ -111,7 +111,7 @@ namespace Test.ME {
 		static Delegate GetAppend_Ljava_lang_CharSequence_Handler ()
 		{
 			if (cb_append_Ljava_lang_CharSequence_ == null)
-				cb_append_Ljava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_V) n_Append_Ljava_lang_CharSequence_);
+				cb_append_Ljava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_Append_Ljava_lang_CharSequence_));
 			return cb_append_Ljava_lang_CharSequence_;
 		}
 
@@ -139,7 +139,7 @@ namespace Test.ME {
 		static Delegate GetIdentity_Ljava_lang_CharSequence_Handler ()
 		{
 			if (cb_identity_Ljava_lang_CharSequence_ == null)
-				cb_identity_Ljava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_L) n_Identity_Ljava_lang_CharSequence_);
+				cb_identity_Ljava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_L (n_Identity_Ljava_lang_CharSequence_));
 			return cb_identity_Ljava_lang_CharSequence_;
 		}
 

--- a/tests/generator-Tests/expected.xaji/java.lang.Enum/Java.Lang.IComparable.cs
+++ b/tests/generator-Tests/expected.xaji/java.lang.Enum/Java.Lang.IComparable.cs
@@ -75,7 +75,7 @@ namespace Java.Lang {
 		static Delegate GetCompareTo_Ljava_lang_Object_Handler ()
 		{
 			if (cb_compareTo_Ljava_lang_Object_ == null)
-				cb_compareTo_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate ((_JniMarshal_PPL_I) n_CompareTo_Ljava_lang_Object_);
+				cb_compareTo_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_CompareTo_Ljava_lang_Object_));
 			return cb_compareTo_Ljava_lang_Object_;
 		}
 

--- a/tools/generator/SourceWriters/MethodCallback.cs
+++ b/tools/generator/SourceWriters/MethodCallback.cs
@@ -145,7 +145,7 @@ namespace generator.SourceWriters
 			var callback_name = method.EscapedCallbackName;
 
 			writer.WriteLine ($"if ({callback_name} == null)");
-			writer.WriteLine ($"\t{callback_name} = JNINativeWrapper.CreateDelegate (({method.GetDelegateType (opt)}) n_{method.Name + method.IDSignature});");
+			writer.WriteLine ($"\t{callback_name} = JNINativeWrapper.CreateDelegate (new {method.GetDelegateType (opt)} (n_{method.Name + method.IDSignature}));");
 			writer.WriteLine ($"return {callback_name};");
 		}
 	}


### PR DESCRIPTION
Fixes: https://github.com/xamarin/java.interop/issues/1034
Context: https://github.com/dotnet/roslyn/issues/62832#issuecomment-1198456455

On a recent .NET 7 bump, we found a ~4.5% app size regression related to a new C# 11 delegate feature. 

Instead of emitting e.g.

```csharp
static Delegate GetGetActionBarHandler ()
{
	if (cb_getActionBar == null)
		cb_getActionBar = JNINativeWrapper.CreateDelegate ((_JniMarshal_PP_L) n_GetActionBar);
	return cb_getActionBar;
}
```

`generator` should instead emit:

```csharp
static Delegate GetGetActionBarHandler ()
{
	if (cb_getActionBar == null)
		cb_getActionBar = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L(n_GetActionBar));
	return cb_getActionBar;
}
```

This should avoid a C#11 "caching method group conversion", allowing `Mono.Android.dll` assembly size to be ~unchanged between C#10 and C#11.

Test JI bump with this change is green: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6867774&view=results.