### PR TITLE
[Xamarin.Android.Tools.Bytecode] Handle empty `bv` values.

### DIFF
--- a/src/Xamarin.Android.Tools.Bytecode/Kotlin/KotlinMetadata.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/Kotlin/KotlinMetadata.cs
@@ -116,7 +116,8 @@ namespace Xamarin.Android.Tools.Bytecode
 		{
 			var value = GetValue (annotation, key);
 
-			if (value is null)
+			// Version is missing or empty
+			if (value is null || value == "[]")
 				return null;
 
 			var values = value.Trim ('[', ']').Split (',').Select (v => ParseInteger (v)).ToArray ();


### PR DESCRIPTION
Fixes: https://github.com/xamarin/java.interop/issues/1106

We started seeing warnings when parsing newer Kotlin metadata annotations:
```
% dotnet class-parse.dll classes.jar
class-parse: warning: Unable to parse Kotlin metadata on 'Utf8("com/devtodev/analytics/external/DTDLogLevel")': System.FormatException: The input string '' was not in a correct format.
   at System.Number.ThrowOverflowOrFormatException(ParsingStatus status, ReadOnlySpan`1 value, TypeCode type)
   at System.Int32.Parse(String s)
   at Xamarin.Android.Tools.Bytecode.KotlinMetadata.ParseInteger(String value) in …/xamarin/Java.Interop/src/Xamarin.Android.Tools.Bytecode/Kotlin/KotlinMetadata.cs:line 148
   at Xamarin.Android.Tools.Bytecode.KotlinMetadata.<>c.<ParseVersion>b__26_0(String v) in …/xamarin/Java.Interop/src/Xamarin.Android.Tools.Bytecode/Kotlin/KotlinMetadata.cs:line 122
   at System.Linq.Enumerable.SelectArrayIterator`2.ToArray()
   at Xamarin.Android.Tools.Bytecode.KotlinMetadata.ParseVersion(Annotation annotation, String key) in …/xamarin/Java.Interop/src/Xamarin.Android.Tools.Bytecode/Kotlin/KotlinMetadata.cs:line 122
   at Xamarin.Android.Tools.Bytecode.KotlinMetadata.FromAnnotation(Annotation annotation) in …/xamarin/Java.Interop/src/Xamarin.Android.Tools.Bytecode/Kotlin/KotlinMetadata.cs:line 30
   at Xamarin.Android.Tools.Bytecode.KotlinFixups.Fixup(IList`1 classes) in …/xamarin/Java.Interop/src/Xamarin.Android.Tools.Bytecode/Kotlin/KotlinFixups.cs:line 23
```

This is because the `bv` entry is set to an empty byte array instead of an empty string, and we are trying to parse its contents as an integer array: `bv: []`.

Looking at the [Kotlin source](https://github.com/JetBrains/kotlin/blob/master/libraries/stdlib/jvm/runtime/kotlin/Metadata.kt#LL34C1-L42C47), they have decided to deprecate the `bv` value, and it may no longer be supplied:

```java
    /**
     * The version of the bytecode interface (naming conventions, signatures) of the class file annotated with this annotation.
     */
    @Deprecated(
        "Bytecode version had no significant use in Kotlin metadata and it will be removed in a future version.",
        level = DeprecationLevel.WARNING,
    )
    @get:JvmName("bv")
    val bytecodeVersion: IntArray = [1, 0, 3],
```

We will just silently ignore a missing `bv` value, since we do not consume it.