### PR TITLE
[class-parse] support Module AttributeInfo

### DIFF
--- a/src/Xamarin.Android.Tools.Bytecode/ClassFile.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/ClassFile.cs
@@ -48,8 +48,15 @@ namespace Xamarin.Android.Tools.Bytecode {
 			Attributes      = new AttributeCollection (ConstantPool, stream);
 
 			int e = stream.ReadByte ();
-			if (e >= 0)
-				throw new BadImageFormatException ("Stream has trailing data?!");
+			if (e >= 0) {
+				var trailing    = new System.Text.StringBuilder ();
+				trailing.AppendFormat ("{0:x2}", (byte) e);
+				while ((e = stream.ReadByte ()) >= 0) {
+					trailing.Append (" ");
+					trailing.AppendFormat ("{0:x2}", (byte) e);
+				}
+				throw new BadImageFormatException ($"Stream has trailing data?! {{{trailing}}}");
+			}
 		}
 
 		public static bool IsClassFile (Stream stream)
@@ -213,6 +220,10 @@ namespace Xamarin.Android.Tools.Bytecode {
 		Synthetic   = 0x1000,
 		Annotation  = 0x2000,
 		Enum        = 0x4000,
+		Module      = 0x8000,
+
+		// This is not a real Java ClassAccessFlags, it is used to denote non-exported public types
+		Internal    = 0x10000000,
 	}
 }
 

--- a/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
@@ -108,6 +108,14 @@ namespace Xamarin.Android.Tools.Bytecode {
 			classFiles.Add (classFile);
 		}
 
