### PR TITLE
[Java.Interop.Tools.JavaTypeSystem] Add 'annotated-visibility' for types.

### DIFF
--- a/src/Java.Interop.Tools.JavaTypeSystem/Adapters/JavaXmlApiExporter.cs
+++ b/src/Java.Interop.Tools.JavaTypeSystem/Adapters/JavaXmlApiExporter.cs
@@ -58,15 +58,15 @@ namespace Java.Interop.Tools.JavaTypeSystem
 		static void SaveType (JavaTypeModel type, XmlWriter writer)
 		{
 			if (type is JavaClassModel cls)
-				SaveType (type, writer, "class", XmlConvert.ToString (cls.IsAbstract), cls.BaseType, cls.BaseTypeGeneric, cls.BaseTypeJni);
+				SaveType (type, writer, "class", XmlConvert.ToString (cls.IsAbstract), cls.BaseType, cls.BaseTypeGeneric, cls.BaseTypeJni, cls.AnnotatedVisibility);
 			else
-				SaveType (type, writer, "interface", "true", null, null, null);
+				SaveType (type, writer, "interface", "true", null, null, null, type.AnnotatedVisibility);
 
 			foreach (var nested in type.NestedTypes)
 				SaveType (nested, writer);
 		}
 
-		static void SaveType (JavaTypeModel cls, XmlWriter writer, string elementName, string abs, string? ext, string? extgen, string? jniExt)
+		static void SaveType (JavaTypeModel cls, XmlWriter writer, string elementName, string abs, string? ext, string? extgen, string? jniExt, string annotatedVisibility)
 		{
 			writer.WriteStartElement (elementName);
 
@@ -80,6 +80,7 @@ namespace Java.Interop.Tools.JavaTypeSystem
 			writer.WriteAttributeString ("static", XmlConvert.ToString (cls.IsStatic));
 			writer.WriteAttributeString ("visibility", cls.Visibility);
 			writer.WriteAttributeStringIfValue ("jni-signature", cls.ExtendedJniSignature);
+			writer.WriteAttributeStringIfValue ("annotated-visibility", annotatedVisibility);
 
 			if (cls.PropertyBag.TryGetValue ("merge.SourceFile", out var source))
 				writer.WriteAttributeString ("merge.SourceFile", source);

--- a/src/Java.Interop.Tools.JavaTypeSystem/Adapters/JavaXmlApiImporter.cs
+++ b/src/Java.Interop.Tools.JavaTypeSystem/Adapters/JavaXmlApiImporter.cs
@@ -113,7 +113,8 @@ namespace Java.Interop.Tools.JavaTypeSystem
 				javaDeprecated: element.XGetAttribute ("deprecated"),
 				javaStatic: element.XGetAttributeAsBool ("static"),
 				jniSignature: element.XGetAttribute ("jni-signature"),
-				baseTypeJni: element.XGetAttribute ("jni-extends")
+				baseTypeJni: element.XGetAttribute ("jni-extends"),
+				annotatedVisibility: element.XGetAttribute ("annotated-visibility")
 			);
 
 			if (element.XGetAttribute ("merge.SourceFile") is string source && source.HasValue ())
@@ -151,8 +152,9 @@ namespace Java.Interop.Tools.JavaTypeSystem
 			var deprecated = element.XGetAttribute ("deprecated");
 			var is_static = element.XGetAttribute ("static") == "true";
 			var jni_signature = element.XGetAttribute ("jni-signature");
+			var annotated_visibility = element.XGetAttribute ("annotated-visibility");
 
-			var model = new JavaInterfaceModel (package, nested_name, visibility, deprecated, is_static, jni_signature);
+			var model = new JavaInterfaceModel (package, nested_name, visibility, deprecated, is_static, jni_signature, annotated_visibility);
 
 			if (element.XGetAttribute ("merge.SourceFile") is string source && source.HasValue ())
 				model.PropertyBag.Add ("merge.SourceFile", source);

