### PR TITLE
[generator] Inherit declaring type's 'deprecated-since' if lower than member's.

### DIFF
--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
@@ -576,7 +576,7 @@ namespace generatortests
 			    <class abstract='false' deprecated='not deprecated' final='false' name='Object' static='false' visibility='public' jni-signature='Ljava/lang/Object;' />
 			  </package>
 			  <package name='com.xamarin.android' jni-name='com/xamarin/android'>
-			    <class abstract='false' deprecated='This is a class deprecated since 19!' extends='java.lang.Object' extends-generic-aware='java.lang.Object' jni-extends='Ljava/lang/Object;' final='false' name='MyClass' static='false' visibility='public' jni-signature='Lcom/xamarin/android/MyClass;' deprecated-since='19'>
+			    <class abstract='false' deprecated='This is a class deprecated since 28!' extends='java.lang.Object' extends-generic-aware='java.lang.Object' jni-extends='Ljava/lang/Object;' final='false' name='MyClass' static='false' visibility='public' jni-signature='Lcom/xamarin/android/MyClass;' deprecated-since='28'>
 			      <field deprecated='This is a field deprecated since 0!' final='true' name='ACCEPT_HANDOVER' jni-signature='Ljava/lang/String;' static='true' transient='false' type='java.lang.String' type-generic-aware='java.lang.String' value='&quot;android.permission.ACCEPT_HANDOVER&quot;' visibility='public' volatile='false' deprecated-since='0'></field>
 			      <constructor deprecated='This is a constructor deprecated since empty string!' final='false' name='MyClass' jni-signature='()V' bridge='false' static='false' type='com.xamarin.android.MyClass' synthetic='false' visibility='public' deprecated-since=''></constructor>
 			      <method abstract='true' deprecated='deprecated' final='false' name='countAffectedRows' jni-signature='()I' bridge='false' native='false' return='int' jni-return='I' static='false' synchronized='false' synthetic='false' visibility='public' deprecated-since='25'></method>
@@ -599,7 +599,6 @@ namespace generatortests
 			generator.Context.ContextTypes.Pop ();
 
 			// These should use [Obsolete] because they have always been obsolete in all currently supported versions (21+)
-			Assert.True (writer.ToString ().Contains ("[global::System.Obsolete (@\"This is a class deprecated since 19!\")]"), writer.ToString ());
 			Assert.True (writer.ToString ().Contains ("[global::System.Obsolete (@\"This is a field deprecated since 0!\")]"), writer.ToString ());
 			Assert.True (writer.ToString ().Contains ("[global::System.Obsolete (@\"This is a constructor deprecated since empty string!\")]"), writer.ToString ());
 

--- a/tests/generator-Tests/Unit-Tests/XmlApiImporterTests.cs
+++ b/tests/generator-Tests/Unit-Tests/XmlApiImporterTests.cs
@@ -79,6 +79,15 @@ namespace generatortests
 		}
 
 		[Test]
+		public void CreateCtor_CorrectDeprecatedSinceFromClass ()
+		{
+			var xml = XDocument.Parse ("<package name='com.example.test' jni-name='com/example/test'><class name='test' deprecated-since='7'><constructor name='ctor' deprecated-since='17' /></class></package>");
+			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), opt);
+
+			Assert.AreEqual (7, klass.Ctors [0].DeprecatedSince);
+		}
+
+		[Test]
 		public void CreateField_StudlyCaseName ()
 		{
 			var klass = new TestClass ("object", "MyNamespace.MyType");
@@ -136,6 +145,15 @@ namespace generatortests
 			var field = XmlApiImporter.CreateField (klass, xml.Root);
 
 			Assert.AreEqual (7, field.ApiAvailableSince);
+		}
+
+		[Test]
+		public void CreateField_CorrectDeprecatedSinceFromClass ()
+		{
+			var xml = XDocument.Parse ("<package name='com.example.test' jni-name='com/example/test'><class name='test' deprecated-since='7'><field name='$3' deprecated-since='17' /></class></package>");
+			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), opt);
+
+			Assert.AreEqual (7, klass.Fields [0].DeprecatedSince);
 		}
 
 		[Test]
@@ -210,6 +228,15 @@ namespace generatortests
 			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), opt);
 
 			Assert.AreEqual (7, klass.Methods [0].ApiAvailableSince);
+		}
+
+		[Test]
+		public void CreateMethod_CorrectDeprecatedSinceFromClass ()
+		{
+			var xml = XDocument.Parse ("<package name='com.example.test' jni-name='com/example/test'><class name='test' deprecated-since='7'><method name='-3' deprecated-since='17' /></class></package>");
+			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), opt);
+
+			Assert.AreEqual (7, klass.Methods [0].DeprecatedSince);
 		}
 
 		[Test]

--- a/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
@@ -191,6 +191,10 @@ namespace MonoDroid.Generation
 
 			ctor.Name = EnsureValidIdentifer (ctor.Name);
 
+			// If declaring type was deprecated earlier than member, use the type's deprecated-since
+			if (declaringType.DeprecatedSince.HasValue && declaringType.DeprecatedSince.Value < ctor.DeprecatedSince.GetValueOrDefault (0))
+				ctor.DeprecatedSince = declaringType.DeprecatedSince;
+
 			FillApiSince (ctor, elem);
 
 			return ctor;
@@ -229,6 +233,10 @@ namespace MonoDroid.Generation
 				field.Name = TypeNameUtilities.StudlyCase (char.IsLower (field.JavaName [0]) || field.JavaName.ToLowerInvariant ().ToUpperInvariant () != field.JavaName ? field.JavaName : field.JavaName.ToLowerInvariant ());
 				field.Name = EnsureValidIdentifer (field.Name);
 			}
+
+			// If declaring type was deprecated earlier than member, use the type's deprecated-since
+			if (declaringType.DeprecatedSince.HasValue && declaringType.DeprecatedSince.Value < field.DeprecatedSince.GetValueOrDefault (0))
+				field.DeprecatedSince = declaringType.DeprecatedSince;
 
 			FillApiSince (field, elem);
 			SetLineInfo (field, elem, options);
@@ -397,6 +405,10 @@ namespace MonoDroid.Generation
 			method.Name = EnsureValidIdentifer (method.Name);
 
 			method.FillReturnType ();
+
+			// If declaring type was deprecated earlier than member, use the type's deprecated-since
+			if (declaringType.DeprecatedSince.HasValue && declaringType.DeprecatedSince.Value < method.DeprecatedSince.GetValueOrDefault (0))
+				method.DeprecatedSince = declaringType.DeprecatedSince;
 
 			FillApiSince (method, elem);
 			SetLineInfo (method, elem, options);


### PR DESCRIPTION
Imagine a type is deprecated in API-25 but its members are not explicitly marked as deprecated:

```java
@Deprecated
public class TabActivity extends ActivityGroup {
  public void setDefaultTab(String tag) { ... }
}
```

Then in API-29 the member is explicitly marked as deprecated:

```java
@Deprecated
public class TabActivity extends ActivityGroup {
  @Deprecated
  public void setDefaultTab(String tag) { ... }
}
```

Due to the way `api-merge` calculates `deprecated-since`, these would end up with different values, and the resulting C# API would look like:

```csharp
[ObsoletedOSPlatform("android25.0")]
public class TabActivity : ActivityGroup
{
  [ObsoletedOSPlatform("android29.0")]
  public void SetDefaultTab (string tag) { ... }
}
```

While technically "fine", it is confusing that the method says it was obsoleted in API-29 instead of API-25.

To fix this, if a member has a "higher" `deprecated-since` than its declaring type, we set the member to the declaring type's value.