+		public void Add (ClassPath classPath, bool removeModules = true)
+		{
+			classPath.FixupModuleVisibility (removeModules);
+			foreach (var c in classPath.classFiles) {
+				Add (c);
+			}
+		}
+
 		public ReadOnlyDictionary<string, List<ClassFile>> GetPackages ()
 		{
 			return new ReadOnlyDictionary<string, List<ClassFile>> (classFiles
@@ -357,7 +365,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 				FixUpParametersFromClasses ();
 
 			KotlinFixups.Fixup (classFiles);
-			FixupModuleVisibility ();
+			FixupModuleVisibility (removeModules: true);
 
 			var packagesDictionary = GetPackages ();
 			var api = new XElement ("api",
@@ -373,7 +381,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 			return api;
 		}
 
-		void FixupModuleVisibility ()
+		public void FixupModuleVisibility (bool removeModules)
 		{
 			var publicPackages  = new HashSet<string> ();
 
@@ -383,7 +391,9 @@ namespace Xamarin.Android.Tools.Bytecode {
 				return;
 			}
 			foreach (var moduleFile in moduleFiles) {
-				classFiles.Remove (moduleFile);
+				if (removeModules) {
+					classFiles.Remove (moduleFile);
+				}
 				foreach (var moduleAttr in moduleFile.Attributes.OfType<ModuleAttribute> ()) {
 					foreach (var export in moduleAttr.Exports) {
 						publicPackages.Add (export.Exports);
@@ -427,5 +437,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 				contents.Save (writer);
 			textWriter.WriteLine ();
 		}
+
+		public IEnumerable<ClassFile> GetClassFiles () => classFiles;
 	}
 }

--- a/src/Xamarin.Android.Tools.Bytecode/Kotlin/KotlinFixups.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/Kotlin/KotlinFixups.cs
@@ -102,7 +102,7 @@ namespace Xamarin.Android.Tools.Bytecode
 		}
 
 		// Passing null for 'newVisibility' parameter means 'package-private'
-		static ClassAccessFlags SetVisibility (ClassAccessFlags existing, ClassAccessFlags? newVisibility)
+		internal static ClassAccessFlags SetVisibility (ClassAccessFlags existing, ClassAccessFlags? newVisibility)
 		{
 			// First we need to remove any existing visibility flags,
 			// without modifying other flags like Abstract

--- a/src/Xamarin.Android.Tools.Bytecode/Modules.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/Modules.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Xamarin.Android.Tools.Bytecode {
+
+	public enum ModuleFlags {
+		Open        = 0x0020,
+		Synthetic   = 0x1000,
+		Mandated    = 0x8000,
+	}
+
+	public enum ModuleRequiresInfoFlags {
+		Transitive      = 0x0020,
+		StaticPhase     = 0x0040,
+		Synthetic       = 0x1000,
+		Mandated        = 0x8000,
+	}
+
+	// https://docs.oracle.com/javase/specs/jvms/se11/html/jvms-4.html#jvms-4.7.25
+	public sealed class ModuleRequiresInfo {
+		ushort  requiresIndex;
+		ushort  requiresVersionIndex;
+
+
+		public  ConstantPool                ConstantPool    {get; private set;}
+		public  ModuleRequiresInfoFlags     RequiresFlags   {get; private set;}
+
+		public  string Requires =>
+			((ConstantPoolModuleItem) ConstantPool [requiresIndex]).Name.Value;
+		public  string RequiresVersion =>
+			((ConstantPoolUtf8Item) ConstantPool [requiresVersionIndex]).Value;
+
+		public ModuleRequiresInfo (ConstantPool constantPool, Stream stream)
+		{
+			ConstantPool            = constantPool;
+
+			requiresIndex           = stream.ReadNetworkUInt16 ();
+			RequiresFlags           = (ModuleRequiresInfoFlags) stream.ReadNetworkUInt16 ();
+			requiresVersionIndex    = stream.ReadNetworkUInt16 ();
+		}
+
+		public override string ToString ()
+		{
+			return $"Requires({Requires}, Version={RequiresVersion}, Flags={RequiresFlags})";
+		}
+	}
+
+	public enum ModuleExportsPackageInfoFlags {
+		Synthetic   = 0x1000,
+		Mandated    = 0x8000,
+	} 
+
+	// https://docs.oracle.com/javase/specs/jvms/se11/html/jvms-4.html#jvms-4.7.25
+	public sealed class ModuleExportsPackageInfo {
+		ushort  exportsIndex;
+		public  string  Exports =>
+			((ConstantPoolPackageItem) ConstantPool [exportsIndex]).Name.Value;
+
+		public  ConstantPool                            ConstantPool    {get; private set;}
+		public  ModuleExportsPackageInfoFlags	        Flags           {get; private set;}
+		public  Collection<ConstantPoolModuleItem>	ExportsTo       {get;} = new ();
+
+
+		public ModuleExportsPackageInfo (ConstantPool constantPool, Stream stream)
+		{
+			ConstantPool            = constantPool;
+
+			exportsIndex            = stream.ReadNetworkUInt16 ();
+			Flags                   = (ModuleExportsPackageInfoFlags) stream.ReadNetworkUInt16 ();
+
+			var count               = stream.ReadNetworkUInt16 ();
+			for (int i = 0; i < count; ++i) {
+				var exports_to_index = stream.ReadNetworkUInt16 ();
+				ExportsTo.Add ((ConstantPoolModuleItem) constantPool [exports_to_index]);
+			}
+		}
+
+		public override string ToString ()
+		{
+			var s = new StringBuilder ()
+				.Append ("ExportsPackage(Name=\"").Append (Exports).Append ("\"");
+			if (Flags != 0) {
+				s.Append (", Flags=").Append (Flags);
+			}
+			if (ExportsTo.Count > 0) {
+				s.Append (", To={");
+				s.Append (ExportsTo [0].Name.Value);
+				for (int i = 1; i < ExportsTo.Count; ++i) {
+					s.Append (", ");
+					s.Append (ExportsTo [i].Name.Value);
+				}
+				s.Append ("}");
+			}
+			s.Append (")");
+			return s.ToString ();
+		}
+	}
+
+
+	public enum ModuleOpensPackageInfoFlags {
+		Synthetic   = 0x1000,
+		Mandated    = 0x8000,
+	}
+
+	// https://docs.oracle.com/javase/specs/jvms/se11/html/jvms-4.html#jvms-4.7.25
+	public sealed class ModuleOpensPackageInfo {
+		ushort  opensIndex;
+
+		public  ConstantPool                            ConstantPool    {get; private set;}
+
+		public  ModuleOpensPackageInfoFlags	        Flags 	    {get; private set;}
+
+		public  Collection<ConstantPoolModuleItem>	OpensTo     {get;} = new ();
+		public  string  Opens =>
+			((ConstantPoolPackageItem) ConstantPool [opensIndex]).Name.Value;
+
+		public ModuleOpensPackageInfo (ConstantPool constantPool, Stream stream)
+		{
+			ConstantPool            = constantPool;
+
+			opensIndex              = stream.ReadNetworkUInt16 ();
+			Flags                   = (ModuleOpensPackageInfoFlags) stream.ReadNetworkUInt16 ();
+
+			var count               = stream.ReadNetworkUInt16 ();
+			for (int i = 0; i < count; ++i) {
+				var opens_to_index      = stream.ReadNetworkUInt16 ();
+				OpensTo.Add ((ConstantPoolModuleItem) constantPool [opens_to_index]);
+			}
+		}
+
+		public override string ToString ()
+		{
+			var to = string.Join (", ", OpensTo.Select (e => e.Name.Value));
+			return $"Opens({Opens}, Flags={Flags}, To={to})";
+		}
+	}
+
+	// https://docs.oracle.com/javase/specs/jvms/se11/html/jvms-4.html#jvms-4.7.25
+	public sealed class ModuleProvidesInfo {
+		ushort  providesIndex;
+
+		public  string Provides =>
+			((ConstantPoolClassItem) ConstantPool [providesIndex]).Name.Value;
+
+		public  ConstantPool        ConstantPool    {get; private set;}
+
+		public  Collection<ConstantPoolClassItem>       ProvidesWith    {get;} = new ();
+
+		public ModuleProvidesInfo (ConstantPool constantPool, Stream stream)
+		{
+			ConstantPool            = constantPool;
+
+			providesIndex           = stream.ReadNetworkUInt16 ();
+
+			var count               = stream.ReadNetworkUInt16 ();
+			for (int i = 0; i < count; ++i) {
+				var provides_with_index = stream.ReadNetworkUInt16 ();
+				ProvidesWith.Add ((ConstantPoolClassItem) constantPool [provides_with_index]);
+			}
+		}
+
+		public override string ToString ()
+		{
+			var with = string.Join (", ", ProvidesWith.Select (e => e.Name.Value));
+			return $"Service(ServiceInterface={Provides}, ServiceImplementations={{{with}}})";
+		}
+	}
+}

--- a/src/Xamarin.Android.Tools.Bytecode/Xamarin.Android.Tools.Bytecode.csproj
+++ b/src/Xamarin.Android.Tools.Bytecode/Xamarin.Android.Tools.Bytecode.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;$(DotNetTargetFramework)</TargetFrameworks>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
     <DefineConstants>INTERNAL_NULLABLE_ATTRIBUTES</DefineConstants>

--- a/src/Xamarin.Android.Tools.Bytecode/XmlClassDeclarationBuilder.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/XmlClassDeclarationBuilder.cs
@@ -40,7 +40,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 					GetSourceFile (),
 					new XAttribute ("static",                   classFile.IsStatic),
 					new XAttribute ("visibility",               GetVisibility (classFile.Visibility)),
-					GetAnnotatedVisibility (classFile.Attributes),
+					GetAnnotatedVisibility (classFile.Visibility, classFile.Attributes),
 					GetTypeParmeters (signature == null ? null : signature.TypeParameters),
 					GetImplementedInterfaces (),
 					GetConstructors (),
@@ -111,7 +111,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 			if ((accessFlags & ClassAccessFlags.Private) != 0)
 				return "private";
 			if (accessFlags.HasFlag (ClassAccessFlags.Internal))
-				return "kotlin-internal";
+				return "public";    // TODO: `kotlin-internal` at some point?  See also GetAnnotatedVisibility()
 			return "";
 		}
 
@@ -429,6 +429,19 @@ namespace Xamarin.Android.Tools.Bytecode {
 							? SignatureToGenericJavaTypeName (t.TypeSignature)
 							: BinaryNameToJavaClassName (t.BinaryName)));
 			}
