### PR TITLE
[ci] Enable CodeQL static analysis.

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -86,6 +86,7 @@ jobs:
     - ImageOverride -equals $(1ESWindowsImage)
   variables:
     VSINSTALLDIR: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\
+    Codeql.Enabled: true
   timeoutInMinutes: 20
   workspace:
     clean: all


### PR DESCRIPTION
Enable `CodeQL` static code analysis on this repository to help catch potential issues.

This will only run on the `Windows - .NET Core` build lane, as we do not want to run it on all 4 builds.

Note the analysis only runs on `main` builds, so it will not show up in *this* CI build.