### PR TITLE
[class-parse] Ignore `module-info.class` file.

### DIFF
--- a/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
@@ -66,12 +66,9 @@ namespace Xamarin.Android.Tools.Bytecode {
 
 			using (var jar = CreateZipArchive (jarStream, leaveOpen)) {
 				foreach (var entry in jar.Entries) {
-					if (entry.Length == 0)
+					if (!ShouldLoadEntry (entry))
 						continue;
-					using (var s = entry.Open ()) {
-						if (!ClassFile.IsClassFile (s) || entry.Name.EndsWith (".jnilib", StringComparison.OrdinalIgnoreCase))
-							continue;
-					}
+
 					using (var s = entry.Open ()) {
 						try {
 							var c   = new ClassFile (s);
@@ -83,6 +80,22 @@ namespace Xamarin.Android.Tools.Bytecode {
 					}
 				}
 			}
+		}
+
+		static bool ShouldLoadEntry (ZipArchiveEntry entry)
+		{
+			if (entry.Length == 0)
+				return false;
+
+			if (entry.Name == "module-info.class")
+				return false;
+
+			if (entry.Name.EndsWith (".jnilib", StringComparison.OrdinalIgnoreCase))
+				return false;
+
+			using var s = entry.Open ();
+
+			return ClassFile.IsClassFile (s);
 		}
 
 		static ZipArchive CreateZipArchive (Stream jarStream, bool leaveOpen)


### PR DESCRIPTION
Some AndroidX packages contain a file called `module-info.class` that is not a standard `.class` file.  Rather, this file is a metadata file for Java Modules ([documentation](https://www.oracle.com/corporate/features/understanding-java-9-modules.html)).

![image](https://user-images.githubusercontent.com/179295/229861846-cbd04239-9d7b-470b-ae6c-844713009104.png)

`class-parse` emit this for the file:

```xml
<package
  name=""
  jni-name="">
  <class
    abstract="false"
    deprecated="not deprecated"
    final="false"
    name="module-info"
    jni-signature="Lmodule-info;"
    source-file-name="module-info.java"
    static="false"
    visibility="" />
</package>
```

When we try to resolve this type, `generator` emits the following warning:

```
warning BG8605: The Java type '' could not be found (are you missing a Java reference jar/aar or a Java binding library NuGet?)
```

This is neither useful nor actionable.  Instead, we should ignore this file in `class-parse`.