+		}
+
+		static XAttribute? GetAnnotatedVisibility (ClassAccessFlags flags, AttributeCollection attributes)
+		{
+			var attr = GetAnnotatedVisibility (attributes);
+			if (flags.HasFlag (ClassAccessFlags.Internal)) {
+				if (attr == null) {
+					attr = new XAttribute ("annotated-visibility", "module-info");
+				} else {
+					attr.Value += " module-info";
+				}
+			}
+			return attr;
 		}
 
 		static XAttribute? GetAnnotatedVisibility (AttributeCollection attributes)

--- a/src/Xamarin.Android.Tools.Bytecode/XmlClassDeclarationBuilder.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/XmlClassDeclarationBuilder.cs
@@ -110,6 +110,8 @@ namespace Xamarin.Android.Tools.Bytecode {
 				return "protected";
 			if ((accessFlags & ClassAccessFlags.Private) != 0)
 				return "private";
+			if (accessFlags.HasFlag (ClassAccessFlags.Internal))
+				return "kotlin-internal";
 			return "";
 		}
 

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/ExpectedTypeDeclaration.cs
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/ExpectedTypeDeclaration.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 			NAssert.AreEqual (ConstantPoolCount,        classDeclaration.ConstantPool.Count,    FullName + " ConstantPool Count");
 			NAssert.AreEqual (AccessFlags,              classDeclaration.AccessFlags,           FullName + " AccessFlags");
 			NAssert.AreEqual (FullName,                 classDeclaration.ThisClass.Name.Value,  FullName + " Name");
