### PR TITLE
[class-parse] Use `BufferedStream` for up to 10x performance gain

### DIFF
--- a/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
@@ -72,7 +72,8 @@ namespace Xamarin.Android.Tools.Bytecode {
 						if (!ClassFile.IsClassFile (s) || entry.Name.EndsWith (".jnilib", StringComparison.OrdinalIgnoreCase))
 							continue;
 					}
-					using (var s = entry.Open ()) {
+					using (var entry_stream = entry.Open ())
+					using (var s = new BufferedStream (entry_stream)) {
 						try {
 							var c   = new ClassFile (s);
 							Add (c);


### PR DESCRIPTION
While building `AndroidX.sln`, `class-parse` is taking up a considerable amount of time.  After some quick profiling, this seems to be caused by reading from a `ZipStream` one or two bytes at a time.  Wrapping the `ZipStream` in a `BufferedStream` makes the `class-parse` process about 10x faster on larger test cases.

|   | `main` | This PR |
| - | - | - |
| `class-parse` on API-33 `android.jar` (26.5 MB) | 16.675s | 2.759s |
| `class-parse` on `androidx.compose.runtime.runtime` (1.044 MB) | 9.713s | .893s |
| Total `class-parse` time building `AndroidX.sln` | 5:48.46m | 2:09.73m |
| Total time building `AndroidX.sln` | 7:40.19m | 4:42.34m |