### PR TITLE
[Dynamic-Tests] Replace Microsoft.CSharp reference with NuGet package.

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -17,6 +17,7 @@
     <PackageReference Update="Microsoft.Build.Framework"                    Version="17.3.2" />
     <PackageReference Update="Microsoft.Build.Utilities.Core"               Version="17.3.2" />
     <PackageReference Update="Microsoft.CodeAnalysis.CSharp"                Version="4.3.1" />
+    <PackageReference Update="Microsoft.CSharp"                             Version="4.7.0" />
     <PackageReference Update="Microsoft.DotNet.GenAPI"                      Version="7.0.0-beta.22103.1" />
     <PackageReference Update="Microsoft.NET.Test.Sdk"                       Version="17.5.0-preview-20221003-04" />
     <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies"   Version="1.0.3" />

--- a/tests/Java.Interop.Dynamic-Tests/Java.Interop.Dynamic-Tests.csproj
+++ b/tests/Java.Interop.Dynamic-Tests/Java.Interop.Dynamic-Tests.csproj
@@ -13,10 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" />
     <PackageReference Include="nunit" />


### PR DESCRIPTION
Each CI job reports the following warnings:

```
C:\hostedtoolcache\windows\dotnet\sdk\7.0.100-rc.1.22431.12\Microsoft.Common.CurrentVersion.targets(2350,5): warning MSB3245: Could not resolve this reference. Could not locate the assembly "Microsoft.CSharp". Check to make sure the assembly exists on disk. If this reference is required by your code, you may get compilation errors. [D:\a\_work\1\s\tests\Java.Interop.Dynamic-Tests\Java.Interop.Dynamic-Tests.csproj::TargetFramework=net7.0]
C:\hostedtoolcache\windows\dotnet\sdk\7.0.100-rc.1.22431.12\Microsoft.Common.CurrentVersion.targets(2350,5): warning MSB3243: No way to resolve conflict between "Microsoft.CSharp, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" and "Microsoft.CSharp". Choosing "Microsoft.CSharp, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" arbitrarily. [D:\a\_work\1\s\tests\Java.Interop.Dynamic-Tests\Java.Interop.Dynamic-Tests.csproj::TargetFramework=net7.0]
```

Fix this by using a `<PackageReference>` to `Microsoft.CSharp` instead of a `<Reference>`.