### PR TITLE
[build] Remove support for JDK 8.

### DIFF
--- a/Configuration.Override.props.in
+++ b/Configuration.Override.props.in
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <JdkJvmPath>/Library/Java/JavaVirtualMachines/jdk1.8.0_77.jdk/Contents/Home/jre/jli/libjli.dylib</JdkJvmPath>
+    <JdkJvmPath>/Library/Java/JavaVirtualMachines/microsoft-11.jdk/Contents/Home/lib/jli/libjli.dylib</JdkJvmPath>
     <MonoFrameworkPath>/Library/Frameworks/Mono.framework/Libraries/libmonosgen-2.0.1.dylib</MonoFrameworkPath>
     <UtilityOutputFullPath>$(MSBuildThisFileDirectory)bin\$(Configuration)\</UtilityOutputFullPath>
   </PropertyGroup>
   <ItemGroup>
     <!-- JDK C `include` directories -->
-    <JdkIncludePath Include="/Library/Java/JavaVirtualMachines/jdk1.8.0_77.jdk/Contents/Home/include" />
-    <JdkIncludePath Include="/Library/Java/JavaVirtualMachines/jdk1.8.0_77.jdk/Contents/Home/include/darwin" />
+    <JdkIncludePath Include="/Library/Java/JavaVirtualMachines/microsoft-11.jdk/Contents/Home/include" />
+    <JdkIncludePath Include="/Library/Java/JavaVirtualMachines/microsoft-11.jdk/Contents/Home/include/darwin" />
   </ItemGroup>
   <ItemGroup>
     <!-- Mono C `include` directories -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -58,8 +58,8 @@
     <GradleHome Condition=" '$(GradleHome)' == '' ">$(MSBuildThisFileDirectory)build-tools\gradle</GradleHome>
     <GradleWPath Condition=" '$(GradleWPath)' == '' ">$(GradleHome)\gradlew</GradleWPath>
     <GradleArgs Condition=" '$(GradleArgs)' == '' ">--stacktrace --no-daemon</GradleArgs>
-    <JavacSourceVersion Condition=" '$(JavacSourceVersion)' == '' ">1.8</JavacSourceVersion>
-    <JavacTargetVersion Condition=" '$(JavacTargetVersion)' == '' ">1.8</JavacTargetVersion>
+    <JavacSourceVersion Condition=" '$(JavacSourceVersion)' == '' ">11</JavacSourceVersion>
+    <JavacTargetVersion Condition=" '$(JavacTargetVersion)' == '' ">11</JavacTargetVersion>
     <_BootClassPath Condition=" '$(JreRtJarPath)' != '' ">-bootclasspath "$(JreRtJarPath)"</_BootClassPath>
     <_JavacSourceOptions>-source $(JavacSourceVersion) -target $(JavacTargetVersion) $(_BootClassPath)</_JavacSourceOptions>
   </PropertyGroup>

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -20,7 +20,6 @@ pr:
 variables:
   RunningOnCI: true
   Build.Configuration: Release
-  MaxJdkVersion: 8
   DotNetCoreVersion: 7.x
   DotNetTargetFramework: net7.0
   NetCoreTargetFrameworkPathSuffix: -$(DotNetTargetFramework)

--- a/build-tools/automation/templates/core-build.yaml
+++ b/build-tools/automation/templates/core-build.yaml
@@ -6,7 +6,7 @@ steps:
   displayName: Prepare Solution
   inputs:
     projects: Java.Interop.sln
-    arguments: '-c $(Build.Configuration) -target:Prepare -p:MaxJdkVersion=$(MaxJdkVersion)'
+    arguments: '-c $(Build.Configuration) -target:Prepare'
 
 - task: DotNetCoreCLI@2
   displayName: Shut down existing build server

--- a/build-tools/gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/build-tools/gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/build-tools/scripts/Prepare.targets
+++ b/build-tools/scripts/Prepare.targets
@@ -15,26 +15,15 @@
     <PropertyGroup>
       <_MaxJdk>$(MaxJdkVersion)</_MaxJdk>
       <_MaxJdk Condition=" '$(_MaxJdk)' == '' ">$(JI_MAX_JDK)</_MaxJdk>
-      <Jdks8Root Condition=" '$(Jdks8Root)' == '' And '$(JAVA_HOME_8_X64)' != '' And Exists($(JAVA_HOME_8_X64)) ">$(JAVA_HOME_8_X64)</Jdks8Root>
+      <JdksRoot Condition=" '$(JdksRoot)' == '' And '$(JAVA_HOME_11_X64)' != '' And Exists($(JAVA_HOME_11_X64)) ">$(JAVA_HOME_11_X64)</JdksRoot>
     </PropertyGroup>
     <JdkInfo
-        JdksRoot="$(Jdks8Root)"
+        JdksRoot="$(JdksRoot)"
         MakeFragmentFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\JdkInfo.mk"
         MaximumJdkVersion="$(_MaxJdk)"
         DotnetToolPath="$(DotnetToolPath)"
         PropertyFile="$(_TopDir)\bin\Build$(Configuration)\JdkInfo.props">
       <Output TaskParameter="JavaHomePath" PropertyName="_JavaSdkDirectory" />
-    </JdkInfo>
-    <PropertyGroup>
-      <Jdks11Root Condition=" '$(Jdks11Root)' == '' And '$(JAVA_HOME_11_X64)' != '' And Exists($(JAVA_HOME_11_X64)) ">$(JAVA_HOME_11_X64)</Jdks11Root>
-    </PropertyGroup>
-    <JdkInfo
-        JdksRoot="$(Jdks11Root)"
-        PropertyNameModifier="11"
-        MinimumJdkVersion="11.0"
-        MaximumJdkVersion="11.99.0"
-        PropertyFile="$(_TopDir)\bin\Build$(Configuration)\JdkInfo-11.props">
-      <Output TaskParameter="JavaHomePath" PropertyName="Java11SdkDirectory"/>
     </JdkInfo>
   </Target>
 </Project>

--- a/src/Java.Base/Java.Base.targets
+++ b/src/Java.Base/Java.Base.targets
@@ -9,8 +9,8 @@
   </ItemGroup>
 
   <Target Name="_GetJavaBaseJmodPath">
