### PR TITLE
[generator] Fix an NRE when cloning a method with generic arguments.

### DIFF
--- a/tests/generator-Tests/Unit-Tests/GenBaseTests.cs
+++ b/tests/generator-Tests/Unit-Tests/GenBaseTests.cs
@@ -91,6 +91,22 @@ namespace generatortests
 			Assert.False (c.RequiresNew (m.Name, m));
 		}
 
+		[Test]
+		public void TestMethodClone_GenericArguments ()
+		{
+			var c = SupportTypeBuilder.CreateClass ("java.myClass", options);
+			var m = SupportTypeBuilder.CreateMethod (c, "DoStuff", options);
+
+			m.GenericArguments = new GenericParameterDefinitionList {
+				new GenericParameterDefinition ("T", null)
+			};
+
+			var clone = m.Clone (c);
+
+			Assert.AreEqual (1, clone.GenericArguments.Count);
+			Assert.AreEqual ("T", clone.GenericArguments [0].Name);
+		}
+
 		void TestParameterlessMethods (string name)
 		{
 			var c = SupportTypeBuilder.CreateClass ("java.myClass", options);

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Method.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Method.cs
@@ -126,9 +126,13 @@ namespace MonoDroid.Generation
 			clone.SourceFile = SourceFile;
 			clone.JavadocInfo = JavadocInfo;
 
-			if (GenericArguments != null)
+			if (GenericArguments != null) {
+				if (clone.GenericArguments is null)
+					clone.GenericArguments = new GenericParameterDefinitionList ();
+
 				foreach (var ga in GenericArguments)
 					clone.GenericArguments.Add (ga.Clone ());
+			}
 
 			foreach (var p in Parameters)
 				clone.Parameters.Add (p.Clone ());


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/pull/1080

When running the latest `generator` against `GooglePlayServices`, it hits an NRE when attempting to `Method.Clone (...)` a method with generic arguments while building `com.google.firebase.firebase-components.csproj`:

```
BINDINGSGENERATOR error BG0000: System.NullReferenceException: Object reference not set to an instance of an object. [c:\g\generated\com.google.firebase.firebase-components\com.google.firebase.firebase-components.csproj]
error BG0000: System.NullReferenceException: Object reference not set to an instance of an object.
   at MonoDroid.Generation.Method.Clone(GenBase declaringType) in C:\code\xamarin-android\external\Java.Interop\tools\generator\Java.Interop.Tools.Generator.ObjectModel\Method.cs:line 131
   at MonoDroid.Generation.Method.Clone(GenBase declaringType) in C:\code\xamarin-android\external\Java.Interop\tools\generator\Java.Interop.Tools.Generator.ObjectModel\Method.cs:line 131
   at MonoDroid.Generation.ClassGen.FixupAccessModifiers(CodeGenerationOptions opt) in C:\code\xamarin-android\external\Java.Interop\tools\generator\Java.Interop.Tools.Generator.ObjectModel\ClassGen.cs:line 67
   at MonoDroid.Generation.ClassGen.FixupAccessModifiers(CodeGenerationOptions opt) in C:\code\xamarin-android\external\Java.Interop\tools\generator\Java.Interop.Tools.Generator.ObjectModel\ClassGen.cs:line 67
   at Xamarin.Android.Binder.CodeGenerator.Validate(List`1 gens, CodeGenerationOptions opt, CodeGeneratorContext context) in C:\code\xamarin-android\external\Java.Interop\tools\generator\CodeGenerator.cs:line 300
   at Xamarin.Android.Binder.CodeGenerator.Validate(List`1 gens, CodeGenerationOptions opt, CodeGeneratorContext context) in C:\code\xamarin-android\external\Java.Interop\tools\generator\CodeGenerator.cs:line 300
   at Xamarin.Android.Binder.CodeGenerator.Run(CodeGeneratorOptions options, DirectoryAssemblyResolver resolver) in C:\code\xamarin-android\external\Java.Interop\tools\generator\CodeGenerator.cs:line 208
   at Xamarin.Android.Binder.CodeGenerator.Run(CodeGeneratorOptions options, DirectoryAssemblyResolver resolver) in C:\code\xamarin-android\external\Java.Interop\tools\generator\CodeGenerator.cs:line 208
   at Xamarin.Android.Binder.CodeGenerator.Run(CodeGeneratorOptions options) in C:\code\xamarin-android\external\Java.Interop\tools\generator\CodeGenerator.cs:line 50
   at Xamarin.Android.Binder.CodeGenerator.Run(CodeGeneratorOptions options) in C:\code\xamarin-android\external\Java.Interop\tools\generator\CodeGenerator.cs:line 50
   at Xamarin.Android.Binder.CodeGenerator.Main(String[] args) in C:\code\xamarin-android\external\Java.Interop\tools\generator\CodeGenerator.cs:line 33
   at Xamarin.Android.Binder.CodeGenerator.Main(String[] args) in C:\code\xamarin-android\external\Java.Interop\tools\generator\CodeGenerator.cs:line 33
```

This is because the `MethodBase.GenericArguments` collection is `null` unless it has items.  Thus we need to create it before populating it with items.