### PR TITLE
[generator] Support [Obsolete]/[SupportedOSPlatform] attributes for enum members.

### DIFF
--- a/tests/generator-Tests/Unit-Tests/EnumGeneratorTests.cs
+++ b/tests/generator-Tests/Unit-Tests/EnumGeneratorTests.cs
@@ -1,24 +1,26 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Text;
 using Java.Interop.Tools.Generator.Enumification;
 using MonoDroid.Generation;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
+using Xamarin.Android.Binder;
 
 namespace generatortests
 {
 	[TestFixture]
-	class EnumGeneratorTests
+	class EnumGeneratorTests : CodeGeneratorTestBase
 	{
-		protected EnumGenerator generator;
-		protected StringBuilder builder;
-		protected StringWriter writer;
+		protected new EnumGenerator generator;
+
+		protected override CodeGenerationTarget Target => CodeGenerationTarget.XAJavaInterop1;
 
 		[SetUp]
-		public void SetUp ()
+		public new void SetUp ()
 		{
 			builder = new StringBuilder ();
 			writer = new StringWriter (builder);
@@ -60,7 +62,78 @@ namespace generatortests
 			Assert.AreEqual (GetExpected (nameof (WriteEnumWithGens)), writer.ToString ().NormalizeLineEndings ());
 		}
 
-		protected string GetExpected (string testName)
+		[Test]
+		public void ObsoletedOSPlatformAttributeSupport ()
+		{
+			var xml = @"<api>
+			  <package name='java.lang' jni-name='java/lang'>
+			    <class abstract='false' deprecated='not deprecated' final='false' name='Object' static='false' visibility='public' jni-signature='Ljava/lang/Object;' />
+			  </package>
+			  <package name='android.app' jni-name='android/app'>
+			    <class abstract='false' deprecated='not deprecated' extends='java.lang.Object' extends-generic-aware='java.lang.Object' jni-extends='Ljava/lang/Object;' final='false' name='ActivityManager' static='false' visibility='public' jni-signature='Landroid/app/ActivityManager;'>
+			      <field deprecated='deprecated' final='true' name='RECENT_IGNORE_UNAVAILABLE' jni-signature='Ljava/lang/String;' static='true' transient='false' type='java.lang.String' type-generic-aware='java.lang.String' value='&quot;android.permission.BIND_CHOOSER_TARGET_SERVICE&quot;' visibility='public' volatile='false' deprecated-since='31' api-since='30' />
+			    </class>
+			  </package>
+			</api>";
+
+			options.UseObsoletedOSPlatformAttributes = true;
+
+			var enu = CreateEnum ();
+			var gens = ParseApiDefinition (xml);
+
+			generator.WriteEnumeration (options, enu, gens.ToArray ());
+
+			// Ensure [ObsoletedOSPlatform] and [SupportedOSPlatform] are written
+			Assert.True (writer.ToString ().NormalizeLineEndings ().Contains ("[global::System.Runtime.Versioning.SupportedOSPlatformAttribute(\"android30.0\")][global::System.Runtime.Versioning.ObsoletedOSPlatform(\"android31.0\")]WithExcluded=1"), writer.ToString ());
+		}
+
+		[Test]
+		public void ObsoleteAttributeSupport ()
+		{
+			var xml = @"<api>
+			  <package name='java.lang' jni-name='java/lang'>
+			    <class abstract='false' deprecated='not deprecated' final='false' name='Object' static='false' visibility='public' jni-signature='Ljava/lang/Object;' />
+			  </package>
+			  <package name='android.app' jni-name='android/app'>
+			    <class abstract='false' deprecated='not deprecated' extends='java.lang.Object' extends-generic-aware='java.lang.Object' jni-extends='Ljava/lang/Object;' final='false' name='ActivityManager' static='false' visibility='public' jni-signature='Landroid/app/ActivityManager;'>
+			      <field deprecated='deprecated' final='true' name='RECENT_IGNORE_UNAVAILABLE' jni-signature='Ljava/lang/String;' static='true' transient='false' type='java.lang.String' type-generic-aware='java.lang.String' value='&quot;android.permission.BIND_CHOOSER_TARGET_SERVICE&quot;' visibility='public' volatile='false' deprecated-since='31' api-since='30' />
+			    </class>
+			  </package>
+			</api>";
+
+			var enu = CreateEnum ();
+			var gens = ParseApiDefinition (xml);
+
+			generator.WriteEnumeration (options, enu, gens.ToArray ());
+
+			// Ensure [Obsolete] is written
+			Assert.True (writer.ToString ().NormalizeLineEndings ().Contains ("[global::System.Obsolete(@\"deprecated\")]WithExcluded=1"), writer.ToString ());
+		}
+
+		[Test]
+		public void ObsoleteFieldButNotEnumAttributeSupport ()
+		{
+			var xml = @"<api>
+			  <package name='java.lang' jni-name='java/lang'>
+			    <class abstract='false' deprecated='not deprecated' final='false' name='Object' static='false' visibility='public' jni-signature='Ljava/lang/Object;' />
+			  </package>
+			  <package name='android.app' jni-name='android/app'>
+			    <class abstract='false' deprecated='not deprecated' extends='java.lang.Object' extends-generic-aware='java.lang.Object' jni-extends='Ljava/lang/Object;' final='false' name='ActivityManager' static='false' visibility='public' jni-signature='Landroid/app/ActivityManager;'>
+			      <field deprecated='This constant will be removed in the future version. Use Android.App.RecentTaskFlags enum directly instead of this field.' final='true' name='RECENT_IGNORE_UNAVAILABLE' jni-signature='Ljava/lang/String;' static='true' transient='false' type='java.lang.String' type-generic-aware='java.lang.String' value='&quot;android.permission.BIND_CHOOSER_TARGET_SERVICE&quot;' visibility='public' volatile='false' deprecated-since='31' api-since='30' />
+			    </class>
+			  </package>
+			</api>";
+
+			var enu = CreateEnum ();
+			var gens = ParseApiDefinition (xml);
+
+			generator.WriteEnumeration (options, enu, gens.ToArray ());
+
+			// [Obsolete] should not be written because the value isn't deprecated, just the _field_ is deprecated because we want people to use the enum instead
+			Assert.False (writer.ToString ().NormalizeLineEndings ().Contains ("[global::System.Obsolete(@\"deprecated\")]WithExcluded=1"), writer.ToString ());
+		}
+
+		protected new string GetExpected (string testName)
 		{
 			var root = Path.GetDirectoryName (Assembly.GetExecutingAssembly ().Location);
 
@@ -71,7 +144,7 @@ namespace generatortests
 		{
 			var enu = new EnumMappings.EnumDescription {
 				Members = new List<ConstantEntry> {
-					new ConstantEntry { EnumMember = "WithExcluded", Value = "1", JavaSignature = "android/app/ActivityManager.RECENT_IGNORE_UNAVAILABLE" },
+					new ConstantEntry { EnumMember = "WithExcluded", Value = "1", JavaSignature = "android/app/ActivityManager.RECENT_IGNORE_UNAVAILABLE", ApiLevel = 30 },
 					new ConstantEntry { EnumMember = "IgnoreUnavailable", Value = "2", JavaSignature = "android/app/ActivityManager.RECENT_WITH_EXCLUDED" }
 				},
 				BitField = false,

--- a/tools/generator/SourceWriters/Extensions/SourceWriterExtensions.cs
+++ b/tools/generator/SourceWriters/Extensions/SourceWriterExtensions.cs
@@ -293,12 +293,14 @@ namespace generator.SourceWriters
 		}
 
 		public static void AddSupportedOSPlatform (List<AttributeWriter> attributes, ApiVersionsSupport.IApiAvailability member, CodeGenerationOptions opt)
+			=> AddSupportedOSPlatform (attributes, member.ApiAvailableSince, opt);
+
+		public static void AddSupportedOSPlatform (List<AttributeWriter> attributes, int since, CodeGenerationOptions opt)
 		{
 			// There's no sense in writing say 'android15' because we do not support older APIs,
 			// so those APIs will be available in all of our versions.
-			if (member.ApiAvailableSince > 21 && opt.CodeGenerationTarget == Xamarin.Android.Binder.CodeGenerationTarget.XAJavaInterop1)
-				attributes.Add (new SupportedOSPlatformAttr (member.ApiAvailableSince));
-
+			if (since > 21 && opt.CodeGenerationTarget == Xamarin.Android.Binder.CodeGenerationTarget.XAJavaInterop1)
+				attributes.Add (new SupportedOSPlatformAttr (since));
 		}
 
 		public static void AddObsolete (List<AttributeWriter> attributes, string message, CodeGenerationOptions opt, bool forceDeprecate = false, bool isError = false, int? deprecatedSince = null)


### PR DESCRIPTION
Fixes: https://github.com/xamarin/java.interop/issues/1037

Adds support for `[Obsolete]`/`[ObsoletedOSPlatform]` and `[SupportedOSPlatform]` attributes on enum members.

## [SupportedOSPlatform]

The data for `[SupportedOSPlatform]` comes from the values provided in the enum-mapping file:

```
// src/Mono.Android/map.csv
E,29,android/media/MediaRecorder$AudioEncoder.OPUS,7,Android.Media.AudioEncoder,Opus,keep,
```

The `29` is the API in which we added the enum, which becomes `[SupportedOSPlatform ("android-29.0")]`.

## [Obsolete]/[ObsoletedOSPlatform]

The data for the "obsolete" attributes comes from the `deprecated` and `deprecated-since` attributes on the original field in the `api.xml` (if it can be found):

```xml
<field deprecated='deprecated' deprecated-since='31' api-since='30' final='true' name='BIND_CHOOSER_TARGET_SERVICE' jni-signature='Ljava/lang/String;' static='true' transient='false' type='java.lang.String' type-generic-aware='java.lang.String' value='&quot;android.permission.BIND_CHOOSER_TARGET_SERVICE&quot;' visibility='public' volatile='false' />
```

This example results in:

```csharp
// When using classic obsolete attributes:
[global::System.Obsolete("deprecated")]

// When using new obsolete attributes:
[global::System.Runtime.Versioning.ObsoletedOSPlatform("android31.0")]
```

One wrinkle is we may have obsoleted the field because we want the user to use the enum instead:

```xml
<field deprecated='This constant will be removed in the future version. Use Android.App.RecentTaskFlags enum directly instead of this field.' final='true' name='RECENT_IGNORE_UNAVAILABLE' jni-signature='Ljava/lang/String;' static='true' transient='false' type='java.lang.String' type-generic-aware='java.lang.String' value='&quot;android.permission.BIND_CHOOSER_TARGET_SERVICE&quot;' visibility='public' volatile='false' deprecated-since='31' api-since='30' />
```

We need to detect this message and not obsolete the enum in this case.