### PR TITLE
Support testing with JDK 17

### DIFF
--- a/Configuration.Override.props.in
+++ b/Configuration.Override.props.in
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <JdkJvmPath>/Library/Java/JavaVirtualMachines/jdk1.8.0_77.jdk/Contents/Home/jre/jli/libjli.dylib</JdkJvmPath>
+    <JdkJvm11Path>/Library/Java/JavaVirtualMachines/jdk1.8.0_77.jdk/Contents/Home/jre/jli/libjli.dylib</JdkJvmPath>
     <MonoFrameworkPath>/Library/Frameworks/Mono.framework/Libraries/libmonosgen-2.0.1.dylib</MonoFrameworkPath>
     <UtilityOutputFullPath>$(MSBuildThisFileDirectory)bin\$(Configuration)\</UtilityOutputFullPath>
   </PropertyGroup>
   <ItemGroup>
     <!-- JDK C `include` directories -->
-    <JdkIncludePath Include="/Library/Java/JavaVirtualMachines/jdk1.8.0_77.jdk/Contents/Home/include" />
-    <JdkIncludePath Include="/Library/Java/JavaVirtualMachines/jdk1.8.0_77.jdk/Contents/Home/include/darwin" />
+    <Jdk11IncludePath Include="/Library/Java/JavaVirtualMachines/jdk1.8.0_77.jdk/Contents/Home/include" />
+    <Jdk11IncludePath Include="/Library/Java/JavaVirtualMachines/jdk1.8.0_77.jdk/Contents/Home/include/darwin" />
   </ItemGroup>
   <ItemGroup>
     <!-- Mono C `include` directories -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,8 +33,8 @@
       Condition=" Exists('$(MSBuildThisFileDirectory)bin\Build$(Configuration)\Version.props') "
   />
   <Import
-      Project="$(_OutputPath)JdkInfo.props"
-      Condition="Exists('$(_OutputPath)JdkInfo.props')"
+      Project="$(_OutputPath)JdkInfo-8.props"
+      Condition="Exists('$(_OutputPath)JdkInfo-8.props')"
   />
   <Import
       Project="$(_OutputPath)JdkInfo-11.props"
@@ -69,7 +69,7 @@
     <JavacSourceVersion Condition=" '$(JavacSourceVersion)' == '' ">1.8</JavacSourceVersion>
     <JavacTargetVersion Condition=" '$(JavacTargetVersion)' == '' ">1.8</JavacTargetVersion>
     <_BootClassPath Condition=" '$(JreRtJarPath)' != '' ">-bootclasspath "$(JreRtJarPath)"</_BootClassPath>
-    <_JavacSourceOptions>-source $(JavacSourceVersion) -target $(JavacTargetVersion) $(_BootClassPath)</_JavacSourceOptions>
+    <_Javac8SourceOptions>-source $(JavacSourceVersion) -target $(JavacTargetVersion) $(_BootClassPath)</_Javac8SourceOptions>
   </PropertyGroup>
   <PropertyGroup>
     <XamarinAndroidToolsFullPath>$([System.IO.Path]::GetFullPath ('$(XamarinAndroidToolsDirectory)'))</XamarinAndroidToolsFullPath>

--- a/Documentation/BuildConfiguration.md
+++ b/Documentation/BuildConfiguration.md
@@ -21,8 +21,8 @@ Overridable MSBuild properties include:
     [`java-interop`](src/java-interop) against. By default this is
     probed for from numerous locations within
     [`build-tools/scripts/jdk.mk`](build-tools/scripts/jdk.mk).
-* `$(JavaCPath)`: Path to the `javac` command-line tool, by default set to `javac`.
-* `$(JarPath)`: Path to the `jar` command-line tool, by default set to `jar`.
+* `$(JavaC8Path)`: Path to the `javac` command-line tool, by default set to `javac`.
+* `$(Jar8Path)`: Path to the `jar` command-line tool, by default set to `jar`.
   * It may be desirable to override these on Windows, depending on your `PATH`.
 * `$(UtilityOutputFullPath)`: Directory to place various utilities such as
     [`class-parse`](tools/class-parse), [`generator`](tools/generator),

--- a/build-tools/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks/JdkInfo.cs
+++ b/build-tools/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks/JdkInfo.cs
@@ -61,7 +61,7 @@ namespace Java.Interop.BootstrapTasks
 			JavaHomePath  = jdk.HomePath;
 
 			Directory.CreateDirectory (Path.GetDirectoryName (PropertyFile.ItemSpec));