-    <PropertyGroup Condition=" '$(Java11SdkDirectory)' != '' ">
-      <_JavaBaseJmod>$(Java11SdkDirectory)/jmods/java.base.jmod</_JavaBaseJmod>
+    <PropertyGroup Condition=" '$(JavaSdkDirectory)' != '' ">
+      <_JavaBaseJmod>$(JavaSdkDirectory)/jmods/java.base.jmod</_JavaBaseJmod>
     </PropertyGroup>
   </Target>
 

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/IJavaInterfaceTests.cs
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/IJavaInterfaceTests.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 		{
 			var c   = LoadClassFile (JavaType + ".class");
 			new ExpectedTypeDeclaration {
-				MajorVersion        = 0x34,
+				MajorVersion        = 0x37,
 				MinorVersion        = 0,
 				ConstantPoolCount   = 23,
 				AccessFlags         = ClassAccessFlags.Interface | ClassAccessFlags.Abstract,

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/JavaAnnotationTests.cs
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/JavaAnnotationTests.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 		{
 			var c   = LoadClassFile (JavaType + ".class");
 			new ExpectedTypeDeclaration {
-				MajorVersion        = 0x34,
+				MajorVersion        = 0x37,
 				MinorVersion        = 0,
 				ConstantPoolCount   = 23,
 				AccessFlags         = ClassAccessFlags.Public | ClassAccessFlags.Interface | ClassAccessFlags.Abstract | ClassAccessFlags.Annotation,

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/JavaEnumTests.cs
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/JavaEnumTests.cs
@@ -20,7 +20,7 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 		{
 			var c   = LoadClassFile (JavaType + ".class");
 			new ExpectedTypeDeclaration {
-				MajorVersion        = 0x34,
+				MajorVersion        = 0x37,
 				MinorVersion        = 0,
 				ConstantPoolCount   = 53,
 				AccessFlags         = ClassAccessFlags.Final | ClassAccessFlags.Super | ClassAccessFlags.Enum,

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/JavaType.1MyStringListTests.cs
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/JavaType.1MyStringListTests.cs
@@ -26,9 +26,9 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 				: new ParameterInfo ("val$value1",        "Ljava/lang/Object;",   "Ljava/lang/Object;");
 			var c       = LoadClassFile (JavaType + ".class");
 			new ExpectedTypeDeclaration {
-				MajorVersion        = 0x34,
+				MajorVersion        = 0x37,
 				MinorVersion        = 0,
-				ConstantPoolCount   = 73,
+				ConstantPoolCount   = 74,
 				AccessFlags         = ClassAccessFlags.Super,
 				FullName            = "com/xamarin/JavaType$1MyStringList",
 				Superclass          = new TypeInfo ("java/util/ArrayList", "Ljava/util/ArrayList<Ljava/lang/String;>;"),

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/JavaType.1Tests.cs
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/JavaType.1Tests.cs
@@ -16,9 +16,9 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 		{
 			var c   = LoadClassFile (JavaType + ".class");
 			new ExpectedTypeDeclaration {
-				MajorVersion        = 0x34,
+				MajorVersion        = 0x37,
 				MinorVersion        = 0,
-				ConstantPoolCount   = 47,
+				ConstantPoolCount   = 48,
 				AccessFlags         = ClassAccessFlags.Super,
 				FullName            = "com/xamarin/JavaType$1",
 				Superclass          = new TypeInfo ("java/lang/Object", "Ljava/lang/Object;"),

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/JavaType.ASCTests.cs
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/JavaType.ASCTests.cs
@@ -16,9 +16,9 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 		{
 			var c   = LoadClassFile (JavaType + ".class");
 			new ExpectedTypeDeclaration {
-				MajorVersion        = 0x34,
+				MajorVersion        = 0x37,
 				MinorVersion        = 0,
-				ConstantPoolCount   = 23,
+				ConstantPoolCount   = 24,
 				Deprecated          = true,
 				AccessFlags         = ClassAccessFlags.Super,
 				FullName            = "com/xamarin/JavaType$ASC",

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/JavaType.PSCTests.cs
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/JavaType.PSCTests.cs
@@ -16,9 +16,9 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 		{
 			var c   = LoadClassFile (JavaType + ".class");
 			new ExpectedTypeDeclaration {
-				MajorVersion        = 0x34,
+				MajorVersion        = 0x37,
 				MinorVersion        = 0,
-				ConstantPoolCount   = 20,
+				ConstantPoolCount   = 21,
 				AccessFlags         = ClassAccessFlags.Public | ClassAccessFlags.Super | ClassAccessFlags.Abstract,
 				FullName            = "com/xamarin/JavaType$PSC",
 				Superclass          = new TypeInfo ("java/lang/Object", "Ljava/lang/Object;"),

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/JavaType.RNC.RPNCTests.cs
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/JavaType.RNC.RPNCTests.cs
@@ -16,9 +16,9 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 		{
 			var c   = LoadClassFile (JavaType + ".class");
 			new ExpectedTypeDeclaration {
-				MajorVersion        = 0x34,
+				MajorVersion        = 0x37,
 				MinorVersion        = 0,
-				ConstantPoolCount   = 46,
+				ConstantPoolCount   = 47,
 				AccessFlags         = ClassAccessFlags.Public | ClassAccessFlags.Super | ClassAccessFlags.Abstract,
 				FullName            = "com/xamarin/JavaType$RNC$RPNC",
 				Superclass          = new TypeInfo ("java/lang/Object", "Ljava/lang/Object;"),

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/JavaType.RNCTests.cs
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/JavaType.RNCTests.cs
@@ -16,9 +16,9 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 		{
 			var c   = LoadClassFile (JavaType + ".class");
 			new ExpectedTypeDeclaration {
-				MajorVersion        = 0x34,
+				MajorVersion        = 0x37,
 				MinorVersion        = 0,
-				ConstantPoolCount   = 44,
+				ConstantPoolCount   = 45,
 				AccessFlags         = ClassAccessFlags.Public | ClassAccessFlags.Super | ClassAccessFlags.Abstract,
 				FullName            = "com/xamarin/JavaType$RNC",
 				Superclass          = new TypeInfo ("java/lang/Object", "Ljava/lang/Object;"),

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/JavaTypeNoParametersTests.cs
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/JavaTypeNoParametersTests.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 		{
 			var c   = LoadClassFile (JavaType + ".class");
 			new ExpectedTypeDeclaration {
-				MajorVersion        = 0x34,
+				MajorVersion        = 0x37,
 				MinorVersion        = 0,
 				ConstantPoolCount   = 18,
 				AccessFlags         = ClassAccessFlags.Public | ClassAccessFlags.Super,

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/JavaTypeTests.cs
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/JavaTypeTests.cs
@@ -18,9 +18,9 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 		{
 			var c   = LoadClassFile ("JavaType.class");
 			new ExpectedTypeDeclaration {
-				MajorVersion        = 0x34,
+				MajorVersion        = 0x37,
 				MinorVersion        = 0,
-				ConstantPoolCount   = 198,
+				ConstantPoolCount   = 202,
 				AccessFlags         = ClassAccessFlags.Public | ClassAccessFlags.Super,
 				FullName            = "com/xamarin/JavaType",
 				Superclass          = new TypeInfo ("java/lang/Object", "Ljava/lang/Object;"),
@@ -64,6 +64,12 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 						OuterClassName  = null,
 						InnerName       = null,
 						AccessFlags     = 0,
+					},
+					new ExpectedInnerClassInfo {
+						InnerClassName  = "com/xamarin/JavaType$RNC$RPNC",
+						OuterClassName  = "com/xamarin/JavaType$RNC",
+						InnerName       = "RPNC",
+						AccessFlags     = ClassAccessFlags.Public | ClassAccessFlags.Abstract,
 					},
 				},
 				Fields = {
@@ -143,7 +149,7 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 						Name                = "STATIC_FINAL_STRING",
 						Descriptor          = "Ljava/lang/String;",
 						AccessFlags         = FieldAccessFlags.Public | FieldAccessFlags.Static | FieldAccessFlags.Final,
-						ConstantValue       = "String(stringIndex=188 Utf8=\"Hello, \\\"embedded\0Nulls\" and \ud83d\udca9!\")",
+						ConstantValue       = "String(stringIndex=190 Utf8=\"Hello, \\\"embedded\0Nulls\" and \ud83d\udca9!\")",
 					},
 					new ExpectedFieldDeclaration {
 						Name                = "STATIC_FINAL_BOOL_FALSE",

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/NonGenericGlobalTypeTests.cs
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/NonGenericGlobalTypeTests.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 		{
 			var c   = LoadClassFile (JavaType + ".class");
 			new ExpectedTypeDeclaration {
-				MajorVersion        = 0x34,
+				MajorVersion        = 0x37,
 				MinorVersion        = 0,
 				ConstantPoolCount   = 16,
 				AccessFlags         = ClassAccessFlags.Super,

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/ParameterFixupTests.cs
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/ParameterFixupTests.cs
@@ -24,7 +24,7 @@ namespace Xamarin.Android.Tools.BytecodeTests
 				return;
 			}
 			try {
-				AssertXmlDeclaration ("Collection.class", "ParameterFixupFromDocs.xml", Path.Combine (Environment.GetEnvironmentVariable ("ANDROID_SDK_PATH"), "docs", "reference"));
+				AssertXmlDeclaration ("TypeEvaluator.class", "ParameterFixupFromDocs.xml", Path.Combine (Environment.GetEnvironmentVariable ("ANDROID_SDK_PATH"), "docs", "reference"));
 			} catch (Exception ex) {
 				Assert.Fail ("An unexpected exception was thrown : {0}", ex);
 			}
@@ -38,7 +38,7 @@ namespace Xamarin.Android.Tools.BytecodeTests
 			try {
 				tempFile = LoadToTempFile ("ParameterFixupApiXmlDocs.xml");
 
-				AssertXmlDeclaration ("Collection.class", "ParameterFixupFromDocs.xml", tempFile);
+				AssertXmlDeclaration ("TypeEvaluator.class", "ParameterFixupFromDocs.xml", tempFile);
 			} finally {
 				if (File.Exists (tempFile))
 					File.Delete (tempFile);
@@ -111,7 +111,7 @@ namespace Xamarin.Android.Tools.BytecodeTests
 			try {
 				tempFile = LoadToTempFile ("ParameterDescription.txt");
 
-				AssertXmlDeclaration (new string [] { "Collection.class" }, "ParameterFixupFromDocs.xml", tempFile);
+				AssertXmlDeclaration (new string [] { "TypeEvaluator.class" }, "ParameterFixupFromDocs.xml", tempFile);
 			}
 			finally {
 				if (File.Exists (tempFile))

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/Resources/ParameterDescription.txt
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/Resources/ParameterDescription.txt
@@ -1,9 +1,8 @@
 ﻿
 ; This is a comment line.
-package java.util ; Anything after semicolon is comment.
-  class Collection<E>
-    add(E e)
-    #ctor()
+package android.animation ; Anything after semicolon is comment.
+  class TypeEvaluator<T>
+    evaluate(float fraction, T startValue, T endValue)
 
 package com.xamarin
   interface NestedInterface.DnsSdTxtRecordListener

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/Resources/ParameterFixupApiXmlDocs.xml
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/Resources/ParameterFixupApiXmlDocs.xml
@@ -1,10 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <api>
-	<package name="java.util">
-		<class name="Collection">
-			<method name="add">
-				<parameter name="e" type="E" />
-			</method>
-		</class>
-	</package>
+  <package name="android.animation">
+    <class name="TypeEvaluator">
+      <method name="evaluate">
+        <parameter name="fraction"    type="float" />
+        <parameter name="startValue"  type="T" />
+        <parameter name="endValue"    type="T" />
+      </method>
+    </class>
+  </package>
 </api>

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/Resources/ParameterFixupFromDocs.xml
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/Resources/ParameterFixupFromDocs.xml
@@ -1,47 +1,51 @@
 <api
   api-source="class-parse">
   <package
-    name="java.util"
-    jni-name="java/util">
+    name="android.animation"
+    jni-name="android/animation">
     <interface
       abstract="true"
       deprecated="not deprecated"
       final="false"
-      name="Collection"
-      jni-signature="Ljava/util/Collection;"
-      source-file-name="Collection.java"
+      name="TypeEvaluator"
+      jni-signature="Landroid/animation/TypeEvaluator;"
+      source-file-name="TypeEvaluator.java"
       static="false"
       visibility="public">
       <typeParameters>
         <typeParameter
-          name="E"
+          name="T"
           jni-classBound="Ljava/lang/Object;"
           classBound="java.lang.Object"
           interfaceBounds=""
           jni-interfaceBounds="" />
       </typeParameters>
-      <implements
-        name="java.lang.Iterable"
-        name-generic-aware="java.lang.Iterable&lt;E&gt;"
-        jni-type="Ljava/lang/Iterable&lt;TE;&gt;;" />
       <method
         abstract="true"
         deprecated="not deprecated"
         final="false"
-        name="add"
+        name="evaluate"
         native="false"
-        return="boolean"
-        jni-return="Z"
+        return="T"
+        jni-return="TT;"
         static="false"
         synchronized="false"
         visibility="public"
         bridge="false"
         synthetic="false"
-        jni-signature="(Ljava/lang/Object;)Z">
+        jni-signature="(FLjava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;">
         <parameter
-          name="e"
-          type="E"
-          jni-type="TE;" />
+          name="fraction"
+          type="float"
+          jni-type="F" />
+        <parameter
+          name="startValue"
+          type="T"
+          jni-type="TT;" />
+        <parameter
+          name="endValue"
+          type="T"
+          jni-type="TT;" />
       </method>
     </interface>
   </package>

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj
@@ -46,7 +46,7 @@
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\xamarin\ParameterAbstractClass.class" />
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\xamarin\ParameterClass.class" />
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\xamarin\ParameterClass2.class" />
-    <EmbeddedResource Include="$(IntermediateOutputPath)classes\java\util\Collection.class" />
+    <EmbeddedResource Include="$(IntermediateOutputPath)classes\android\animation\TypeEvaluator.class" />
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\module-info.class" />
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\NonGenericGlobalType.class" />
   </ItemGroup>

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.targets
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.targets
@@ -1,27 +1,24 @@
 <Project>
 
   <ItemGroup>
-    <TestJarNoParameters Include="java/**/Collection.java" />
+    <TestJarNoParameters Include="java/**/TypeEvaluator.java" />
     <TestJarNoParameters Include="java/**/*NoParameters.java" />
-    <TestJarJdk11 Include="java\**\module-info.java" />
-    <TestJar Include="java\**\*.java" Exclude="@(TestJarNoParameters);@(TestJarJdk11);java\android\annotation\NonNull.java;" />
+    <TestJar Include="java\**\*.java" Exclude="@(TestJarNoParameters);java\android\annotation\NonNull.java;" />
     <TestKotlinJar Include="kotlin\**\*.kt" />
   </ItemGroup>
 
   <ItemGroup>
     <_BuildClassOutputs Include="@(TestJar->'$(IntermediateOutputPath)classes\%(RecursiveDir)%(Filename).class')" />
-    <_BuildClassOutputs Include="@(TestJarJdk11->'$(IntermediateOutputPath)classes\%(RecursiveDir)%(Filename).class')" />
     <_BuildClassOutputs Include="@(TestJarNoParameters->'$(IntermediateOutputPath)classes\%(RecursiveDir)%(Filename).class')" />
   </ItemGroup>
 
   <Target Name="BuildClasses"
         BeforeTargets="BeforeCompile"
-        Inputs="@(TestJar);@(TestJarNoParameters);@(TestJarJdk11)"
+        Inputs="@(TestJar);@(TestJarNoParameters)"
         Outputs="@(_BuildClassOutputs)">
     <MakeDir Directories="$(IntermediateOutputPath)classes" />
     <Exec Command="&quot;$(JavaCPath)&quot; -parameters $(_JavacSourceOptions) -g -d &quot;$(IntermediateOutputPath)classes&quot; java/android/annotation/NonNull.java @(TestJar->'%(Identity)', ' ')" />
     <Exec Command="&quot;$(JavaCPath)&quot; $(_JavacSourceOptions) -g -d &quot;$(IntermediateOutputPath)classes&quot; @(TestJarNoParameters->'%(Identity)', ' ')" />
-    <Exec Command="&quot;$(JavaC11Path)&quot; -source 11 -target 11 -g -d &quot;$(IntermediateOutputPath)classes&quot; @(TestJarJdk11->'%(Identity)', ' ')" />
   </Target>
 
   <!-- 
@@ -41,7 +38,7 @@
       AfterTargets="BuildClasses"
       Inputs="@(_BuildClassOutputs)"
       Outputs="$(IntermediateOutputPath)xatb.jar">
-    <Exec Command="&quot;$(Jar11Path)&quot; cf &quot;$(IntermediateOutputPath)xatb.jar&quot; -C &quot;$(IntermediateOutputPath)classes&quot; ." />
+    <Exec Command="&quot;$(JarPath)&quot; cf &quot;$(IntermediateOutputPath)xatb.jar&quot; -C &quot;$(IntermediateOutputPath)classes&quot; ." />
   </Target>
 
 </Project>

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/java/android/animation/TypeEvaluator.java
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/java/android/animation/TypeEvaluator.java
@@ -1,0 +1,5 @@
+package android.animation;
+
+public interface TypeEvaluator<T> {
+	T evaluate(float fraction, T startValue, T endValue);
+}

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/java/java/util/Collection.java
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/java/java/util/Collection.java
@@ -1,5 +1,0 @@
-package java.util;
-
-public interface Collection<E> extends Iterable<E> {
-	boolean add(E e);
-}

--- a/tools/class-parse/Program.cs
+++ b/tools/class-parse/Program.cs
@@ -83,10 +83,11 @@ namespace Xamarin.Android.Tools {
 					}
 					using (var s = File.OpenRead (file)) {
 						if (!ClassFile.IsClassFile (s)) {
-							Console.Error.WriteLine ("class-parse: Unable to read file '{0}': Unknown file format.");
+							Console.Error.WriteLine ($"class-parse: Unable to read file '{file}': Unknown file format.");
 							Environment.ExitCode    = 1;
 							continue;
 						}
+						s.Position  = 0;
 						globalClassPath.Add (new ClassFile (s));
 					}
 				} catch (Exception e) {

--- a/tools/java-source-utils/build.gradle
+++ b/tools/java-source-utils/build.gradle
@@ -52,11 +52,12 @@ jar {
     } {
         exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA'
     }
-    archiveName 'java-source-utils.jar'
+    archiveFileName.set('java-source-utils.jar')
 }
 
 test {
     reports {
-        junitXml.enabled = true
+        junitXml {
+        }
     }
 }

--- a/tools/java-source-utils/src/test/java/com/microsoft/android/JavadocXmlGeneratorTest.java
+++ b/tools/java-source-utils/src/test/java/com/microsoft/android/JavadocXmlGeneratorTest.java
@@ -58,58 +58,10 @@ public final class JavadocXmlGeneratorTest {
 
 
 	@Test
-	public void testWritePackages_demo() throws ParserConfigurationException, TransformerException {
-		final   ByteArrayOutputStream   bytes       = new ByteArrayOutputStream();
-		final   JavadocXmlGenerator     generator   = new JavadocXmlGenerator(new PrintStream(bytes));
+	public void testWritePackages_demo() throws Throwable {
 		final   JniPackagesInfo         packages    = JniPackagesInfoTest.createDemoInfo();
 
-		final   String                  expected    = (
-			"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-			"<api api-source=\"java-source-utils\">\n" +
-			"  <package jni-name=\"\" name=\"\">\n" +
-			"    <class jni-signature=\"LA;\" name=\"A\">\n" +
-			"      <javadoc><![CDATA[jni-sig=LA;]]></javadoc>\n" +
-			"      <constructor jni-signature=\"(ILjava/lang/String;)V\">\n" +
-			"        <parameter jni-type=\"I\" name=\"one\" type=\"int\"/>\n" +
-			"        <parameter jni-type=\"Ljava/lang/String;\" name=\"two\" type=\"java.lang.String\"/>\n" +
-			"        <javadoc><![CDATA[jni-sig=<init>.(ILjava/lang/String;)V]]></javadoc>\n" +
-			"      </constructor>\n" +
-			"      <field jni-signature=\"I\" name=\"field\">\n" +
-			"        <javadoc><![CDATA[jni-sig=field.I]]></javadoc>\n" +
-			"      </field>\n" +
-			"      <method jni-return=\"V\" jni-signature=\"(Ljava/lang/Object;J)V\" name=\"m\" return=\"void\">\n" +
-			"        <parameter jni-type=\"Ljava/lang/Object;\" name=\"value\" type=\"T\"/>\n" +
-			"        <parameter jni-type=\"J\" name=\"x\" type=\"long\"/>\n" +
-			"        <javadoc><![CDATA[jni-sig=m.(Ljava/lang/Object;J)V]]></javadoc>\n" +
-			"      </method>\n" +
-			"    </class>\n" +
-			"    <interface jni-signature=\"LI;\" name=\"I\">\n" +
-			"      <javadoc><![CDATA[jni-sig=LI;]]></javadoc>\n" +
-			"      <method jni-return=\"Ljava/lang/Object;\" jni-signature=\"(Ljava/util/List;)Ljava/lang/Object;\" name=\"m\" return=\"T\">\n" +
-			"        <parameter jni-type=\"Ljava/util/List;\" name=\"x\" type=\"java.util.List&lt;T&gt;\"/>\n" +
-			"        <javadoc><![CDATA[jni-sig=m.(Ljava/util/List;)Ljava/lang/Object;]]></javadoc>\n" +
-			"      </method>\n" +
-			"    </interface>\n" +
-			"  </package>\n" +
-			"  <package jni-name=\"before/example\" name=\"before.example\"/>\n" +
-			"  <package jni-name=\"example\" name=\"example\">\n" +
-			"    <interface jni-signature=\"Lexample/Exampleable;\" name=\"Exampleable\">\n" +
-			"      <javadoc><![CDATA[jni-sig=Lexample/Exampleable;]]></javadoc>\n" +
-			"      <method jni-return=\"V\" jni-signature=\"(Ljava/lang/String;)V\" name=\"example\" return=\"void\">\n" +
-			"        <parameter jni-type=\"Ljava/lang/String;\" name=\"e\" type=\"java.lang.String\"/>\n" +
-			"        <javadoc><![CDATA[jni-sig=example.(Ljava/lang/String;)V]]></javadoc>\n" +
-			"      </method>\n" +
-			"      <method jni-return=\"V\" jni-signature=\"()V\" name=\"noParameters\" return=\"void\">\n" +
-			"        <javadoc><![CDATA[jni-sig=noParameters.()V]]></javadoc>\n" +
-			"      </method>\n" +
-			"    </interface>\n" +
-			"  </package>\n" +
-			"</api>\n"
-		).replace("\n", System.lineSeparator());
-
-		generator.writePackages(packages);
-		generator.close();
-		assertEquals("global package + example packages", expected, bytes.toString());
+		testWritePackages (packages, "global package + example packages", "DemoInfo.xml");
 	}
 
 	@Test
@@ -133,16 +85,23 @@ public final class JavadocXmlGeneratorTest {
 		final   File                    demoSource      = new File(JniPackagesInfoFactoryTest.class.getResource(resourceJava).toURI());
 		final   JniPackagesInfo         packagesInfo    = factory.parse(Arrays.asList(new File[]{demoSource}));
 
+		int                             lastSlash       = resourceJava.lastIndexOf('/');
+		final   String                  assertDesc      = resourceJava.substring(lastSlash+1) + " Javadoc XML";
+
+		testWritePackages(packagesInfo, assertDesc, resourceXml);
+	}
+
+	private static void testWritePackages(final JniPackagesInfo packagesInfo, final String assertDescription, final String expectedResourceXml) throws Throwable {
 		final   ByteArrayOutputStream   bytes           = new ByteArrayOutputStream();
 		final   JavadocXmlGenerator     generator       = new JavadocXmlGenerator(new PrintStream(bytes));
 
-		final   String                  expected        = JniPackagesInfoTest.getResourceContents(resourceXml);
+		final   String                  expected        = JniPackagesInfoTest.getResourceContents(expectedResourceXml);
 
 		generator.writePackages(packagesInfo);
 		generator.close();
-		// try (FileOutputStream o = new FileOutputStream(resourceXml + "-jonp.xml")) {
+		// try (FileOutputStream o = new FileOutputStream(assertDescription + "-jonp.xml")) {
 		// 	bytes.writeTo(o);
 		// }
-		assertEquals(resourceJava + " Javadoc XML", expected, bytes.toString());
+		assertEquals(assertDescription, expected, bytes.toString());
 	}
 }

--- a/tools/java-source-utils/src/test/resources/UnresolvedTypes.xml
+++ b/tools/java-source-utils/src/test/resources/UnresolvedTypes.xml
@@ -4,9 +4,11 @@
     <class jni-signature="Lexample/UnresolvedTypes;" name="UnresolvedTypes">
       <method jni-return="L.*UnresolvedReturnType;" jni-signature="([L.*example.name.UnresolvedParameterType;)L.*UnresolvedReturnType;" name="method" return=".*UnresolvedReturnType">
         <parameter jni-type="[L.*example.name.UnresolvedParameterType;" name="parameter" type=".*example.name.UnresolvedParameterType..."/>
-        <javadoc><![CDATA[Method using unresolvable types.  As such, we make do.
+        <javadoc>
+          <![CDATA[Method using unresolvable types.  As such, we make do.
 
-JNI Sig: method.([L.*example.name.UnresolvedParameterType;)L.*UnresolvedReturnType;]]></javadoc>
+JNI Sig: method.([L.*example.name.UnresolvedParameterType;)L.*UnresolvedReturnType;]]>
+        </javadoc>
       </method>
     </class>
   </package>

--- a/tools/java-source-utils/src/test/resources/com/microsoft/android/DemoInfo.xml
+++ b/tools/java-source-utils/src/test/resources/com/microsoft/android/DemoInfo.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<api api-source="java-source-utils">
+  <package jni-name="" name="">
+    <class jni-signature="LA;" name="A">
+      <javadoc>
+        <![CDATA[jni-sig=LA;]]>
+      </javadoc>
+      <constructor jni-signature="(ILjava/lang/String;)V">
+        <parameter jni-type="I" name="one" type="int"/>
+        <parameter jni-type="Ljava/lang/String;" name="two" type="java.lang.String"/>
+        <javadoc>
+          <![CDATA[jni-sig=<init>.(ILjava/lang/String;)V]]>
+        </javadoc>
+      </constructor>
+      <field jni-signature="I" name="field">
+        <javadoc>
+          <![CDATA[jni-sig=field.I]]>
+        </javadoc>
+      </field>
+      <method jni-return="V" jni-signature="(Ljava/lang/Object;J)V" name="m" return="void">
+        <parameter jni-type="Ljava/lang/Object;" name="value" type="T"/>
+        <parameter jni-type="J" name="x" type="long"/>
+        <javadoc>
+          <![CDATA[jni-sig=m.(Ljava/lang/Object;J)V]]>
+        </javadoc>
+      </method>
+    </class>
+    <interface jni-signature="LI;" name="I">
+      <javadoc>
+        <![CDATA[jni-sig=LI;]]>
+      </javadoc>
+      <method jni-return="Ljava/lang/Object;" jni-signature="(Ljava/util/List;)Ljava/lang/Object;" name="m" return="T">
+        <parameter jni-type="Ljava/util/List;" name="x" type="java.util.List&lt;T&gt;"/>
+        <javadoc>
+          <![CDATA[jni-sig=m.(Ljava/util/List;)Ljava/lang/Object;]]>
+        </javadoc>
+      </method>
+    </interface>
+  </package>
+  <package jni-name="before/example" name="before.example"/>
+  <package jni-name="example" name="example">
+    <interface jni-signature="Lexample/Exampleable;" name="Exampleable">
+      <javadoc>
+        <![CDATA[jni-sig=Lexample/Exampleable;]]>
+      </javadoc>
+      <method jni-return="V" jni-signature="(Ljava/lang/String;)V" name="example" return="void">
+        <parameter jni-type="Ljava/lang/String;" name="e" type="java.lang.String"/>
+        <javadoc>
+          <![CDATA[jni-sig=example.(Ljava/lang/String;)V]]>
+        </javadoc>
+      </method>
+      <method jni-return="V" jni-signature="()V" name="noParameters" return="void">
+        <javadoc>
+          <![CDATA[jni-sig=noParameters.()V]]>
+        </javadoc>
+      </method>
+    </interface>
+  </package>
+</api>

--- a/tools/java-source-utils/src/test/resources/com/microsoft/android/JavaType.xml
+++ b/tools/java-source-utils/src/test/resources/com/microsoft/android/JavaType.xml
@@ -2,122 +2,192 @@
 <api api-source="java-source-utils">
   <package jni-name="com/xamarin" name="com.xamarin">
     <class jni-signature="Lcom/xamarin/JavaEnum;" name="JavaEnum">
-      <javadoc><![CDATA[JNI sig: Lcom/xamarin/JavaEnum;]]></javadoc>
+      <javadoc>
+        <![CDATA[JNI sig: Lcom/xamarin/JavaEnum;]]>
+      </javadoc>
       <method jni-return="I" jni-signature="()I" name="switchValue" return="int">
-        <javadoc><![CDATA[summary
+        <javadoc>
+          <![CDATA[summary
 
 <p>Paragraphs of text?
 
-@return some value]]></javadoc>
+@return some value]]>
+        </javadoc>
       </method>
     </class>
     <class jni-signature="Lcom/xamarin/JavaType;" name="JavaType">
-      <javadoc><![CDATA[JNI sig: Lcom/xamarin/JavaType;
+      <javadoc>
+        <![CDATA[JNI sig: Lcom/xamarin/JavaType;
 
-@param <E>]]></javadoc>
+@param <E>]]>
+      </javadoc>
       <constructor jni-signature="()V">
-        <javadoc><![CDATA[JNI sig: ()V]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: ()V]]>
+        </javadoc>
       </constructor>
       <constructor jni-signature="(Ljava/lang/String;)V">
         <parameter jni-type="Ljava/lang/String;" name="value" type="java.lang.String"/>
-        <javadoc><![CDATA[JNI sig: (Ljava/lang/String;)V]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: (Ljava/lang/String;)V]]>
+        </javadoc>
       </constructor>
       <field jni-signature="Ljava/lang/Object;" name="INSTANCE_FINAL_E">
-        <javadoc><![CDATA[JNI sig: INSTANCE_FINAL_E.Ljava/lang/Object;]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: INSTANCE_FINAL_E.Ljava/lang/Object;]]>
+        </javadoc>
       </field>
       <field jni-signature="Ljava/lang/Object;" name="INSTANCE_FINAL_OBJECT">
-        <javadoc><![CDATA[JNI sig: INSTANCE_FINAL_OBJECT.Ljava/lang/Object;]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: INSTANCE_FINAL_OBJECT.Ljava/lang/Object;]]>
+        </javadoc>
       </field>
       <field jni-signature="D" name="NEGATIVE_INFINITY">
-        <javadoc><![CDATA[JNI sig: NEGATIVE_INFINITY.D]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: NEGATIVE_INFINITY.D]]>
+        </javadoc>
       </field>
       <field jni-signature="D" name="NaN">
-        <javadoc><![CDATA[JNI sig: NaN.D]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: NaN.D]]>
+        </javadoc>
       </field>
       <field jni-signature="D" name="POSITIVE_INFINITY">
-        <javadoc><![CDATA[JNI sig: POSITIVE_INFINITY.D]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: POSITIVE_INFINITY.D]]>
+        </javadoc>
       </field>
       <field jni-signature="Z" name="STATIC_FINAL_BOOL_FALSE">
-        <javadoc><![CDATA[JNI sig: STATIC_FINAL_BOOL_FALSE.Z]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: STATIC_FINAL_BOOL_FALSE.Z]]>
+        </javadoc>
       </field>
       <field jni-signature="Z" name="STATIC_FINAL_BOOL_TRUE">
-        <javadoc><![CDATA[JNI sig: STATIC_FINAL_BOOL_TRUE.Z]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: STATIC_FINAL_BOOL_TRUE.Z]]>
+        </javadoc>
       </field>
       <field jni-signature="C" name="STATIC_FINAL_CHAR_MAX">
-        <javadoc><![CDATA[JNI sig: STATIC_FINAL_CHAR_MAX.C]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: STATIC_FINAL_CHAR_MAX.C]]>
+        </javadoc>
       </field>
       <field jni-signature="C" name="STATIC_FINAL_CHAR_MIN">
-        <javadoc><![CDATA[JNI sig: STATIC_FINAL_CHAR_MIN.C]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: STATIC_FINAL_CHAR_MIN.C]]>
+        </javadoc>
       </field>
       <field jni-signature="D" name="STATIC_FINAL_DOUBLE_MAX">
-        <javadoc><![CDATA[JNI sig: STATIC_FINAL_DOUBLE_MAX.D]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: STATIC_FINAL_DOUBLE_MAX.D]]>
+        </javadoc>
       </field>
       <field jni-signature="D" name="STATIC_FINAL_DOUBLE_MIN">
-        <javadoc><![CDATA[JNI sig: STATIC_FINAL_DOUBLE_MIN.D]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: STATIC_FINAL_DOUBLE_MIN.D]]>
+        </javadoc>
       </field>
       <field jni-signature="I" name="STATIC_FINAL_INT32">
-        <javadoc><![CDATA[JNI sig: STATIC_FINAL_INT32.I]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: STATIC_FINAL_INT32.I]]>
+        </javadoc>
       </field>
       <field jni-signature="I" name="STATIC_FINAL_INT32_MAX">
-        <javadoc><![CDATA[JNI sig: STATIC_FINAL_INT32_MAX.I]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: STATIC_FINAL_INT32_MAX.I]]>
+        </javadoc>
       </field>
       <field jni-signature="I" name="STATIC_FINAL_INT32_MIN">
-        <javadoc><![CDATA[JNI sig: STATIC_FINAL_INT32_MIN.I]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: STATIC_FINAL_INT32_MIN.I]]>
+        </javadoc>
       </field>
       <field jni-signature="J" name="STATIC_FINAL_INT64_MAX">
-        <javadoc><![CDATA[JNI sig: STATIC_FINAL_INT64_MAX.J]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: STATIC_FINAL_INT64_MAX.J]]>
+        </javadoc>
       </field>
       <field jni-signature="J" name="STATIC_FINAL_INT64_MIN">
-        <javadoc><![CDATA[JNI sig: STATIC_FINAL_INT64_MIN.J]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: STATIC_FINAL_INT64_MIN.J]]>
+        </javadoc>
       </field>
       <field jni-signature="Ljava/lang/Object;" name="STATIC_FINAL_OBJECT">
-        <javadoc><![CDATA[JNI sig: STATIC_FINAL_OBJECT.L/java/lang/Object;]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: STATIC_FINAL_OBJECT.L/java/lang/Object;]]>
+        </javadoc>
       </field>
       <field jni-signature="F" name="STATIC_FINAL_SINGLE_MAX">
-        <javadoc><![CDATA[JNI sig: STATIC_FINAL_SINGLE_MAX.F]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: STATIC_FINAL_SINGLE_MAX.F]]>
+        </javadoc>
       </field>
       <field jni-signature="F" name="STATIC_FINAL_SINGLE_MIN">
-        <javadoc><![CDATA[JNI sig: STATIC_FINAL_SINGLE_MIN.F]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: STATIC_FINAL_SINGLE_MIN.F]]>
+        </javadoc>
       </field>
       <field jni-signature="Ljava/lang/String;" name="STATIC_FINAL_STRING">
-        <javadoc><![CDATA[JNI sig: STATIC_FINAL_STRING.Ljava/lang/String;]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: STATIC_FINAL_STRING.Ljava/lang/String;]]>
+        </javadoc>
       </field>
       <method jni-return="V" jni-signature="(Ljava/lang/Object;)V" name="action" return="void">
         <parameter jni-type="Ljava/lang/Object;" name="value" type="java.lang.Object"/>
-        <javadoc><![CDATA[JNI sig: action.(Ljava/lang/Object;)V]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: action.(Ljava/lang/Object;)V]]>
+        </javadoc>
       </method>
       <method jni-return="I" jni-signature="(Lcom/xamarin/JavaType;)I" name="compareTo" return="int">
         <parameter jni-type="Lcom/xamarin/JavaType;" name="value" type="com.xamarin.JavaType&lt;E&gt;"/>
-        <javadoc><![CDATA[JNI sig: compareTo.(Lcom/xamarin/JavaType;)I]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: compareTo.(Lcom/xamarin/JavaType;)I]]>
+        </javadoc>
       </method>
       <method jni-return="V" jni-signature="()V" name="finalize" return="void">
-        <javadoc><![CDATA[JNI sig: finalize.()V]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: finalize.()V]]>
+        </javadoc>
       </method>
       <method jni-return="I" jni-signature="(I)I" name="finalize" return="int">
         <parameter jni-type="I" name="value" type="int"/>
