### PR TITLE
[Java.Interop.Tools.Cecil] avoid `File.Exists()` check in `DirectoryAssemblyResolver`

### DIFF
--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/DirectoryAssemblyResolver.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/DirectoryAssemblyResolver.cs
@@ -124,9 +124,6 @@ namespace Java.Interop.Tools.Cecil {
 
 		public virtual AssemblyDefinition? Load (string fileName, bool forceLoad = false)
 		{
-			if (!File.Exists (fileName))
-				return null;
-
 			AssemblyDefinition? assembly = null;
 			var name = Path.GetFileNameWithoutExtension (fileName);
 			if (!forceLoad && cache.TryGetValue (name, out assembly))
@@ -134,6 +131,9 @@ namespace Java.Interop.Tools.Cecil {
 
 			try {
 				assembly  = ReadAssembly (fileName);
+			} catch (FileNotFoundException) {
+				// This one is ok, we can return null
+				return null;
 			} catch (Exception e) {
 				Diagnostic.Error (9, e, Localization.Resources.CecilResolver_XA0009, fileName);
 			}
@@ -144,8 +144,8 @@ namespace Java.Interop.Tools.Cecil {
 		protected virtual AssemblyDefinition ReadAssembly (string file)
 		{
 			bool haveDebugSymbols = loadDebugSymbols &&
-				(File.Exists (file + ".mdb") ||
-				 File.Exists (Path.ChangeExtension (file, ".pdb")));
+				(File.Exists (Path.ChangeExtension (file, ".pdb")) ||
+				 File.Exists (file + ".mdb"));
 			var reader_parameters = new ReaderParameters () {
 				ApplyWindowsRuntimeProjections  = loadReaderParameters.ApplyWindowsRuntimeProjections,
 				AssemblyResolver                = this,


### PR DESCRIPTION
`dotnet-trace` of a `dotnet new maui` app:

    dotnet trace collect --format speedscope -- C:\src\xamarin-android\bin\Release\dotnet\dotnet.exe build -bl --no-restore bar.csproj

Shows some interesting time spent in:

    179.53ms java.interop.tools.cecil!Java.Interop.Tools.Cecil.DirectoryAssemblyResolver.Load(class System.String,bool)
      7.89ms system.private.corelib.il!System.IO.File.Exists(class System.String)
    171.63ms java.interop.tools.cecil!Java.Interop.Tools.Cecil.DirectoryAssemblyResolver.ReadAssembly(class System.String)
     24.18ms system.private.corelib.il!System.IO.File.Exists(class System.String)

For `LoadAssembly()`, the common case is that the files always exist, and the rare case they would be missing. Instead of calling `File.Exists()` on every assembly, we can handle
`FileNotFoundException` and `return null` appropriately.

For `ReadAssembly()` we can reorder the check for symbol files:

    bool haveDebugSymbols = loadDebugSymbols &&
        (File.Exists (Path.ChangeExtension (file, ".pdb")) ||
        File.Exists (file + ".mdb"));

So we check for `.pdb` files first, which should more likely exist in modern projects. We could drop `.mdb` file checks at some point, when this code isn't shared with classic Xamarin.Android.

Testing the changes afterward:

    167.57ms java.interop.tools.cecil!Java.Interop.Tools.Cecil.DirectoryAssemblyResolver.Load(class System.String,bool)
    141.56ms xamarin.android.cecil!Mono.Cecil.AssemblyDefinition.ReadAssembly(class System.String,class Mono.Cecil.ReaderParameters)

There appears to be some variance in the timing, but my rough estimate is this saves about 15-20ms on incremental builds of `dotnet new maui` projects. Larger projects could potentially save more.