### PR TITLE
[Prepare.targets] Specify JDK 11 as our minimum.

### DIFF
--- a/build-tools/scripts/Prepare.targets
+++ b/build-tools/scripts/Prepare.targets
@@ -20,6 +20,7 @@
     <JdkInfo
         JdksRoot="$(JdksRoot)"
         MakeFragmentFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\JdkInfo.mk"
+        MinimumJdkVersion="11"
         MaximumJdkVersion="$(_MaxJdk)"
         DotnetToolPath="$(DotnetToolPath)"
         PropertyFile="$(_TopDir)\bin\Build$(Configuration)\JdkInfo.props">


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/pull/1120

When multiple JDK's are found, a JDK 8 might be chosen.  Specify `MinimumJdkVersion` as `11` to ensure we get JDK 11 or newer.