### PR TITLE
[generator] Add support for `@RestrictTo`.

### DIFF
--- a/src/Java.Interop.Tools.JavaTypeSystem/Adapters/JavaXmlApiExporter.cs
+++ b/src/Java.Interop.Tools.JavaTypeSystem/Adapters/JavaXmlApiExporter.cs
@@ -158,7 +158,7 @@ namespace Java.Interop.Tools.JavaTypeSystem
 		}
 
 		static void SaveConstructor (JavaConstructorModel ctor, XmlWriter writer)
-			=> SaveMember (ctor, writer, "constructor", null, null, null, null, null, ctor.DeclaringType.FullName, null, null, null, ctor.Parameters, ctor.IsBridge, null, ctor.IsSynthetic, null);
+			=> SaveMember (ctor, writer, "constructor", null, null, null, null, null, ctor.DeclaringType.FullName, null, null, null, ctor.Parameters, ctor.IsBridge, null, ctor.IsSynthetic, null, ctor.AnnotatedVisibility);
 
 		static void SaveField (JavaFieldModel field, XmlWriter writer)
 		{
@@ -177,7 +177,8 @@ namespace Java.Interop.Tools.JavaTypeSystem
 				null,
 				null,
 				null,
-				field.IsNotNull);
+				field.IsNotNull,
+				field.AnnotatedVisibility);
 		}
 
 		static void SaveMethod (JavaMethodModel method, XmlWriter writer)
@@ -228,7 +229,8 @@ namespace Java.Interop.Tools.JavaTypeSystem
 				extBridge: method.IsBridge,
 				jniReturn: method.ReturnJni,
 				extSynthetic: method.IsSynthetic,
-				notNull: method.ReturnNotNull);
+				notNull: method.ReturnNotNull,
+				annotatedVisibility: method.AnnotatedVisibility);
 		}
 
 		static string GetVisibleReturnTypeString (JavaMethodModel method)
@@ -277,7 +279,7 @@ namespace Java.Interop.Tools.JavaTypeSystem
 				string? transient, string? type, string? typeGeneric,
 				string? value, string? volat,
 				IEnumerable<JavaParameterModel>? parameters,
-				bool? extBridge, string? jniReturn, bool? extSynthetic, bool? notNull)
+				bool? extBridge, string? jniReturn, bool? extSynthetic, bool? notNull, string? annotatedVisibility)
 		{
 			// If any of the parameters contain reference to non-public type, it cannot be generated.
 			// TODO
@@ -310,6 +312,7 @@ namespace Java.Interop.Tools.JavaTypeSystem
 			writer.WriteAttributeStringIfValue ("type", type);
 			writer.WriteAttributeStringIfValue ("type-generic-aware", typeGeneric);
 			writer.WriteAttributeStringIfValue ("value", value);
+			writer.WriteAttributeStringIfValue ("annotated-visibility", annotatedVisibility);
 
 			if (extSynthetic.HasValue)
 				writer.WriteAttributeString ("synthetic", extSynthetic.Value ? "true" : "false");

--- a/src/Java.Interop.Tools.JavaTypeSystem/Adapters/JavaXmlApiImporter.cs
+++ b/src/Java.Interop.Tools.JavaTypeSystem/Adapters/JavaXmlApiImporter.cs
@@ -197,7 +197,8 @@ namespace Java.Interop.Tools.JavaTypeSystem
 				returnJni: element.XGetAttribute ("jni-return"),
 				isNative: element.XGetAttributeAsBool ("native"),
 				isSynchronized: element.XGetAttributeAsBool ("synchronized"),
-				returnNotNull: element.XGetAttributeAsBool ("return-not-null")
+				returnNotNull: element.XGetAttributeAsBool ("return-not-null"),
+				annotatedVisibility: element.XGetAttributeOrNull ("annotated-visibility")
 			);
 
 			if (element.Element ("typeParameters") is XElement tp)
@@ -226,7 +227,8 @@ namespace Java.Interop.Tools.JavaTypeSystem
 				deprecated: element.XGetAttribute ("deprecated"),
 				jniSignature: element.XGetAttribute ("jni-signature"),
 				isSynthetic: element.XGetAttributeAsBool ("synthetic"),
-				isBridge: element.XGetAttributeAsBool ("bridge")
+				isBridge: element.XGetAttributeAsBool ("bridge"),
+				annotatedVisibility: element.XGetAttributeOrNull ("annotated-visibility")
 			);
 
 			// Yes, constructors in Java can have generic type parameters ¯\_(ツ)_/¯
@@ -262,7 +264,8 @@ namespace Java.Interop.Tools.JavaTypeSystem
 				jniSignature: element.XGetAttribute ("jni-signature"),
 				isTransient: element.XGetAttributeAsBool ("transient"),
 				isVolatile: element.XGetAttributeAsBool ("volatile"),
-				isNotNull: element.XGetAttributeAsBool ("not-null")
+				isNotNull: element.XGetAttributeAsBool ("not-null"),
+				annotatedVisibility: element.XGetAttributeOrNull ("annotated-visibility")
 			);
 
 			if (element.XGetAttribute ("merge.SourceFile") is string source && source.HasValue ())

