### PR TITLE
[generator] Allow 'managedOverride' metadata to support 'abstract' methods.

### DIFF
--- a/src/Xamarin.SourceWriter/Models/MethodWriter.cs
+++ b/src/Xamarin.SourceWriter/Models/MethodWriter.cs
@@ -88,7 +88,8 @@ namespace Xamarin.SourceWriter
 
 			if (IsOverride)
 				writer.Write ("override ");
-			else if (IsVirtual)
+
+			if (IsVirtual)
 				writer.Write ("virtual ");
 			else if (IsAbstract)
 				writer.Write ("abstract ");

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
@@ -151,6 +151,30 @@ namespace generatortests
 		}
 
 		[Test]
+		public void ManagedOverrideAbstractMethod_Override ()
+		{
+			var xml = @"<api>
+			  <package name='java.lang' jni-name='java/lang'>
+			    <class abstract='false' deprecated='not deprecated' final='false' name='Object' static='false' visibility='public' jni-signature='Ljava/lang/Object;' />
+			  </package>
+			  <package name='com.xamarin.android' jni-name='com/xamarin/android'>
+			    <class abstract='false' deprecated='not deprecated' extends='java.lang.Object' extends-generic-aware='java.lang.Object' jni-extends='Ljava/lang/Object;' final='false' name='MyClass' static='false' visibility='public' jni-signature='Lcom/xamarin/android/MyClass;'>
+			      <method abstract='true' deprecated='not deprecated' final='true' name='DoStuff' jni-signature='()I' bridge='false' native='false' return='int' jni-return='I' static='false' synchronized='false' synthetic='false' visibility='public' managedOverride='override'></method>
+			    </class>
+			  </package>
+			</api>";
+
+			var gens = ParseApiDefinition (xml);
+			var klass = gens.Single (g => g.Name == "MyClass");
+
+			generator.Context.ContextTypes.Push (klass);
+			generator.WriteType (klass, string.Empty, new GenerationInfo ("", "", "MyAssembly"));
+			generator.Context.ContextTypes.Pop ();
+
+			Assert.True (writer.ToString ().Contains ("public override abstract int DoStuff ();"), $"was: `{writer}`");
+		}
+
+		[Test]
 		public void ManagedOverrideMethod_None ()
 		{
 			var xml = @"<api>

--- a/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
@@ -116,6 +116,10 @@ namespace MonoDroid.Generation
 					 !options.SupportNestedInterfaceTypes
 			};
 
+			if (elem.Attribute ("skipInvokerMethods")?.Value is string skip)
+				foreach (var m in skip.Split (new char [] { ',' }))
+					klass.SkippedInvokerMethods.Add (m);
+
 			FillApiSince (klass, pkg, elem);
 			SetLineInfo (klass, elem, options);
 

--- a/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
@@ -117,7 +117,7 @@ namespace MonoDroid.Generation
 			};
 
 			if (elem.Attribute ("skipInvokerMethods")?.Value is string skip)
-				foreach (var m in skip.Split (new char [] { ',', ' ' }))
+				foreach (var m in skip.Split (new char [] { ',', ' ', '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries))
 					klass.SkippedInvokerMethods.Add (m);
 
 			FillApiSince (klass, pkg, elem);

--- a/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
@@ -117,7 +117,7 @@ namespace MonoDroid.Generation
 			};
 
 			if (elem.Attribute ("skipInvokerMethods")?.Value is string skip)
-				foreach (var m in skip.Split (new char [] { ',' }))
+				foreach (var m in skip.Split (new char [] { ',', ' ' }))
 					klass.SkippedInvokerMethods.Add (m);
 
 			FillApiSince (klass, pkg, elem);

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ClassGen.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ClassGen.cs
@@ -11,6 +11,7 @@ namespace MonoDroid.Generation
 	public class ClassGen : GenBase
 	{
 		bool fill_explicit_implementation_started;
+		HashSet<string> skipped_invoker_methods;
 
 		public List<Ctor> Ctors { get; private set; } = new List<Ctor> ();
 
@@ -354,6 +355,8 @@ namespace MonoDroid.Generation
 			validated = false;
 			base.ResetValidation ();
 		}
+
+		public HashSet<string> SkippedInvokerMethods => skipped_invoker_methods ??= new HashSet<string> ();
 
 		public override string ToNative (CodeGenerationOptions opt, string varname, Dictionary<string, string> mappings = null)
 		{

--- a/tools/generator/SourceWriters/BoundMethodAbstractDeclaration.cs
+++ b/tools/generator/SourceWriters/BoundMethodAbstractDeclaration.cs
@@ -44,6 +44,9 @@ namespace generator.SourceWriters
 
 			NewFirst = true;
 
+			if (method.ManagedOverride?.ToLowerInvariant () == "override")
+				IsOverride = true;
+
 			if (opt.CodeGenerationTarget != CodeGenerationTarget.JavaInterop1) {
 				method_callback = new MethodCallback (impl, method, opt, null, method.IsReturnCharSequence);
 			}


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/7796

Imagine the following construct, which is new in `android.jar` API-34:

```java
public abstract class CharBuffer extends Buffer {
  public abstract CharBuffer duplicate ();
}

public abstract class Buffer  {
  public abstract Buffer duplicate ();
}
```

Generating the subclass's `abstract` method causes:
```
error CS0533: 'CharBuffer.Duplicate()' hides inherited abstract member 'Buffer.Duplicate()'
```

C# supports this construct if we make the subclass's `abstract` method with `override`:
```csharp
public abstract class CharBuffer : Buffer {
  public override abstract CharBuffer Duplicate ();
}
```

Theoretically we can tell `generator` how to fix this thanks [to our addition](https://github.com/xamarin/java.interop/pull/701) of the `managedOverride` metadata property:

```xml
<attr path="/api/package[@name='java.nio']/class[@name='CharBuffer']/method[@name='duplicate']" name="managedOverride">override</attr>
```

However, `managedOverride` was not written to support `abstract` methods.  This commit fixes that issue so that using `managedOverride` to create an `override abstract` method is possible.

## Method Invokers

This gets us halfway there, but there is another issue: method invokers for both the class and base class methods will be generated:

```csharp
[global::Android.Runtime.Register ("java/nio/CharBuffer", DoNotGenerateAcw=true)]
internal partial class CharBufferInvoker : CharBuffer {
	[Register ("duplicate", "()Ljava/nio/CharBuffer;", "")]
	public override sealed unsafe CharBuffer Duplicate () { ... }

	[Register ("duplicate", "()Ljava/nio/Buffer;", "")]
	public override sealed unsafe Buffer Duplicate () { ... }
}
```

This creates the following error:
```
error CS0111: Type 'CharBufferInvoker' already defines a member called 'Duplicate' with the same parameter types
error CS0508: 'CharBufferInvoker.Duplicate()': return type must be 'CharBuffer' to match overridden member 'CharBuffer.Duplicate()'
```

This perhaps(?) could be something `generator` could detect and prevent, but the feasibility and cost is unknown and expected to be high.  Since this is a very rare case, we will fix it with metadata, however we have never had metadata to apply to invokers before.

We have decided to add a `skipMethodInvokers` metadata to the `class` that the invoker class would be created for:

```xml
<attr path="/api/package[@name='java.nio']/class[@name='CharBuffer']" name="skipInvokerMethods">java/nio/Buffer.duplicate()Ljava/nio/Buffer;</attr>
```

This tells `generator` to skip generating the `Buffer Buffer.duplicate ()` invoker when generating the `CharBuffer` type.  Multiple invokers to skip can be specified as a comma or space separated list.