### PR TITLE
[generator] Refactor enum writing to use SourceWriters.

### DIFF
--- a/src/Java.Interop.Tools.Generator/Enumification/ConstantEntry.cs
+++ b/src/Java.Interop.Tools.Generator/Enumification/ConstantEntry.cs
@@ -163,6 +163,8 @@ namespace Java.Interop.Tools.Generator.Enumification
 			return entry;
 		}
 
+		public override string ToString () => $"[{EnumMember}, {Value}]";
+
 		public string ToVersion2String ()
 		{
 			var fields = new [] {

--- a/src/Xamarin.SourceWriter/Models/EnumMemberWriter.cs
+++ b/src/Xamarin.SourceWriter/Models/EnumMemberWriter.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+
+namespace Xamarin.SourceWriter
+{
+	public class EnumMemberWriter : ISourceWriter
+	{
+		public string Name { get; set; }
+		public List<string> Comments { get; } = new List<string> ();
+		public List<AttributeWriter> Attributes { get; } = new List<AttributeWriter> ();
+		public string Value { get; set; }
+		public int Priority { get; set; }
+
+		public virtual void Write (CodeWriter writer)
+		{
+			WriteComments (writer);
+			WriteAttributes (writer);
+			WriteSignature (writer);
+		}
+
+		public virtual void WriteComments (CodeWriter writer)
+		{
+			foreach (var c in Comments)
+				writer.WriteLine (c);
+		}
+
+		public virtual void WriteAttributes (CodeWriter writer)
+		{
+			foreach (var att in Attributes)
+				att.WriteAttribute (writer);
+		}
+
+		public virtual void WriteSignature (CodeWriter writer)
+		{
+			if (Value.HasValue ()) {
+				writer.Write (Name + " = ");
+				writer.Write (Value);
+				writer.WriteLine (",");
+			} else {
+				writer.WriteLine ($"{Name},");
+			}
+		}
+	}
+}

--- a/src/Xamarin.SourceWriter/Models/EnumWriter.cs
+++ b/src/Xamarin.SourceWriter/Models/EnumWriter.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+
+namespace Xamarin.SourceWriter
+{
+	public class EnumWriter : ISourceWriter
+	{
+		Visibility visibility;
+
+		public string Name { get; set; }
+		public bool IsPublic { get => visibility.HasFlag (Visibility.Public); set => visibility = value ? Visibility.Public : Visibility.Default; }
+		public bool IsInternal { get => visibility.HasFlag (Visibility.Internal); set => visibility = value ? Visibility.Internal : Visibility.Default; }
+		public bool IsPrivate { get => visibility.HasFlag (Visibility.Private); set => visibility = value ? Visibility.Private : Visibility.Default; }
+		public bool IsProtected { get => visibility.HasFlag (Visibility.Protected); set => visibility = value ? Visibility.Protected : Visibility.Default; }
+		public List<string> Comments { get; } = new List<string> ();
+		public List<AttributeWriter> Attributes { get; } = new List<AttributeWriter> ();
+		public List<EnumMemberWriter> Members { get; } = new List<EnumMemberWriter> ();
+
+		public int Priority { get; set; }
+
+		public void Write (CodeWriter writer)
+		{
+			WriteComments (writer);
+			WriteAttributes (writer);
+			WriteSignature (writer);
+			WriteMembers (writer);
+			WriteTypeClose (writer);
+		}
+
+		public virtual void WriteComments (CodeWriter writer)
+		{
+			foreach (var c in Comments)
+				writer.WriteLine (c);
+		}
+
+		public virtual void WriteAttributes (CodeWriter writer)
+		{
+			foreach (var att in Attributes)
+				att.WriteAttribute (writer);
+		}
+
+		public virtual void WriteSignature (CodeWriter writer)
+		{
+			if (IsPublic)
+				writer.Write ("public ");
+			if (IsProtected)
+				writer.Write ("protected ");
+			if (IsInternal)
+				writer.Write ("internal ");
+			if (IsPrivate)
+				writer.Write ("private ");
+
+			writer.Write ("enum ");
+			writer.WriteLine (Name + " ");
+
+			writer.WriteLine ("{");
+			writer.Indent ();
+		}
+
+		public virtual void WriteMembers (CodeWriter writer)
+		{
+			foreach (var member in Members) {
+				member.Write (writer);
+				writer.WriteLine ();
+			}
+		}
+
+		public virtual void WriteTypeClose (CodeWriter writer)
+		{
+			writer.Unindent ();
+			writer.WriteLine ("}");
+		}
+	}
+}

--- a/tests/generator-Tests/Unit-Tests/EnumGeneratorTests.cs
+++ b/tests/generator-Tests/Unit-Tests/EnumGeneratorTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Text;
+using Java.Interop.Tools.Generator.Enumification;
 using MonoDroid.Generation;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
@@ -69,13 +70,9 @@ namespace generatortests
 		KeyValuePair<string, EnumMappings.EnumDescription> CreateEnum ()
 		{
 			var enu = new EnumMappings.EnumDescription {
-				Members = new Dictionary<string, string> {
-					{ "WithExcluded", "1" },
-					{ "IgnoreUnavailable", "2" }
-				},
-				JniNames = new Dictionary<string, string> {
-					{ "WithExcluded", "android/app/ActivityManager.RECENT_IGNORE_UNAVAILABLE" },
-					{ "IgnoreUnavailable", "android/app/ActivityManager.RECENT_WITH_EXCLUDED" }
+				Members = new List<ConstantEntry> {
+					new ConstantEntry { EnumMember = "WithExcluded", Value = "1", JavaSignature = "android/app/ActivityManager.RECENT_IGNORE_UNAVAILABLE" },
+					new ConstantEntry { EnumMember = "IgnoreUnavailable", Value = "2", JavaSignature = "android/app/ActivityManager.RECENT_WITH_EXCLUDED" }
 				},
 				BitField = false,
 				FieldsRemoved = false

--- a/tests/generator-Tests/Unit-Tests/EnumMappingsTests.cs
+++ b/tests/generator-Tests/Unit-Tests/EnumMappingsTests.cs
@@ -29,7 +29,7 @@ namespace generatortests
 			Assert.AreEqual ("Org.XmlPull.V1.XmlPullParserNode", enums.Single ().Key);
 			Assert.AreEqual (false, enums.Single ().Value.BitField);
 			Assert.AreEqual (true, enums.Single ().Value.FieldsRemoved);
-			Assert.AreEqual ("[Cdsect, I:org/xmlpull/v1/XmlPullParser.CDSECT]", enums.First ().Value.JniNames.Single ().ToString ());
+			Assert.AreEqual ("I:org/xmlpull/v1/XmlPullParser.CDSECT", enums.First ().Value.Members.Single ().JavaSignature);
 			Assert.AreEqual ("[Cdsect, 5]", enums.First ().Value.Members.Single ().ToString ());
 		}
 
@@ -65,7 +65,7 @@ namespace generatortests
 			Assert.AreEqual ("Org.XmlPull.V1.XmlPullParserNode", enums.Single ().Key);
 			Assert.AreEqual (false, enums.Single ().Value.BitField);
 			Assert.AreEqual (true, enums.Single ().Value.FieldsRemoved);
-			Assert.AreEqual ("[Cdsect, ]", enums.First ().Value.JniNames.Single ().ToString ());
+			Assert.AreEqual ("", enums.First().Value.Members.Single ().JavaSignature);
 			Assert.AreEqual ("[Cdsect, 5]", enums.First ().Value.Members.Single ().ToString ());
 		}
 
@@ -128,7 +128,7 @@ namespace generatortests
 			Assert.AreEqual ("Org.XmlPull.V1.XmlPullParserNode", enums.Single ().Key);
 			Assert.AreEqual (false, enums.Single ().Value.BitField);
 			Assert.AreEqual (false, enums.Single ().Value.FieldsRemoved);
-			Assert.AreEqual ("[Cdsect, I:org/xmlpull/v1/XmlPullParser.CDSECT]", enums.First ().Value.JniNames.Single ().ToString ());
+			Assert.AreEqual ("I:org/xmlpull/v1/XmlPullParser.CDSECT", enums.First().Value.Members.Single ().JavaSignature);
 			Assert.AreEqual ("[Cdsect, 5]", enums.First ().Value.Members.Single ().ToString ());
 		}
 
@@ -164,7 +164,7 @@ namespace generatortests
 			Assert.AreEqual ("Org.XmlPull.V1.XmlPullParserNode", enums.Single ().Key);
 			Assert.AreEqual (false, enums.Single ().Value.BitField);
 			Assert.AreEqual (false, enums.Single ().Value.FieldsRemoved);
-			Assert.AreEqual ("[Cdsect, ]", enums.First ().Value.JniNames.Single ().ToString ());
+			Assert.AreEqual ("", enums.First ().Value.Members.Single ().JavaSignature);
 			Assert.AreEqual ("[Cdsect, 5]", enums.First ().Value.Members.Single ().ToString ());
 		}
 		[Test]
@@ -183,7 +183,7 @@ namespace generatortests
 			Assert.AreEqual ("Org.XmlPull.V1.XmlPullParserNode", enums.Single ().Key);
 			Assert.AreEqual (false, enums.Single ().Value.BitField);
 			Assert.AreEqual (true, enums.Single ().Value.FieldsRemoved);
-			Assert.AreEqual ("[Cdsect, I:org/xmlpull/v1/XmlPullParser.CDSECT]", enums.First ().Value.JniNames.Single ().ToString ());
+			Assert.AreEqual ("I:org/xmlpull/v1/XmlPullParser.CDSECT", enums.First ().Value.Members.Single ().JavaSignature);
 			Assert.AreEqual ("[Cdsect, 5]", enums.First ().Value.Members.Single ().ToString ());
 		}
 
