### PR TITLE
[Java.Interop.Tools.Cecil] use MemoryMappedFile in DirectoryAssemblyResolver

### DIFF
--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/DirectoryAssemblyResolver.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/DirectoryAssemblyResolver.cs
@@ -179,6 +179,10 @@ namespace Java.Interop.Tools.Cecil {
 
 		AssemblyDefinition LoadFromMemoryMappedFile(string file, ReaderParameters options)
 		{
+			// We can't use MemoryMappedFile when ReadWrite is true
+			if (options.ReadWrite)
+				return AssemblyDefinition.ReadAssembly (file, options);
+
 			MemoryMappedViewStream? viewStream = null;
 			try {
 				// Create stream because CreateFromFile(string, ...) uses FileShare.None which is too strict

--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/DirectoryAssemblyResolver.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/DirectoryAssemblyResolver.cs
@@ -177,11 +177,12 @@ namespace Java.Interop.Tools.Cecil {
 			}
 		}
 
-		AssemblyDefinition LoadFromMemoryMappedFile(string file, ReaderParameters options)
+		AssemblyDefinition LoadFromMemoryMappedFile (string file, ReaderParameters options)
 		{
 			// We can't use MemoryMappedFile when ReadWrite is true
-			if (options.ReadWrite)
+			if (options.ReadWrite) {
 				return AssemblyDefinition.ReadAssembly (file, options);
+			}
 
 			MemoryMappedViewStream? viewStream = null;
 			try {

--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/DirectoryAssemblyResolver.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/DirectoryAssemblyResolver.cs
@@ -32,6 +32,7 @@ using System.Diagnostics;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.MemoryMappedFiles;
 using System.Linq;
 using System.Reflection;
 
@@ -61,6 +62,7 @@ namespace Java.Interop.Tools.Cecil {
 
 		public ICollection<string> SearchDirectories {get; private set;}
 
+		readonly List<MemoryMappedViewStream> viewStreams = new List<MemoryMappedViewStream> ();
 		Dictionary<string, AssemblyDefinition?> cache;
 		bool loadDebugSymbols;
 		Action<TraceLevel, string>              logger;
@@ -103,6 +105,10 @@ namespace Java.Interop.Tools.Cecil {
 				e.Value?.Dispose ();
 			}
 			cache.Clear ();
+			foreach (var viewStream in viewStreams) {
+				viewStream.Dispose ();
+			}
+			viewStreams.Clear ();
 		}
 
 		public Dictionary<string, AssemblyDefinition?> ToResolverCache ()
@@ -160,14 +166,36 @@ namespace Java.Interop.Tools.Cecil {
 				SymbolStream                    = loadReaderParameters.SymbolStream,
 			};
 			try {
-				return AssemblyDefinition.ReadAssembly (file, reader_parameters);
+				return LoadFromMemoryMappedFile (file, reader_parameters);
 			} catch (Exception ex) {
 				logger (
 						TraceLevel.Verbose,
 						$"Failed to read '{file}' with debugging symbols. Retrying to load it without it. Error details are logged below.");
 				logger (TraceLevel.Verbose, $"{ex.ToString ()}");
 				reader_parameters.ReadSymbols = false;
-				return AssemblyDefinition.ReadAssembly (file, reader_parameters);
+				return LoadFromMemoryMappedFile (file, reader_parameters);
+			}
+		}
+
+		AssemblyDefinition LoadFromMemoryMappedFile(string file, ReaderParameters options)
+		{
+			MemoryMappedViewStream? viewStream = null;
+			try {
+				// Create stream because CreateFromFile(string, ...) uses FileShare.None which is too strict
+				using var fileStream = new FileStream (file, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, false);
+				using var mappedFile = MemoryMappedFile.CreateFromFile (
+					fileStream, null, fileStream.Length, MemoryMappedFileAccess.Read, HandleInheritability.None, true);
+				viewStream = mappedFile.CreateViewStream (0, 0, MemoryMappedFileAccess.Read);
+
+				AssemblyDefinition result = ModuleDefinition.ReadModule (viewStream, options).Assembly;
+				viewStreams.Add (viewStream);
+
+				// We transferred the ownership of the viewStream to the collection.
+				viewStream = null;
+
+				return result;
+			} finally {
+				viewStream?.Dispose ();
 			}
 		}
 


### PR DESCRIPTION
Context: https://github.com/dotnet/linker/pull/1130
Context: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1783420

In dotnet/linker#1130, their version of `DirectoryAssemblyResolver` was reworked to use `MemoryMappedFile` in the .NET 6 timeframe. This commit ports these changes here, as we have MSBuild tasks in xamarin/xamarin-android that use `DirectoryAssemblyResolver`.

Primarily, the `<GenerateJavaStubs />` MSBuild task uses `DirectoryAssemblyResolver` to iterate over types in assembly to emit Java source code and generate `AndroidManifest.xml`.

The results of these changes in a `dotnet new maui` project, an initial clean build:

    GenerateJavaStubs = 1.318 s, 1 calls.
    GenerateJavaStubs = 1.254 s, 1 calls.

Saving ~64ms or about ~5% in this example.

The current version of the linker's resolver in .NET 8+ has moved to the dotnet/runtime repo at:

https://github.com/dotnet/runtime/blob/cd7d006030a7feace9076fa275fb5bffc1bf4a90/src/tools/illink/src/linker/Linker/AssemblyResolver.cs