### PR TITLE
[Java.Interop.Tools.JavaCallableWrappers] fix more places to use TypeDefinitionCache

### DIFF
--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/MethodDefinitionRocks.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/MethodDefinitionRocks.cs
@@ -9,14 +9,14 @@ namespace Java.Interop.Tools.Cecil {
 
 	public static class MethodDefinitionRocks
 	{
-		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
+		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
 		public static MethodDefinition GetBaseDefinition (this MethodDefinition method) =>
-			GetBaseDefinition (method, resolver: null);
+			GetBaseDefinition (method, resolver: null!);
 
-		public static MethodDefinition GetBaseDefinition (this MethodDefinition method, TypeDefinitionCache? cache) =>
-			GetBaseDefinition (method, (IMetadataResolver?) cache);
+		public static MethodDefinition GetBaseDefinition (this MethodDefinition method, TypeDefinitionCache cache) =>
+			GetBaseDefinition (method, (IMetadataResolver) cache);
 
-		public static MethodDefinition GetBaseDefinition (this MethodDefinition method, IMetadataResolver? resolver)
+		public static MethodDefinition GetBaseDefinition (this MethodDefinition method, IMetadataResolver resolver)
 		{
 			if (method.IsStatic || method.IsNewSlot || !method.IsVirtual)
 				return method;
@@ -34,14 +34,14 @@ namespace Java.Interop.Tools.Cecil {
 			return method;
 		}
 
-		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
+		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
 		public static IEnumerable<MethodDefinition> GetOverriddenMethods (MethodDefinition method, bool inherit) =>
-			GetOverriddenMethods (method, inherit, resolver: null);
+			GetOverriddenMethods (method, inherit, resolver: null!);
 
-		public static IEnumerable<MethodDefinition> GetOverriddenMethods (MethodDefinition method, bool inherit, TypeDefinitionCache? cache) =>
-			GetOverriddenMethods (method, inherit, (IMetadataResolver?) cache);
+		public static IEnumerable<MethodDefinition> GetOverriddenMethods (MethodDefinition method, bool inherit, TypeDefinitionCache cache) =>
+			GetOverriddenMethods (method, inherit, (IMetadataResolver) cache);
 
-		public static IEnumerable<MethodDefinition> GetOverriddenMethods (MethodDefinition method, bool inherit, IMetadataResolver? resolver)
+		public static IEnumerable<MethodDefinition> GetOverriddenMethods (MethodDefinition method, bool inherit, IMetadataResolver resolver)
 		{
 			yield return method;
 			if (inherit) {
@@ -53,14 +53,14 @@ namespace Java.Interop.Tools.Cecil {
 			}
 		}
 
-		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
+		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
 		public static bool AreParametersCompatibleWith (this Collection<ParameterDefinition> a, Collection<ParameterDefinition> b) =>
-			AreParametersCompatibleWith (a, b, resolver: null);
+			AreParametersCompatibleWith (a, b, resolver: null!);
 
-		public static bool AreParametersCompatibleWith (this Collection<ParameterDefinition> a, Collection<ParameterDefinition> b, TypeDefinitionCache? cache) =>
-			AreParametersCompatibleWith (a, b, (IMetadataResolver?) cache);
+		public static bool AreParametersCompatibleWith (this Collection<ParameterDefinition> a, Collection<ParameterDefinition> b, TypeDefinitionCache cache) =>
+			AreParametersCompatibleWith (a, b, (IMetadataResolver) cache);
 
-		public static bool AreParametersCompatibleWith (this Collection<ParameterDefinition> a, Collection<ParameterDefinition> b, IMetadataResolver? resolver)
+		public static bool AreParametersCompatibleWith (this Collection<ParameterDefinition> a, Collection<ParameterDefinition> b, IMetadataResolver resolver)
 		{
 			if (a.Count != b.Count)
 				return false;
@@ -75,7 +75,7 @@ namespace Java.Interop.Tools.Cecil {
 			return true;
 		}
 
-		static bool IsParameterCompatibleWith (IModifierType a, IModifierType b, IMetadataResolver? cache)
+		static bool IsParameterCompatibleWith (IModifierType a, IModifierType b, IMetadataResolver cache)
 		{
 			if (!IsParameterCompatibleWith (a.ModifierType, b.ModifierType, cache))
 				return false;
@@ -83,7 +83,7 @@ namespace Java.Interop.Tools.Cecil {
 			return IsParameterCompatibleWith (a.ElementType, b.ElementType, cache);
 		}
 
-		static bool IsParameterCompatibleWith (TypeSpecification a, TypeSpecification b, IMetadataResolver? cache)
+		static bool IsParameterCompatibleWith (TypeSpecification a, TypeSpecification b, IMetadataResolver cache)
 		{
 			if (a is GenericInstanceType)
 				return IsParameterCompatibleWith ((GenericInstanceType) a, (GenericInstanceType) b, cache);
@@ -94,7 +94,7 @@ namespace Java.Interop.Tools.Cecil {
 			return IsParameterCompatibleWith (a.ElementType, b.ElementType, cache);
 		}
 
-		static bool IsParameterCompatibleWith (GenericInstanceType a, GenericInstanceType b, IMetadataResolver? cache)
+		static bool IsParameterCompatibleWith (GenericInstanceType a, GenericInstanceType b, IMetadataResolver cache)
 		{
 			if (!IsParameterCompatibleWith (a.ElementType, b.ElementType, cache))
 				return false;
@@ -112,7 +112,7 @@ namespace Java.Interop.Tools.Cecil {
 			return true;
 		}
 
-		static bool IsParameterCompatibleWith (TypeReference a, TypeReference b, IMetadataResolver? cache)
+		static bool IsParameterCompatibleWith (TypeReference a, TypeReference b, IMetadataResolver cache)
 		{
 			if (a is TypeSpecification || b is TypeSpecification) {
 				if (a.GetType () != b.GetType ())

--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/MethodDefinitionRocks.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/MethodDefinitionRocks.cs
@@ -10,8 +10,7 @@ namespace Java.Interop.Tools.Cecil {
 	public static class MethodDefinitionRocks
 	{
 		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
-		public static MethodDefinition GetBaseDefinition (this MethodDefinition method) =>
-			GetBaseDefinition (method, resolver: null!);
+		public static MethodDefinition GetBaseDefinition (this MethodDefinition method) => throw new NotSupportedException ();
 
 		public static MethodDefinition GetBaseDefinition (this MethodDefinition method, TypeDefinitionCache cache) =>
 			GetBaseDefinition (method, (IMetadataResolver) cache);
@@ -35,8 +34,7 @@ namespace Java.Interop.Tools.Cecil {
 		}
 
 		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
-		public static IEnumerable<MethodDefinition> GetOverriddenMethods (MethodDefinition method, bool inherit) =>
-			GetOverriddenMethods (method, inherit, resolver: null!);
+		public static IEnumerable<MethodDefinition> GetOverriddenMethods (MethodDefinition method, bool inherit) => throw new NotSupportedException ();
 
 		public static IEnumerable<MethodDefinition> GetOverriddenMethods (MethodDefinition method, bool inherit, TypeDefinitionCache cache) =>
 			GetOverriddenMethods (method, inherit, (IMetadataResolver) cache);
@@ -54,8 +52,7 @@ namespace Java.Interop.Tools.Cecil {
 		}
 
 		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
-		public static bool AreParametersCompatibleWith (this Collection<ParameterDefinition> a, Collection<ParameterDefinition> b) =>
-			AreParametersCompatibleWith (a, b, resolver: null!);
+		public static bool AreParametersCompatibleWith (this Collection<ParameterDefinition> a, Collection<ParameterDefinition> b) => throw new NotSupportedException ();
 
 		public static bool AreParametersCompatibleWith (this Collection<ParameterDefinition> a, Collection<ParameterDefinition> b, TypeDefinitionCache cache) =>
 			AreParametersCompatibleWith (a, b, (IMetadataResolver) cache);

--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/TypeDefinitionRocks.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/TypeDefinitionRocks.cs
@@ -6,18 +6,17 @@ using Mono.Cecil;
 namespace Java.Interop.Tools.Cecil {
 
 	public static class TypeDefinitionRocks {
-
-		public static TypeDefinition ResolveCached (this TypeReference type, IMetadataResolver? resolver) =>
+		static TypeDefinition ResolveCached (this TypeReference type, IMetadataResolver? resolver) =>
 			resolver != null ? resolver.Resolve (type) : type.Resolve ();
 
-		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
+		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
 		public static TypeDefinition? GetBaseType (this TypeDefinition type) =>
-			GetBaseType (type, resolver: null);
+			GetBaseType (type, resolver: null!);
 
-		public static TypeDefinition? GetBaseType (this TypeDefinition type, TypeDefinitionCache? cache) =>
-			GetBaseType (type, (IMetadataResolver?) cache);
+		public static TypeDefinition? GetBaseType (this TypeDefinition type, TypeDefinitionCache cache) =>
+			GetBaseType (type, (IMetadataResolver) cache);
 
-		public static TypeDefinition? GetBaseType (this TypeDefinition type, IMetadataResolver? resolver)
+		public static TypeDefinition? GetBaseType (this TypeDefinition type, IMetadataResolver resolver)
 		{
 			var bt = type.BaseType;
 			if (bt == null)
@@ -25,14 +24,14 @@ namespace Java.Interop.Tools.Cecil {
 			return bt.ResolveCached (resolver);
 		}
 
-		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
+		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
 		public static IEnumerable<TypeDefinition> GetTypeAndBaseTypes (this TypeDefinition type) =>
-			GetTypeAndBaseTypes (type, resolver: null);
+			GetTypeAndBaseTypes (type, resolver: null!);
 
-		public static IEnumerable<TypeDefinition> GetTypeAndBaseTypes (this TypeDefinition type, TypeDefinitionCache? cache) =>
-			GetTypeAndBaseTypes (type, (IMetadataResolver?) cache);
+		public static IEnumerable<TypeDefinition> GetTypeAndBaseTypes (this TypeDefinition type, TypeDefinitionCache cache) =>
+			GetTypeAndBaseTypes (type, (IMetadataResolver) cache);
 
-		public static IEnumerable<TypeDefinition> GetTypeAndBaseTypes (this TypeDefinition type, IMetadataResolver? resolver)
+		public static IEnumerable<TypeDefinition> GetTypeAndBaseTypes (this TypeDefinition type, IMetadataResolver resolver)
 		{
 			TypeDefinition? t = type;
 
@@ -42,14 +41,14 @@ namespace Java.Interop.Tools.Cecil {
 			}
 		}
 
-		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
+		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
 		public static IEnumerable<TypeDefinition> GetBaseTypes (this TypeDefinition type) =>
-			GetBaseTypes (type, resolver: null);
+			GetBaseTypes (type, resolver: null!);
 
-		public static IEnumerable<TypeDefinition> GetBaseTypes (this TypeDefinition type, TypeDefinitionCache? cache) =>
-			GetBaseTypes (type, (IMetadataResolver?) cache);
+		public static IEnumerable<TypeDefinition> GetBaseTypes (this TypeDefinition type, TypeDefinitionCache cache) =>
+			GetBaseTypes (type, (IMetadataResolver) cache);
 
-		public static IEnumerable<TypeDefinition> GetBaseTypes (this TypeDefinition type, IMetadataResolver? resolver)
+		public static IEnumerable<TypeDefinition> GetBaseTypes (this TypeDefinition type, IMetadataResolver resolver)
 		{
 			TypeDefinition? t = type;
 
@@ -58,14 +57,14 @@ namespace Java.Interop.Tools.Cecil {
 			}
 		}
 
-		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
+		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
 		public static bool IsAssignableFrom (this TypeReference type, TypeReference c) =>
-			IsAssignableFrom (type, c, resolver: null);
+			IsAssignableFrom (type, c, resolver: null!);
 
-		public static bool IsAssignableFrom (this TypeReference type, TypeReference c, TypeDefinitionCache? cache) =>
-			IsAssignableFrom (type, c, (IMetadataResolver?) cache);
+		public static bool IsAssignableFrom (this TypeReference type, TypeReference c, TypeDefinitionCache cache) =>
+			IsAssignableFrom (type, c, (IMetadataResolver) cache);
 
-		public static bool IsAssignableFrom (this TypeReference type, TypeReference c, IMetadataResolver? resolver)
+		public static bool IsAssignableFrom (this TypeReference type, TypeReference c, IMetadataResolver resolver)
 		{
 			if (type.FullName == c.FullName)
 				return true;
@@ -84,13 +83,13 @@ namespace Java.Interop.Tools.Cecil {
 			return false;
 		}
 
-		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
+		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
 		public static bool IsSubclassOf (this TypeDefinition type, string typeName) =>
-			IsSubclassOf (type, typeName, resolver: null);
+			IsSubclassOf (type, typeName, resolver: null!);
 
-		public static bool IsSubclassOf (this TypeDefinition type, string typeName, TypeDefinitionCache? cache) =>
-			IsSubclassOf (type, typeName, (IMetadataResolver?) cache);
-		public static bool IsSubclassOf (this TypeDefinition type, string typeName, IMetadataResolver? resolver)
+		public static bool IsSubclassOf (this TypeDefinition type, string typeName, TypeDefinitionCache cache) =>
+			IsSubclassOf (type, typeName, (IMetadataResolver) cache);
+		public static bool IsSubclassOf (this TypeDefinition type, string typeName, IMetadataResolver resolver)
 		{
 			foreach (var t in type.GetTypeAndBaseTypes (resolver)) {
 				if (t.FullName == typeName) {
@@ -100,14 +99,14 @@ namespace Java.Interop.Tools.Cecil {
 			return false;
 		}
 
-		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
+		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
 		public static bool ImplementsInterface (this TypeDefinition type, string interfaceName) =>
-			ImplementsInterface (type, interfaceName, resolver: null);
+			ImplementsInterface (type, interfaceName, resolver: null!);
 
-		public static bool ImplementsInterface (this TypeDefinition type, string interfaceName, TypeDefinitionCache? cache) =>
-			ImplementsInterface (type, interfaceName, (IMetadataResolver?) cache);
+		public static bool ImplementsInterface (this TypeDefinition type, string interfaceName, TypeDefinitionCache cache) =>
+			ImplementsInterface (type, interfaceName, (IMetadataResolver) cache);
 
-		public static bool ImplementsInterface (this TypeDefinition type, string interfaceName, IMetadataResolver? resolver)
+		public static bool ImplementsInterface (this TypeDefinition type, string interfaceName, IMetadataResolver resolver)
 		{
 			foreach (var t in type.GetTypeAndBaseTypes (resolver)) {
 				foreach (var i in t.Interfaces) {

--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/TypeDefinitionRocks.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/TypeDefinitionRocks.cs
@@ -6,8 +6,6 @@ using Mono.Cecil;
 namespace Java.Interop.Tools.Cecil {
 
 	public static class TypeDefinitionRocks {
-		static TypeDefinition ResolveCached (this TypeReference type, IMetadataResolver? resolver) =>
-			resolver != null ? resolver.Resolve (type) : type.Resolve ();
 
 		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
 		public static TypeDefinition? GetBaseType (this TypeDefinition type) => throw new NotSupportedException ();
@@ -20,7 +18,7 @@ namespace Java.Interop.Tools.Cecil {
 			var bt = type.BaseType;
 			if (bt == null)
 				return null;
-			return bt.ResolveCached (resolver);
+			return resolver.Resolve (bt);
 		}
 
 		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
@@ -64,7 +62,7 @@ namespace Java.Interop.Tools.Cecil {
 		{
 			if (type.FullName == c.FullName)
 				return true;
-			var d = c.ResolveCached (resolver);
+			var d = resolver.Resolve (c);
 			if (d == null)
 				return false;
 			foreach (var t in d.GetTypeAndBaseTypes (resolver)) {
@@ -112,27 +110,25 @@ namespace Java.Interop.Tools.Cecil {
 			return false;
 		}
 
-		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
-		public static string GetPartialAssemblyName (this TypeReference type) =>
-			GetPartialAssemblyName (type, resolver: null);
+		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
+		public static string GetPartialAssemblyName (this TypeReference type) => throw new NotSupportedException ();
 
-		public static string GetPartialAssemblyName (this TypeReference type, TypeDefinitionCache? cache) =>
-			GetPartialAssemblyName (type, (IMetadataResolver?) cache);
+		public static string GetPartialAssemblyName (this TypeReference type, TypeDefinitionCache cache) =>
+			GetPartialAssemblyName (type, (IMetadataResolver) cache);
 
-		public static string GetPartialAssemblyName (this TypeReference type, IMetadataResolver? resolver)
+		public static string GetPartialAssemblyName (this TypeReference type, IMetadataResolver resolver)
 		{
-			TypeDefinition? def = type.ResolveCached (resolver);
+			TypeDefinition? def = resolver.Resolve (type);
 			return (def ?? type).Module.Assembly.Name.Name;
 		}
 
-		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
-		public static string GetPartialAssemblyQualifiedName (this TypeReference type) =>
-			GetPartialAssemblyQualifiedName (type, resolver: null);
+		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
+		public static string GetPartialAssemblyQualifiedName (this TypeReference type) => throw new NotSupportedException ();
 
-		public static string GetPartialAssemblyQualifiedName (this TypeReference type, TypeDefinitionCache? cache) =>
-			GetPartialAssemblyQualifiedName (type, (IMetadataResolver?) cache);
+		public static string GetPartialAssemblyQualifiedName (this TypeReference type, TypeDefinitionCache cache) =>
+			GetPartialAssemblyQualifiedName (type, (IMetadataResolver) cache);
 
-		public static string GetPartialAssemblyQualifiedName (this TypeReference type, IMetadataResolver? resolver)
+		public static string GetPartialAssemblyQualifiedName (this TypeReference type, IMetadataResolver resolver)
 		{
 			return string.Format ("{0}, {1}",
 					// Cecil likes to use '/' as the nested type separator, while
@@ -141,16 +137,15 @@ namespace Java.Interop.Tools.Cecil {
 					type.GetPartialAssemblyName (resolver));
 		}
 
-		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
-		public static string GetAssemblyQualifiedName (this TypeReference type) =>
-			GetAssemblyQualifiedName (type, resolver: null);
+		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
+		public static string GetAssemblyQualifiedName (this TypeReference type) => throw new NotSupportedException ();
 
-		public static string GetAssemblyQualifiedName (this TypeReference type, TypeDefinitionCache? cache) =>
-			GetAssemblyQualifiedName (type, (IMetadataResolver?) cache);
+		public static string GetAssemblyQualifiedName (this TypeReference type, TypeDefinitionCache cache) =>
+			GetAssemblyQualifiedName (type, (IMetadataResolver) cache);
 
-		public static string GetAssemblyQualifiedName (this TypeReference type, IMetadataResolver? resolver)
+		public static string GetAssemblyQualifiedName (this TypeReference type, IMetadataResolver resolver)
 		{
-			TypeDefinition? def = type.ResolveCached(resolver);
+			TypeDefinition? def = resolver.Resolve (type);
 			return string.Format ("{0}, {1}",
 					// Cecil likes to use '/' as the nested type separator, while
 					// Reflection uses '+' as the nested type separator. Use Reflection.

--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/TypeDefinitionRocks.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/TypeDefinitionRocks.cs
@@ -10,8 +10,7 @@ namespace Java.Interop.Tools.Cecil {
 			resolver != null ? resolver.Resolve (type) : type.Resolve ();
 
 		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
-		public static TypeDefinition? GetBaseType (this TypeDefinition type) =>
-			GetBaseType (type, resolver: null!);
+		public static TypeDefinition? GetBaseType (this TypeDefinition type) => throw new NotSupportedException ();
 
 		public static TypeDefinition? GetBaseType (this TypeDefinition type, TypeDefinitionCache cache) =>
 			GetBaseType (type, (IMetadataResolver) cache);
@@ -25,8 +24,7 @@ namespace Java.Interop.Tools.Cecil {
 		}
 
 		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
-		public static IEnumerable<TypeDefinition> GetTypeAndBaseTypes (this TypeDefinition type) =>
-			GetTypeAndBaseTypes (type, resolver: null!);
+		public static IEnumerable<TypeDefinition> GetTypeAndBaseTypes (this TypeDefinition type) => throw new NotSupportedException ();
 
 		public static IEnumerable<TypeDefinition> GetTypeAndBaseTypes (this TypeDefinition type, TypeDefinitionCache cache) =>
 			GetTypeAndBaseTypes (type, (IMetadataResolver) cache);
@@ -42,8 +40,7 @@ namespace Java.Interop.Tools.Cecil {
 		}
 
 		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
-		public static IEnumerable<TypeDefinition> GetBaseTypes (this TypeDefinition type) =>
-			GetBaseTypes (type, resolver: null!);
+		public static IEnumerable<TypeDefinition> GetBaseTypes (this TypeDefinition type) => throw new NotSupportedException();
 
 		public static IEnumerable<TypeDefinition> GetBaseTypes (this TypeDefinition type, TypeDefinitionCache cache) =>
 			GetBaseTypes (type, (IMetadataResolver) cache);
@@ -58,8 +55,7 @@ namespace Java.Interop.Tools.Cecil {
 		}
 
 		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
-		public static bool IsAssignableFrom (this TypeReference type, TypeReference c) =>
-			IsAssignableFrom (type, c, resolver: null!);
+		public static bool IsAssignableFrom (this TypeReference type, TypeReference c) => throw new NotSupportedException ();
 
 		public static bool IsAssignableFrom (this TypeReference type, TypeReference c, TypeDefinitionCache cache) =>
 			IsAssignableFrom (type, c, (IMetadataResolver) cache);
@@ -84,8 +80,7 @@ namespace Java.Interop.Tools.Cecil {
 		}
 
 		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
-		public static bool IsSubclassOf (this TypeDefinition type, string typeName) =>
-			IsSubclassOf (type, typeName, resolver: null!);
+		public static bool IsSubclassOf (this TypeDefinition type, string typeName) => throw new NotSupportedException ();
 
 		public static bool IsSubclassOf (this TypeDefinition type, string typeName, TypeDefinitionCache cache) =>
 			IsSubclassOf (type, typeName, (IMetadataResolver) cache);
@@ -100,8 +95,7 @@ namespace Java.Interop.Tools.Cecil {
 		}
 
 		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
-		public static bool ImplementsInterface (this TypeDefinition type, string interfaceName) =>
-			ImplementsInterface (type, interfaceName, resolver: null!);
+		public static bool ImplementsInterface (this TypeDefinition type, string interfaceName) => throw new NotSupportedException ();
 
 		public static bool ImplementsInterface (this TypeDefinition type, string interfaceName, TypeDefinitionCache cache) =>
 			ImplementsInterface (type, interfaceName, (IMetadataResolver) cache);

--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/TypeDefinitionRocks.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/TypeDefinitionRocks.cs
@@ -7,6 +7,9 @@ namespace Java.Interop.Tools.Cecil {
 
 	public static class TypeDefinitionRocks {
 
+		public static TypeDefinition ResolveCached (this TypeReference type, IMetadataResolver? resolver) =>
+			resolver != null ? resolver.Resolve (type) : type.Resolve ();
+
 		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
 		public static TypeDefinition? GetBaseType (this TypeDefinition type) =>
 			GetBaseType (type, resolver: null);
@@ -19,9 +22,7 @@ namespace Java.Interop.Tools.Cecil {
 			var bt = type.BaseType;
 			if (bt == null)
 				return null;
-			if (resolver != null)
-				return resolver.Resolve (bt);
-			return bt.Resolve ();
+			return bt.ResolveCached (resolver);
 		}
 
 		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
@@ -68,7 +69,7 @@ namespace Java.Interop.Tools.Cecil {
 		{
 			if (type.FullName == c.FullName)
 				return true;
-			var d = (resolver?.Resolve (c)) ?? c.Resolve ();
+			var d = c.ResolveCached (resolver);
 			if (d == null)
 				return false;
 			foreach (var t in d.GetTypeAndBaseTypes (resolver)) {
@@ -127,7 +128,7 @@ namespace Java.Interop.Tools.Cecil {
 
 		public static string GetPartialAssemblyName (this TypeReference type, IMetadataResolver? resolver)
 		{
-			TypeDefinition? def = (resolver?.Resolve (type)) ?? type.Resolve ();
+			TypeDefinition? def = type.ResolveCached (resolver);
 			return (def ?? type).Module.Assembly.Name.Name;
 		}
 
@@ -156,7 +157,7 @@ namespace Java.Interop.Tools.Cecil {
 
 		public static string GetAssemblyQualifiedName (this TypeReference type, IMetadataResolver? resolver)
 		{
-			TypeDefinition? def = (resolver?.Resolve (type)) ?? type.Resolve ();
+			TypeDefinition? def = type.ResolveCached(resolver);
 			return string.Format ("{0}, {1}",
 					// Cecil likes to use '/' as the nested type separator, while
 					// Reflection uses '+' as the nested type separator. Use Reflection.

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
@@ -70,9 +70,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 		readonly JavaCallableMethodClassifier? methodClassifier;
 
 		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
-		public JavaCallableWrapperGenerator (TypeDefinition type, Action<string, object []> log)
-			: this (type, log, resolver: null!, methodClassifier: null)
-		{ }
+		public JavaCallableWrapperGenerator (TypeDefinition type, Action<string, object []> log) => throw new NotSupportedException ();
 
 		public JavaCallableWrapperGenerator (TypeDefinition type, Action<string, object[]> log, TypeDefinitionCache cache)
 			: this (type, log, (IMetadataResolver) cache, methodClassifier: null)

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaTypeScanner.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaTypeScanner.cs
@@ -76,14 +76,14 @@ namespace Java.Interop.Tools.JavaCallableWrappers
 				AddJavaTypes (javaTypes, nested);
 		}
 
-		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
+		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
 		public static bool ShouldSkipJavaCallableWrapperGeneration (TypeDefinition type) =>
-			ShouldSkipJavaCallableWrapperGeneration (type, resolver: null);
+			ShouldSkipJavaCallableWrapperGeneration (type, resolver: null!);
 
-		public static bool ShouldSkipJavaCallableWrapperGeneration (TypeDefinition type, TypeDefinitionCache? cache) =>
-			ShouldSkipJavaCallableWrapperGeneration (type, (IMetadataResolver?) cache);
+		public static bool ShouldSkipJavaCallableWrapperGeneration (TypeDefinition type, TypeDefinitionCache cache) =>
+			ShouldSkipJavaCallableWrapperGeneration (type, (IMetadataResolver) cache);
 
-		public static bool ShouldSkipJavaCallableWrapperGeneration (TypeDefinition type, IMetadataResolver? resolver)
+		public static bool ShouldSkipJavaCallableWrapperGeneration (TypeDefinition type, IMetadataResolver resolver)
 		{
 			if (JavaNativeTypeManager.IsNonStaticInnerClass (type, resolver))
 				return true;

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaTypeScanner.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaTypeScanner.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -77,8 +77,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers
 		}
 
 		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
-		public static bool ShouldSkipJavaCallableWrapperGeneration (TypeDefinition type) =>
-			ShouldSkipJavaCallableWrapperGeneration (type, resolver: null!);
+		public static bool ShouldSkipJavaCallableWrapperGeneration (TypeDefinition type) => throw new NotSupportedException ();
 
 		public static bool ShouldSkipJavaCallableWrapperGeneration (TypeDefinition type, TypeDefinitionCache cache) =>
 			ShouldSkipJavaCallableWrapperGeneration (type, (IMetadataResolver) cache);

--- a/src/Java.Interop.Tools.JavaTypeSystem/Adapters/ManagedApiImporter.cs
+++ b/src/Java.Interop.Tools.JavaTypeSystem/Adapters/ManagedApiImporter.cs
@@ -11,8 +11,7 @@ namespace Java.Interop.Tools.JavaTypeSystem
 	public static class ManagedApiImporter
 	{
 		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
-		public static JavaTypeCollection Parse (AssemblyDefinition assembly, JavaTypeCollection collection) =>
-			Parse (assembly, collection, resolver: null!);
+		public static JavaTypeCollection Parse (AssemblyDefinition assembly, JavaTypeCollection collection) => throw new NotSupportedException ();
 
 		public static JavaTypeCollection Parse (AssemblyDefinition assembly, JavaTypeCollection collection, TypeDefinitionCache resolver)
 		{

--- a/src/Java.Interop.Tools.JavaTypeSystem/Adapters/ManagedApiImporter.cs
+++ b/src/Java.Interop.Tools.JavaTypeSystem/Adapters/ManagedApiImporter.cs
@@ -10,13 +10,17 @@ namespace Java.Interop.Tools.JavaTypeSystem
 {
 	public static class ManagedApiImporter
 	{
-		public static JavaTypeCollection Parse (AssemblyDefinition assembly, JavaTypeCollection collection)
+		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
+		public static JavaTypeCollection Parse (AssemblyDefinition assembly, JavaTypeCollection collection) =>
+			Parse (assembly, collection, resolver: null!);
+
+		public static JavaTypeCollection Parse (AssemblyDefinition assembly, JavaTypeCollection collection, TypeDefinitionCache resolver)
 		{
 			var types_to_add = new List<JavaTypeModel> ();
 
 			foreach (var md in assembly.Modules)
 				foreach (var td in md.Types) {
-					if (!ShouldSkipType (td) && ParseType (td, collection) is JavaTypeModel type)
+					if (!ShouldSkipType (td, resolver) && ParseType (td, collection) is JavaTypeModel type)
 						types_to_add.Add (type);
 				}
 
@@ -219,7 +223,7 @@ namespace Java.Interop.Tools.JavaTypeSystem
 				AddReferenceTypeRecursive (nested, collection);
 		}
 
-		static bool ShouldSkipType (TypeDefinition type)
+		static bool ShouldSkipType (TypeDefinition type, TypeDefinitionCache cache)
 		{
 			// We want to use Java's collection types instead of our managed adapter.
 			// eg: 'Java.Util.ArrayList' over 'Android.Runtime.JavaList'
@@ -240,13 +244,13 @@ namespace Java.Interop.Tools.JavaTypeSystem
 				? type.Module.GetType (type.FullName.Substring (0, type.FullName.IndexOf ('`')))
 				: null;
 
-			if (ShouldSkipGeneric (type, non_generic_type, null))
+			if (ShouldSkipGeneric (type, non_generic_type, cache))
 				return true;
 
 			return false;
 		}
 
-		static bool ShouldSkipGeneric (TypeDefinition? a, TypeDefinition? b, TypeDefinitionCache? cache)
+		static bool ShouldSkipGeneric (TypeDefinition? a, TypeDefinition? b, TypeDefinitionCache cache)
 		{
 			if (a == null || b == null)
 				return false;

--- a/src/Java.Interop.Tools.TypeNameMappings/Java.Interop.Tools.TypeNameMappings/JavaNativeTypeManager.cs
+++ b/src/Java.Interop.Tools.TypeNameMappings/Java.Interop.Tools.TypeNameMappings/JavaNativeTypeManager.cs
@@ -414,39 +414,39 @@ namespace Java.Interop.Tools.TypeNameMappings
 			return new ExportParameterAttribute ((ExportParameterKind)attr.ConstructorArguments [0].Value);
 		}
 
-		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
+		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
 		public static bool IsApplication (TypeDefinition type) =>
-			IsApplication (type, resolver: null);
+			IsApplication (type, resolver: null!);
 
-		public static bool IsApplication (TypeDefinition type, TypeDefinitionCache? cache) =>
-			IsApplication (type, (IMetadataResolver?) cache);
+		public static bool IsApplication (TypeDefinition type, TypeDefinitionCache cache) =>
+			IsApplication (type, (IMetadataResolver) cache);
 
-		public static bool IsApplication (TypeDefinition type, IMetadataResolver? resolver)
+		public static bool IsApplication (TypeDefinition type, IMetadataResolver resolver)
 		{
 			return type.GetBaseTypes (resolver).Any (b => b.FullName == "Android.App.Application");
 		}
 
-		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
+		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
 		public static bool IsInstrumentation (TypeDefinition type) =>
-			IsInstrumentation (type, resolver: null);
+			IsInstrumentation (type, resolver: null!);
 
-		public static bool IsInstrumentation (TypeDefinition type, TypeDefinitionCache? cache) =>
-			IsInstrumentation (type, (IMetadataResolver?) cache);
+		public static bool IsInstrumentation (TypeDefinition type, TypeDefinitionCache cache) =>
+			IsInstrumentation (type, (IMetadataResolver) cache);
 
-		public static bool IsInstrumentation (TypeDefinition type, IMetadataResolver? resolver)
+		public static bool IsInstrumentation (TypeDefinition type, IMetadataResolver resolver)
 		{
 			return type.GetBaseTypes (resolver).Any (b => b.FullName == "Android.App.Instrumentation");
 		}
 
 		// moved from JavaTypeInfo
-		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
+		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
 		public static string? GetJniSignature (MethodDefinition method) =>
-			GetJniSignature (method, resolver: null);
+			GetJniSignature (method, resolver: null!);
 
-		public static string? GetJniSignature (MethodDefinition method, TypeDefinitionCache? cache) =>
-			GetJniSignature (method, (IMetadataResolver?) cache);
+		public static string? GetJniSignature (MethodDefinition method, TypeDefinitionCache cache) =>
+			GetJniSignature (method, (IMetadataResolver) cache);
 
-		public static string? GetJniSignature (MethodDefinition method, IMetadataResolver? resolver)
+		public static string? GetJniSignature (MethodDefinition method, IMetadataResolver resolver)
 		{
 			return GetJniSignature<TypeReference,ParameterDefinition> (
 				method.Parameters,
@@ -459,35 +459,35 @@ namespace Java.Interop.Tools.TypeNameMappings
 		}
 
 		// moved from JavaTypeInfo
-		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
+		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
 		public static string? GetJniTypeName (TypeReference typeRef) =>
-			GetJniTypeName (typeRef, resolver: null);
+			GetJniTypeName (typeRef, resolver: null!);
 
-		public static string? GetJniTypeName (TypeReference typeRef, TypeDefinitionCache? cache) =>
-			GetJniTypeName (typeRef, (IMetadataResolver?) cache);
+		public static string? GetJniTypeName (TypeReference typeRef, TypeDefinitionCache cache) =>
+			GetJniTypeName (typeRef, (IMetadataResolver) cache);
 
-		public static string? GetJniTypeName (TypeReference typeRef, IMetadataResolver? resolver)
+		public static string? GetJniTypeName (TypeReference typeRef, IMetadataResolver resolver)
 		{
 			return GetJniTypeName (typeRef, ExportParameterKind.Unspecified, resolver);
 		}
 
-		internal static string? GetJniTypeName (TypeReference typeRef, ExportParameterKind exportKind, IMetadataResolver? cache)
+		internal static string? GetJniTypeName (TypeReference typeRef, ExportParameterKind exportKind, IMetadataResolver cache)
 		{
-			return GetJniTypeName<TypeReference, TypeDefinition> (typeRef, exportKind, t => t.ResolveCached (cache), t => {
+			return GetJniTypeName<TypeReference, TypeDefinition> (typeRef, exportKind, t => cache.Resolve (t), t => {
 				TypeReference etype;
 				int rank = GetArrayInfo (typeRef, out etype);
 				return new KeyValuePair<int,TypeReference> (rank,etype);
 				}, t => t.FullName, (t, k) => ToJniName (t, k, cache));
 		}
 
-		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
+		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
 		public static string ToCompatJniName (TypeDefinition type) =>
-			ToCompatJniName (type, resolver: null);
+			ToCompatJniName (type, resolver: null!);
 
-		public static string ToCompatJniName (TypeDefinition type, TypeDefinitionCache? cache) =>
-			ToCompatJniName (type, (IMetadataResolver?) cache);
+		public static string ToCompatJniName (TypeDefinition type, TypeDefinitionCache cache) =>
+			ToCompatJniName (type, (IMetadataResolver) cache);
 
-		public static string ToCompatJniName (TypeDefinition type, IMetadataResolver? resolver)
+		public static string ToCompatJniName (TypeDefinition type, IMetadataResolver resolver)
 		{
 			return ToJniName (
 					type:               type,
@@ -505,21 +505,21 @@ namespace Java.Interop.Tools.TypeNameMappings
 		}
 
 		// Keep in sync with ToJniNameFromAttributes(Type) and ToJniName(Type)
-		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
+		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
 		public static string ToJniName (TypeDefinition type) =>
-			ToJniName (type, resolver: null);
+			ToJniName (type, resolver: null!);
 
-		public static string ToJniName (TypeDefinition type, TypeDefinitionCache? cache) =>
-			ToJniName (type, (IMetadataResolver?) cache);
+		public static string ToJniName (TypeDefinition type, TypeDefinitionCache cache) =>
+			ToJniName (type, (IMetadataResolver) cache);
 
-		public static string ToJniName (TypeDefinition type, IMetadataResolver? resolver)
+		public static string ToJniName (TypeDefinition type, IMetadataResolver resolver)
 		{
 			var x = ToJniName (type, ExportParameterKind.Unspecified, resolver) ??
 				"java/lang/Object";
 			return x;
 		}
 
-		static string? ToJniName (TypeDefinition type, ExportParameterKind exportKind, IMetadataResolver? cache)
+		static string? ToJniName (TypeDefinition type, ExportParameterKind exportKind, IMetadataResolver cache)
 		{
 			if (type == null)
 				throw new ArgumentNullException ("type");
@@ -545,16 +545,16 @@ namespace Java.Interop.Tools.TypeNameMappings
 			);
 		}
 
-		static string? ToJniNameFromAttributes (TypeDefinition type, IMetadataResolver? resolver)
+		static string? ToJniNameFromAttributes (TypeDefinition type, IMetadataResolver resolver)
 		{
 			return ToJniNameFromAttributesForAndroid (type, resolver) ??
 				ToJniNameFromAttributesForInterop (type, resolver);
 		}
 
-		static string? ToJniNameFromAttributesForInterop (TypeDefinition type, IMetadataResolver? resolver)
+		static string? ToJniNameFromAttributesForInterop (TypeDefinition type, IMetadataResolver resolver)
 		{
 			var attr = type.CustomAttributes.FirstOrDefault (a =>
-				a.AttributeType.ResolveCached (resolver)
+				resolver.Resolve (a.AttributeType)
 				.FullName == "Java.Interop.JniTypeSignatureAttribute");
 			if (attr == null) {
 				return null;
@@ -565,7 +565,7 @@ namespace Java.Interop.Tools.TypeNameMappings
 			return (string) carg.Value;
 		}
 
-		static string? ToJniNameFromAttributesForAndroid (TypeDefinition type, IMetadataResolver? resolver)
+		static string? ToJniNameFromAttributesForAndroid (TypeDefinition type, IMetadataResolver resolver)
 		{
 			if (!type.HasCustomAttributes)
 				return null;
@@ -597,14 +597,14 @@ namespace Java.Interop.Tools.TypeNameMappings
 			"Android.Runtime.RegisterAttribute",
 		};
 
-		static bool IsIJniNameProviderAttribute (CustomAttribute attr, IMetadataResolver? resolver)
+		static bool IsIJniNameProviderAttribute (CustomAttribute attr, IMetadataResolver resolver)
 		{
 			// Fast path for a list of known IJniNameProviderAttribute implementations
 			if (KnownIJniNameProviders.Contains (attr.AttributeType.FullName))
 				return true;
 
 			// Slow path resolves the type, looking for IJniNameProviderAttribute
-			var attributeType = attr.AttributeType.ResolveCached (resolver);
+			var attributeType = resolver.Resolve (attr.AttributeType);
 			if (!attributeType.HasInterfaces)
 				return false;
 			return attributeType.Interfaces.Any (it => it.InterfaceType.FullName == typeof (IJniNameProviderAttribute).FullName);
@@ -621,10 +621,10 @@ namespace Java.Interop.Tools.TypeNameMappings
 			return rank;
 		}
 
-		static string? GetPrimitiveClass (Mono.Cecil.TypeDefinition type, IMetadataResolver? cache)
+		static string? GetPrimitiveClass (Mono.Cecil.TypeDefinition type, IMetadataResolver cache)
 		{
 			if (type.IsEnum)
-				return GetPrimitiveClass (type.Fields.First (f => f.IsSpecialName).FieldType.ResolveCached (cache), cache);
+				return GetPrimitiveClass (cache.Resolve (type.Fields.First (f => f.IsSpecialName).FieldType), cache);
 			if (type.FullName == "System.Byte")
 				return "B";
 			if (type.FullName == "System.Char")
@@ -707,7 +707,7 @@ namespace Java.Interop.Tools.TypeNameMappings
 		}
 
 #if HAVE_CECIL
-		internal static bool IsNonStaticInnerClass (TypeDefinition? type, IMetadataResolver? cache)
+		internal static bool IsNonStaticInnerClass (TypeDefinition? type, IMetadataResolver cache)
 		{
 			if (type == null)
 				return false;
@@ -721,7 +721,7 @@ namespace Java.Interop.Tools.TypeNameMappings
 				.Any (ctor => ctor.Parameters.Any (p => p.Name == "__self"));
 		}
 
-		static IEnumerable<MethodDefinition> GetBaseConstructors (TypeDefinition type, IMetadataResolver? cache)
+		static IEnumerable<MethodDefinition> GetBaseConstructors (TypeDefinition type, IMetadataResolver cache)
 		{
 			var baseType = type.GetBaseTypes (cache).FirstOrDefault (t => t.GetCustomAttributes (typeof (RegisterAttribute)).Any ());
 			if (baseType != null)

--- a/src/Java.Interop.Tools.TypeNameMappings/Java.Interop.Tools.TypeNameMappings/JavaNativeTypeManager.cs
+++ b/src/Java.Interop.Tools.TypeNameMappings/Java.Interop.Tools.TypeNameMappings/JavaNativeTypeManager.cs
@@ -638,14 +638,13 @@ namespace Java.Interop.Tools.TypeNameMappings
 			return null;
 		}
 
-		[Obsolete ("Use the TypeDefinitionCache overload for better performance.")]
-		public static string GetPackageName (TypeDefinition type) =>
-			GetPackageName (type, resolver: null);
+		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
+		public static string GetPackageName (TypeDefinition type) => throw new NotSupportedException ();
 
-		public static string GetPackageName (TypeDefinition type, TypeDefinitionCache? cache) =>
-			GetPackageName (type, (IMetadataResolver?) cache);
+		public static string GetPackageName (TypeDefinition type, TypeDefinitionCache cache) =>
+			GetPackageName (type, (IMetadataResolver) cache);
 
-		public static string GetPackageName (TypeDefinition type, IMetadataResolver? resolver)
+		public static string GetPackageName (TypeDefinition type, IMetadataResolver resolver)
 		{
 			if (IsPackageNamePreservedForAssembly (type.GetPartialAssemblyName (resolver)))
 				return type.Namespace.ToLowerInvariant ();

--- a/src/Java.Interop.Tools.TypeNameMappings/Java.Interop.Tools.TypeNameMappings/JavaNativeTypeManager.cs
+++ b/src/Java.Interop.Tools.TypeNameMappings/Java.Interop.Tools.TypeNameMappings/JavaNativeTypeManager.cs
@@ -415,8 +415,7 @@ namespace Java.Interop.Tools.TypeNameMappings
 		}
 
 		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
-		public static bool IsApplication (TypeDefinition type) =>
-			IsApplication (type, resolver: null!);
+		public static bool IsApplication (TypeDefinition type) => throw new NotSupportedException ();
 
 		public static bool IsApplication (TypeDefinition type, TypeDefinitionCache cache) =>
 			IsApplication (type, (IMetadataResolver) cache);
@@ -427,8 +426,7 @@ namespace Java.Interop.Tools.TypeNameMappings
 		}
 
 		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
-		public static bool IsInstrumentation (TypeDefinition type) =>
-			IsInstrumentation (type, resolver: null!);
+		public static bool IsInstrumentation (TypeDefinition type) => throw new NotSupportedException ();
 
 		public static bool IsInstrumentation (TypeDefinition type, TypeDefinitionCache cache) =>
 			IsInstrumentation (type, (IMetadataResolver) cache);
@@ -440,8 +438,7 @@ namespace Java.Interop.Tools.TypeNameMappings
 
 		// moved from JavaTypeInfo
 		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
-		public static string? GetJniSignature (MethodDefinition method) =>
-			GetJniSignature (method, resolver: null!);
+		public static string? GetJniSignature (MethodDefinition method) => throw new NotSupportedException ();
 
 		public static string? GetJniSignature (MethodDefinition method, TypeDefinitionCache cache) =>
 			GetJniSignature (method, (IMetadataResolver) cache);
@@ -460,8 +457,7 @@ namespace Java.Interop.Tools.TypeNameMappings
 
 		// moved from JavaTypeInfo
 		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
-		public static string? GetJniTypeName (TypeReference typeRef) =>
-			GetJniTypeName (typeRef, resolver: null!);
+		public static string? GetJniTypeName (TypeReference typeRef) => throw new NotSupportedException ();
 
 		public static string? GetJniTypeName (TypeReference typeRef, TypeDefinitionCache cache) =>
 			GetJniTypeName (typeRef, (IMetadataResolver) cache);
@@ -481,8 +477,7 @@ namespace Java.Interop.Tools.TypeNameMappings
 		}
 
 		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
-		public static string ToCompatJniName (TypeDefinition type) =>
-			ToCompatJniName (type, resolver: null!);
+		public static string ToCompatJniName (TypeDefinition type) => throw new NotSupportedException ();
 
 		public static string ToCompatJniName (TypeDefinition type, TypeDefinitionCache cache) =>
 			ToCompatJniName (type, (IMetadataResolver) cache);
@@ -506,8 +501,7 @@ namespace Java.Interop.Tools.TypeNameMappings
 
 		// Keep in sync with ToJniNameFromAttributes(Type) and ToJniName(Type)
 		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
-		public static string ToJniName (TypeDefinition type) =>
-			ToJniName (type, resolver: null!);
+		public static string ToJniName (TypeDefinition type) => throw new NotSupportedException ();
 
 		public static string ToJniName (TypeDefinition type, TypeDefinitionCache cache) =>
 			ToJniName (type, (IMetadataResolver) cache);

--- a/tools/generator/CodeGenerator.cs
+++ b/tools/generator/CodeGenerator.cs
@@ -110,7 +110,7 @@ namespace Xamarin.Android.Binder
 			// Resolve types using Java.Interop.Tools.JavaTypeSystem
 			if (is_classparse && !options.UseLegacyJavaResolver) {
 				var output_xml = api_xml_adjuster_output ?? Path.Combine (Path.GetDirectoryName (filename), Path.GetFileName (filename) + ".adjusted");
-				JavaTypeResolutionFixups.Fixup (filename, output_xml, resolver, references.Distinct ().ToArray ());
+				JavaTypeResolutionFixups.Fixup (filename, output_xml, resolver, references.Distinct ().ToArray (), resolverCache);
 
 				if (only_xml_adjuster)
 					return;

--- a/tools/generator/Java.Interop.Tools.Generator.Transformation/JavaTypeResolutionFixups.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Transformation/JavaTypeResolutionFixups.cs
@@ -9,9 +9,13 @@ namespace generator
 {
 	public static class JavaTypeResolutionFixups
 	{
+		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
+		public static void Fixup (string xmlFile, string outputXmlFile, DirectoryAssemblyResolver resolver, string [] references) =>
+			Fixup(xmlFile, outputXmlFile, resolver, references, cache: null!);
+
 		// This fixup ensures all referenced Java types can be resolved, and
 		// removes types and members that rely on unresolvable Java types.
-		public static void Fixup (string xmlFile, string outputXmlFile, DirectoryAssemblyResolver resolver, string [] references)
+		public static void Fixup (string xmlFile, string outputXmlFile, DirectoryAssemblyResolver resolver, string [] references, TypeDefinitionCache cache)
 		{
 			// Parse api.xml
 			var type_collection = JavaXmlApiImporter.Parse (xmlFile);
@@ -21,7 +25,7 @@ namespace generator
 				Report.Verbose (0, "Resolving assembly for Java type resolution: '{0}'.", reference);
 				var assembly = resolver.Load (reference);
 
-				ManagedApiImporter.Parse (assembly, type_collection);
+				ManagedApiImporter.Parse (assembly, type_collection, cache);
 			}
 
 			// Run the type resolution pass

--- a/tools/generator/Java.Interop.Tools.Generator.Transformation/JavaTypeResolutionFixups.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Transformation/JavaTypeResolutionFixups.cs
@@ -10,8 +10,7 @@ namespace generator
 	public static class JavaTypeResolutionFixups
 	{
 		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
-		public static void Fixup (string xmlFile, string outputXmlFile, DirectoryAssemblyResolver resolver, string [] references) =>
-			Fixup(xmlFile, outputXmlFile, resolver, references, cache: null!);
+		public static void Fixup (string xmlFile, string outputXmlFile, DirectoryAssemblyResolver resolver, string [] references) => throw new NotSupportedException ();
 
 		// This fixup ensures all referenced Java types can be resolved, and
 		// removes types and members that rely on unresolvable Java types.


### PR DESCRIPTION
Reviewing code in `JavaCallableWrapperGenerator`, I found places we weren't using the supplied `TypeDefinitionCache` or `IMetadataResolver`. Thus we appeared to be calling `TypeReference.Resolve()` potentially on the same types.

For example, `dotnet trace` output of an incremental build of a `dotnet new maui` project:

    41.65ms xamarin.android.cecil!Mono.Cecil.TypeReference.Resolve()

I created a new `TypeDefinitionRocks.ResolveCached()` method to be used everywhere instead. Resulting with:

    23.89ms xamarin.android.cecil!Mono.Cecil.TypeReference.Resolve()

Additionally, I updated to places to use plain `foreach` loops instead of System.Linq.

    Before:
    1.03s xamarin.android.build.tasks!Xamarin.Android.Tasks.GenerateJavaStubs.RunTask()
    After:
    944.48ms xamarin.android.build.tasks!Xamarin.Android.Tasks.GenerateJavaStubs.RunTask()

I think this likely saves about ~50ms off incremental builds of a `dotnet new maui` project.