### PR TITLE
[build] Switch to NuGet's Central Package Management.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,6 +9,7 @@
     <ProduceReferenceAssemblyInOutDir>true</ProduceReferenceAssemblyInOutDir>
     <DotNetTargetFrameworkVersion>7.0</DotNetTargetFrameworkVersion>
     <DotNetTargetFramework>net$(DotNetTargetFrameworkVersion)</DotNetTargetFramework>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
   <Import

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -3,37 +3,18 @@
 
   <!-- Add Roslyn analyzers NuGet to all projects -->
   <ItemGroup Condition=" '$(DisableRoslynAnalyzers)' != 'True' ">
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 
-  <!-- NuGet Dependencies -->
+  <!-- Set Assets for NUnit3TestAdapter -->
   <ItemGroup>
-    <PackageReference Update="GitInfo"                                      Version="2.1.2" />
-    <PackageReference Update="HtmlAgilityPack"                              Version="1.11.30" />
-    <PackageReference Update="Irony"                                        Version="1.1.0" />
-    <PackageReference Update="Microsoft.Build.Framework"                    Version="17.3.2" />
-    <PackageReference Update="Microsoft.Build.Utilities.Core"               Version="17.3.2" />
-    <PackageReference Update="Microsoft.CodeAnalysis.CSharp"                Version="4.3.1" />
-    <PackageReference Update="Microsoft.CSharp"                             Version="4.7.0" />
-    <PackageReference Update="Microsoft.DotNet.GenAPI"                      Version="7.0.0-beta.22103.1" />
-    <PackageReference Update="Microsoft.NET.Test.Sdk"                       Version="17.5.0-preview-20221003-04" />
-    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies"   Version="1.0.3" />
-    <PackageReference Update="Microsoft.SourceLink.GitHub"                  Version="1.1.1" />
-    <PackageReference Update="Microsoft.Xml.SgmlReader"                     Version="1.8.16" />
-    <PackageReference Update="Mono.CSharp"                                  Version="4.0.0.143" />
-    <PackageReference Update="Mono.Linq.Expressions"                        Version="2.0.0" />
-    <PackageReference Update="Mono.Options"                                 Version="6.12.0.148" />
-    <PackageReference Update="Mono.Terminal"                                Version="5.4.2" />
-    <PackageReference Update="nunit"                                        Version="3.13.2" />
-    <PackageReference Update="NUnit.ConsoleRunner"                          Version="3.12.0" />
-    <PackageReference Update="NUnit3TestAdapter"                            Version="4.0.0">
+    <PackageReference Update="NUnit3TestAdapter">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Update="protobuf-net"                                 Version="2.4.4" />
   </ItemGroup>
 
   <Import Project="build-tools\scripts\VersionInfo.targets" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,31 @@
+<Project>
+
+  <PropertyGroup>
+    <_XamarinAndroidCecilVersion Condition=" '$(_XamarinAndroidCecilVersion)' == '' ">0.11.4</_XamarinAndroidCecilVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="GitInfo"                                      Version="2.1.2" />
+    <PackageVersion Include="HtmlAgilityPack"                              Version="1.11.30" />
+    <PackageVersion Include="Irony"                                        Version="1.1.0" />
+    <PackageVersion Include="Microsoft.Build.Framework"                    Version="17.3.2" />
+    <PackageVersion Include="Microsoft.Build.Utilities.Core"               Version="17.3.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp"                Version="4.3.1" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.FxCopAnalyzers"        Version="3.3.0" />
+    <PackageVersion Include="Microsoft.CSharp"                             Version="4.7.0" />
+    <PackageVersion Include="Microsoft.DotNet.GenAPI"                      Version="7.0.0-beta.22103.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk"                       Version="17.5.0-preview-20221003-04" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub"                  Version="1.1.1" />
+    <PackageVersion Include="Microsoft.Xml.SgmlReader"                     Version="1.8.16" />
+    <PackageVersion Include="Mono.Cecil"                                   Version="$(_XamarinAndroidCecilVersion)" />
+    <PackageVersion Include="Mono.CSharp"                                  Version="4.0.0.143" />
+    <PackageVersion Include="Mono.Linq.Expressions"                        Version="2.0.0" />
+    <PackageVersion Include="Mono.Options"                                 Version="6.12.0.148" />
+    <PackageVersion Include="Mono.Terminal"                                Version="5.4.2" />
+    <PackageVersion Include="nunit"                                        Version="3.13.2" />
+    <PackageVersion Include="NUnit.ConsoleRunner"                          Version="3.12.0" />
+    <PackageVersion Include="NUnit3TestAdapter"                            Version="4.0.0" />
+    <PackageVersion Include="protobuf-net"                                 Version="2.4.4" />
+  </ItemGroup>
+
+</Project>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -11,4 +11,14 @@
     <!-- For Microsoft.DotNet.GenAPI -->
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" protocolVersion="3" />
   </packageSources>
+  
+  <packageSourceMapping>
+    <!-- key value for <packageSource> should match key values from <packageSources> element -->
+    <packageSource key="dotnet-public">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="dotnet-eng">
+      <package pattern="Microsoft.DotNet.GenAPI" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>

--- a/build-tools/scripts/cecil.projitems
+++ b/build-tools/scripts/cecil.projitems
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <_XamarinAndroidCecilVersion Condition=" '$(_XamarinAndroidCecilVersion)' == '' ">0.11.4</_XamarinAndroidCecilVersion>
-  </PropertyGroup>
   <ItemGroup Condition=" '$(_XamarinAndroidCecilPath)' == '' ">
-    <PackageReference Include="Mono.Cecil" Version="$(_XamarinAndroidCecilVersion)" />
+    <PackageReference Include="Mono.Cecil" />
   </ItemGroup>
   <ItemGroup Condition=" '$(_XamarinAndroidCecilPath)' != '' ">
     <Reference Include="$(_XamarinAndroidCecilPath)" />

--- a/tests/Java.Interop.Tools.Expressions-Tests/Java.Interop.Tools.Expressions-Tests.csproj
+++ b/tests/Java.Interop.Tools.Expressions-Tests/Java.Interop.Tools.Expressions-Tests.csproj
@@ -24,7 +24,7 @@
   <Import Project="..\..\build-tools\scripts\cecil.projitems" />
   -->
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="0.11.4" />
+    <PackageReference Include="Mono.Cecil" />
     <PackageReference Include="Mono.Linq.Expressions" />
   </ItemGroup>
 


### PR DESCRIPTION
Context: https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management
Context: https://learn.microsoft.com/en-us/nuget/consume-packages/package-source-mapping

Switch to [NuGet's Central Package Management](https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management).  Although this is very similar to the "homegrown" central package management we currently have, using the "official" version means that there is additional tooling support available, such as being supported by `dotnet add package`, Visual Studio, and dependabot.

Central Package Management also requires [Package Source Mapping](https://learn.microsoft.com/en-us/nuget/consume-packages/package-source-mapping), so we also add that information to our `NuGet.config`.