-        <javadoc><![CDATA[JNI sig: finalize.(I)I]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: finalize.(I)I]]>
+        </javadoc>
       </method>
       <method jni-return="Ljava/util/List;" jni-signature="(Ljava/lang/StringBuilder;)Ljava/util/List;" name="func" return="java.util.List&lt;java.lang.String&gt;">
         <parameter jni-type="Ljava/lang/StringBuilder;" name="value" type="java.lang.StringBuilder"/>
-        <javadoc><![CDATA[JNI sig: func.(Ljava/lang/StringBuilder;)Ljava/util/List;]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: func.(Ljava/lang/StringBuilder;)Ljava/util/List;]]>
+        </javadoc>
       </method>
       <method jni-return="Ljava/lang/Integer;" jni-signature="([Ljava/lang/String;)Ljava/lang/Integer;" name="func" return="java.lang.Integer">
         <parameter jni-type="[Ljava/lang/String;" name="values" type="java.lang.String[]"/>
-        <javadoc><![CDATA[JNI sig: func.([Ljava/lang/String;)Ljava/lang/Integer;]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: func.([Ljava/lang/String;)Ljava/lang/Integer;]]>
+        </javadoc>
       </method>
       <method jni-return="V" jni-signature="(Ljava/lang/Object;Ljava/lang/Object;)V" name="instanceActionWithGenerics" return="void">
         <parameter jni-type="Ljava/lang/Object;" name="value1" type="T"/>
         <parameter jni-type="Ljava/lang/Object;" name="value2" type="E"/>
-        <javadoc><![CDATA[JNI sig: instanceActionWithGenerics.(Ljava/lang/Object;java/lang/Object;)V]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: instanceActionWithGenerics.(Ljava/lang/Object;java/lang/Object;)V]]>
+        </javadoc>
       </method>
       <field jni-signature="[Ljava/lang/Object;" name="packageInstanceEArray">
