### PR TITLE
[generator] Add additional AttributeTargets to our dummy SupportedOSPlatformAttribute.

### DIFF
--- a/tests/generator-Tests/expected.xaji/AccessModifiers/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/AccessModifiers/__NamespaceMapping__.cs
@@ -7,7 +7,7 @@ delegate void _JniMarshal_PP_V (IntPtr jnienv, IntPtr klass);
 #if !NET
 namespace System.Runtime.Versioning {
     [System.Diagnostics.Conditional("NEVER")]
-    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Event | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Enum | AttributeTargets.Event | AttributeTargets.Field | AttributeTargets.Interface | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
     internal sealed class SupportedOSPlatformAttribute : Attribute {
         public SupportedOSPlatformAttribute (string platformName) { }
     }

--- a/tests/generator-Tests/expected.xaji/Adapters/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/Adapters/__NamespaceMapping__.cs
@@ -8,7 +8,7 @@ delegate void _JniMarshal_PPL_V (IntPtr jnienv, IntPtr klass, IntPtr p0);
 #if !NET
 namespace System.Runtime.Versioning {
     [System.Diagnostics.Conditional("NEVER")]
-    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Event | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Enum | AttributeTargets.Event | AttributeTargets.Field | AttributeTargets.Interface | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
     internal sealed class SupportedOSPlatformAttribute : Attribute {
         public SupportedOSPlatformAttribute (string platformName) { }
     }

--- a/tests/generator-Tests/expected.xaji/Android.Graphics.Color/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/Android.Graphics.Color/__NamespaceMapping__.cs
@@ -8,7 +8,7 @@ delegate void _JniMarshal_PPI_V (IntPtr jnienv, IntPtr klass, int p0);
 #if !NET
 namespace System.Runtime.Versioning {
     [System.Diagnostics.Conditional("NEVER")]
-    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Event | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Enum | AttributeTargets.Event | AttributeTargets.Field | AttributeTargets.Interface | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
     internal sealed class SupportedOSPlatformAttribute : Attribute {
         public SupportedOSPlatformAttribute (string platformName) { }
     }

--- a/tests/generator-Tests/expected.xaji/Arrays/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/Arrays/__NamespaceMapping__.cs
@@ -6,7 +6,7 @@ using System;
 #if !NET
 namespace System.Runtime.Versioning {
     [System.Diagnostics.Conditional("NEVER")]
-    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Event | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Enum | AttributeTargets.Event | AttributeTargets.Field | AttributeTargets.Interface | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
     internal sealed class SupportedOSPlatformAttribute : Attribute {
         public SupportedOSPlatformAttribute (string platformName) { }
     }

--- a/tests/generator-Tests/expected.xaji/CSharpKeywords/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/CSharpKeywords/__NamespaceMapping__.cs
@@ -8,7 +8,7 @@ delegate IntPtr _JniMarshal_PPI_L (IntPtr jnienv, IntPtr klass, int p0);
 #if !NET
 namespace System.Runtime.Versioning {
     [System.Diagnostics.Conditional("NEVER")]
-    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Event | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Enum | AttributeTargets.Event | AttributeTargets.Field | AttributeTargets.Interface | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
     internal sealed class SupportedOSPlatformAttribute : Attribute {
         public SupportedOSPlatformAttribute (string platformName) { }
     }

--- a/tests/generator-Tests/expected.xaji/Constructors/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/Constructors/__NamespaceMapping__.cs
@@ -6,7 +6,7 @@ using System;
 #if !NET
 namespace System.Runtime.Versioning {
     [System.Diagnostics.Conditional("NEVER")]
-    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Event | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Enum | AttributeTargets.Event | AttributeTargets.Field | AttributeTargets.Interface | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
     internal sealed class SupportedOSPlatformAttribute : Attribute {
         public SupportedOSPlatformAttribute (string platformName) { }
     }

--- a/tests/generator-Tests/expected.xaji/Core_ClassParse/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/Core_ClassParse/__NamespaceMapping__.cs
@@ -7,7 +7,7 @@ using System;
 #if !NET
 namespace System.Runtime.Versioning {
     [System.Diagnostics.Conditional("NEVER")]
-    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Event | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Enum | AttributeTargets.Event | AttributeTargets.Field | AttributeTargets.Interface | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
     internal sealed class SupportedOSPlatformAttribute : Attribute {
         public SupportedOSPlatformAttribute (string platformName) { }
     }

--- a/tests/generator-Tests/expected.xaji/Core_Jar2Xml/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/Core_Jar2Xml/__NamespaceMapping__.cs
@@ -9,7 +9,7 @@ delegate void _JniMarshal_PPL_V (IntPtr jnienv, IntPtr klass, IntPtr p0);
 #if !NET
 namespace System.Runtime.Versioning {
     [System.Diagnostics.Conditional("NEVER")]
-    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Event | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Enum | AttributeTargets.Event | AttributeTargets.Field | AttributeTargets.Interface | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
     internal sealed class SupportedOSPlatformAttribute : Attribute {
         public SupportedOSPlatformAttribute (string platformName) { }
     }

--- a/tests/generator-Tests/expected.xaji/GenericArguments/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/GenericArguments/__NamespaceMapping__.cs
@@ -9,7 +9,7 @@ delegate void _JniMarshal_PPLLIIL_V (IntPtr jnienv, IntPtr klass, IntPtr p0, Int
 #if !NET
 namespace System.Runtime.Versioning {
     [System.Diagnostics.Conditional("NEVER")]
-    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Event | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Enum | AttributeTargets.Event | AttributeTargets.Field | AttributeTargets.Interface | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
     internal sealed class SupportedOSPlatformAttribute : Attribute {
         public SupportedOSPlatformAttribute (string platformName) { }
     }

--- a/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/__NamespaceMapping__.cs
@@ -7,7 +7,7 @@ delegate void _JniMarshal_PP_V (IntPtr jnienv, IntPtr klass);
 #if !NET
 namespace System.Runtime.Versioning {
     [System.Diagnostics.Conditional("NEVER")]
-    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Event | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Enum | AttributeTargets.Event | AttributeTargets.Field | AttributeTargets.Interface | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
     internal sealed class SupportedOSPlatformAttribute : Attribute {
         public SupportedOSPlatformAttribute (string platformName) { }
     }

--- a/tests/generator-Tests/expected.xaji/NestedTypes/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/NestedTypes/__NamespaceMapping__.cs
@@ -7,7 +7,7 @@ delegate IntPtr _JniMarshal_PPI_L (IntPtr jnienv, IntPtr klass, int p0);
 #if !NET
 namespace System.Runtime.Versioning {
     [System.Diagnostics.Conditional("NEVER")]
-    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Event | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Enum | AttributeTargets.Event | AttributeTargets.Field | AttributeTargets.Interface | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
     internal sealed class SupportedOSPlatformAttribute : Attribute {
         public SupportedOSPlatformAttribute (string platformName) { }
     }

--- a/tests/generator-Tests/expected.xaji/NonStaticFields/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/NonStaticFields/__NamespaceMapping__.cs
@@ -6,7 +6,7 @@ using System;
 #if !NET
 namespace System.Runtime.Versioning {
     [System.Diagnostics.Conditional("NEVER")]
-    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Event | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Enum | AttributeTargets.Event | AttributeTargets.Field | AttributeTargets.Interface | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
     internal sealed class SupportedOSPlatformAttribute : Attribute {
         public SupportedOSPlatformAttribute (string platformName) { }
     }

--- a/tests/generator-Tests/expected.xaji/NormalMethods/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/NormalMethods/__NamespaceMapping__.cs
@@ -13,7 +13,7 @@ delegate int _JniMarshal_PPLL_I (IntPtr jnienv, IntPtr klass, IntPtr p0, IntPtr 
 #if !NET
 namespace System.Runtime.Versioning {
     [System.Diagnostics.Conditional("NEVER")]
-    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Event | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Enum | AttributeTargets.Event | AttributeTargets.Field | AttributeTargets.Interface | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
     internal sealed class SupportedOSPlatformAttribute : Attribute {
         public SupportedOSPlatformAttribute (string platformName) { }
     }

--- a/tests/generator-Tests/expected.xaji/NormalProperties/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/NormalProperties/__NamespaceMapping__.cs
@@ -10,7 +10,7 @@ delegate void _JniMarshal_PPL_V (IntPtr jnienv, IntPtr klass, IntPtr p0);
 #if !NET
 namespace System.Runtime.Versioning {
     [System.Diagnostics.Conditional("NEVER")]
-    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Event | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Enum | AttributeTargets.Event | AttributeTargets.Field | AttributeTargets.Interface | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
     internal sealed class SupportedOSPlatformAttribute : Attribute {
         public SupportedOSPlatformAttribute (string platformName) { }
     }

--- a/tests/generator-Tests/expected.xaji/ParameterXPath/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/ParameterXPath/__NamespaceMapping__.cs
@@ -7,7 +7,7 @@ delegate void _JniMarshal_PPL_V (IntPtr jnienv, IntPtr klass, IntPtr p0);
 #if !NET
 namespace System.Runtime.Versioning {
     [System.Diagnostics.Conditional("NEVER")]
-    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Event | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Enum | AttributeTargets.Event | AttributeTargets.Field | AttributeTargets.Interface | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
     internal sealed class SupportedOSPlatformAttribute : Attribute {
         public SupportedOSPlatformAttribute (string platformName) { }
     }

--- a/tests/generator-Tests/expected.xaji/StaticFields/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/StaticFields/__NamespaceMapping__.cs
@@ -6,7 +6,7 @@ using System;
 #if !NET
 namespace System.Runtime.Versioning {
     [System.Diagnostics.Conditional("NEVER")]
-    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Event | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Enum | AttributeTargets.Event | AttributeTargets.Field | AttributeTargets.Interface | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
     internal sealed class SupportedOSPlatformAttribute : Attribute {
         public SupportedOSPlatformAttribute (string platformName) { }
     }

--- a/tests/generator-Tests/expected.xaji/StaticMethods/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/StaticMethods/__NamespaceMapping__.cs
@@ -6,7 +6,7 @@ using System;
 #if !NET
 namespace System.Runtime.Versioning {
     [System.Diagnostics.Conditional("NEVER")]
-    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Event | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Enum | AttributeTargets.Event | AttributeTargets.Field | AttributeTargets.Interface | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
     internal sealed class SupportedOSPlatformAttribute : Attribute {
         public SupportedOSPlatformAttribute (string platformName) { }
     }

--- a/tests/generator-Tests/expected.xaji/StaticProperties/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/StaticProperties/__NamespaceMapping__.cs
@@ -6,7 +6,7 @@ using System;
 #if !NET
 namespace System.Runtime.Versioning {
     [System.Diagnostics.Conditional("NEVER")]
-    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Event | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Enum | AttributeTargets.Event | AttributeTargets.Field | AttributeTargets.Interface | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
     internal sealed class SupportedOSPlatformAttribute : Attribute {
         public SupportedOSPlatformAttribute (string platformName) { }
     }

--- a/tests/generator-Tests/expected.xaji/Streams/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/Streams/__NamespaceMapping__.cs
@@ -16,7 +16,7 @@ delegate void _JniMarshal_PPLII_V (IntPtr jnienv, IntPtr klass, IntPtr p0, int p
 #if !NET
 namespace System.Runtime.Versioning {
     [System.Diagnostics.Conditional("NEVER")]
-    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Event | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Enum | AttributeTargets.Event | AttributeTargets.Field | AttributeTargets.Interface | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
     internal sealed class SupportedOSPlatformAttribute : Attribute {
         public SupportedOSPlatformAttribute (string platformName) { }
     }

--- a/tests/generator-Tests/expected.xaji/TestInterface/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/__NamespaceMapping__.cs
@@ -12,7 +12,7 @@ delegate void _JniMarshal_PPL_V (IntPtr jnienv, IntPtr klass, IntPtr p0);
 #if !NET
 namespace System.Runtime.Versioning {
     [System.Diagnostics.Conditional("NEVER")]
-    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Event | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Enum | AttributeTargets.Event | AttributeTargets.Field | AttributeTargets.Interface | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
     internal sealed class SupportedOSPlatformAttribute : Attribute {
         public SupportedOSPlatformAttribute (string platformName) { }
     }

--- a/tests/generator-Tests/expected.xaji/java.lang.Enum/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/java.lang.Enum/__NamespaceMapping__.cs
@@ -6,7 +6,7 @@ delegate int _JniMarshal_PPL_I (IntPtr jnienv, IntPtr klass, IntPtr p0);
 #if !NET
 namespace System.Runtime.Versioning {
     [System.Diagnostics.Conditional("NEVER")]
-    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Event | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Enum | AttributeTargets.Event | AttributeTargets.Field | AttributeTargets.Interface | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
     internal sealed class SupportedOSPlatformAttribute : Attribute {
         public SupportedOSPlatformAttribute (string platformName) { }
     }

--- a/tests/generator-Tests/expected.xaji/java.util.List/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/java.util.List/__NamespaceMapping__.cs
@@ -6,7 +6,7 @@ using System;
 #if !NET
 namespace System.Runtime.Versioning {
     [System.Diagnostics.Conditional("NEVER")]
-    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Event | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Enum | AttributeTargets.Event | AttributeTargets.Field | AttributeTargets.Interface | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
     internal sealed class SupportedOSPlatformAttribute : Attribute {
         public SupportedOSPlatformAttribute (string platformName) { }
     }

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/NamespaceMapping.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/NamespaceMapping.cs
@@ -41,7 +41,7 @@ namespace MonoDroid.Generation
 					sw.WriteLine ("#if !NET");
 					sw.WriteLine ("namespace System.Runtime.Versioning {");
 					sw.WriteLine ("    [System.Diagnostics.Conditional(\"NEVER\")]");
-					sw.WriteLine ("    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Event | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]");
+					sw.WriteLine ("    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Enum | AttributeTargets.Event | AttributeTargets.Field | AttributeTargets.Interface | AttributeTargets.Method | AttributeTargets.Module | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]");
 					sw.WriteLine ("    internal sealed class SupportedOSPlatformAttribute : Attribute {");
 					sw.WriteLine ("        public SupportedOSPlatformAttribute (string platformName) { }");
 					sw.WriteLine ("    }");


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/pull/1052
Context: https://github.com/buyaa-n/runtime/blob/7a62a22db186fda42dad6cbd681cf056fcf6aee6/src/libraries/System.Private.CoreLib/src/System/Runtime/Versioning/PlatformAttributes.cs#L52-L62

In order to compile classic MonoAndroid bindings that contain the new .NET `[SupportedOSPlatform]` attributes, we have a dummy copy that we can compile against.  However this copy does not allow `AttributeTargets.Field`, so compiling with #1052 causes:

```
/Users/builder/azdo/_work/1/s/xamarin-android/src/Mono.Android/obj/Release/monoandroid10/android-33
/mcw/Dalvik.Bytecode.IOpcodes.cs(646,4): error CS0592: Attribute 
 global::System.Runtime.Versioning.SupportedOSPlatformAttribute' 
is not valid on this declaration type. It is only valid on 'assembly, module, 
class, struct, constructor, method, property, indexer, event' declarations. 
```

Update our copy to have the same `AttributeTargets` as the .NET version so we can compile on classic.