@@ -219,7 +219,7 @@ namespace generatortests
 			Assert.AreEqual ("Org.XmlPull.V1.XmlPullParserNode", enums.Single ().Key);
 			Assert.AreEqual (false, enums.Single ().Value.BitField);
 			Assert.AreEqual (true, enums.Single ().Value.FieldsRemoved);
-			Assert.AreEqual ("[Cdsect, ]", enums.First ().Value.JniNames.Single ().ToString ());
+			Assert.AreEqual ("", enums.First ().Value.Members.Single ().JavaSignature);
 			Assert.AreEqual ("[Cdsect, 5]", enums.First ().Value.Members.Single ().ToString ());
 		}
 
@@ -282,7 +282,7 @@ namespace generatortests
 			Assert.AreEqual ("Org.XmlPull.V1.XmlPullParserNode", enums.Single ().Key);
 			Assert.AreEqual (false, enums.Single ().Value.BitField);
 			Assert.AreEqual (false, enums.Single ().Value.FieldsRemoved);
-			Assert.AreEqual ("[Cdsect, I:org/xmlpull/v1/XmlPullParser.CDSECT]", enums.First ().Value.JniNames.Single ().ToString ());
+			Assert.AreEqual ("I:org/xmlpull/v1/XmlPullParser.CDSECT", enums.First ().Value.Members.Single ().JavaSignature);
 			Assert.AreEqual ("[Cdsect, 5]", enums.First ().Value.Members.Single ().ToString ());
 		}
 