-        <javadoc><![CDATA[JNI sig: packageInstanceEArray.[Ljava/lang/Object;]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: packageInstanceEArray.[Ljava/lang/Object;]]>
+        </javadoc>
       </field>
       <field jni-signature="Ljava/util/List;" name="protectedInstanceEList">
-        <javadoc><![CDATA[JNI sig: protectedInstanceEList.Ljava/util/List;]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: protectedInstanceEList.Ljava/util/List;]]>
+        </javadoc>
       </field>
       <method jni-return="V" jni-signature="()V" name="run" return="void">
-        <javadoc><![CDATA[JNI sig: run.()V]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: run.()V]]>
+        </javadoc>
       </method>
       <method jni-return="V" jni-signature="(Ljava/lang/Object;Ljava/lang/Number;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V" name="staticActionWithGenerics" return="void">
         <parameter jni-type="Ljava/lang/Object;" name="value1" type="T"/>
@@ -125,49 +195,73 @@
         <parameter jni-type="Ljava/util/List;" name="unboundedList" type="java.util.List&lt;?&gt;"/>
         <parameter jni-type="Ljava/util/List;" name="extendsList" type="java.util.List&lt;? extends java.lang.Number&gt;"/>
         <parameter jni-type="Ljava/util/List;" name="superList" type="java.util.List&lt;? super java.lang.Throwable&gt;"/>