-			NAssert.AreEqual (Superclass.BinaryName,    classDeclaration.SuperClass.Name.Value, FullName + " SuperClass Name");
+			NAssert.AreEqual (Superclass?.BinaryName,   classDeclaration?.SuperClass?.Name?.Value,  FullName + " SuperClass Name");
 
 			NAssert.AreEqual (Deprecated,   classDeclaration.Attributes.Get<DeprecatedAttribute> () != null,    FullName + " Deprecated");
 

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/ModuleInfoTests.cs
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/ModuleInfoTests.cs
@@ -1,0 +1,45 @@
+﻿using System;
+
+using Xamarin.Android.Tools.Bytecode;
+
+using NUnit.Framework;
+
+namespace Xamarin.Android.Tools.BytecodeTests {
+
+	[TestFixture]
+	public class ModuleInfoTests : ClassFileFixture {
+
+		const string JavaType = "module-info";
+
+		[Test]
+		public void ClassFile ()
+		{
+			var c   = LoadClassFile (JavaType + ".class");
+			new ExpectedTypeDeclaration {
+				MajorVersion        = 0x37,
+				MinorVersion        = 0,
+				ConstantPoolCount   = 13,
+				AccessFlags         = ClassAccessFlags.Module,
+				FullName            = "module-info",
+			}.Assert (c);
+
+			Assert.AreEqual (2, c.Attributes.Count);
+
+			Assert.AreEqual ("SourceFile",          c.Attributes [0].Name);
+			var sourceFileAttr = c.Attributes [0] as SourceFileAttribute;
+			Assert.IsTrue (sourceFileAttr != null);
+			Assert.AreEqual ("module-info.java",    sourceFileAttr.FileName);
+
+			Assert.AreEqual ("Module",              c.Attributes [1].Name);
+			var moduleAttr = c.Attributes [1] as ModuleAttribute;
+			Assert.IsTrue (moduleAttr != null);
+			Assert.AreEqual ("com.xamarin",         moduleAttr.ModuleName);
+			Assert.AreEqual (null,                  moduleAttr.ModuleVersion);
+			Assert.AreEqual (1,                     moduleAttr.Requires.Count);
+			Assert.AreEqual ("java.base",           moduleAttr.Requires [0].Requires);
+			Assert.AreEqual (1,                     moduleAttr.Exports.Count);
+			Assert.AreEqual ("com/xamarin",         moduleAttr.Exports [0].Exports);
+		}
+	}
+}
+

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj
@@ -49,6 +49,7 @@
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\xamarin\ParameterClass.class" />
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\xamarin\ParameterClass2.class" />
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\java\util\Collection.class" />
+    <EmbeddedResource Include="$(IntermediateOutputPath)classes\module-info.class" />
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\NonGenericGlobalType.class" />
   </ItemGroup>
 

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.targets
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.targets
@@ -3,22 +3,25 @@
   <ItemGroup>
     <TestJarNoParameters Include="java/**/Collection.java" />
     <TestJarNoParameters Include="java/**/*NoParameters.java" />
