### PR TITLE
[ci] Increase timeout to 60 mins for CodeQL

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -87,7 +87,7 @@ jobs:
   variables:
     VSINSTALLDIR: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\
     Codeql.Enabled: true
-  timeoutInMinutes: 20
+  timeoutInMinutes: 60
   workspace:
     clean: all
   steps:


### PR DESCRIPTION
CodeQL was added in https://github.com/xamarin/java.interop/pull/1057, however it does not complete within our current 20 minute timeout.  The documentation recommends tripling the timeout, so set it to 60.