-        <javadoc><![CDATA[JNI sig: staticActionWithGenerics.(Ljava/lang/Object;Ljava/lang/Number;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: staticActionWithGenerics.(Ljava/lang/Object;Ljava/lang/Number;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V]]>
+        </javadoc>
       </method>
       <method jni-return="I" jni-signature="(I[I)I" name="sum" return="int">
         <parameter jni-type="I" name="first" type="int"/>
         <parameter jni-type="[I" name="remaining" type="int..."/>
-        <javadoc><![CDATA[JNI sig: sum.(I[I)I]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: sum.(I[I)I]]>
+        </javadoc>
       </method>
     </class>
     <class jni-signature="Lcom/xamarin/JavaType$ASC;" name="JavaType.ASC">
-      <javadoc><![CDATA[JNI sig: Lcom/xamarin/JavaType$ASC;]]></javadoc>
+      <javadoc>
+        <![CDATA[JNI sig: Lcom/xamarin/JavaType$ASC;]]>
+      </javadoc>
     </class>
     <class jni-signature="Lcom/xamarin/JavaType$PSC;" name="JavaType.PSC">
-      <javadoc><![CDATA[JNI sig: Lcom/xamarin/JavaType$PSC;]]></javadoc>
+      <javadoc>
+        <![CDATA[JNI sig: Lcom/xamarin/JavaType$PSC;]]>
+      </javadoc>
     </class>
     <class jni-signature="Lcom/xamarin/JavaType$RNC;" name="JavaType.RNC">
-      <javadoc><![CDATA[JNI sig: Lcom/xamarin/JavaType$RNC;]]></javadoc>
+      <javadoc>
+        <![CDATA[JNI sig: Lcom/xamarin/JavaType$RNC;]]>
+      </javadoc>
       <constructor jni-signature="()V">
-        <javadoc><![CDATA[JNI sig: ()V]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: ()V]]>
+        </javadoc>
       </constructor>
       <constructor jni-signature="(Ljava/lang/Object;Ljava/lang/Object;)V">
         <parameter jni-type="Ljava/lang/Object;" name="value1" type="E"/>
         <parameter jni-type="Ljava/lang/Object;" name="value2" type="E2"/>
-        <javadoc><![CDATA[JNI sig: (Ljava/lang/Object;Ljava/lang/Object;)V]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: (Ljava/lang/Object;Ljava/lang/Object;)V]]>
+        </javadoc>
       </constructor>
       <method jni-return="Ljava/lang/Object;" jni-signature="(Ljava/lang/Object;)Ljava/lang/Object;" name="fromE" return="E2">
         <parameter jni-type="Ljava/lang/Object;" name="value" type="E"/>
-        <javadoc><![CDATA[JNI sig: (Ljava/lang/Object;)Ljava/lang/Object;]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: (Ljava/lang/Object;)Ljava/lang/Object;]]>
+        </javadoc>
       </method>
     </class>
     <class jni-signature="Lcom/xamarin/JavaType$RNC$RPNC;" name="JavaType.RNC.RPNC">