-			WritePropertyFile (jdk.JavaPath, jdk.JarPath, jdk.JavacPath, jdk.JdkJvmPath, rtJarPath, jdk.IncludePath);
+			WritePropertyFile (jdk, rtJarPath);
 
 			if (MakeFragmentFile != null) {
 				Directory.CreateDirectory (Path.GetDirectoryName (MakeFragmentFile.ItemSpec));
@@ -117,8 +117,14 @@ namespace Java.Interop.BootstrapTasks
 			return logger;
 		}
 
-		void WritePropertyFile (string javaPath, string jarPath, string javacPath, string jdkJvmPath, string rtJarPath, IEnumerable<string> includes)
+		void WritePropertyFile (XATInfo jdk, string rtJarPath)
 		{
+			var jarPath     = jdk.JarPath;
+			var javacPath   = jdk.JavacPath;
+			var javaPath    = jdk.JavaPath;
+			var jdkJvmPath	= jdk.JdkJvmPath;
+			var includes    = jdk.IncludePath;
+
 			var msbuild = XNamespace.Get ("http://schemas.microsoft.com/developer/msbuild/2003");
 			var jdkJvmP = $"JdkJvm{PropertyNameModifier}Path";
 			var project = new XElement (msbuild + "Project",
@@ -129,6 +135,7 @@ namespace Java.Interop.BootstrapTasks
 						new XElement (msbuild + "ItemGroup",
 							includes.Select (i => new XElement (msbuild + $"Jdk{PropertyNameModifier}IncludePath", new XAttribute ("Include", i)))))),
 				new XElement (msbuild + "PropertyGroup",
+					CreateProperty (msbuild, $"Java{PropertyNameModifier}MajorVersion", jdk.Version.Major.ToString ()),
 					CreateProperty (msbuild, $"Java{PropertyNameModifier}SdkDirectory", JavaHomePath),
 					CreateProperty (msbuild, $"Java{PropertyNameModifier}Path", javaPath),
 					CreateProperty (msbuild, $"JavaC{PropertyNameModifier}Path", javacPath),

--- a/build-tools/gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/build-tools/gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/build-tools/scripts/Prepare.targets
+++ b/build-tools/scripts/Prepare.targets
@@ -19,20 +19,22 @@
     </PropertyGroup>
     <JdkInfo
         JdksRoot="$(Jdks8Root)"
+        PropertyNameModifier="8"
         MakeFragmentFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\JdkInfo.mk"
         MaximumJdkVersion="$(_MaxJdk)"
         DotnetToolPath="$(DotnetToolPath)"
-        PropertyFile="$(_TopDir)\bin\Build$(Configuration)\JdkInfo.props">
+        PropertyFile="$(_TopDir)\bin\Build$(Configuration)\JdkInfo-8.props">
       <Output TaskParameter="JavaHomePath" PropertyName="_JavaSdkDirectory" />
     </JdkInfo>
     <PropertyGroup>
       <Jdks11Root Condition=" '$(Jdks11Root)' == '' And '$(JAVA_HOME_11_X64)' != '' And Exists($(JAVA_HOME_11_X64)) ">$(JAVA_HOME_11_X64)</Jdks11Root>
+      <Jdks11MaxVersion Condition=" '$(Jdks11MaxVersion)' == '' ">11.99.0</Jdks11MaxVersion>
     </PropertyGroup>
     <JdkInfo
         JdksRoot="$(Jdks11Root)"
         PropertyNameModifier="11"
         MinimumJdkVersion="11.0"
-        MaximumJdkVersion="11.99.0"
+        MaximumJdkVersion="$(Jdks11MaxVersion)"
         PropertyFile="$(_TopDir)\bin\Build$(Configuration)\JdkInfo-11.props">
       <Output TaskParameter="JavaHomePath" PropertyName="Java11SdkDirectory"/>
     </JdkInfo>

--- a/build-tools/scripts/RunNUnitTests.targets
+++ b/build-tools/scripts/RunNUnitTests.targets
@@ -13,8 +13,8 @@
     <_Run Condition=" '$(RUN)' != '' ">--run=&quot;$(RUN)&quot;</_Run>
   </PropertyGroup>
   <Import
-      Condition=" Exists('..\..\bin\Build$(Configuration)\JdkInfo.props') "
-      Project="..\..\bin\Build$(Configuration)\JdkInfo.props"
+      Condition=" Exists('..\..\bin\Build$(Configuration)\JdkInfo-11.props') "
+      Project="..\..\bin\Build$(Configuration)\JdkInfo-11.props"
   />
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Java.Interop.BootstrapTasks.dll" TaskName="Java.Interop.BootstrapTasks.SetEnvironmentVariable" />
   <ItemGroup>
@@ -27,7 +27,7 @@
     <SetEnvironmentVariable Name="MONO_TRACE_LISTENER"   Value="Console.Out" />
     <SetEnvironmentVariable Name="JAVA_INTEROP_GREF_LOG" Value="bin\Test$(Configuration)\g-%(_TestAssembly.Filename).txt" />
     <SetEnvironmentVariable Name="JAVA_INTEROP_LREF_LOG" Value="bin\Test$(Configuration)\l-%(_TestAssembly.Filename).txt" />
-    <SetEnvironmentVariable Name="JI_JVM_PATH"           Value="$(JdkJvmPath)" />
+    <SetEnvironmentVariable Name="JI_JVM_PATH"           Value="$(JdkJvm11Path)" />
     <Exec
         Command="$(_NUnit) $(NUNIT_EXTRA) %(_TestAssembly.Identity) $(_Run) --result=&quot;TestResult-%(Filename).xml&quot; --output=&quot;bin\Test$(Configuration)\TestOutput-%(Filename).txt&quot;"
         WorkingDirectory="$(_TopDir)"

--- a/src/Java.Base/Java.Base.csproj
+++ b/src/Java.Base/Java.Base.csproj
@@ -5,6 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
     <NoWarn>$(NoWarn);8764</NoWarn>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <Import Project="..\..\TargetFrameworkDependentValues.props" />

--- a/src/Java.Base/Java.Base.targets
+++ b/src/Java.Base/Java.Base.targets
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <GeneratorPath>$(UtilityOutputFullPath)generator.dll</GeneratorPath>
+    <DefineConstants>$(DefineConstants);JAVA_$(Java11MajorVersion)</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Java.Base/Java.Lang/Class.cs
+++ b/src/Java.Base/Java.Lang/Class.cs
@@ -1,0 +1,14 @@
+using System;
+using Java.Interop;
+
+#if JAVA_17
+using Java.Lang.Invoke;
+using Java.Lang.Constants;
+
+namespace Java.Lang {
+	public partial class Class {
+
+	}
+}
+
+#endif  // JAVA_17

--- a/src/Java.Base/Java.Lang/Double.cs
+++ b/src/Java.Base/Java.Lang/Double.cs
@@ -1,0 +1,16 @@
+using System;
+using Java.Interop;
+
+#if JAVA_17
+using Java.Lang.Invoke;
+using Java.Lang.Constants;
+
+namespace Java.Lang {
+	public partial class Double {
+
+		Java.Lang.Object? IConstantDesc.ResolveConstantDesc (MethodHandles.Lookup? lookup) =>
+			ResolveConstantDesc (lookup);
+	}
+}
+
+#endif  // JAVA_17

--- a/src/Java.Base/Java.Lang/Float.cs
+++ b/src/Java.Base/Java.Lang/Float.cs
@@ -1,0 +1,16 @@
+using System;
+using Java.Interop;
+
+#if JAVA_17
+using Java.Lang.Invoke;
+using Java.Lang.Constants;
+
+namespace Java.Lang {
+	public partial class Float {
+
+		Java.Lang.Object? IConstantDesc.ResolveConstantDesc (MethodHandles.Lookup? lookup) =>
+			ResolveConstantDesc (lookup);
+	}
+}
+
+#endif  // JAVA_17

--- a/src/Java.Base/Java.Lang/Integer.cs
+++ b/src/Java.Base/Java.Lang/Integer.cs
@@ -1,0 +1,16 @@
+using System;
+using Java.Interop;
+
+#if JAVA_17
+using Java.Lang.Invoke;
+using Java.Lang.Constants;
+
+namespace Java.Lang {
+	public partial class Integer {
+
+		Java.Lang.Object? IConstantDesc.ResolveConstantDesc (MethodHandles.Lookup? lookup) =>
+			ResolveConstantDesc (lookup);
+	}
+}
+
+#endif  // JAVA_17

--- a/src/Java.Base/Java.Lang/Long.cs
+++ b/src/Java.Base/Java.Lang/Long.cs
@@ -1,0 +1,16 @@
+using System;
+using Java.Interop;
+
+#if JAVA_17
+using Java.Lang.Invoke;
+using Java.Lang.Constants;
+
+namespace Java.Lang {
+	public partial class Long {
+
+		Java.Lang.Object? IConstantDesc.ResolveConstantDesc (MethodHandles.Lookup? lookup) =>
+			ResolveConstantDesc (lookup);
+	}
+}
+
+#endif  // JAVA_17

--- a/src/Java.Base/Java.Lang/String.cs
+++ b/src/Java.Base/Java.Lang/String.cs
@@ -3,7 +3,27 @@ using System.Collections;
 using System.Collections.Generic;
 using Java.Interop;
 
+#if JAVA_17
+using Java.Lang.Invoke;
+using Java.Lang.Constants;
+#endif  // JAVA_17
+
 namespace Java.Lang {
 	public partial class String : IEnumerable, IEnumerable<char> {
+
+#if JAVA_17
+		unsafe Java.Lang.Object? IConstantDesc.ResolveConstantDesc (MethodHandles.Lookup? lookup)
+		{
+			const string __id = "resolveConstantDesc.(Ljava/lang/invoke/MethodHandles$Lookup;)Ljava/lang/String;";
+			try {
+				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+				__args [0] = new JniArgumentValue (lookup);
+				var __rm = _members.InstanceMethods.InvokeAbstractObjectMethod (__id, this, __args);
+				return JniEnvironment.Runtime.ValueManager.GetValue<String>(ref __rm, JniObjectReferenceOptions.CopyAndDispose);
+			} finally {
+				global::System.GC.KeepAlive (lookup);
+			}
+		}
+#endif  // JAVA_17
 	}
 }

--- a/src/Java.Base/Transforms/Metadata.xml
+++ b/src/Java.Base/Transforms/Metadata.xml
@@ -6,6 +6,8 @@
 
   <!-- Type / Namespace conflicts -->
   <ns-replace source="java.lang.module" replacement="Java.Lang.Modules" />
+  <ns-replace source="java.lang.runtime" replacement="Java.Lang.Runtimes" />
+  <ns-replace source="java.lang.constant" replacement="Java.Lang.Constants" />
 
   <!-- Bind `Object.finalize()` as `Object.JavaFinalize()` -->
   <attr path="/api/package[@name='java.lang']//method[@name='finalize' and count(parameter)=0]" name="managedName">JavaFinalize</attr>
@@ -62,4 +64,21 @@
   <attr path="/api/package[@name='java.lang']/class[@name='StringBuffer']" name="extends">java.lang.Object</attr>
   <remove-node path="//api/package[@name='java.lang']/class[@name='StringBuffer']/method[@jni-return='Ljava/lang/AbstractStringBuilder;']" />
   <remove-node path="//api/package[@name='java.lang']/class[@name='StringBuffer']/method[@jni-return='Ljava/lang/Appendable;']" />
+
+  <!-- JDK 17? -->
+  <remove-node path="/api/package[@name='java.lang.invoke']/interface[@name='TypeDescriptor']" />
+  <attr path="/api/package[@name='java.lang']/class[@name='Record']/method[@name='equals' and count(parameter)=1 and parameter[1][@type='java.lang.Object']]"
+      name="managedOverride">override</attr>
+  <attr path="/api/package[@name='java.lang.reflect']/interface[@name='AnnotatedType']/method[@name='getAnnotation' and count(parameter)=1 and parameter[1][@type='java.lang.Class&lt;T&gt;']]"
+      name="managedOverride">reabstract</attr>
+  <attr path="/api/package[@name='java.lang.reflect']/interface[@name='AnnotatedType']/method[@name='getAnnotation' and count(parameter)=1 and parameter[1][@type='java.lang.Class&lt;T&gt;']]"
+      name="explicitInterface">IAnnotatedElement</attr>
+  <attr path="/api/package[@name='java.lang.reflect']/interface[@name='AnnotatedType']/method[@name='getAnnotations' and count(parameter)=0]"
+      name="managedOverride">reabstract</attr>
+  <attr path="/api/package[@name='java.lang.reflect']/interface[@name='AnnotatedType']/method[@name='getAnnotations' and count(parameter)=0]"
+      name="explicitInterface">IAnnotatedElement</attr>
+  <attr path="/api/package[@name='java.lang.reflect']/interface[@name='AnnotatedType']/method[@name='getDeclaredAnnotations' and count(parameter)=0]"
+      name="managedOverride">reabstract</attr>
+  <attr path="/api/package[@name='java.lang.reflect']/interface[@name='AnnotatedType']/method[@name='getDeclaredAnnotations' and count(parameter)=0]"
+      name="explicitInterface">IAnnotatedElement</attr>
 </metadata>

--- a/src/Java.Interop/Java.Interop.targets
+++ b/src/Java.Interop/Java.Interop.targets
@@ -28,8 +28,8 @@
       Inputs="@(CompileJavaInteropJar)"
       Outputs="$(OutputPath)java-interop.jar">
     <MakeDir Directories="$(OutputPath);$(IntermediateOutputPath)ji-classes" />
-    <Exec Command="&quot;$(JavaCPath)&quot; $(_JavacSourceOptions) -d &quot;$(IntermediateOutputPath)ji-classes&quot; @(CompileJavaInteropJar -&gt; '%(Identity)', ' ')" />
-    <Exec Command="&quot;$(JarPath)&quot; cf &quot;$(OutputPath)java-interop.jar&quot; -C &quot;$(IntermediateOutputPath)ji-classes&quot; ." />
+    <Exec Command="&quot;$(JavaC8Path)&quot; $(_Javac8SourceOptions) -d &quot;$(IntermediateOutputPath)ji-classes&quot; @(CompileJavaInteropJar -&gt; '%(Identity)', ' ')" />
+    <Exec Command="&quot;$(Jar8Path)&quot; cf &quot;$(OutputPath)java-interop.jar&quot; -C &quot;$(IntermediateOutputPath)ji-classes&quot; ." />
   </Target>
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Java.Interop.BootstrapTasks.dll" TaskName="Java.Interop.BootstrapTasks.ReplaceFileContents" />
   <Target Name="BuildVersionInfo_g_cs"

--- a/src/java-interop/java-interop.targets
+++ b/src/java-interop/java-interop.targets
@@ -53,7 +53,7 @@
       <_EnableMono>-DENABLE_MONO_INTEGRATION=ON</_EnableMono>
     </PropertyGroup>
     <PropertyGroup>
-      <_JdkDirs>"-DJDK_INCLUDE_LIST=@(JdkIncludePath, ';')"</_JdkDirs>
+      <_JdkDirs>"-DJDK_INCLUDE_LIST=@(Jdk11IncludePath, ';')"</_JdkDirs>
       <_Jni_c>"-DJNI_C_PATH=$(MSBuildThisFileDirectory)$(IntermediateOutputPath)jni.c"</_Jni_c>
       <_ExtraArgs>$([MSBuild]::Escape('$(_JdkDirs) $(_Jni_c) $(_EnableMono) $(_MonoDirs) $(_MonoLib)'))</_ExtraArgs>
     </PropertyGroup>

--- a/tests/Java.Base-Tests/Java.Base-Tests.targets
+++ b/tests/Java.Base-Tests/Java.Base-Tests.targets
@@ -42,8 +42,8 @@
     <ItemGroup>
       <_JcwSourceReal Include="$(IntermediateOutputPath)java\**\*.java;java\**\*.java" />
     </ItemGroup>
-    <Exec Command="&quot;$(JavaCPath)&quot; $(_JavacSourceOptions) -d &quot;$(IntermediateOutputPath)classes&quot; -classpath &quot;$(OutputPath)/java-interop.jar&quot; @(_JcwSourceReal->'%(Identity)', ' ')" />
-    <Exec Command="&quot;$(JarPath)&quot; cf &quot;$(OutputPath)java.base-tests.jar&quot; -C &quot;$(IntermediateOutputPath)classes&quot; ." />
+    <Exec Command="&quot;$(JavaC11Path)&quot; $(_Javac8SourceOptions) -d &quot;$(IntermediateOutputPath)classes&quot; -classpath &quot;$(OutputPath)/java-interop.jar&quot; @(_JcwSourceReal->'%(Identity)', ' ')" />
+    <Exec Command="&quot;$(Jar11Path)&quot; cf &quot;$(OutputPath)java.base-tests.jar&quot; -C &quot;$(IntermediateOutputPath)classes&quot; ." />
   </Target>
 
 </Project>

--- a/tests/Java.Interop-PerformanceTests/Java.Interop-PerformanceTests.targets
+++ b/tests/Java.Interop-PerformanceTests/Java.Interop-PerformanceTests.targets
@@ -5,8 +5,8 @@
       Inputs="@(JavaPerformanceTestJar)"
       Outputs="$(OutputPath)performance-test.jar">
     <MakeDir Directories="$(IntermediateOutputPath)pt-classes" />
-    <Exec Command="&quot;$(JavaCPath)&quot; $(_JavacSourceOptions) -d &quot;$(IntermediateOutputPath)pt-classes&quot; @(JavaPerformanceTestJar->'%(Identity)', ' ')" />
-    <Exec Command="&quot;$(JarPath)&quot; cf &quot;$(OutputPath)performance-test.jar&quot; -C &quot;$(IntermediateOutputPath)pt-classes&quot; ." />
+    <Exec Command="&quot;$(JavaC8Path)&quot; $(_Javac8SourceOptions) -d &quot;$(IntermediateOutputPath)pt-classes&quot; @(JavaPerformanceTestJar->'%(Identity)', ' ')" />
+    <Exec Command="&quot;$(Jar8Path)&quot; cf &quot;$(OutputPath)performance-test.jar&quot; -C &quot;$(IntermediateOutputPath)pt-classes&quot; ." />
   </Target>
 
 </Project>

--- a/tests/Java.Interop-Tests/Java.Interop-Tests.targets
+++ b/tests/Java.Interop-Tests/Java.Interop-Tests.targets
@@ -13,9 +13,9 @@
         Lines="@(_Source)"
         Overwrite="True"
     />
-    <Exec Command="&quot;$(JavaCPath)&quot; $(_JavacSourceOptions) -d &quot;$(IntermediateOutputPath)it-classes&quot; -classpath &quot;$(OutputPath)../$(Configuration)/java-interop.jar&quot; &quot;@$(IntermediateOutputPath)_java_sources.txt&quot;" />
+    <Exec Command="&quot;$(JavaC8Path)&quot; $(_Javac8SourceOptions) -d &quot;$(IntermediateOutputPath)it-classes&quot; -classpath &quot;$(OutputPath)../$(Configuration)/java-interop.jar&quot; &quot;@$(IntermediateOutputPath)_java_sources.txt&quot;" />
     <Delete Files="$(IntermediateOutputPath)_java_sources.txt" />
-    <Exec Command="&quot;$(JarPath)&quot; cf &quot;$(OutputPath)interop-test.jar&quot; -C &quot;$(IntermediateOutputPath)it-classes&quot; ." />
+    <Exec Command="&quot;$(Jar8Path)&quot; cf &quot;$(OutputPath)interop-test.jar&quot; -C &quot;$(IntermediateOutputPath)it-classes&quot; ." />
   </Target>
 
 </Project>

--- a/tests/Java.Interop.Export-Tests/Java.Interop.Export-Tests.csproj
+++ b/tests/Java.Interop.Export-Tests/Java.Interop.Export-Tests.csproj
@@ -34,8 +34,8 @@
 
   <Target Name="BuildExportTestJar" BeforeTargets="Build" Inputs="@(JavaExportTestJar)" Outputs="$(OutputPath)export-test.jar">
     <MakeDir Directories="$(IntermediateOutputPath)et-classes" />
-    <Exec Command="&quot;$(JavaCPath)&quot; -classpath &quot;$(OutputPath)../$(Configuration)/java-interop.jar&quot; $(_JavacSourceOptions) -d &quot;$(IntermediateOutputPath)et-classes&quot; @(JavaExportTestJar->'%(Identity)', ' ')" />
-    <Exec Command="&quot;$(JarPath)&quot; cf &quot;$(OutputPath)export-test.jar&quot; -C &quot;$(IntermediateOutputPath)et-classes&quot; ." />
+    <Exec Command="&quot;$(JavaC8Path)&quot; -classpath &quot;$(OutputPath)../$(Configuration)/java-interop.jar&quot; $(_Javac8SourceOptions) -d &quot;$(IntermediateOutputPath)et-classes&quot; @(JavaExportTestJar->'%(Identity)', ' ')" />
+    <Exec Command="&quot;$(Jar8Path)&quot; cf &quot;$(OutputPath)export-test.jar&quot; -C &quot;$(IntermediateOutputPath)et-classes&quot; ." />
   </Target>
 
 </Project>

--- a/tests/NativeTiming/NativeTiming.targets
+++ b/tests/NativeTiming/NativeTiming.targets
@@ -47,7 +47,7 @@
       Outputs="$(OutputPath)%(_NativeTimingLib.Dir)$(_NativeTimingLibName)">
     <MakeDir Directories="$(IntermediateOutputPath)" />
     <PropertyGroup>
-      <_JdkDirs>"-DJDK_INCLUDE_LIST=@(JdkIncludePath, ';')"</_JdkDirs>
+      <_JdkDirs>"-DJDK_INCLUDE_LIST=@(Jdk11IncludePath, ';')"</_JdkDirs>
     </PropertyGroup>
     <ItemGroup>
       <_Cmake

--- a/tests/TestJVM/TestJVM.cs
+++ b/tests/TestJVM/TestJVM.cs
@@ -93,7 +93,7 @@ namespace Java.InteropTests
 			if (buildName.Contains ('-')) {
 				buildName   = buildName.Substring (0, buildName.IndexOf ('-'));
 			}
-			var jdkPropFile = Path.Combine (binDir, buildName, "JdkInfo.props");
+			var jdkPropFile = Path.Combine (binDir, buildName, "JdkInfo-11.props");
 			if (!File.Exists (jdkPropFile)) {
 				return null;
 			}
@@ -105,7 +105,7 @@ namespace Java.InteropTests
 				.Elements (msbuild + "Choose")
 				.Elements (msbuild + "When")
 				.Elements (msbuild + "PropertyGroup")
-				.Elements (msbuild + "JdkJvmPath")
+				.Elements (msbuild + "JdkJvm11Path")
 				.FirstOrDefault ();
 			if (jdkJvmPath == null) {
 				return null;

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/ConfiguredJdkInfo.cs
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/ConfiguredJdkInfo.cs
@@ -33,7 +33,7 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 			if (buildName.IndexOf ("-", StringComparison.Ordinal) >= 0) {
 				buildName   = buildName.Substring (0, buildName.IndexOf ('-'));
 			}
-			var jdkPropFile = Path.Combine (binDir, buildName, "JdkInfo.props");
+			var jdkPropFile = Path.Combine (binDir, buildName, "JdkInfo-8.props");
 			if (!File.Exists (jdkPropFile)) {
 				return null;
 			}
@@ -43,7 +43,7 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 			var jdkProps    = XDocument.Load (jdkPropFile);
 			var jdkPath     = jdkProps.Elements ()
 				.Elements (msbuild + "PropertyGroup")
-				.Elements (msbuild + "JavaSdkDirectory")
+				.Elements (msbuild + "Java8SdkDirectory")
 				.FirstOrDefault ();
 			if (jdkPath == null) {
 				return null;

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.targets
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.targets
@@ -19,8 +19,8 @@
         Inputs="@(TestJar);@(TestJarNoParameters);@(TestJarJdk11)"
         Outputs="@(_BuildClassOutputs)">
     <MakeDir Directories="$(IntermediateOutputPath)classes" />
-    <Exec Command="&quot;$(JavaCPath)&quot; -parameters $(_JavacSourceOptions) -g -d &quot;$(IntermediateOutputPath)classes&quot; java/android/annotation/NonNull.java @(TestJar->'%(Identity)', ' ')" />
-    <Exec Command="&quot;$(JavaCPath)&quot; $(_JavacSourceOptions) -g -d &quot;$(IntermediateOutputPath)classes&quot; @(TestJarNoParameters->'%(Identity)', ' ')" />
+    <Exec Command="&quot;$(JavaC8Path)&quot; -parameters $(_Javac8SourceOptions) -g -d &quot;$(IntermediateOutputPath)classes&quot; java/android/annotation/NonNull.java @(TestJar->'%(Identity)', ' ')" />
+    <Exec Command="&quot;$(JavaC8Path)&quot; $(_Javac8SourceOptions) -g -d &quot;$(IntermediateOutputPath)classes&quot; @(TestJarNoParameters->'%(Identity)', ' ')" />
     <Exec Command="&quot;$(JavaC11Path)&quot; -source 11 -target 11 -g -d &quot;$(IntermediateOutputPath)classes&quot; @(TestJarJdk11->'%(Identity)', ' ')" />
   </Target>
 

--- a/tools/java-source-utils/build.gradle
+++ b/tools/java-source-utils/build.gradle
@@ -52,11 +52,12 @@ jar {
     } {
         exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA'
     }
-    archiveName 'java-source-utils.jar'
+    archiveFileName.set('java-source-utils.jar')
 }
 
 test {
     reports {
-        junitXml.enabled = true
+        junitXml {
+        }
     }
 }

--- a/tools/java-source-utils/java-source-utils.targets
+++ b/tools/java-source-utils/java-source-utils.targets
@@ -7,7 +7,7 @@
       Outputs="$(OutputPath)\java-source-utils.jar">
     <Exec
         Command="&quot;$(GradleWPath)&quot; -d $(GradleArgs) -PjavaSourceVer=$(JavacSourceVersion) -PjavaTargetVer=$(JavacTargetVersion) jar"
-        EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);APP_HOME=$(GradleHome)"
+        EnvironmentVariables="JAVA_HOME=$(Java8SdkDirectory);APP_HOME=$(GradleHome)"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
         IgnoreStandardErrorWarningFormat="true"
     />
@@ -40,7 +40,7 @@
       DependsOnTargets="_BuildJava;_CopyJavaType_java">
     <Exec
         Command="&quot;$(GradleWPath)&quot; $(GradleArgs) test"
-        EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);APP_HOME=$(GradleHome)"
+        EnvironmentVariables="JAVA_HOME=$(Java8SdkDirectory);APP_HOME=$(GradleHome)"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
     />
   </Target>
