### PR TITLE
[build] Update Microsoft.* NuGet package versions

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -11,17 +11,17 @@
 
   <!-- NuGet Dependencies -->
   <ItemGroup>
-    <PackageReference Update="Microsoft.Xml.SgmlReader"                     Version="1.8.16" />
     <PackageReference Update="GitInfo"                                      Version="2.1.2" />
     <PackageReference Update="HtmlAgilityPack"                              Version="1.11.30" />
     <PackageReference Update="Irony"                                        Version="1.1.0" />
-    <PackageReference Update="Microsoft.Build.Framework"                    Version="16.11.0" />
-    <PackageReference Update="Microsoft.Build.Utilities.Core"               Version="16.11.0" />
-    <PackageReference Update="Microsoft.CodeAnalysis.CSharp"                Version="3.11.0" />
+    <PackageReference Update="Microsoft.Build.Framework"                    Version="17.3.2" />
+    <PackageReference Update="Microsoft.Build.Utilities.Core"               Version="17.3.2" />
+    <PackageReference Update="Microsoft.CodeAnalysis.CSharp"                Version="4.3.1" />
     <PackageReference Update="Microsoft.DotNet.GenAPI"                      Version="7.0.0-beta.22103.1" />
-    <PackageReference Update="Microsoft.NET.Test.Sdk"                       Version="16.11.0" />
-    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies"   Version="1.0.2" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk"                       Version="17.5.0-preview-20221003-04" />
+    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies"   Version="1.0.3" />
     <PackageReference Update="Microsoft.SourceLink.GitHub"                  Version="1.1.1" />
+    <PackageReference Update="Microsoft.Xml.SgmlReader"                     Version="1.8.16" />
     <PackageReference Update="Mono.CSharp"                                  Version="4.0.0.143" />
     <PackageReference Update="Mono.Linq.Expressions"                        Version="2.0.0" />
     <PackageReference Update="Mono.Options"                                 Version="6.12.0.148" />

--- a/samples/Hello-Java.Base/Hello-Java.Base.csproj
+++ b/samples/Hello-Java.Base/Hello-Java.Base.csproj
@@ -5,6 +5,7 @@
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
+    <StartupObject>Hello.App</StartupObject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Java.Interop.Tools.JavaTypeSystem-Tests/Java.Interop.Tools.JavaTypeSystem-Tests.csproj
+++ b/tests/Java.Interop.Tools.JavaTypeSystem-Tests/Java.Interop.Tools.JavaTypeSystem-Tests.csproj
@@ -13,14 +13,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit.ConsoleRunner" Version="3.11.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
+    <PackageReference Include="nunit" />
+    <PackageReference Include="NUnit.ConsoleRunner" />
+    <PackageReference Include="NUnit3TestAdapter">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
[build] Update Microsoft.* NuGet package versions

Context: c936d09aec8171fa99a37fd99dba253e41fec05d
Context: https://devdiv.visualstudio.com/DevDiv/_componentGovernance/112825/alert/7082457?typeId=12393424

[Component Governance][0] is a Microsoft internal tool which checks
for known security issues in product dependencies.  It is currently
reporting a defect in Java.Interop because of Newtonsoft.Json 9.0.1
and [GHSA-5crp-9r3c-p9vr][1].  This is a tad odd because Java.Interop
*does not use* Newtonsoft.Json.

Apparently the [Microsoft.NET.Test.Sdk 16.11.0 package][2] pulls in
Newtonsoft.Json 9.0.1 when `$(TargetFramework)`=UAP10.0, which is
also something that Java.Interop does not use.

Regardless!  Take this as a reminder and opportunity to update some
NuGet packages.  Update all of the `Microsoft.*` NuGet packages
*except* `Microsoft.Xml.SgmlReader`; as mentioned in c936d09a, newer
versions of that package have an API break, which prevent us from
trivially bumping the dependency.

Most other `Microsoft.*` NuGet packages are updated to the latest
*non-preview* versions listed on NuGet.org and available on
[dotnet-public][3].

`Microsoft.NET.Test.Sdk` is updated to the *preview* version
17.5.0-preview-20221003-04, because the [current stable 17.3.2][4]
version *still* references Newtonsoft.Json 9.0.1 for UAP10.0! 🙃

I have also sorted the `Microsoft.*` entries in
`Directory.Build.targets`.

One oddity: updating the `Microsoft.NET.Test.Sdk` NuGet package to
anything after 17.4.0-preview-20220726-02 results in a CS0017!

	samples/Hello-Java.Base/Program.cs(15,22):
	error CS0017: Program has more than one entry point defined.
	Compile with /main to specify the type that contains the entry point.

This is because `Hello-Java.Base.csproj` references
`TestJVM.csproj`, which references `Microsoft.NET.Test.Sdk`, and
more recent versions of the `Microsoft.NET.Test.Sdk` package contain
`buildTransitive/netcoreapp3.1/Microsoft.NET.Test.Sdk.Program.cs`,
which contains a `Main()` method!

	[Microsoft.VisualStudio.TestPlatform.TestSDKAutoGeneratedCode]                  
	class AutoGeneratedProgram {static void Main(string[] args){}}

I am not at all sure why this was done.

Prevent the CS0017 by setting the [`$(StartupObject)`][5] MSBuild
property to `Hello.App`.

[0]: https://docs.opensource.microsoft.com/tools/cg/
[1]: https://github.com/advisories/GHSA-5crp-9r3c-p9vr
[2]: https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/16.11.0
[3]: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json
[4]: https://www.fuget.org/packages/Microsoft.NET.Test.Sdk/17.3.2
[5]: https://learn.microsoft.com/en-us/visualstudio/msbuild/common-msbuild-project-properties?view=vs-2022
