### PR TITLE
[Java.Interop.Tools.JavaTypeSystem] Prefer matching to non-synthetic base methods.

### DIFF
--- a/src/Java.Interop.Tools.JavaTypeSystem/JavaModels/JavaMethodModel.cs
+++ b/src/Java.Interop.Tools.JavaTypeSystem/JavaModels/JavaMethodModel.cs
@@ -77,7 +77,15 @@ namespace Java.Interop.Tools.JavaTypeSystem.Models
 
 			var pt = (JavaClassModel)DeclaringType;
 
-			var candidate = type.Methods.FirstOrDefault (p => p.Name == Name && IsImplementing (this, p, pt.GenericInheritanceMapping ?? throw new InvalidOperationException ($"missing {nameof (pt.GenericInheritanceMapping)}!")));
+			var candidates = type.Methods.Where (p => p.Name == Name && IsImplementing (this, p, pt.GenericInheritanceMapping ?? throw new InvalidOperationException ($"missing {nameof (pt.GenericInheritanceMapping)}!")));
+
+			JavaMethodModel? candidate;
+
+			// Prefer non-synthetic, non-bridge methods
+			if (candidates.FirstOrDefault (c => !c.IsSynthetic && !c.IsBridge) is JavaMethodModel jm)
+				candidate = jm;
+			else
+				candidate = candidates.FirstOrDefault ();
 
 			if (candidate != null) {
 				BaseMethod = candidate;


### PR DESCRIPTION
Context: https://github.com/xamarin/AndroidX/pull/723

Imagine we have the following Java:

```java
public final class AesGcmHkdfStreamingKey extends StreamingAeadKey {
  @Override
  public AesGcmHkdfStreamingParameters getParameters() { ... }
}

public abstract class StreamingAeadKey extends Key {
  @Override
  public abstract StreamingAeadParameters getParameters();
}

public abstract class Key {
  public abstract Parameters getParameters();
}
```

The reabstraction in `StreamingAeadKey` causes an additional synthetic method to be generated:

```xml
<class abstract="true" deprecated="not deprecated" jni-extends="Lcom/google/crypto/tink/Key;" extends="com.google.crypto.tink.Key" extends-generic-aware="com.google.crypto.tink.Key" final="false" name="StreamingAeadKey" jni-signature="Lcom/google/crypto/tink/streamingaead/StreamingAeadKey;" source-file-name="StreamingAeadKey.java" static="false" visibility="public">
  <method abstract="false" deprecated="not deprecated" final="false" name="getParameters" native="false" return="com.google.crypto.tink.Parameters" jni-return="Lcom/google/crypto/tink/Parameters;" static="false" synchronized="false" visibility="public" bridge="true" synthetic="true" jni-signature="()Lcom/google/crypto/tink/Parameters;" />
  <method abstract="true" deprecated="not deprecated" final="false" name="getParameters" native="false" return="com.google.crypto.tink.streamingaead.StreamingAeadParameters" jni-return="Lcom/google/crypto/tink/streamingaead/StreamingAeadParameters;" static="false" synchronized="false" visibility="public" bridge="false" synthetic="false" jni-signature="()Lcom/google/crypto/tink/streamingaead/StreamingAeadParameters;" />
</class>
```

When looking for the "base method" for `AesGcmHkdfStreamingKey.getParameters` we grab the "first" one we find with a matching name and parameters.  In this case, it is the synthetic method instead of the "regular" method.

Note that the synthetic method is not `abstract`.  When deciding if we need to output `AesGcmHkdfStreamingKey.getParameters`, we see that both it and the "base method" are not `abstract`, so we don't need to bother outputting the derived method.

In reality, the base method should be the `abstract` method.  Then it is different from the derived non-abstract method, and we will output the derived method to `api.xml.adjusted`.

The fix is to prefer non-synthetic, non-bridge methods when choosing base methods.