### PR TITLE
[build] set `$(DisableTransitiveFrameworkReferenceDownloads)`

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,6 +7,8 @@
     <_OutputPath>$(MSBuildThisFileDirectory)bin\Build$(Configuration)\</_OutputPath>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <ProduceReferenceAssemblyInOutDir>true</ProduceReferenceAssemblyInOutDir>
+    <!-- Disables the transitive restore of packages like Microsoft.AspNetCore.App.Ref, Microsoft.WindowsDesktop.App.Ref -->
+    <DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
     <DotNetTargetFrameworkVersion>7.0</DotNetTargetFrameworkVersion>
     <DotNetTargetFramework>net$(DotNetTargetFrameworkVersion)</DotNetTargetFramework>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>


### PR DESCRIPTION
As we consume nightly .NET 8 builds, they sometimes depend on nightly .NET 7 builds.

One error you can run into is:

    error NU1102: Unable to find package Microsoft.AspNetCore.App.Ref with version (= 7.0.11)
    error NU1102: Unable to find package Microsoft.WindowsDesktop.App.Ref with version (= 7.0.11)

For projects that are not even ASP.NET or Windows desktop apps! To even be able to access these feeds, they would be something like:

    <add key="darc-pub-dotnet-aspnetcore-[SHA]" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspnetcore-[SHA]/nuget/v3/index.json" />
    <add key="darc-pub-dotnet-windowsdesktop-[SHA]" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-windowsdesktop-[SHA]/nuget/v3/index.json" />

We don't currently track these packages, because we don't actually use them.

The .NET SDK team has provided a setting to workaround this, `$(DisableTransitiveFrameworkReferenceDownloads)`, we have been using in xamarin/xamarin-android for some time:

https://github.com/xamarin/xamarin-android/blob/6768c731d327c8148c45304c895ca8987a9cc2f1/Directory.Build.props#L26-L27

Let's do the same here to avoid this problem as seen in 81c228d1.