### PR TITLE
[Java.Interop.Tools.JavaCallableWrappers] add overload for `JavaTypeScanner`

### DIFF
--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaTypeScanner.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaTypeScanner.cs
@@ -51,6 +51,19 @@ namespace Java.Interop.Tools.JavaCallableWrappers
 			return javaTypes;
 		}
 
+		public List<TypeDefinition> GetJavaTypes (AssemblyDefinition assembly)
+		{
+			var javaTypes = new List<TypeDefinition> ();
+
+			foreach (ModuleDefinition md in assembly.Modules) {
+				foreach (TypeDefinition td in md.Types) {
+					AddJavaTypes (javaTypes, td);
+				}
+			}
+
+			return javaTypes;
+		}
+
 		void AddJavaTypes (List<TypeDefinition> javaTypes, TypeDefinition type)
 		{
 			if (type.IsSubclassOf ("Java.Lang.Object", cache) ||


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/7694

Add an overload of `JavaTypeScanner.GetJavaTypes()` that takes in a `Mono.Cecil.AssemblyDefinition` to be more easily consumed by linker steps.