### PR TITLE
[generator] Add support for 'compatVirtualMethod'.

### DIFF
--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
@@ -353,6 +353,30 @@ namespace generatortests
 		}
 
 		[Test]
+		public void CompatVirtualMethod_Class ()
+		{
+			var xml = @"<api>
+			  <package name='java.lang' jni-name='java/lang'>
+			    <class abstract='false' deprecated='not deprecated' final='false' name='Object' static='false' visibility='public' jni-signature='Ljava/lang/Object;' />
+			  </package>
+			  <package name='com.xamarin.android' jni-name='com/xamarin/android'>
+			    <class abstract='false' deprecated='not deprecated' extends='java.lang.Object' extends-generic-aware='java.lang.Object' jni-extends='Ljava/lang/Object;' final='false' name='MyClass' static='false' visibility='public' jni-signature='Lcom/xamarin/android/MyClass;'>
+			      <method abstract='false' deprecated='not deprecated' final='true' name='DoStuff' jni-signature='()I' bridge='false' native='false' return='int' jni-return='I' static='false' synchronized='false' synthetic='false' visibility='public' compatVirtualMethod='true'></method>
+			    </class>
+			  </package>
+			</api>";
+
+			var gens = ParseApiDefinition (xml);
+			var klass = gens.Single (g => g.Name == "MyClass");
+
+			generator.Context.ContextTypes.Push (klass);
+			generator.WriteType (klass, string.Empty, new GenerationInfo ("", "", "MyAssembly"));
+			generator.Context.ContextTypes.Pop ();
+
+			Assert.True (writer.ToString ().NormalizeLineEndings ().Contains ("catch (Java.Lang.NoSuchMethodError) { throw new Java.Lang.AbstractMethodError (__id); }".NormalizeLineEndings ()), $"was: `{writer}`");
+		}
+
+		[Test]
 		public void WriteDuplicateInterfaceEventArgs ()
 		{
 			// If we have 2 methods that would each create the same EventArgs class,

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
@@ -361,7 +361,7 @@ namespace generatortests
 			  </package>
 			  <package name='com.xamarin.android' jni-name='com/xamarin/android'>
 			    <class abstract='false' deprecated='not deprecated' extends='java.lang.Object' extends-generic-aware='java.lang.Object' jni-extends='Ljava/lang/Object;' final='false' name='MyClass' static='false' visibility='public' jni-signature='Lcom/xamarin/android/MyClass;'>
-			      <method abstract='false' deprecated='not deprecated' final='true' name='DoStuff' jni-signature='()I' bridge='false' native='false' return='int' jni-return='I' static='false' synchronized='false' synthetic='false' visibility='public' compatVirtualMethod='true'></method>
+			      <method abstract='true' deprecated='not deprecated' final='true' name='DoStuff' jni-signature='()I' bridge='false' native='false' return='int' jni-return='I' static='false' synchronized='false' synthetic='false' visibility='public' compatVirtualMethod='true'></method>
 			    </class>
 			  </package>
 			</api>";

--- a/tests/generator-Tests/Unit-Tests/DefaultInterfaceMethodsTests.cs
+++ b/tests/generator-Tests/Unit-Tests/DefaultInterfaceMethodsTests.cs
@@ -490,5 +490,29 @@ namespace generatortests
 
 			AssertTargetedExpected (nameof (WriteInterfaceFieldAsDimProperty), writer.ToString ());
 		}
+
+		[Test]
+		public void CompatVirtualMethod_Interface ()
+		{
+			var xml = @"<api>
+			  <package name='java.lang' jni-name='java/lang'>
+			    <class abstract='false' deprecated='not deprecated' final='false' name='Object' static='false' visibility='public' jni-signature='Ljava/lang/Object;' />
+			  </package>
+			  <package name='com.xamarin.android' jni-name='com/xamarin/android'>
+			    <interface abstract='true' deprecated='not deprecated' final='false' name='Cursor' static='false' visibility='public' jni-signature='Landroid/database/Cursor;'>
+			      <method abstract='true' deprecated='not deprecated' final='false' name='getNotificationUri' jni-signature='()Ljava/lang/Object;' bridge='false' native='false' return='java.lang.Object' jni-return='Ljava/lang/Object;' static='false' synchronized='false' synthetic='false' visibility='public' compatVirtualMethod='true' />
+			    </interface>
+			  </package>
+			</api>";
+
+			var gens = ParseApiDefinition (xml);
+			var klass = gens.Single (g => g.Name == "ICursor");
+
+			generator.Context.ContextTypes.Push (klass);
+			generator.WriteType (klass, string.Empty, new GenerationInfo ("", "", "MyAssembly"));
+			generator.Context.ContextTypes.Pop ();
+
+			Assert.True (writer.ToString ().NormalizeLineEndings ().Contains ("catch (Java.Lang.NoSuchMethodError) { throw new Java.Lang.AbstractMethodError (__id); }".NormalizeLineEndings ()), $"was: `{writer}`");
+		}
 	}
 }

