### PR TITLE
[generator] improve *Implementor constructors

### DIFF
--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteDuplicateInterfaceEventArgs.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteDuplicateInterfaceEventArgs.txt
@@ -157,14 +157,18 @@ public partial class AnimationEndEventArgs : global::System.EventArgs {
 
 }
 
-[global::Android.Runtime.Register ("mono/java/code/AnimatorListenerImplementor")]
 internal sealed partial class AnimatorListenerImplementor : global::Java.Lang.Object, AnimatorListener {
 
 	object sender;
 
-	public AnimatorListenerImplementor (object sender) : base (global::Android.Runtime.JNIEnv.StartCreateInstance ("mono/java/code/AnimatorListenerImplementor", "()V"), JniHandleOwnership.TransferLocalRef)
+	public unsafe AnimatorListenerImplementor (object sender) : base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 	{
-		global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "()V");
+		const string __id = "()V";
+		if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+			return;
+		var h = JniPeerMembers.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), null);
+		SetHandle (h.Handle, JniHandleOwnership.TransferLocalRef);
+		JniPeerMembers.InstanceMethods.FinishCreateInstance (__id, this, null);
 		this.sender = sender;
 	}
 

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteDuplicateInterfaceEventArgs.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteDuplicateInterfaceEventArgs.txt
@@ -47,14 +47,18 @@ public partial class AnimationEndEventArgs : global::System.EventArgs {
 
 }
 
-[global::Android.Runtime.Register ("mono/java/code/AnimatorListenerImplementor")]
 internal sealed partial class AnimatorListenerImplementor : global::Java.Lang.Object, AnimatorListener {
 
 	object sender;
 
-	public AnimatorListenerImplementor (object sender) : base (global::Android.Runtime.JNIEnv.StartCreateInstance ("mono/java/code/AnimatorListenerImplementor", "()V"), JniHandleOwnership.TransferLocalRef)
+	public unsafe AnimatorListenerImplementor (object sender) : base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 	{
-		global::Android.Runtime.JNIEnv.FinishCreateInstance (this.PeerReference, "()V");
+		const string __id = "()V";
+		if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+			return;
+		var h = JniPeerMembers.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), null);
+		SetHandle (h.Handle, JniHandleOwnership.TransferLocalRef);
+		JniPeerMembers.InstanceMethods.FinishCreateInstance (__id, this, null);
 		this.sender = sender;
 	}
 

--- a/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Views.View.cs
+++ b/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Views.View.cs
@@ -111,11 +111,15 @@ namespace Android.Views {
 
 		}
 
-		[global::Android.Runtime.Register ("mono/android/view/View_OnClickListenerImplementor")]
 		internal sealed partial class IOnClickListenerImplementor : global::Java.Lang.Object, IOnClickListener {
-			public IOnClickListenerImplementor () : base (global::Android.Runtime.JNIEnv.StartCreateInstance ("mono/android/view/View_OnClickListenerImplementor", "()V"), JniHandleOwnership.TransferLocalRef)
+			public unsafe IOnClickListenerImplementor () : base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 			{
-				global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "()V");
+				const string __id = "()V";
+				if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+					return;
+				var h = JniPeerMembers.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), null);
+				SetHandle (h.Handle, JniHandleOwnership.TransferLocalRef);
+				JniPeerMembers.InstanceMethods.FinishCreateInstance (__id, this, null);
 			}
 
 			#pragma warning disable 0649

--- a/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
+++ b/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
@@ -162,14 +162,18 @@ namespace Com.Google.Android.Exoplayer.Drm {
 
 	}
 
-	[global::Android.Runtime.Register ("mono/com/google/android/exoplayer/drm/ExoMediaDrm_OnEventListenerImplementor")]
 	internal sealed partial class IExoMediaDrmOnEventListenerImplementor : global::Java.Lang.Object, IExoMediaDrmOnEventListener {
 
 		object sender;
 
-		public IExoMediaDrmOnEventListenerImplementor (object sender) : base (global::Android.Runtime.JNIEnv.StartCreateInstance ("mono/com/google/android/exoplayer/drm/ExoMediaDrm_OnEventListenerImplementor", "()V"), JniHandleOwnership.TransferLocalRef)
+		public unsafe IExoMediaDrmOnEventListenerImplementor (object sender) : base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 		{
-			global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "()V");
+			const string __id = "()V";
+			if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
+				return;
+			var h = JniPeerMembers.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), null);
+			SetHandle (h.Handle, JniHandleOwnership.TransferLocalRef);
+			JniPeerMembers.InstanceMethods.FinishCreateInstance (__id, this, null);
 			this.sender = sender;
 		}
 


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/issues/12130
Context: https://github.com/angelru/CvSlowJittering

Profiling a .NET MAUI customer sample while scrolling on a Pixel 5, I see ~2.2% of the time spent in:

    (2.2%) mono.android!Android.Views.View.IOnFocusChangeListenerImplementor..ctor()

https://github.com/dotnet/maui/blob/2041476e78452891029f4d2bd806c45be42f4878/src/Core/src/Handlers/View/ViewHandler.Android.cs#L14

MAUI subscribes to `Android.Views.View.FocusChange` for every view placed on the screen -- which happens while scrolling in this sample.

Reviewing, the generated code for this constructor still uses the outdated `JNIEnv` APIs:

    public IOnFocusChangeListenerImplementor () : base (global::Android.Runtime.JNIEnv.StartCreateInstance ("mono/android/view/View_OnFocusChangeListenerImplementor", "()V"), JniHandleOwnership.TransferLocalRef)
    {
        global::Android.Runtime.JNIEnv.FinishCreateInstance (((global::Java.Lang.Object) this).Handle, "()V");
    }

Which we can change to use the newer/faster Java.Interop APIs:

    public unsafe IOnFocusChangeListenerImplementor () : base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
    {
        const string __id = "()V";
        if (((global::Java.Lang.Object) this).Handle != IntPtr.Zero)
            return;
        var h = JniPeerMembers.InstanceMethods.StartCreateInstance (__id, ((object) this).GetType (), null);
        SetHandle (h.Handle, JniHandleOwnership.TransferLocalRef);
        JniPeerMembers.InstanceMethods.FinishCreateInstance (__id, this, null);
    }

These are better because the equivalent call to `JNIEnv.FindClass()` is cached among other things.

After these changes, I instead see:

    (0.81%) mono.android!Android.Views.View.IOnFocusChangeListenerImplementor..ctor()

This should improve the performance of all C# events that wrap Java listeners -- and all .NET MAUI views on Android.

These changes also stop emitting the `[Register]` attribute for `*Implementor` classes:

    [global::Android.Runtime.Register ("mono/android/view/View_OnFocusChangeListenerImplementor")]

Which is not needed, because `*Implementor` classes are generated, internal implementation details.