--- a/tools/generator/Java.Interop.Tools.Generator.Transformation/EnumMappings.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Transformation/EnumMappings.cs
@@ -20,8 +20,7 @@ namespace MonoDroid.Generation {
 	partial class EnumMappings {
 
 		public class EnumDescription {
-			public Dictionary<string, string> Members = new Dictionary<string, string> ();
-			public Dictionary<string, string> JniNames = new Dictionary<string, string> ();
+			public List<ConstantEntry> Members = new List<ConstantEntry> ();
 			public bool BitField;
 			public bool FieldsRemoved;
 		}
@@ -69,10 +68,7 @@ namespace MonoDroid.Generation {
 					BitField = group.Any (c => c.IsFlags) || enumFlags?.Contains (group.Key) == true
 				};
 
-				foreach (var c in group) {
-					desc.Members.Add (c.EnumMember, c.Value);
-					desc.JniNames.Add (c.EnumMember, c.JavaSignature);
-				}
+				desc.Members.AddRange (group);
 
 				enums.Add (group.Key, desc);
 			}

--- a/tools/generator/SourceWriters/Attributes/FlagsAttr.cs
+++ b/tools/generator/SourceWriters/Attributes/FlagsAttr.cs
@@ -1,0 +1,13 @@
+using System;
+using Xamarin.SourceWriter;
+
+namespace generator.SourceWriters
+{
+	public class FlagsAttr : AttributeWriter
+	{
+		public override void WriteAttribute (CodeWriter writer)
+		{
+			writer.WriteLine ("[System.Flags]");
+		}
+	}
+}

--- a/tools/generator/SourceWriters/Attributes/IntDefinitionAttr.cs
+++ b/tools/generator/SourceWriters/Attributes/IntDefinitionAttr.cs
@@ -1,0 +1,23 @@
+using System;
+using Xamarin.SourceWriter;
+
+namespace generator.SourceWriters
+{
+	public class IntDefinitionAttr : AttributeWriter
+	{
+		public string ManagedMember { get; set; }
+		public string JniField { get; set; }
+
+		public IntDefinitionAttr (string managedMember, string jniField)
+		{
+			ManagedMember = managedMember;
+			JniField = jniField;
+		}
+
+		public override void WriteAttribute (CodeWriter writer)
+		{
+			var member = ManagedMember is null ? "null" : "\"" + ManagedMember + "\"";
+			writer.WriteLine ($"[global::Android.Runtime.IntDefinition ({member}, JniField = \"{JniField}\")]");
+		}
+	}
+}


### PR DESCRIPTION
Refactor `EnumGenerator` to use SourceWriters instead of a direct `TextWriter`.  This will make it possible to use our existing code to apply `[PlatformOSSupported]` attributes to enums in a future PR.

This is a separate PR to help verify there was no output changed from the refactor.

Tested with ApiCompat on https://github.com/xamarin/xamarin-android/pull/7619 to help ensure no changes.