--- a/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
@@ -371,6 +371,7 @@ namespace MonoDroid.Generation
 				GenericArguments = elem.GenericArguments (),
 				IsAbstract = elem.XGetAttribute ("abstract") == "true",
 				IsAcw = true,
+				IsCompatVirtualMethod = elem.XGetAttribute ("compatVirtualMethod") == "true",
 				IsFinal = elem.XGetAttribute ("final") == "true",
 				IsReturnEnumified = elem.Attribute ("enumReturn") != null,
 				IsStatic = elem.XGetAttribute ("static") == "true",

--- a/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
@@ -385,6 +385,10 @@ namespace MonoDroid.Generation
 				Visibility = elem.Visibility ()
 			};
 
+			// CompatVirtualMethods aren't abstract
+			if (method.IsCompatVirtualMethod)
+				method.IsAbstract = false;
+
 			method.IsVirtual = !method.IsStatic && elem.XGetAttribute ("final") == "false";
 
 			if (elem.Attribute ("managedName") != null)

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Method.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Method.cs
@@ -19,6 +19,7 @@ namespace MonoDroid.Generation
 		public bool GenerateAsyncWrapper { get; set; }
 		public bool GenerateDispatchingSetter { get; set; }
 		public bool IsAbstract { get; set; }
+		public bool IsCompatVirtualMethod { get; set; }
 		public bool IsFinal { get; set; }
 		public bool IsInterfaceDefaultMethod { get; set; }
 		public Method OverriddenInterfaceMethod { get; set; }

--- a/tools/generator/SourceWriters/Extensions/SourceWriterExtensions.cs
+++ b/tools/generator/SourceWriters/Extensions/SourceWriterExtensions.cs
@@ -266,6 +266,12 @@ namespace generator.SourceWriters
 				body.Add ($"\treturn {method.RetVal.ReturnCast}{method.RetVal.FromNative (opt, r, true) + opt.GetNullForgiveness (method.RetVal)};");
 			}
 
+			if (method.IsCompatVirtualMethod) {
+				body.Add ("}");
+				body.Add ("catch (Java.Lang.NoSuchMethodError) {");
+				body.Add ("	throw new Java.Lang.AbstractMethodError (__id);");
+			}
+
 			body.Add ("} finally {");
 
 			foreach (string cleanup in method.Parameters.GetCallCleanup (opt))


### PR DESCRIPTION
Fixes: https://github.com/xamarin/java.interop/issues/810

When a new `abstract` method is added to an existing class, that is a breaking change that we do not wish to inflict upon our users.  Instead, we will change it to a "normal" method that catches a Java `NoSuchMethodError` if the `abstract` method is not implemented.  If the method does not exist, we throw a `AbstractMethodError` instead.

This is accomplished by using metadata to set `compatVirtualMethod` on a method to `true`.

## Example:
API-34 adds:
```csharp
public abstract Java.Nio.ByteBuffer Slice (int index, int length);
```

Setting `compatVirtualMethod` to `true`:

```xml
<attr path="/api/package[@name='java.nio']/class[@name='ByteBuffer']/method[@name='slice']" name="compatVirtualMethod">true</attr>
```

Changes the method to:
```csharp
public virtual unsafe Java.Nio.ByteBuffer Slice (int index, int length)
{
  const string __id = "slice.(II)Ljava/nio/ByteBuffer;";
  try {
    JniArgumentValue* __args = stackalloc JniArgumentValue [2];
    __args [0] = new JniArgumentValue (index);
    __args [1] = new JniArgumentValue (length);
    var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, __args);
    return global::Java.Lang.Object.GetObject<Java.Nio.ByteBuffer> (__rm.Handle, JniHandleOwnership.TransferLocalRef)!;
  }
  catch (Java.Lang.NoSuchMethodError) {  // This "catch" block is added when 'compatVirtualMethod' is 'true'
    throw new Java.Lang.AbstractMethodError (__id);
  } finally {
  }
}
```

This also works for `interface` types.