--- a/src/Java.Interop.Tools.JavaTypeSystem/Adapters/ManagedApiImporter.cs
+++ b/src/Java.Interop.Tools.JavaTypeSystem/Adapters/ManagedApiImporter.cs
@@ -114,7 +114,8 @@ namespace Java.Interop.Tools.JavaTypeSystem
 				javaDeprecated: obs_attr != null ? "deprecated" : "not-deprecated",
 				javaStatic: false,
 				jniSignature: FormatJniSignature (package, nested_name),
-				baseTypeJni: base_jni.HasValue () ? $"L{base_jni};" : string.Empty
+				baseTypeJni: base_jni.HasValue () ? $"L{base_jni};" : string.Empty,
+				annotatedVisibility: string.Empty
 			); ;
 
 			ParseImplementedInterfaces (type, model);
@@ -144,7 +145,8 @@ namespace Java.Interop.Tools.JavaTypeSystem
 				javaVisibility: type.IsPublic || type.IsNestedPublic ? "public" : "protected internal",
 				javaDeprecated: obs_attr != null ? "deprecated" : "not-deprecated",
 				javaStatic: false,
-				jniSignature: FormatJniSignature (package, nested_name)
+				jniSignature: FormatJniSignature (package, nested_name),
+				annotatedVisibility: ""
 			);
 
 			ParseImplementedInterfaces (type, model);