--- a/src/Java.Interop.Tools.JavaTypeSystem/Adapters/ManagedApiImporter.cs
+++ b/src/Java.Interop.Tools.JavaTypeSystem/Adapters/ManagedApiImporter.cs
@@ -185,7 +185,8 @@ namespace Java.Interop.Tools.JavaTypeSystem
 				returnJni: jni_signature.Return.Jni,
 				isNative: false,
 				isSynchronized: false,
-				returnNotNull: false
+				returnNotNull: false,
+				annotatedVisibility: null
 			);
 
 			for (var i = 0; i < jni_signature.Parameters.Count; i++)

--- a/src/Java.Interop.Tools.JavaTypeSystem/JavaModels/JavaConstructorModel.cs
+++ b/src/Java.Interop.Tools.JavaTypeSystem/JavaModels/JavaConstructorModel.cs
@@ -4,8 +4,8 @@ namespace Java.Interop.Tools.JavaTypeSystem.Models
 {
 	public class JavaConstructorModel : JavaMethodModel
 	{
-		public JavaConstructorModel (string javaName, string javaVisibility, bool javaStatic, JavaTypeModel javaDeclaringType, string deprecated, string jniSignature, bool isSynthetic, bool isBridge)
-			: base (javaName, javaVisibility, false, false, javaStatic, "void", javaDeclaringType, deprecated, jniSignature, isSynthetic, isBridge, string.Empty, false, false, false)
+		public JavaConstructorModel (string javaName, string javaVisibility, bool javaStatic, JavaTypeModel javaDeclaringType, string deprecated, string jniSignature, bool isSynthetic, bool isBridge, string? annotatedVisibility)
+			: base (javaName, javaVisibility, false, false, javaStatic, "void", javaDeclaringType, deprecated, jniSignature, isSynthetic, isBridge, string.Empty, false, false, false, annotatedVisibility)
 		{
 		}
 

--- a/src/Java.Interop.Tools.JavaTypeSystem/JavaModels/JavaFieldModel.cs
+++ b/src/Java.Interop.Tools.JavaTypeSystem/JavaModels/JavaFieldModel.cs
@@ -15,8 +15,8 @@ namespace Java.Interop.Tools.JavaTypeSystem.Models
 
 		public JavaTypeReference? TypeModel { get; private set; }
 
-		public JavaFieldModel (string name, string visibility, string type, string typeGeneric, string? value, bool isStatic, JavaTypeModel declaringType, bool isFinal, string deprecated, string jniSignature, bool isTransient, bool isVolatile, bool isNotNull)
-			: base (name, isStatic, isFinal, visibility, declaringType, deprecated, jniSignature)
+		public JavaFieldModel (string name, string visibility, string type, string typeGeneric, string? value, bool isStatic, JavaTypeModel declaringType, bool isFinal, string deprecated, string jniSignature, bool isTransient, bool isVolatile, bool isNotNull, string? annotatedVisibility)
+			: base (name, isStatic, isFinal, visibility, declaringType, deprecated, jniSignature, annotatedVisibility)
 		{
 			Type = type;
 			TypeGeneric = typeGeneric;

--- a/src/Java.Interop.Tools.JavaTypeSystem/JavaModels/JavaMemberModel.cs
+++ b/src/Java.Interop.Tools.JavaTypeSystem/JavaModels/JavaMemberModel.cs
@@ -12,10 +12,11 @@ namespace Java.Interop.Tools.JavaTypeSystem.Models
 		public string Visibility { get; }
 		public string Deprecated { get; }
 		public string JniSignature { get; }
+		public string? AnnotatedVisibility { get; }
 
 		public Dictionary<string, string> PropertyBag { get; } = new Dictionary<string, string> ();
 
-		public JavaMemberModel (string name, bool isStatic, bool isFinal, string visibility, JavaTypeModel declaringType, string deprecated, string jniSignature)
+		public JavaMemberModel (string name, bool isStatic, bool isFinal, string visibility, JavaTypeModel declaringType, string deprecated, string jniSignature, string? annotatedVisibility)
 		{
 			Name = name;
 			IsStatic = isStatic;
@@ -24,6 +25,7 @@ namespace Java.Interop.Tools.JavaTypeSystem.Models
 			DeclaringType = declaringType;
 			Deprecated = deprecated;
 			JniSignature = jniSignature;
+			AnnotatedVisibility = annotatedVisibility;
 		}
 
 		public abstract void Resolve (JavaTypeCollection types, ICollection<JavaUnresolvableModel> unresolvables);

--- a/src/Java.Interop.Tools.JavaTypeSystem/JavaModels/JavaMethodModel.cs
+++ b/src/Java.Interop.Tools.JavaTypeSystem/JavaModels/JavaMethodModel.cs
@@ -22,8 +22,8 @@ namespace Java.Interop.Tools.JavaTypeSystem.Models
 		public List<JavaParameterModel> Parameters { get; } = new List<JavaParameterModel> ();
 		public List<JavaExceptionModel> Exceptions { get; } = new List<JavaExceptionModel> ();
 
-		public JavaMethodModel (string javaName, string javaVisibility, bool javaAbstract, bool javaFinal, bool javaStatic, string javaReturn, JavaTypeModel javaDeclaringType, string deprecated, string jniSignature, bool isSynthetic, bool isBridge, string returnJni, bool isNative, bool isSynchronized, bool returnNotNull)
-			: base (javaName, javaStatic, javaFinal, javaVisibility, javaDeclaringType, deprecated, jniSignature)
+		public JavaMethodModel (string javaName, string javaVisibility, bool javaAbstract, bool javaFinal, bool javaStatic, string javaReturn, JavaTypeModel javaDeclaringType, string deprecated, string jniSignature, bool isSynthetic, bool isBridge, string returnJni, bool isNative, bool isSynchronized, bool returnNotNull, string? annotatedVisibility)
+			: base (javaName, javaStatic, javaFinal, javaVisibility, javaDeclaringType, deprecated, jniSignature, annotatedVisibility)
 		{
 			IsAbstract = javaAbstract;
 			Return = javaReturn;

--- a/src/Xamarin.Android.Tools.Bytecode/XmlClassDeclarationBuilder.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/XmlClassDeclarationBuilder.cs
@@ -433,8 +433,19 @@ namespace Xamarin.Android.Tools.Bytecode {
 		{
 			var annotations = attributes?.OfType<RuntimeInvisibleAnnotationsAttribute> ().FirstOrDefault ()?.Annotations;
 
-			if (annotations?.FirstOrDefault (a => a.Type == "Landroidx/annotation/RestrictTo;") is Annotation annotation)
-				return new XAttribute ("annotated-visibility", ((annotation.Values.FirstOrDefault ().Value as AnnotationElementArray)?.Values?.FirstOrDefault () as AnnotationElementEnum)?.ConstantName ?? string.Empty);
+			if (annotations?.FirstOrDefault (a => a.Type == "Landroidx/annotation/RestrictTo;") is Annotation annotation) {
+				var annotation_element_values = (annotation.Values.FirstOrDefault ().Value as AnnotationElementArray)?.Values?.OfType<AnnotationElementEnum> ();
+
+				if (annotation_element_values is null || !annotation_element_values.Any ())
+					return null;
+
+				var value_string = string.Join (" ", annotation_element_values.Select (v => v.ConstantName).Where (p => p != null));
+
+				if (string.IsNullOrWhiteSpace (value_string))
+					return null;
+
+				return new XAttribute ("annotated-visibility", value_string);
+			}
 
 			return null;
 		}

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
@@ -893,6 +893,144 @@ namespace generatortests
 		}
 
 		[Test]
+		public void RestrictToType ()
+		{
+			options.UseRestrictToAttributes = true;
+
+			var xml = @"<api>
+			  <package name='java.lang' jni-name='java/lang'>
+			    <class abstract='false' deprecated='not deprecated' final='false' name='Object' static='false' visibility='public' jni-signature='Ljava/lang/Object;' />
+			  </package>
+			  <package name='com.xamarin.android' jni-name='com/xamarin/android'>
+			    <class abstract='false' deprecated='not deprecated' extends='java.lang.Object' extends-generic-aware='java.lang.Object' jni-extends='Ljava/lang/Object;' final='false' name='MyClass' static='false' visibility='public' jni-signature='Lcom/xamarin/android/MyClass;' annotated-visibility='LIBRARY_GROUP_PREFIX' />
+			  </package>
+			</api>";
+
+			var gens = ParseApiDefinition (xml);
+			var iface = gens.Single (g => g.Name == "MyClass");
+
+			generator.Context.ContextTypes.Push (iface);
+			generator.WriteType (iface, string.Empty, new GenerationInfo ("", "", "MyAssembly"));
+			generator.Context.ContextTypes.Pop ();
+
+			// This should use a special [Obsolete] describing the "internal" nature of this API
+			Assert.True (writer.ToString ().NormalizeLineEndings ().Contains ("[global::System.Obsolete (\"While this type is 'public', Google considers it internal API and reserves the right to modify or delete it in the future. Use at your own risk.\", DiagnosticId = \"XAOBS001\")]".NormalizeLineEndings ()), writer.ToString ());
+		}
+
+		[Test]
+		public void RestrictToField ()
+		{
+			options.UseRestrictToAttributes = true;
+
+			var xml = @"<api>
+			  <package name='java.lang' jni-name='java/lang'>
+			    <class abstract='false' deprecated='not deprecated' final='false' name='Object' static='false' visibility='public' jni-signature='Ljava/lang/Object;' />
+			  </package>
+			  <package name='com.xamarin.android' jni-name='com/xamarin/android'>
+			    <class abstract='false' deprecated='not deprecated' extends='java.lang.Object' extends-generic-aware='java.lang.Object' jni-extends='Ljava/lang/Object;' final='false' name='MyClass' static='false' visibility='public' jni-signature='Lcom/xamarin/android/MyClass;'>
+			      <field deprecated='not deprecated' name='ACCEPT_HANDOVER' jni-signature='Ljava/lang/String;' transient='false' type='java.lang.String' type-generic-aware='java.lang.String' visibility='public' volatile='false' annotated-visibility='LIBRARY_GROUP_PREFIX'></field>
+			    </class>
+			  </package>
+			</api>";
+
+			var gens = ParseApiDefinition (xml);
+			var iface = gens.Single (g => g.Name == "MyClass");
+
+			generator.Context.ContextTypes.Push (iface);
+			generator.WriteType (iface, string.Empty, new GenerationInfo ("", "", "MyAssembly"));
+			generator.Context.ContextTypes.Pop ();
+
+			// This should use a special [Obsolete] describing the "internal" nature of this API
+			Assert.True (writer.ToString ().NormalizeLineEndings ().Contains ("[global::System.Obsolete (\"While this member is 'public', Google considers it internal API and reserves the right to modify or delete it in the future. Use at your own risk.\", DiagnosticId = \"XAOBS001\")]".NormalizeLineEndings ()), writer.ToString ());
+		}
+
+		[Test]
+		public void RestrictToMethod ()
+		{
+			options.UseRestrictToAttributes = true;
+
+			var xml = @"<api>
+			  <package name='java.lang' jni-name='java/lang'>
+			    <class abstract='false' deprecated='not deprecated' final='false' name='Object' static='false' visibility='public' jni-signature='Ljava/lang/Object;' />
+			  </package>
+			  <package name='com.xamarin.android' jni-name='com/xamarin/android'>
+			    <class abstract='false' deprecated='not deprecated' extends='java.lang.Object' extends-generic-aware='java.lang.Object' jni-extends='Ljava/lang/Object;' final='false' name='MyClass' static='false' visibility='public' jni-signature='Lcom/xamarin/android/MyClass;'>
+			      <method abstract='false' final='false' name='countAffectedRows' jni-signature='()I' bridge='false' native='false' return='int' jni-return='I' static='false' synchronized='false' synthetic='false' visibility='public' annotated-visibility='LIBRARY_GROUP_PREFIX'></method>
+			    </class>
+			  </package>
+			</api>";
+
+			var gens = ParseApiDefinition (xml);
+			var iface = gens.Single (g => g.Name == "MyClass");
+
+			generator.Context.ContextTypes.Push (iface);
+			generator.WriteType (iface, string.Empty, new GenerationInfo ("", "", "MyAssembly"));
+			generator.Context.ContextTypes.Pop ();
+
+			// This should use a special [Obsolete] describing the "internal" nature of this API
+			Assert.True (writer.ToString ().NormalizeLineEndings ().Contains ("[global::System.Obsolete (\"While this member is 'public', Google considers it internal API and reserves the right to modify or delete it in the future. Use at your own risk.\", DiagnosticId = \"XAOBS001\")]".NormalizeLineEndings ()), writer.ToString ());
+		}
+
+		[Test]
+		public void RestrictToProperty ()
+		{
+			options.UseRestrictToAttributes = true;
+
+			var xml = @"<api>
+			  <package name='java.lang' jni-name='java/lang'>
+			    <class abstract='false' deprecated='not deprecated' final='false' name='Object' static='false' visibility='public' jni-signature='Ljava/lang/Object;' />
+			  </package>
+			  <package name='com.xamarin.android' jni-name='com/xamarin/android'>
+			    <class abstract='false' deprecated='not deprecated' extends='java.lang.Object' extends-generic-aware='java.lang.Object' jni-extends='Ljava/lang/Object;' final='false' name='MyClass' static='false' visibility='public' jni-signature='Lcom/xamarin/android/MyClass;'>
+			      <method abstract='false' deprecated='not deprecated' final='false' name='getCount' jni-signature='()I' bridge='false' native='false' return='int' jni-return='I' static='false' synchronized='false' synthetic='false' visibility='public' annotated-visibility='LIBRARY_GROUP_PREFIX'></method>
+			      <method abstract='false' deprecated='not deprecated' final='false' name='setCount' jni-signature='(I)V' bridge='false' native='false' return='void' jni-return='V' static='false' synchronized='false' synthetic='false' visibility='public' annotated-visibility='LIBRARY_GROUP_PREFIX'>
+				<parameter name='count' type='int' jni-type='I'></parameter>
+			      </method>
+			    </class>
+			  </package>
+			</api>";
+
+			var gens = ParseApiDefinition (xml);
+			var iface = gens.Single (g => g.Name == "MyClass");
+
+			generator.Context.ContextTypes.Push (iface);
+			generator.WriteType (iface, string.Empty, new GenerationInfo ("", "", "MyAssembly"));
+			generator.Context.ContextTypes.Pop ();
+
+			// This should use a special [Obsolete] describing the "internal" nature of this API
+			Assert.True (writer.ToString ().NormalizeLineEndings ().Contains ("[global::System.Obsolete (\"While this member is 'public', Google considers it internal API and reserves the right to modify or delete it in the future. Use at your own risk.\", DiagnosticId = \"XAOBS001\")]".NormalizeLineEndings ()), writer.ToString ());
+		}
+
+		[Test]
+		public void DoNotWriteObsoleteAndRestrictTo ()
+		{
+			options.UseRestrictToAttributes = true;
+
+			var xml = @"<api>
+			  <package name='java.lang' jni-name='java/lang'>
+			    <class abstract='false' deprecated='not deprecated' final='false' name='Object' static='false' visibility='public' jni-signature='Ljava/lang/Object;' />
+			  </package>
+			  <package name='com.xamarin.android' jni-name='com/xamarin/android'>
+			    <class abstract='false' deprecated='not deprecated' extends='java.lang.Object' extends-generic-aware='java.lang.Object' jni-extends='Ljava/lang/Object;' final='false' name='MyClass' static='false' visibility='public' jni-signature='Lcom/xamarin/android/MyClass;'>
+			      <method deprecated='deprecated' abstract='false' final='false' name='countAffectedRows' jni-signature='()I' bridge='false' native='false' return='int' jni-return='I' static='false' synchronized='false' synthetic='false' visibility='public' annotated-visibility='LIBRARY_GROUP_PREFIX'></method>
+			    </class>
+			  </package>
+			</api>";
+
+			var gens = ParseApiDefinition (xml);
+			var iface = gens.Single (g => g.Name == "MyClass");
+
+			generator.Context.ContextTypes.Push (iface);
+			generator.WriteType (iface, string.Empty, new GenerationInfo ("", "", "MyAssembly"));
+			generator.Context.ContextTypes.Pop ();
+
+			// This method is both @Deprecated and @RestrictTo. We cannot write 2 [Obsolete] attributes, so
+			// only write the deprecated one.
+			Assert.True (writer.ToString ().Replace (" (@\"deprecated\")", "").NormalizeLineEndings ().Contains ("[global::System.Obsolete]".NormalizeLineEndings ()), writer.ToString ());
+			Assert.False (writer.ToString ().NormalizeLineEndings ().Contains ("[global::System.Obsolete (\"While this member is 'public', Google considers it internal API and reserves the right to modify or delete it in the future. Use at your own risk.\", DiagnosticId = \"XAOBS001\")]".NormalizeLineEndings ()), writer.ToString ());
+		}
+
+		[Test]
 		[NonParallelizable]     // We are setting a static property on Report
 		public void WarnIfTypeNameMatchesNamespace ()
 		{

--- a/tools/generator/CodeGenerationOptions.cs
+++ b/tools/generator/CodeGenerationOptions.cs
@@ -67,6 +67,7 @@ namespace MonoDroid.Generation
 		public bool SupportNullableReferenceTypes { get; set; }
 		public bool UseShallowReferencedTypes { get; set; }
 		public bool UseObsoletedOSPlatformAttributes { get; set; }
+		public bool UseRestrictToAttributes { get; set; }
 		public bool RemoveConstSugar => BuildingCoreAssembly;
 
 		bool? buildingCoreAssembly;

--- a/tools/generator/CodeGenerator.cs
+++ b/tools/generator/CodeGenerator.cs
@@ -84,6 +84,7 @@ namespace Xamarin.Android.Binder
 				SupportNestedInterfaceTypes = options.SupportNestedInterfaceTypes,
 				SupportNullableReferenceTypes = options.SupportNullableReferenceTypes,
 				UseObsoletedOSPlatformAttributes = options.UseObsoletedOSPlatformAttributes,
+				UseRestrictToAttributes = options.UseRestrictToAttributes,
 			};
 			var resolverCache       = new TypeDefinitionCache ();
 

--- a/tools/generator/CodeGeneratorOptions.cs
+++ b/tools/generator/CodeGeneratorOptions.cs
@@ -52,6 +52,7 @@ namespace Xamarin.Android.Binder
 		public bool		    SupportDefaultInterfaceMethods { get; set; }
 		public bool		    SupportNestedInterfaceTypes { get; set; }
 		public bool		    SupportNullableReferenceTypes { get; set; }
+		public bool		    UseRestrictToAttributes { get; set; }
 		public bool		    UseLegacyJavaResolver { get; set; }
 		public bool			UseObsoletedOSPlatformAttributes { get; set; }
 
@@ -103,13 +104,14 @@ namespace Xamarin.Android.Binder
 					"SDK Platform {VERSION}/API level.",
 					v => opts.ApiLevel = v },
 				{ "lang-features=",
-					"For internal use. (Flags: interface-constants,default-interface-methods,nested-interface-types,nullable-reference-types,obsoleted-platform-attributes)",
+					"For internal use. (Flags: interface-constants,default-interface-methods,nested-interface-types,nullable-reference-types,obsoleted-platform-attributes,restrict-to-attributes)",
 					v => {
 						opts.SupportInterfaceConstants = v?.Contains ("interface-constants") == true;
 						opts.SupportDefaultInterfaceMethods = v?.Contains ("default-interface-methods") == true;
 						opts.SupportNestedInterfaceTypes = v?.Contains ("nested-interface-types") == true;
 						opts.SupportNullableReferenceTypes = v?.Contains ("nullable-reference-types") == true;
 						opts.UseObsoletedOSPlatformAttributes = v?.Contains ("obsoleted-platform-attributes") == true;
+						opts.UseRestrictToAttributes = v?.Contains ("restrict-to-attributes") == true;
 						}},
 				{ "preserve-enums",
 					"For internal use.",

--- a/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
@@ -157,6 +157,7 @@ namespace MonoDroid.Generation
 		public static Ctor CreateCtor (GenBase declaringType, XElement elem, CodeGenerationOptions options = null)
 		{
 			var ctor = new Ctor (declaringType) {
+				AnnotatedVisibility = elem.XGetAttribute ("annotated-visibility"),
 				ApiAvailableSince = declaringType.ApiAvailableSince,
 				CustomAttributes = elem.XGetAttribute ("customAttributes"),
 				Deprecated = elem.Deprecated (),
@@ -208,6 +209,7 @@ namespace MonoDroid.Generation
 		public static Field CreateField (GenBase declaringType, XElement elem, CodeGenerationOptions options = null)
 		{
 			var field = new Field {
+				AnnotatedVisibility = elem.XGetAttribute ("annotated-visibility"),
 				ApiAvailableSince = declaringType.ApiAvailableSince,
 				DeprecatedComment = elem.XGetAttribute ("deprecated"),
 				DeprecatedSince = elem.XGetAttributeAsIntOrNull ("deprecated-since"),
@@ -252,6 +254,7 @@ namespace MonoDroid.Generation
 		public static GenBaseSupport CreateGenBaseSupport (XElement pkg, XElement elem, CodeGenerationOptions opt, bool isInterface)
 		{
 			var support = new GenBaseSupport {
+				AnnotatedVisibility = elem.XGetAttribute ("annotated-visibility"),
 				DeprecatedSince = elem.XGetAttributeAsIntOrNull ("deprecated-since"),
 				IsAcw = true,
 				IsDeprecated = elem.XGetAttribute ("deprecated") != "not deprecated",
@@ -360,6 +363,7 @@ namespace MonoDroid.Generation
 		public static Method CreateMethod (GenBase declaringType, XElement elem, CodeGenerationOptions options = null)
 		{
 			var method = new Method (declaringType) {
+				AnnotatedVisibility = elem.XGetAttribute ("annotated-visibility"),
 				ApiAvailableSince = declaringType.ApiAvailableSince,
 				ArgsType = elem.Attribute ("argsType")?.Value,
 				CustomAttributes = elem.XGetAttribute ("customAttributes"),

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Field.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Field.cs
@@ -6,6 +6,7 @@ namespace MonoDroid.Generation
 {
 	public class Field : ApiVersionsSupport.IApiAvailability, ISourceLineInfo
 	{
+		public string AnnotatedVisibility { get; set; }
 		public string Annotation { get; set; }
 		public int ApiAvailableSince { get; set; }
 		public string DeprecatedComment { get; set; }

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
@@ -178,6 +178,8 @@ namespace MonoDroid.Generation
 				yield return g;
 		}
 
+		public string AnnotatedVisibility => support.AnnotatedVisibility;
+
 		// not: not currently assembly qualified, but it uses needed
 		// Type.GetType() conventions such as '/' for nested types.
 		public string AssemblyQualifiedName => string.IsNullOrWhiteSpace (Namespace)

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBaseSupport.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBaseSupport.cs
@@ -4,6 +4,7 @@ namespace MonoDroid.Generation
 {
 	public class GenBaseSupport
 	{
+		public string AnnotatedVisibility { get; set; }
 		public bool IsAcw { get; set; }
 		public bool IsDeprecated { get; set; }
 		public string DeprecatedComment { get; set; }

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/MethodBase.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/MethodBase.cs
@@ -13,6 +13,7 @@ namespace MonoDroid.Generation
 			DeclaringType = declaringType;
 		}
 
+		public string AnnotatedVisibility { get; set; }
 		public string Annotation { get; internal set; }
 		public int ApiAvailableSince { get; set; }
 		public string AssemblyName { get; set; }

--- a/tools/generator/SourceWriters/Attributes/RestrictToAttr.cs
+++ b/tools/generator/SourceWriters/Attributes/RestrictToAttr.cs
@@ -1,0 +1,20 @@
+using System;
+using Xamarin.SourceWriter;
+
+namespace generator.SourceWriters
+{
+	public class RestrictToAttr : AttributeWriter
+	{
+		bool is_type;
+
+		public RestrictToAttr (bool isType)
+		{
+			is_type = isType;
+		}
+
+		public override void WriteAttribute (CodeWriter writer)
+		{
+			writer.WriteLine ($"[global::System.Obsolete (\"While this {(is_type ? "type" : "member")} is 'public', Google considers it internal API and reserves the right to modify or delete it in the future. Use at your own risk.\", DiagnosticId = \"XAOBS001\")]");
+		}
+	}
+}

--- a/tools/generator/SourceWriters/BoundClass.cs
+++ b/tools/generator/SourceWriters/BoundClass.cs
@@ -45,6 +45,7 @@ namespace generator.SourceWriters
 			Comments.Add ($"// Metadata.xml XPath class reference: path=\"{klass.MetadataXPathReference}\"");
 
 			SourceWriterExtensions.AddObsolete (Attributes, klass.DeprecatedComment, opt, forceDeprecate: klass.IsDeprecated, deprecatedSince: klass.DeprecatedSince);
+			SourceWriterExtensions.AddRestrictToWarning (Attributes, klass.AnnotatedVisibility, true, opt);
 
 			SourceWriterExtensions.AddSupportedOSPlatform (Attributes, klass, opt);
 

--- a/tools/generator/SourceWriters/BoundConstructor.cs
+++ b/tools/generator/SourceWriters/BoundConstructor.cs
@@ -34,6 +34,7 @@ namespace generator.SourceWriters
 			}
 
 			SourceWriterExtensions.AddObsolete (Attributes, constructor.Deprecated, opt, deprecatedSince: constructor.DeprecatedSince);
+			SourceWriterExtensions.AddRestrictToWarning (Attributes, constructor.AnnotatedVisibility, false, opt);
 
 			if (constructor.CustomAttributes != null)
 				Attributes.Add (new CustomAttr (constructor.CustomAttributes));

--- a/tools/generator/SourceWriters/BoundField.cs
+++ b/tools/generator/SourceWriters/BoundField.cs
@@ -33,6 +33,7 @@ namespace generator.SourceWriters
 
 			SourceWriterExtensions.AddSupportedOSPlatform (Attributes, field, opt);
 			SourceWriterExtensions.AddObsolete (Attributes, field.DeprecatedComment, opt, field.IsDeprecated, isError: field.IsDeprecatedError, deprecatedSince: field.DeprecatedSince);
+			SourceWriterExtensions.AddRestrictToWarning (Attributes, field.AnnotatedVisibility, false, opt);
 
 			if (field.Annotation.HasValue ())
 				Attributes.Add (new CustomAttr (field.Annotation));

--- a/tools/generator/SourceWriters/BoundFieldAsProperty.cs
+++ b/tools/generator/SourceWriters/BoundFieldAsProperty.cs
@@ -48,6 +48,7 @@ namespace generator.SourceWriters
 			}
 
 			SourceWriterExtensions.AddObsolete (Attributes, field.DeprecatedComment, opt, field.IsDeprecated, isError: field.IsDeprecatedError, deprecatedSince: field.DeprecatedSince);
+			SourceWriterExtensions.AddRestrictToWarning (Attributes, field.AnnotatedVisibility, false, opt);
 
 			SetVisibility (field.Visibility);
 			UseExplicitPrivateKeyword = true;

--- a/tools/generator/SourceWriters/BoundInterface.cs
+++ b/tools/generator/SourceWriters/BoundInterface.cs
@@ -44,6 +44,7 @@ namespace generator.SourceWriters
 			Comments.Add ($"// Metadata.xml XPath interface reference: path=\"{iface.MetadataXPathReference}\"");
 
 			SourceWriterExtensions.AddObsolete (Attributes, iface.DeprecatedComment, opt, iface.IsDeprecated, deprecatedSince: iface.DeprecatedSince);
+			SourceWriterExtensions.AddRestrictToWarning (Attributes, iface.AnnotatedVisibility, true, opt);
 
 			if (!iface.IsConstSugar (opt)) {
 				var signature = string.IsNullOrWhiteSpace (iface.Namespace)

--- a/tools/generator/SourceWriters/BoundInterfaceMethodDeclaration.cs
+++ b/tools/generator/SourceWriters/BoundInterfaceMethodDeclaration.cs
@@ -35,6 +35,7 @@ namespace generator.SourceWriters
 				Comments.Add ($"// Metadata.xml XPath method reference: path=\"{method.GetMetadataXPathReference (method.DeclaringType)}\"");
 
 			SourceWriterExtensions.AddObsolete (Attributes, method.Deprecated, opt, deprecatedSince: method.DeprecatedSince);
+			SourceWriterExtensions.AddRestrictToWarning (Attributes, method.AnnotatedVisibility, false, opt);
 
 			if (method.IsReturnEnumified)
 				Attributes.Add (new GeneratedEnumAttr (true));

--- a/tools/generator/SourceWriters/BoundMethod.cs
+++ b/tools/generator/SourceWriters/BoundMethod.cs
@@ -75,6 +75,7 @@ namespace generator.SourceWriters
 				Comments.Add ($"// Metadata.xml XPath method reference: path=\"{method.GetMetadataXPathReference (method.DeclaringType)}\"");
 
 			SourceWriterExtensions.AddObsolete (Attributes, method.Deprecated, opt, deprecatedSince: method.DeprecatedSince);
+			SourceWriterExtensions.AddRestrictToWarning (Attributes, method.AnnotatedVisibility, false, opt);
 
 			if (method.IsReturnEnumified)
 				Attributes.Add (new GeneratedEnumAttr (true));

--- a/tools/generator/SourceWriters/BoundMethodAbstractDeclaration.cs
+++ b/tools/generator/SourceWriters/BoundMethodAbstractDeclaration.cs
@@ -57,6 +57,7 @@ namespace generator.SourceWriters
 				Comments.Add ($"// Metadata.xml XPath method reference: path=\"{method.GetMetadataXPathReference (method.DeclaringType)}\"");
 
 			SourceWriterExtensions.AddObsolete (Attributes, method.Deprecated, opt, deprecatedSince: method.DeprecatedSince);
+			SourceWriterExtensions.AddRestrictToWarning (Attributes, method.AnnotatedVisibility, false, opt);
 
 			SourceWriterExtensions.AddSupportedOSPlatform (Attributes, method, opt);
 

--- a/tools/generator/SourceWriters/BoundMethodExtensionStringOverload.cs
+++ b/tools/generator/SourceWriters/BoundMethodExtensionStringOverload.cs
@@ -27,6 +27,7 @@ namespace generator.SourceWriters
 			ReturnType = new TypeReferenceWriter (opt.GetTypeReferenceName (method.RetVal).Replace ("Java.Lang.ICharSequence", "string").Replace ("global::string", "string"));
 
 			SourceWriterExtensions.AddObsolete (Attributes, method.Deprecated, opt, deprecatedSince: method.DeprecatedSince);
+			SourceWriterExtensions.AddRestrictToWarning (Attributes, method.AnnotatedVisibility, false, opt);
 
 			SourceWriterExtensions.AddSupportedOSPlatform (Attributes, method, opt);
 

--- a/tools/generator/SourceWriters/BoundMethodStringOverload.cs
+++ b/tools/generator/SourceWriters/BoundMethodStringOverload.cs
@@ -25,6 +25,7 @@ namespace generator.SourceWriters
 			ReturnType = new TypeReferenceWriter (opt.GetTypeReferenceName (method.RetVal).Replace ("Java.Lang.ICharSequence", "string").Replace ("global::string", "string"));
 
 			SourceWriterExtensions.AddObsolete (Attributes, method.Deprecated, opt, deprecatedSince: method.DeprecatedSince);
+			SourceWriterExtensions.AddRestrictToWarning (Attributes, method.AnnotatedVisibility, false, opt);
 
 			SourceWriterExtensions.AddSupportedOSPlatform (Attributes, method, opt);
 

--- a/tools/generator/SourceWriters/BoundProperty.cs
+++ b/tools/generator/SourceWriters/BoundProperty.cs
@@ -86,6 +86,9 @@ namespace generator.SourceWriters
 					SourceWriterExtensions.AddObsolete (SetterAttributes, property.Setter.Deprecated.Trim (), opt, deprecatedSince: property.Setter?.DeprecatedSince);
 			}
 
+			SourceWriterExtensions.AddRestrictToWarning (GetterAttributes, property.Getter.AnnotatedVisibility, false, opt);
+			SourceWriterExtensions.AddRestrictToWarning (SetterAttributes, property.Setter?.AnnotatedVisibility, false, opt);
+
 			SourceWriterExtensions.AddSupportedOSPlatform (Attributes, property.Getter, opt);
 
 			SourceWriterExtensions.AddMethodCustomAttributes (GetterAttributes, property.Getter);

--- a/tools/generator/SourceWriters/Extensions/SourceWriterExtensions.cs
+++ b/tools/generator/SourceWriters/Extensions/SourceWriterExtensions.cs
@@ -341,6 +341,23 @@ namespace generator.SourceWriters
 			return true;
 		}
 
+		public static void AddRestrictToWarning (List<AttributeWriter> attributes, string scope, bool isType, CodeGenerationOptions opt)
+		{
+			if (!opt.UseRestrictToAttributes)
+				return;
+
+			// Empty scope means there is no @RestrictTo annotation
+			if (!scope.HasValue ())
+				return;
+
+			// We can't add 2 [Obsolete] attributes, we'll let a "real" obsolete message take precedence
+			if (attributes.OfType<ObsoleteAttr> ().Any ())
+				return;
+
+			// We consider all scopes to be "internal" API we need to warn about
+			attributes.Add (new RestrictToAttr (isType));
+		}
+
 		public static void WriteMethodInvokerBody (CodeWriter writer, Method method, CodeGenerationOptions opt, string contextThis)
 		{
 			writer.WriteLine ($"if ({method.EscapedIdName} == IntPtr.Zero)");


### PR DESCRIPTION
Fixes: https://github.com/xamarin/java.interop/issues/1081

Android has an [annotation](https://developer.android.com/reference/androidx/annotation/RestrictTo) `androidx.annotation.RestrictTo` (`@RestrictTo`) that essentially means "this API is implemented as `public`, but we do not consider it public API".  This means that Google reserves the right to change it at any time (see https://github.com/xamarin/AndroidX/issues/690).  Because we simply bind the API as `public`, it misleads our users into thinking this is a stable API they can rely on.

## Example
In `androidx.appcompat.appcompat-resources` `1.6.0`, Google [decided to promote classes](https://android-review.googlesource.com/c/platform/frameworks/support/+/2120177) that were previously marked as `@RestrictTo({RestrictTo.Scope.LIBRARY_GROUP_PREFIX})` to full public supported classes.  However, when they did this they changed the names of the classes, breaking our users (including XF) who were using the "internal" classes.

### 1.5.1
![image](https://user-images.githubusercontent.com/179295/216440200-ff4f3bd3-1a86-419d-adff-9460976a6355.png)

### 1.6.0
![image](https://user-images.githubusercontent.com/179295/216440273-917a74a0-a1b5-4bdc-bb56-8615be89f18e.png)

## Support

We are going to support this by adding a new `[Obsolete]` attribute on the affected API with a message describing the situation.  We will use the new ability in `ObsoleteAttribute` to provide a custom warning code.  This will allow users to `<NoWarn>` the code if they wish to ignore all of these types of warnings.

```
[Obsolete ("While this type is 'public', Google considers it internal API and reserves the right to modify or delete it in the future. Use at your own risk.", DiagnosticId = "XAOBS001")]
```

## Changes

To accomplish this, the following changes were needed:

- Update `class-parse` to look for the `@RestrictTo` annotation, and output its value as an `annotated-visibility` in `api.xml`.
- Update `xml-adjuster` to support and pass through the `annotated-visibility` attribute.
- Update `generator` to add the appropriate `[Obsolete]` attribute when needed.

Note that only one `[Obsolete]` attribute is allowed per type/member, so if the API already has a regular `[Obsolete]` attribute, we do not add the `@RestrictTo` information.

The `generator` changes are gated behind `--lang-features=restrict-to-attributes`.  It is off by default.  I propose we turn it on by default using MSBuild, but provide an opt-out MSBuild property in case a user wishes to opt out.