@@ -58,7 +58,7 @@
       DependsOnTargets="_BuildJava">
     <Exec
         Command="&quot;$(GradleWPath)&quot; $(GradleArgs) test"
-        EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);APP_HOME=$(GradleHome)"
+        EnvironmentVariables="JAVA_HOME=$(Java8SdkDirectory);APP_HOME=$(GradleHome)"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
     />
   </Target>
@@ -67,7 +67,7 @@
       DependsOnTargets="_BuildJava">
     <Exec
         Command="&quot;$(JavaPath)&quot; -jar &quot;$(ToolOutputFullPath)$(TargetFileName)&quot; $(Args)"
-        EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory)"
+        EnvironmentVariables="JAVA_HOME=$(Java8SdkDirectory)"
     />
   </Target>
 
@@ -75,7 +75,7 @@
     <Delete Files="$(OutputPath)java-source-utils.jar" />
     <Exec
         Command="&quot;$(GradleWPath)&quot; clean $(GradleArgs)"
-        EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);APP_HOME=$(GradleHome)"
+        EnvironmentVariables="JAVA_HOME=$(Java8SdkDirectory);APP_HOME=$(GradleHome)"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
     />
   </Target>
@@ -88,7 +88,7 @@
     </ItemGroup>
     <Exec
         Command="&quot;$(JavaPath)&quot; -jar &quot;$(ToolOutputFullPath)$(TargetFileName)&quot; @(_JavaSource) --output-params src/test/resources/com/microsoft/android/%(Filename).params.txt --output-javadoc src/test/resources/com/microsoft/android/%(Filename).xml"