-      <javadoc><![CDATA[JNI sig: Lcom/xamarin/JavaType$RNC$RPNC;]]></javadoc>
+      <javadoc>
+        <![CDATA[JNI sig: Lcom/xamarin/JavaType$RNC$RPNC;]]>
+      </javadoc>
       <constructor jni-signature="()V">
-        <javadoc><![CDATA[JNI sig: ()V]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: ()V]]>
+        </javadoc>
       </constructor>
       <constructor jni-signature="(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V">
         <parameter jni-type="Ljava/lang/Object;" name="value1" type="E"/>
         <parameter jni-type="Ljava/lang/Object;" name="value2" type="E2"/>
         <parameter jni-type="Ljava/lang/Object;" name="value3" type="E3"/>
-        <javadoc><![CDATA[JNI sig: (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V]]>
+        </javadoc>
       </constructor>
       <method jni-return="Ljava/lang/Object;" jni-signature="(Ljava/lang/Object;)Ljava/lang/Object;" name="fromE2" return="E3">
         <parameter jni-type="Ljava/lang/Object;" name="value" type="E2"/>
-        <javadoc><![CDATA[JNI sig: fromE2.(Ljava/lang/Object;)Ljava/lang/Object;]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: fromE2.(Ljava/lang/Object;)Ljava/lang/Object;]]>
+        </javadoc>
       </method>
     </class>
   </package>