--- a/src/Java.Interop.Tools.JavaTypeSystem/JavaModels/JavaBuiltInType.cs
+++ b/src/Java.Interop.Tools.JavaTypeSystem/JavaModels/JavaBuiltInType.cs
@@ -6,7 +6,7 @@ namespace Java.Interop.Tools.JavaTypeSystem.Models
 	// Represents a Java built-in type like 'int' or 'float'
 	public class JavaBuiltInType : JavaTypeModel
 	{
-		public JavaBuiltInType (string name) : base (new JavaPackage ("", "", null), name, "public", false, true, "not deprecated", false, "") { }
+		public JavaBuiltInType (string name) : base (new JavaPackage ("", "", null), name, "public", false, true, "not deprecated", false, "", "") { }
 
 		public override void Resolve (JavaTypeCollection types, ICollection<JavaUnresolvableModel> unresolvables)
 		{

--- a/src/Java.Interop.Tools.JavaTypeSystem/JavaModels/JavaClassModel.cs
+++ b/src/Java.Interop.Tools.JavaTypeSystem/JavaModels/JavaClassModel.cs
@@ -15,8 +15,8 @@ namespace Java.Interop.Tools.JavaTypeSystem.Models
 		public JavaTypeReference? BaseTypeReference { get; private set; }
 		public List<JavaConstructorModel> Constructors { get; } = new List<JavaConstructorModel> ();
 
-		public JavaClassModel (JavaPackage javaPackage, string javaNestedName, string javaVisibility, bool javaAbstract, bool javaFinal, string javaBaseType, string javaBaseTypeGeneric, string javaDeprecated, bool javaStatic, string jniSignature, string baseTypeJni) :
-			base (javaPackage, javaNestedName, javaVisibility, javaAbstract, javaFinal, javaDeprecated, javaStatic, jniSignature)
+		public JavaClassModel (JavaPackage javaPackage, string javaNestedName, string javaVisibility, bool javaAbstract, bool javaFinal, string javaBaseType, string javaBaseTypeGeneric, string javaDeprecated, bool javaStatic, string jniSignature, string baseTypeJni, string annotatedVisibility) :
+			base (javaPackage, javaNestedName, javaVisibility, javaAbstract, javaFinal, javaDeprecated, javaStatic, jniSignature, annotatedVisibility)
 		{
 			BaseType = javaBaseType;
 			BaseTypeGeneric = javaBaseTypeGeneric;

--- a/src/Java.Interop.Tools.JavaTypeSystem/JavaModels/JavaInterfaceModel.cs
+++ b/src/Java.Interop.Tools.JavaTypeSystem/JavaModels/JavaInterfaceModel.cs
@@ -4,8 +4,8 @@ namespace Java.Interop.Tools.JavaTypeSystem.Models
 {
 	public class JavaInterfaceModel : JavaTypeModel
 	{
-		public JavaInterfaceModel (JavaPackage javaPackage, string javaNestedName, string javaVisibility, string javaDeprecated, bool javaStatic, string jniSignature) :
-			base (javaPackage, javaNestedName, javaVisibility, false, false, javaDeprecated, javaStatic, jniSignature)
+		public JavaInterfaceModel (JavaPackage javaPackage, string javaNestedName, string javaVisibility, string javaDeprecated, bool javaStatic, string jniSignature, string annotatedVisibility) :
+			base (javaPackage, javaNestedName, javaVisibility, false, false, javaDeprecated, javaStatic, jniSignature, annotatedVisibility)
 		{
 		}
 

--- a/src/Java.Interop.Tools.JavaTypeSystem/JavaModels/JavaTypeModel.cs
+++ b/src/Java.Interop.Tools.JavaTypeSystem/JavaModels/JavaTypeModel.cs
@@ -17,6 +17,7 @@ namespace Java.Interop.Tools.JavaTypeSystem.Models
 		public string NestedName { get; set; }
 
 		public string Visibility { get; }
+		public string AnnotatedVisibility { get; }
 		public bool IsAbstract { get; }
 		public bool IsFinal { get; }
 		public string Deprecated { get; }
@@ -36,12 +37,13 @@ namespace Java.Interop.Tools.JavaTypeSystem.Models
 
 		public Dictionary<string, string> PropertyBag { get; } = new Dictionary<string, string> ();
 
-		protected JavaTypeModel (JavaPackage javaPackage, string javaNestedName, string javaVisibility, bool javaAbstract, bool javaFinal, string deprecated, bool javaStatic, string jniSignature)
+		protected JavaTypeModel (JavaPackage javaPackage, string javaNestedName, string javaVisibility, bool javaAbstract, bool javaFinal, string deprecated, bool javaStatic, string jniSignature, string annotatedVisibility)
 		{
 			Package = javaPackage;
 			NestedName = javaNestedName.Replace ('$', '.');
 			Name = NestedName.LastSubset ('.');
 			Visibility = javaVisibility;
+			AnnotatedVisibility = annotatedVisibility;
 			IsAbstract = javaAbstract;
 			IsFinal = javaFinal;
 			Deprecated = deprecated;

--- a/tests/Java.Interop.Tools.JavaTypeSystem-Tests/Java.Interop.Tools.JavaTypeSystem-Tests.csproj
+++ b/tests/Java.Interop.Tools.JavaTypeSystem-Tests/Java.Interop.Tools.JavaTypeSystem-Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net472;$(DotNetTargetFramework)</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <RootNamespace>Java.Interop.Tools.JavaTypeSystem.Tests</RootNamespace>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <Import Project="..\..\TargetFrameworkDependentValues.props" />

--- a/tests/Java.Interop.Tools.JavaTypeSystem-Tests/JavaApiTestHelper.cs
+++ b/tests/Java.Interop.Tools.JavaTypeSystem-Tests/JavaApiTestHelper.cs
@@ -14,7 +14,7 @@ namespace Java.Interop.Tools.JavaTypeSystem.Tests
 			return JavaXmlApiImporter.Parse (ApiPath);
 		}
 
-		public static JavaClassModel CreateClass (JavaPackage javaPackage, string javaNestedName, string javaVisibility = "public", bool javaAbstract = false, bool javaFinal = false, string javaBaseType = "java.lang.Object", string javaBaseTypeGeneric = "java.lang.Object", string javaDeprecated = "not deprecated", bool javaStatic = false, string jniSignature = "", string baseTypeJni = "java/lang/Object")
+		public static JavaClassModel CreateClass (JavaPackage javaPackage, string javaNestedName, string javaVisibility = "public", bool javaAbstract = false, bool javaFinal = false, string javaBaseType = "java.lang.Object", string javaBaseTypeGeneric = "java.lang.Object", string javaDeprecated = "not deprecated", bool javaStatic = false, string jniSignature = "", string baseTypeJni = "java/lang/Object", string annotatedVisibility = "")
 		{
 			if (string.IsNullOrWhiteSpace (jniSignature))
 				jniSignature = $"{(!string.IsNullOrWhiteSpace (javaPackage.Name) ? javaPackage.Name + "." : "")}{javaNestedName}".Replace ('.', '/');
@@ -30,7 +30,8 @@ namespace Java.Interop.Tools.JavaTypeSystem.Tests
 				javaDeprecated: javaDeprecated,
 				javaStatic: javaStatic,
 				jniSignature: jniSignature,
-				baseTypeJni: baseTypeJni
+				baseTypeJni: baseTypeJni,
+				annotatedVisibility: annotatedVisibility
 			);
 
 			return klass;

--- a/tests/Java.Interop.Tools.JavaTypeSystem-Tests/JavaTypeModelsTests.cs
+++ b/tests/Java.Interop.Tools.JavaTypeSystem-Tests/JavaTypeModelsTests.cs
@@ -1,5 +1,7 @@
 using System;
+using System.IO;
 using System.Linq;
+using System.Xml;
 using Java.Interop.Tools.JavaTypeSystem.Models;
 using NUnit.Framework;
 
@@ -24,6 +26,36 @@ namespace Java.Interop.Tools.JavaTypeSystem.Tests
 
 			var kls = pkg.Types.First (t => t.FullName == "android.database.ContentObservable");
 			Assert.AreEqual ("[Class] android.database.ContentObservable", kls.ToString ());
+		}
+
+		[Test]
+		public void AnnotatedVisibility ()
+		{
+			// Ensure the 'annotated-visibility' attribute gets passed through
+			using var sw = new StringWriter ();
+
+			using (var xml = XmlWriter.Create (sw))
+				JavaXmlApiExporter.Save (api, xml);
+
+			var doc = new XmlDocument { XmlResolver = null };
+			using var sreader = new StringReader (sw.ToString ());
+			using var reader = XmlReader.Create (sreader, new XmlReaderSettings { XmlResolver = null });
+			doc.Load (reader);
+
+			var annotated_class = doc.SelectSingleNode ("/api/package/class[@name='StateListAnimator']");
+			Assert.AreEqual ("TESTS", annotated_class.Attributes ["annotated-visibility"].InnerText);
+
+			var annotated_ctor = annotated_class ["constructor"];
+			Assert.AreEqual ("TESTS", annotated_ctor.Attributes ["annotated-visibility"].InnerText);
+
+			var annotated_method = annotated_class ["method"];
+			Assert.AreEqual ("TESTS", annotated_method.Attributes ["annotated-visibility"].InnerText);
+
+			var annotated_interface = doc.SelectSingleNode ("/api/package/interface[@name='DrmStore.ConstraintsColumns']");
+			Assert.AreEqual ("TESTS", annotated_interface.Attributes ["annotated-visibility"].InnerText);
+
+			var annotated_field = annotated_interface ["field"];
+			Assert.AreEqual ("TESTS", annotated_field.Attributes ["annotated-visibility"].InnerText);
 		}
 	}
 }


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/pull/1094

When adding support for Android's `@RestrictTo` annotation in https://github.com/xamarin/java.interop/pull/1094, the XML Adjuster step was accidentally only modified to pass through the `annotated-visibility` attribute for members and not for types.

Fix this by storing and emitting the `annotated-visibility` attribute for types.