### PR TITLE
[Java.Interop.Tools.JavaSource] Improve `<a>` parsing

### DIFF
--- a/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/SourceJavadocToXmldocGrammar.HtmlBnfTerms.cs
+++ b/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/SourceJavadocToXmldocGrammar.HtmlBnfTerms.cs
@@ -113,8 +113,7 @@ namespace Java.Interop.Tools.JavaSource {
 					var attributeName = parseNode.ChildNodes [0].Term.Name;
 					var attributeValue = nodesAsString.Substring (0, stopIndex).Trim ().Trim ('\'', '"');
 					var elementValue = nodesAsString.Substring (stopIndex + 1);
-					if (!string.IsNullOrEmpty (attributeValue) &&
-						(attributeValue.StartsWith ("http", StringComparison.OrdinalIgnoreCase) || attributeValue.StartsWith ("www", StringComparison.OrdinalIgnoreCase))) {
+					if (!string.IsNullOrEmpty (attributeValue) && attributeValue.StartsWith ("http", StringComparison.OrdinalIgnoreCase)) {
 						var unparsed = $"<see href=\"{attributeValue}\">{elementValue}</see>";
 						XNode? seeElement = TryParseElement (unparsed);
 						if (seeElement == null) {

--- a/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/SourceJavadocToXmldocGrammar.HtmlBnfTerms.cs
+++ b/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/SourceJavadocToXmldocGrammar.HtmlBnfTerms.cs
@@ -25,7 +25,6 @@ namespace Java.Interop.Tools.JavaSource {
 				AllHtmlTerms.Rule = TopLevelInlineDeclaration
 					| PBlockDeclaration
 					| PreBlockDeclaration
-					| IgnorableElementDeclaration
 					;
 
 				var inlineDeclaration = new NonTerminal ("<html inline decl>", ConcatChildNodes) {
@@ -100,41 +99,37 @@ namespace Java.Interop.Tools.JavaSource {
 					parseNode.AstNode   = p;
 				};
 
-				InlineHyperLinkDeclaration.Rule = InlineHyperLinkOpenTerm + InlineDeclarations + CreateEndElement ("a", grammar, optional: true);
+				InlineHyperLinkDeclaration.Rule = HtmlAElementStart + InlineDeclarations + CreateEndElement ("a", grammar, optional: true);
 				InlineHyperLinkDeclaration.AstConfig.NodeCreator = (context, parseNode) => {
-					var unparsedAElementValue = string.Empty;
-					foreach (var cn in parseNode.ChildNodes) {
-						if (cn.ChildNodes?.Count > 1) {
-							foreach (var gcn in cn.ChildNodes) {
-								unparsedAElementValue += gcn.AstNode?.ToString ();
-							}
-						} else {
-							unparsedAElementValue += cn.AstNode?.ToString ();
-						}
+					var nodesAsString = GetChildNodesAsString (parseNode);
+					var tokenValue = parseNode.ChildNodes [0].Token.Text;
+					int stopIndex = nodesAsString.IndexOf ('>');
+
+					if (stopIndex == -1 || !tokenValue.Contains ("href", StringComparison.OrdinalIgnoreCase)) {
+						parseNode.AstNode = new XText (nodesAsString);
+						return;
 					}
 
-					var seeElement = TryParseHRef (unparsedAElementValue);
-					if (seeElement == null)
-						seeElement = TryParseHRef (WebUtility.HtmlDecode (unparsedAElementValue), logError: true);
-
-					var hrefValue = seeElement?.Attribute ("href")?.Value ?? string.Empty;
-					if (!string.IsNullOrEmpty (hrefValue) &&
-							(hrefValue.StartsWith ("http", StringComparison.OrdinalIgnoreCase) || hrefValue.StartsWith ("www", StringComparison.OrdinalIgnoreCase))) {
-						parseNode.AstNode = seeElement;
+					var attributeName = parseNode.ChildNodes [0].Term.Name;
+					var attributeValue = nodesAsString.Substring (0, stopIndex).Trim ().Trim ('\'', '"');
+					var elementValue = nodesAsString.Substring (stopIndex + 1);
+					if (!string.IsNullOrEmpty (attributeValue) &&
+						(attributeValue.StartsWith ("http", StringComparison.OrdinalIgnoreCase) || attributeValue.StartsWith ("www", StringComparison.OrdinalIgnoreCase))) {
+						var unparsed = $"<see href=\"{attributeValue}\">{elementValue}</see>";
+						XNode? seeElement = TryParseElement (unparsed);
+						if (seeElement == null) {
+							// Try to parse with HTML entities decoded
+							seeElement = TryParseElement (WebUtility.HtmlDecode (unparsed));
+							if (seeElement == null) {
+								// Finally, try to parse with only the element value encoded
+								seeElement = TryParseElement ($"<see href=\"{attributeValue}\">{WebUtility.HtmlEncode (elementValue)}</see>", logError: true);
+							}
+						}
+						parseNode.AstNode = seeElement ?? new XText (nodesAsString);
 					} else {
 						// TODO: Need to convert relative paths or code references to appropriate CREF value.
-						parseNode.AstNode = new XText (unparsedAElementValue);
+						parseNode.AstNode = new XText (elementValue);
 					}
-				};
-
-				// Start to trim out unusable HTML elements/tags, but not any inner values
-				IgnorableElementDeclaration.Rule =
-					CreateStartElementIgnoreAttribute ("a", "name") + InlineDeclarations + CreateEndElement ("a", grammar, optional: true)
-					| CreateStartElementIgnoreAttribute ("a", "id") + InlineDeclarations + CreateEndElement ("a", grammar, optional: true)
-					;
-				IgnorableElementDeclaration.AstConfig.NodeCreator = (context, parseNode) => {
-					var aElementValue = new XText (parseNode.ChildNodes [1].AstNode.ToString () ?? string.Empty);
-					parseNode.AstNode = aElementValue;
 				};
 
 				CodeElementDeclaration.Rule = CreateStartElement ("code", grammar) + InlineDeclarations + CreateEndElement ("code", grammar);
@@ -184,13 +179,28 @@ namespace Java.Interop.Tools.JavaSource {
 				}
 			}
 
-			static XElement? TryParseHRef (string unparsedAElementValue, bool logError = false)
+			static string GetChildNodesAsString (ParseTreeNode parseNode)
+			{
+				var unparsed = string.Empty;
+				foreach (var cn in parseNode.ChildNodes) {
+					if (cn.ChildNodes?.Count > 1) {
+						foreach (var gcn in cn.ChildNodes) {
+							unparsed += gcn.AstNode?.ToString ();
+						}
+					} else {
+						unparsed += cn.AstNode?.ToString ();
+					}
+				}
+				return unparsed;
+			}
+
+			static XElement? TryParseElement (string unparsed, bool logError = false)
 			{
 				try {
-					return XElement.Parse ($"<see href={unparsedAElementValue}</see>");
+					return XElement.Parse (unparsed);
 				} catch (Exception x) {
 					if (logError)
-						Console.Error.WriteLine ($"## Unable to parse HTML element: <see href={unparsedAElementValue}</see>\n{x.GetType ()}: {x.Message}");
+						Console.Error.WriteLine ($"## Unable to parse HTML element: `{unparsed}`\n{x.GetType ()}: {x.Message}");
 					return null;
 				}
 			}
@@ -221,10 +231,9 @@ namespace Java.Interop.Tools.JavaSource {
 			public  readonly    NonTerminal PBlockDeclaration           = new NonTerminal (nameof (PBlockDeclaration), ConcatChildNodes);
 			public  readonly    NonTerminal PreBlockDeclaration         = new NonTerminal (nameof (PreBlockDeclaration), ConcatChildNodes);
 			public  readonly    NonTerminal InlineHyperLinkDeclaration  = new NonTerminal (nameof (InlineHyperLinkDeclaration), ConcatChildNodes);
-			public  readonly    NonTerminal IgnorableElementDeclaration = new NonTerminal (nameof (IgnorableElementDeclaration), ConcatChildNodes);
 			public  readonly    NonTerminal CodeElementDeclaration      = new NonTerminal (nameof (CodeElementDeclaration), ConcatChildNodes);
 
-			public  readonly    Terminal    InlineHyperLinkOpenTerm     = new RegexBasedTerminal ("<a href=", @"(?i)<a\s*href\s*=") {
+			public  readonly    Terminal    HtmlAElementStart           = new RegexBasedTerminal ("<a attr=", @"(?i)<a\s*.*=") {
 				AstConfig = new AstNodeConfig {
 					NodeCreator = (context, parseNode) => parseNode.AstNode = "",
 				},

--- a/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/SourceJavadocToXmldocGrammar.HtmlBnfTerms.cs
+++ b/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/SourceJavadocToXmldocGrammar.HtmlBnfTerms.cs
@@ -99,7 +99,7 @@ namespace Java.Interop.Tools.JavaSource {
 					parseNode.AstNode   = p;
 				};
 
-				InlineHyperLinkDeclaration.Rule = HtmlAElementStart + InlineDeclarations + CreateEndElement ("a", grammar, optional: true);
+				InlineHyperLinkDeclaration.Rule = InlineHyperLinkOpenTerm + InlineDeclarations + CreateEndElement ("a", grammar, optional: true);
 				InlineHyperLinkDeclaration.AstConfig.NodeCreator = (context, parseNode) => {
 					var nodesAsString = GetChildNodesAsString (parseNode);
 					var tokenValue = parseNode.ChildNodes [0].Token.Text;
@@ -233,7 +233,7 @@ namespace Java.Interop.Tools.JavaSource {
 			public  readonly    NonTerminal InlineHyperLinkDeclaration  = new NonTerminal (nameof (InlineHyperLinkDeclaration), ConcatChildNodes);
 			public  readonly    NonTerminal CodeElementDeclaration      = new NonTerminal (nameof (CodeElementDeclaration), ConcatChildNodes);
 
-			public  readonly    Terminal    HtmlAElementStart           = new RegexBasedTerminal ("<a attr=", @"(?i)<a\s*.*=") {
+			public  readonly    Terminal    InlineHyperLinkOpenTerm     = new RegexBasedTerminal ("<a attr=", @"(?i)<a\s*.*=") {
 				AstConfig = new AstNodeConfig {
 					NodeCreator = (context, parseNode) => parseNode.AstNode = "",
 				},

--- a/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/SourceJavadocToXmldocGrammar.InlineTagsBnfTerms.cs
+++ b/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/SourceJavadocToXmldocGrammar.InlineTagsBnfTerms.cs
@@ -109,15 +109,6 @@ namespace Java.Interop.Tools.JavaSource {
 					}
 				};
 
-				// Inline content may contain reserved characters with no tags or special parsing rules, do not throw when encountering them
-				IgnorableDeclaration.Rule = grammar.ToTerm ("@ ")
-					| grammar.ToTerm ("{")
-					| grammar.ToTerm ("}")
-					;
-				IgnorableDeclaration.AstConfig.NodeCreator = (context, parseNode) => {
-					parseNode.AstNode = new XText (parseNode.ChildNodes [0].Term.Name.Trim ());
-				};
-
 				InlineParamDeclaration.Rule = grammar.ToTerm ("{@param") + InlineValue + "}";
 				InlineParamDeclaration.AstConfig.NodeCreator = (context, parseNode) => {
 					var target = parseNode.ChildNodes [1].AstNode;
@@ -156,9 +147,38 @@ namespace Java.Interop.Tools.JavaSource {
 			// https://docs.oracle.com/javase/7/docs/technotes/tools/windows/javadoc.html#value
 			public  readonly    NonTerminal ValueDeclaration            = new NonTerminal (nameof (ValueDeclaration));
 
-			public  readonly    NonTerminal IgnorableDeclaration        = new NonTerminal (nameof (IgnorableDeclaration));
-
 			public  readonly    NonTerminal InlineParamDeclaration      = new NonTerminal (nameof (InlineParamDeclaration));
+
+			public  readonly    Terminal    IgnorableDeclaration        = new IgnorableCharTerminal (nameof (IgnorableDeclaration)) {
+				AstConfig = new AstNodeConfig {
+					NodeCreator = (context, parseNode) => parseNode.AstNode = parseNode.Token.Value.ToString (),
+				},
+			};
+
 		}
 	}
+
+	class IgnorableCharTerminal : Terminal
+	{
+		public IgnorableCharTerminal (string name)
+			: base (name)
+		{
+			Priority = TerminalPriority.Low - 1;
+		}
+
+		public override Token? TryMatch (ParsingContext context, ISourceStream source)
+		{
+			var startChar = source.Text [source.Location.Position];
+			if (startChar != '@'
+				&& startChar != '{'
+				&& startChar != '}'
+				) {
+				return null;
+			}
+			source.PreviewPosition += 1;
+			return source.CreateToken (OutputTerminal, startChar);
+		}
+
+	}
+
 }

--- a/tests/Java.Interop.Tools.JavaSource-Tests/SourceJavadocToXmldocGrammar.HtmlBnfTermsTests.cs
+++ b/tests/Java.Interop.Tools.JavaSource-Tests/SourceJavadocToXmldocGrammar.HtmlBnfTermsTests.cs
@@ -69,7 +69,11 @@ namespace Java.Interop.Tools.JavaSource.Tests
 
 			r = p.Parse ("<a href=\"AutofillService.html#FieldClassification\">field classification</a>");
 			Assert.IsFalse (r.HasErrors (), DumpMessages (r, p));
-			Assert.AreEqual ("\"AutofillService.html#FieldClassification\"&gt;field classification",
+			Assert.AreEqual ("field classification", r.Root.AstNode.ToString ());
+
+			r = p.Parse ("<a href='https://material.io/guidelines/components/progress-activity.html#progress-activity-types-of-indicators'>\nProgress & activity</a>");
+			Assert.IsFalse (r.HasErrors (), DumpMessages (r, p));
+			Assert.AreEqual ($"<see href=\"https://material.io/guidelines/components/progress-activity.html#progress-activity-types-of-indicators\">{Environment.NewLine}Progress &amp; activity</see>",
 					r.Root.AstNode.ToString ());
 		}
 

--- a/tests/Java.Interop.Tools.JavaSource-Tests/SourceJavadocToXmldocGrammar.HtmlBnfTermsTests.cs
+++ b/tests/Java.Interop.Tools.JavaSource-Tests/SourceJavadocToXmldocGrammar.HtmlBnfTermsTests.cs
@@ -71,6 +71,22 @@ namespace Java.Interop.Tools.JavaSource.Tests
 			Assert.IsFalse (r.HasErrors (), DumpMessages (r, p));
 			Assert.AreEqual ("field classification", r.Root.AstNode.ToString ());
 
+			r = p.Parse ("<a href=https://www.sqlite.org/pragma.html#pragma_journal_mode>here</a>");
+			Assert.IsFalse (r.HasErrors (), DumpMessages (r, p));
+			Assert.AreEqual ("<see href=\"https://www.sqlite.org/pragma.html#pragma_journal_mode\">here</see>", r.Root.AstNode.ToString ());
+
+			r = p.Parse ("<a href=\"https://github.com/google/libphonenumber>libphonenumber</a>");
+			Assert.IsFalse (r.HasErrors (), DumpMessages (r, p));
+			Assert.AreEqual ("<see href=\"https://github.com/google/libphonenumber\">libphonenumber</see>", r.Root.AstNode.ToString ());
+
+			r = p.Parse ("<a href=#BROKEN> broken</a>");
+			Assert.IsFalse (r.HasErrors (), DumpMessages (r, p));
+			Assert.AreEqual (" broken", r.Root.AstNode.ToString ());
+
+			r = p.Parse ("<a href=\"mailto:nobody@google.com\">nobody</a>");
+			Assert.IsFalse (r.HasErrors (), DumpMessages (r, p));
+			Assert.AreEqual ("nobody", r.Root.AstNode.ToString ());
+
 			r = p.Parse ("<a href='https://material.io/guidelines/components/progress-activity.html#progress-activity-types-of-indicators'>\nProgress & activity</a>");
 			Assert.IsFalse (r.HasErrors (), DumpMessages (r, p));
 			Assert.AreEqual ($"<see href=\"https://material.io/guidelines/components/progress-activity.html#progress-activity-types-of-indicators\">{Environment.NewLine}Progress &amp; activity</see>",


### PR DESCRIPTION
Parsing for `<a/>` elements has been improved to fix all 83 cases where
conversion to a `<see/>` element would fail.  Some examples of such
failures include:

    ## Unable to parse HTML element: <see href=https://www.sqlite.org/pragma.html#pragma_journal_mode>here</see>
    System.Xml.XmlException: 'https' is an unexpected token. The expected token is '"' or '''. Line 1, position 11.

    ## Unable to parse HTML element: <see href="https://github.com/google/libphonenumber>libphonenumber</see>
    System.Xml.XmlException: '<', hexadecimal value 0x3C, is an invalid attribute character. Line 1, position 67.

    ## Unable to parse HTML element: <see href="https://material.io/guidelines/components/progress-activity.html#progress-activity-types-of-indicators">
    Progress & activity</see>
    System.Xml.XmlException: An error occurred while parsing EntityName. Line 2, position 11.

    ## Unable to parse HTML element: <see href=#BROKEN> broken</see>
    System.Xml.XmlException: '#' is an unexpected token. The expected token is '"' or '''. Line 1, position 11.

    ## Unable to parse HTML element: <see href=http://www.ietf.org/rfc/rfc2045.txt>RFC 2045</see>
    System.Xml.XmlException: 'http' is an unexpected token. The expected token is '"' or '''. Line 1, position 11.

When we encounter an `<a/>` element that points to code or a local path
we will now only include the element value in the javadoc, and not the
full `href` attribute value.