-    <TestJar Include="java\**\*.java" Exclude="@(TestJarNoParameters);java\android\annotation\NonNull.java" />
+    <TestJarJdk11 Include="java\**\module-info.java" />
+    <TestJar Include="java\**\*.java" Exclude="@(TestJarNoParameters);@(TestJarJdk11);java\android\annotation\NonNull.java;" />
     <TestKotlinJar Include="kotlin\**\*.kt" />
   </ItemGroup>
 
   <ItemGroup>
     <_BuildClassOutputs Include="@(TestJar->'$(IntermediateOutputPath)classes\%(RecursiveDir)%(Filename).class')" />
+    <_BuildClassOutputs Include="@(TestJarJdk11->'$(IntermediateOutputPath)classes\%(RecursiveDir)%(Filename).class')" />
     <_BuildClassOutputs Include="@(TestJarNoParameters->'$(IntermediateOutputPath)classes\%(RecursiveDir)%(Filename).class')" />
   </ItemGroup>
 
   <Target Name="BuildClasses"
         BeforeTargets="BeforeCompile"
-        Inputs="@(TestJar);@(TestJarNoParameters)"
+        Inputs="@(TestJar);@(TestJarNoParameters);@(TestJarJdk11)"
         Outputs="@(_BuildClassOutputs)">
     <MakeDir Directories="$(IntermediateOutputPath)classes" />
     <Exec Command="&quot;$(JavaCPath)&quot; -parameters $(_JavacSourceOptions) -g -d &quot;$(IntermediateOutputPath)classes&quot; java/android/annotation/NonNull.java @(TestJar->'%(Identity)', ' ')" />
     <Exec Command="&quot;$(JavaCPath)&quot; $(_JavacSourceOptions) -g -d &quot;$(IntermediateOutputPath)classes&quot; @(TestJarNoParameters->'%(Identity)', ' ')" />
+    <Exec Command="&quot;$(JavaC11Path)&quot; -source 11 -target 11 -g -d &quot;$(IntermediateOutputPath)classes&quot; @(TestJarJdk11->'%(Identity)', ' ')" />
   </Target>
 
   <!-- 
@@ -32,6 +35,13 @@
         Inputs="@(TestKotlinJar)"
         Outputs="@(TestKotlinJar->'%(RecursiveDir)%(Filename).class')">
     <Exec Command="&quot;$(KotlinCPath)&quot; @(TestKotlinJar->'%(Identity)', ' ') -d &quot;kotlin&quot;" />