--- a/tools/java-source-utils/src/test/resources/com/microsoft/android/Outer.xml
+++ b/tools/java-source-utils/src/test/resources/com/microsoft/android/Outer.xml
@@ -2,77 +2,103 @@
 <api api-source="java-source-utils">
   <package jni-name="example" name="example">
     <class jni-signature="Lexample/Outer;" name="Outer">
-      <javadoc><![CDATA[Yay, Javadoc!
+      <javadoc>
+        <![CDATA[Yay, Javadoc!
 
-JNI sig: Lexample/Outer;]]></javadoc>
+JNI sig: Lexample/Outer;]]>
+      </javadoc>
       <constructor jni-signature="(Ljava/lang/Object;)V">
         <parameter jni-type="Ljava/lang/Object;" name="value" type="T"/>
-        <javadoc><![CDATA[<init>(java.lang.Object value)
+        <javadoc>
+          <![CDATA[<init>(java.lang.Object value)
 
-JNI sig: (Ljava/lang/Object;)V]]></javadoc>
+JNI sig: (Ljava/lang/Object;)V]]>
+        </javadoc>
       </constructor>
       <method jni-return="Ljava/lang/Error;" jni-signature="(Ljava/util/List;)Ljava/lang/Error;" name="isU" return="U">
         <parameter jni-type="Ljava/util/List;" name="list" type="java.util.List&lt;? super U&gt;"/>