-        EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory)"
+        EnvironmentVariables="JAVA_HOME=$(Java8SdkDirectory)"
     />
   </Target>
 

--- a/tools/java-source-utils/java-source-utils.targets
+++ b/tools/java-source-utils/java-source-utils.targets
@@ -49,7 +49,7 @@
       Inputs="@(CompileTestJavaResources)"
       Outputs="@(CompileTestJavaResources->'%(RelativeDir)%(Filename).class')">
     <Exec
-        Command="&quot;$(JavaCPath)&quot; @(CompileTestJavaResources->'%(Identity)', ' ')"
+        Command="&quot;$(JavaC8Path)&quot; @(CompileTestJavaResources->'%(Identity)', ' ')"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
     />
   </Target>

--- a/tools/java-source-utils/src/test/java/com/microsoft/android/JavaSourceUtilsOptionsTest.java
+++ b/tools/java-source-utils/src/test/java/com/microsoft/android/JavaSourceUtilsOptionsTest.java
@@ -9,8 +9,6 @@ import java.io.*;
 
 import org.junit.Test;
 
-import jdk.nashorn.internal.AssertsEnabled;
-
 import static org.junit.Assert.*;
 
 public class JavaSourceUtilsOptionsTest {

--- a/tools/jnimarshalmethod-gen/App.cs
+++ b/tools/jnimarshalmethod-gen/App.cs
@@ -320,7 +320,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 			if (buildName.Contains ('-')) {
 				buildName = buildName.Substring (0, buildName.IndexOf ('-'));
 			}
-			var jdkPropFile = Path.Combine (binDir, buildName, "JdkInfo.props");
+			var jdkPropFile = Path.Combine (binDir, buildName, "JdkInfo-11.props");
 			if (!File.Exists (jdkPropFile)) {
 				return null;
 			}
@@ -332,7 +332,7 @@ namespace Xamarin.Android.Tools.JniMarshalMethodGenerator {
 				.Elements (msbuild + "Choose")
 				.Elements (msbuild + "When")
 				.Elements (msbuild + "PropertyGroup")
-				.Elements (msbuild + "JdkJvmPath")
+				.Elements (msbuild + "JdkJvm11Path")
 				.FirstOrDefault ();
 			if (jdkJvmPath == null) {
 				return null;


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/8029

Update `<JdkInfo/>` task to emit a new `$(Java*MajorVersion)` MSBuild property.  This is used by `src/Java.Base` so that it knows which JDK version it's binding.

Begin explicitly qualifying all `$(Jdk*)` and `$(Java*)` MSBuild properties to explicitly disambiguate between JDK 1.8 and JDK-11 contexts.  Eventually we may "swap" things so that properties without a version are for e.g. JDK 11 (17, etc.) and `$(Jdk8*)` is for JDK 1.8-requiring contexts.

Note: to get this to *build* we had to update `src/Java.Base` to support binding against JDK-17, which was an expected diversion. This "JDK-17 Java.Base binding" was a "time limited" effort.