+  </Target>
+
+  <Target Name="BuildJar"
+      AfterTargets="BuildClasses"
+      Inputs="@(_BuildClassOutputs)"
+      Outputs="$(IntermediateOutputPath)xatb.jar">
+    <Exec Command="&quot;$(Jar11Path)&quot; cf &quot;$(IntermediateOutputPath)xatb.jar&quot; -C &quot;$(IntermediateOutputPath)classes&quot; ." />
   </Target>
 
 </Project>

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/java/com/xamarin/internal/PublicClassNotInModuleExports.java
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/java/com/xamarin/internal/PublicClassNotInModuleExports.java
@@ -1,0 +1,4 @@
+package com.xamarin.internal;
+
+public class PublicClassNotInModuleExports {
+}

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/java/com/xamarin/module-info.java
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/java/com/xamarin/module-info.java
@@ -1,0 +1,4 @@
+module com.xamarin {
+    requires java.base;
+    exports com.xamarin;
+}


### PR DESCRIPTION
Fixes: https://github.com/xamarin/java.interop/issues/1096

Context: https://stackoverflow.com/questions/57358750/module-info-class-file-is-different-in-the-module-jar-file-and-compiled-module-i
Context: 678c4bd2c838141be0e18b23690da8dcdd94e0ec

JDK 9 adds support for [modules][0], which are (kinda sorta) like
.NET Assemblies: modules can depend upon other modules, export
packages, etc.

In particular:

> **exports and exports…to.** An exports module directive specifies
> one of the module’s packages whose `public` types (and their nested
> `public` and `protected` types) should be accessible to code in all
> other modules.

This allows an equivalent to the [C# `internal` access modifier][1]:
`public` types in a *non-`export`ed package* should be treated as
"internal", while `public` types in an `export`ed package are
"fully public".

Update `Xamarin.Android.Tools.Bytecode.dll` to extract the module-
related information, the update `XmlClassDeclarationBuilder` so that
it updates all `public` types *outside* of the "exported" packages to
have a visibility of `kotlin-internal`.

Why a `//*/@visibility` value of `kotlin-internal`?  From a
[suggestion][2] for the commit message of 678c4bd2, which was sadly
overlooked in the final merge:

> Note: we introduce and use a new `//*/@visibility` value of
> `kotlin-internal` because `internal` is an *existing* value that may
> be used in `Metadata.xml` files, e.g. making `public` API `internal`
> so that it can still be used in the binding, but isn't *public*.

If we use `internal`, *those types are still bound*, it's just that
the bound types have C# `internal` visibility, while we *want* them
to be *skipped entirely*.  A visibility value of `kotlin-internal`
allows us to skip them, which is desired.

`tests/Xamarin.Android.Tools.Bytecode-Tests` has been updated to:

 1. Contain a `module-info.java`, which declares a `com.xamarin`
    module.

 2. Add a new `com.xamarin.internal.PublicClassNotInModuleExports`
    type which is *not* in the `com.xamarin` package, but instead
    a *nested* package.  The type is `public`.

 3. Build a `xatb.jar` artifact

This makes for a simple one-off test:

	% dotnet build tests/Xamarin.Android.Tools.Bytecode-Tests/*.csproj
	% dotnet build tools/class-parse/*.csproj
	% dotnet bin/Debug-net7.0/class-parse.dll \
	  tests/Xamarin.Android.Tools.Bytecode-Tests/obj/Debug-net7.0/xatb.jar
	…
	    <class
	      name="PublicClassNotInModuleExports"
	      …
	      visibility="kotlin-internal" />

Note that `com.xamarin.internal.PublicClassNotInModuleExports` is now
shown as `kotlin-internal` instead of `public`.

Aside, a discovered oddity: `jar cf …` *modifies* `module-info.class`,
adding a `ModulePackages` attribute!  (Specifically, if you compare
the "on-disk" `module-info.class` to the one within
`tests/Xamarin.Android.Tools.Bytecode-Tests/obj/$(Configuration)/xatb.jar`,
they differ in size!)

[0]: https://www.oracle.com/corporate/features/understanding-java-9-modules.html
[1]: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/internal
[2]: https://github.com/xamarin/java.interop/pull/793#issuecomment-777762450