-        <javadoc><![CDATA[isU(java.util.List<? super U> list)
+        <javadoc>
+          <![CDATA[isU(java.util.List<? super U> list)
 
 <p>This is a paragraph.  Yay?</p>
 
 JNI sig: (Ljava/util/List;)Ljava/lang/Error;
 
 @param list just some random items
-@return some value]]></javadoc>
+@return some value]]>
+        </javadoc>
       </method>
       <method jni-return="V" jni-signature="([Ljava/lang/String;)V" name="main" return="void">
         <parameter jni-type="[Ljava/lang/String;" name="args" type="java.lang.String[]"/>
-        <javadoc><![CDATA[main(java.lang.String[] args)
+        <javadoc>
+          <![CDATA[main(java.lang.String[] args)
 
-JNI sig: ([Ljava/lang/String;)V]]></javadoc>
+JNI sig: ([Ljava/lang/String;)V]]>
+        </javadoc>
       </method>
       <method jni-return="Ljava/lang/Appendable;" jni-signature="(Ljava/lang/CharSequence;[S[Ljava/lang/Appendable;)Ljava/lang/Appendable;" name="method" return="T">
         <parameter jni-type="Ljava/lang/CharSequence;" name="a" type="java.lang.CharSequence"/>
         <parameter jni-type="[S" name="b" type="short[]"/>
         <parameter jni-type="[Ljava/lang/Appendable;" name="values" type="T[]"/>
-        <javadoc><![CDATA[method(java.lang.CharSequence a, short[] b, T[] values)
+        <javadoc>
+          <![CDATA[method(java.lang.CharSequence a, short[] b, T[] values)
 
-JNI sig: (Ljava/lang/CharSequence;[S[Ljava/lang/Appendable;)Ljava/lang/Appendable;]]></javadoc>
+JNI sig: (Ljava/lang/CharSequence;[S[Ljava/lang/Appendable;)Ljava/lang/Appendable;]]>
+        </javadoc>
       </method>
     </class>
     <interface jni-signature="Lexample/Outer$Inner;" name="Outer.Inner">
-      <javadoc><![CDATA[JNI sig: Lexample/Outer$Inner;]]></javadoc>
+      <javadoc>
+        <![CDATA[JNI sig: Lexample/Outer$Inner;]]>
+      </javadoc>
       <field jni-signature="J" name="COUNT">
-        <javadoc><![CDATA[JNI sig: J]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: J]]>
+        </javadoc>
       </field>
       <method jni-return="V" jni-signature="([[Ljava/lang/Readable;)V" name="m" return="void">
         <parameter jni-type="[[Ljava/lang/Readable;" name="values" type="V[][]"/>
-        <javadoc><![CDATA[m(U value)
+        <javadoc>
+          <![CDATA[m(U value)
 
 JNI sig: ([[Ljava/lang/Readable;)V
 
-@throws Throwable never, just because]]></javadoc>
+@throws Throwable never, just because]]>
+        </javadoc>
       </method>
     </interface>
     <class jni-signature="Lexample/Outer$Inner$NestedInner;" name="Outer.Inner.NestedInner">
-      <javadoc><![CDATA[JNI sig: Lexample/Outer$Inner$NestedInner;]]></javadoc>
+      <javadoc>
+        <![CDATA[JNI sig: Lexample/Outer$Inner$NestedInner;]]>
+      </javadoc>
       <field jni-signature="S" name="S">
-        <javadoc><![CDATA[JNI sig: S]]></javadoc>
+        <javadoc>
+          <![CDATA[JNI sig: S]]>
+        </javadoc>
       </field>
       <method jni-return="V" jni-signature="(Ljava/util/Map;)V" name="map" return="void">
         <parameter jni-type="Ljava/util/Map;" name="m" type="java.util.Map&lt;T, java.lang.String&gt;"/>
-        <javadoc><![CDATA[map(java.util.Map<T, String> map)
+        <javadoc>
+          <![CDATA[map(java.util.Map<T, String> map)
 
 JNI sig: map(Ljava/util/Map;)V
 
-@param map]]></javadoc>
+@param map]]>
+        </javadoc>
       </method>
     </class>
     <interface jni-signature="Lexample/Outer$MyAnnotation;" name="Outer.MyAnnotation">
-      <javadoc><![CDATA[Just an example annotation, for use later…
+      <javadoc>
+        <![CDATA[Just an example annotation, for use later…
 
-JNI sig: Lexample/Outer$MyAnnotation;]]></javadoc>
+JNI sig: Lexample/Outer$MyAnnotation;]]>
+      </javadoc>
       <method jni-return="[Ljava/lang/String;" jni-signature="()[Ljava/lang/String;" name="keys" return="java.lang.String[]">
-        <javadoc><![CDATA[JNI sig: ()[Ljava/lang/String;
+        <javadoc>
+          <![CDATA[JNI sig: ()[Ljava/lang/String;
 
-@return some random keys]]></javadoc>
+@return some random keys]]>
+        </javadoc>
       </method>
     </interface>
   </package>


### PR DESCRIPTION
Context: 7a32bb976ab41dca91f6cff59b8caea9d01ea53d
Context: https://stackoverflow.com/questions/55853220/handling-change-in-newlines-by-xml-transformation-for-cdata-from-java-8-to-java
Context: https://bugs.java.com/bugdatabase/view_bug?bug_id=8223291

**Background**: Since commit bc5bcf4f, *two* JDKs were required in order to *fully* build and test Java.Interop: JDK 1.8 and JDK-11. This is because `src/Java.Interop` requires JDK-11+ to build, while some unit tests required JDK 1.8 to pass (because Java XML output changed between JDK 1.8 and JDK-11; see also 7a32bb97).

Recently, a question arose: how well does .NET Android work with JDK 17?  ([Android Studio recently bumped][0] the bundled JDK from JDK-11 to JDK-17.)  The "straightforward" approach of "provision JDK-17 and just build everything with JDK-17" quickly meant that Java.Interop needed to build under JDK-17.

This in turn segued into a "how do I make the MSBuild property meanings clearer", as `$(JavaCPath)` would be for JDK 1.8, while `$(JavaC11Path)` was for JDK-11, but with JDK-17 being provisioned `$(JavaC11Path)` *actually* was for JDK-17, which is just confusing.

After discussion, we decided that we don't need to continue using JDK 1.8 anymore.  Android API-31 requires JDK-11 in order to use various Android SDK build tools, and the Google Play Store requires a target SDK version of API-33 starting 2023-Aug.  There is not much point in maintaining JDK 1.8 support.

JDK 11 or later is now required.

Update to use Gradle 8.1.1.  This is needed for later JDK-17 support.

`java/util/Collection.java` existed to help test API documentation import (when `$ANDROID_SDK_PATH` is set).  JDK-11 does not support compiling `java/util/Collection.java` anymore; it errors out with:

	java/java/util/Collection.java:1: error: package exists in another module: java.base
	package java.util;
	^

"Rename" this type to `android/animation/TypeEvaluator.java`, and update the API documentation import tests accordingly.

Update the `ExpectedTypeDeclaration.MajorVersion` values to 0x37.

The `.class` files for nested types has seen the addition of a new `NestHost` constant; see also:

  * https://docs.oracle.com/javase/specs/jvms/se11/html/jvms-4.html#jvms-4.7.28
  * https://docs.oracle.com/javase/specs/jvms/se11/html/jvms-5.html#jvms-5.4.4

Update `ExpectedTypeDeclaration.ConstantPoolCount` as appropriate.

Additional `NestHost`-related fallout is that `JavaType.class` now includes `com/xamarin/JavaType$RNC$RPNC` in the `InnerClasses` table.

Update `tools/java-source-utils` unit tests so that JDK-11 can now be used to run (and pass!) the unit tests.  (This previously required JDK 1.8.)

[0]: https://web.archive.org/web/20230507035529/https://developer.android.com/studio/releases/#jdk-17