### PR TITLE
[generator] Prevent BG8A08 warning when using `ns-replace`.

### DIFF
--- a/src/Java.Interop.Tools.Generator/Metadata/FixupXmlDocument.cs
+++ b/src/Java.Interop.Tools.Generator/Metadata/FixupXmlDocument.cs
@@ -41,6 +41,10 @@ namespace Java.Interop.Tools.Generator
 				if (!ShouldApply (metaitem, apiDocument))
 					continue;
 
+				// Namespace replacements are handled elsewhere
+				if (metaitem.Name.LocalName == "ns-replace")
+					continue;
+
 				var path = metaitem.XGetAttribute ("path");
 
 				if (path != prev_path)


### PR DESCRIPTION
As part of the NRT work in https://github.com/xamarin/java.interop/pull/1099, we added a warning when the `path` attribute of a "metadata" element isn't provided.  However, metadata files can also contain `<ns-replace>` elements, which do not have a `path` attribute, and thus erroneously trigger this warning:

```
generated\msbuild-metadata.xml(3,4): warning BG8A08: Metadata.xml element '<ns-replace source="com.google.androidx" replacement="Xamarin.AndroidX" />' is missing the 'path' attribute. 
```

Skip running any of the standard "metadata" logic when we hit a `<ns-replace>` element, as they are handled elsewhere.