### PR TITLE
[build] Add support for JDK 17

### DIFF
--- a/build-tools/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks/JdkInfo.cs
+++ b/build-tools/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks/JdkInfo.cs
@@ -61,11 +61,11 @@ namespace Java.Interop.BootstrapTasks
 			JavaHomePath  = jdk.HomePath;
 
 			Directory.CreateDirectory (Path.GetDirectoryName (PropertyFile.ItemSpec));
-			WritePropertyFile (jdk.JavaPath, jdk.JarPath, jdk.JavacPath, jdk.JdkJvmPath, rtJarPath, jdk.IncludePath);
+			WritePropertyFile (jdk, rtJarPath);
 
 			if (MakeFragmentFile != null) {
 				Directory.CreateDirectory (Path.GetDirectoryName (MakeFragmentFile.ItemSpec));
-				WriteMakeFragmentFile (jdk.JavaPath, jdk.JarPath, jdk.JavacPath, jdk.JdkJvmPath, rtJarPath, jdk.IncludePath);
+				WriteMakeFragmentFile (jdk, rtJarPath);
 			}
 
 			return !Log.HasLoggedErrors;
@@ -117,8 +117,14 @@ namespace Java.Interop.BootstrapTasks
 			return logger;
 		}
 
-		void WritePropertyFile (string javaPath, string jarPath, string javacPath, string jdkJvmPath, string rtJarPath, IEnumerable<string> includes)
+		void WritePropertyFile (XATInfo jdk, string rtJarPath)
 		{
+			var jarPath     = jdk.JarPath;
+			var javacPath   = jdk.JavacPath;
+			var javaPath    = jdk.JavaPath;
+			var jdkJvmPath  = jdk.JdkJvmPath;
+			var includes    = jdk.IncludePath;
+
 			var msbuild = XNamespace.Get ("http://schemas.microsoft.com/developer/msbuild/2003");
 			var jdkJvmP = $"JdkJvm{PropertyNameModifier}Path";
 			var project = new XElement (msbuild + "Project",
@@ -129,6 +135,9 @@ namespace Java.Interop.BootstrapTasks
 						new XElement (msbuild + "ItemGroup",
 							includes.Select (i => new XElement (msbuild + $"Jdk{PropertyNameModifier}IncludePath", new XAttribute ("Include", i)))))),
 				new XElement (msbuild + "PropertyGroup",
+					CreateProperty (msbuild, $"JavaApi{PropertyNameModifier}DefineConstants",
+						string.Join (";", Enumerable.Range (11, jdk.Version.Major-11+1).Select (v => $"JAVA_API_{v}"))),
+					CreateProperty (msbuild, $"Java{PropertyNameModifier}MajorVersion", jdk.Version.Major.ToString ()),
 					CreateProperty (msbuild, $"Java{PropertyNameModifier}SdkDirectory", JavaHomePath),
 					CreateProperty (msbuild, $"Java{PropertyNameModifier}Path", javaPath),
 					CreateProperty (msbuild, $"JavaC{PropertyNameModifier}Path", javacPath),
@@ -148,8 +157,15 @@ namespace Java.Interop.BootstrapTasks
 					new XAttribute ("Condition", $" '$({propertyName})' == '' "),
 					propertyValue);
 		}
-		void WriteMakeFragmentFile (string javaPath, string jarPath, string javacPath, string jdkJvmPath, string rtJarPath, IEnumerable<string> includes)
+
+		void WriteMakeFragmentFile (XATInfo jdk, string rtJarPath)
 		{
+			var jarPath     = jdk.JarPath;
+			var javacPath   = jdk.JavacPath;
+			var javaPath    = jdk.JavaPath;
+			var jdkJvmPath  = jdk.JdkJvmPath;
+			var includes    = jdk.IncludePath;
+
 			using (var o = new StreamWriter (MakeFragmentFile.ItemSpec)) {
 				o.WriteLine ($"export  JI_JAR_PATH          := {jarPath}");
 				o.WriteLine ($"export  JI_JAVA_PATH         := {javaPath}");

--- a/build-tools/scripts/Prepare.targets
+++ b/build-tools/scripts/Prepare.targets
@@ -16,6 +16,7 @@
       <_MaxJdk>$(MaxJdkVersion)</_MaxJdk>
       <_MaxJdk Condition=" '$(_MaxJdk)' == '' ">$(JI_MAX_JDK)</_MaxJdk>
       <JdksRoot Condition=" '$(JdksRoot)' == '' And '$(JAVA_HOME_11_X64)' != '' And Exists($(JAVA_HOME_11_X64)) ">$(JAVA_HOME_11_X64)</JdksRoot>
+      <JdksRoot Condition=" '$(JdksRoot)' == '' And '$(JAVA_HOME_17_X64)' != '' And Exists($(JAVA_HOME_17_X64)) ">$(JAVA_HOME_17_X64)</JdksRoot>
     </PropertyGroup>
     <JdkInfo
         JdksRoot="$(JdksRoot)"

--- a/src/Java.Base/Java.Base.targets
+++ b/src/Java.Base/Java.Base.targets
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <GeneratorPath>$(UtilityOutputFullPath)generator.dll</GeneratorPath>
+    <DefineConstants>$(JavaApiDefineConstants);$(DefineConstants);</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Java.Base/Java.Lang/Class.cs
+++ b/src/Java.Base/Java.Lang/Class.cs
@@ -1,0 +1,14 @@
+using System;
+using Java.Interop;
+
+#if JAVA_API_17
+using Java.Lang.Invoke;
+using Java.Lang.Constants;
+
+namespace Java.Lang {
+	public partial class Class {
+
+	}
+}
+
+#endif  // JAVA_API_17

--- a/src/Java.Base/Java.Lang/Double.cs
+++ b/src/Java.Base/Java.Lang/Double.cs
@@ -1,0 +1,16 @@
+using System;
+using Java.Interop;
+
+#if JAVA_API_17
+using Java.Lang.Invoke;
+using Java.Lang.Constants;
+
+namespace Java.Lang {
+	public partial class Double {
+
+		Java.Lang.Object? IConstantDesc.ResolveConstantDesc (MethodHandles.Lookup? lookup) =>
+			ResolveConstantDesc (lookup);
+	}
+}
+
+#endif  // JAVA_API_17

--- a/src/Java.Base/Java.Lang/Float.cs
+++ b/src/Java.Base/Java.Lang/Float.cs
@@ -1,0 +1,16 @@
+using System;
+using Java.Interop;
+
+#if JAVA_API_17
+using Java.Lang.Invoke;
+using Java.Lang.Constants;
+
+namespace Java.Lang {
+	public partial class Float {
+
+		Java.Lang.Object? IConstantDesc.ResolveConstantDesc (MethodHandles.Lookup? lookup) =>
+			ResolveConstantDesc (lookup);
+	}
+}
+
+#endif  // JAVA_API_17

--- a/src/Java.Base/Java.Lang/Integer.cs
+++ b/src/Java.Base/Java.Lang/Integer.cs
@@ -1,0 +1,16 @@
+using System;
+using Java.Interop;
+
+#if JAVA_API_17
+using Java.Lang.Invoke;
+using Java.Lang.Constants;
+
+namespace Java.Lang {
+	public partial class Integer {
+
+		Java.Lang.Object? IConstantDesc.ResolveConstantDesc (MethodHandles.Lookup? lookup) =>
+			ResolveConstantDesc (lookup);
+	}
+}
+
+#endif  // JAVA_API_17

--- a/src/Java.Base/Java.Lang/Long.cs
+++ b/src/Java.Base/Java.Lang/Long.cs
@@ -1,0 +1,16 @@
+using System;
+using Java.Interop;
+
+#if JAVA_API_17
+using Java.Lang.Invoke;
+using Java.Lang.Constants;
+
+namespace Java.Lang {
+	public partial class Long {
+
+		Java.Lang.Object? IConstantDesc.ResolveConstantDesc (MethodHandles.Lookup? lookup) =>
+			ResolveConstantDesc (lookup);
+	}
+}
+
+#endif  // JAVA_API_17

--- a/src/Java.Base/Java.Lang/String.cs
+++ b/src/Java.Base/Java.Lang/String.cs
@@ -3,7 +3,27 @@ using System.Collections;
 using System.Collections.Generic;
 using Java.Interop;
 
+#if JAVA_API_17
+using Java.Lang.Invoke;
+using Java.Lang.Constants;
+#endif  // JAVA_API_17
+
 namespace Java.Lang {
 	public partial class String : IEnumerable, IEnumerable<char> {
+
+#if JAVA_API_17
+		unsafe Java.Lang.Object? IConstantDesc.ResolveConstantDesc (MethodHandles.Lookup? lookup)
+		{
+			const string __id = "resolveConstantDesc.(Ljava/lang/invoke/MethodHandles$Lookup;)Ljava/lang/String;";
+			try {
+				JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+				__args [0] = new JniArgumentValue (lookup);
+				var __rm = _members.InstanceMethods.InvokeAbstractObjectMethod (__id, this, __args);
+				return JniEnvironment.Runtime.ValueManager.GetValue<String>(ref __rm, JniObjectReferenceOptions.CopyAndDispose);
+			} finally {
+				global::System.GC.KeepAlive (lookup);
+			}
+		}
+#endif  // JAVA_API_17
 	}
 }

--- a/src/Java.Base/Transforms/Metadata.xml
+++ b/src/Java.Base/Transforms/Metadata.xml
@@ -6,6 +6,8 @@
 
   <!-- Type / Namespace conflicts -->
   <ns-replace source="java.lang.module" replacement="Java.Lang.Modules" />
+  <ns-replace source="java.lang.runtime" replacement="Java.Lang.Runtimes" />
+  <ns-replace source="java.lang.constant" replacement="Java.Lang.Constants" />
 
   <!-- Bind `Object.finalize()` as `Object.JavaFinalize()` -->
   <attr path="/api/package[@name='java.lang']//method[@name='finalize' and count(parameter)=0]" name="managedName">JavaFinalize</attr>
@@ -62,4 +64,21 @@
   <attr path="/api/package[@name='java.lang']/class[@name='StringBuffer']" name="extends">java.lang.Object</attr>
   <remove-node path="//api/package[@name='java.lang']/class[@name='StringBuffer']/method[@jni-return='Ljava/lang/AbstractStringBuilder;']" />
   <remove-node path="//api/package[@name='java.lang']/class[@name='StringBuffer']/method[@jni-return='Ljava/lang/Appendable;']" />
+
+  <!-- JDK 17? -->
+  <remove-node path="/api/package[@name='java.lang.invoke']/interface[@name='TypeDescriptor']" />
+  <attr path="/api/package[@name='java.lang']/class[@name='Record']/method[@name='equals' and count(parameter)=1 and parameter[1][@type='java.lang.Object']]"
+      name="managedOverride">override</attr>
+  <attr path="/api/package[@name='java.lang.reflect']/interface[@name='AnnotatedType']/method[@name='getAnnotation' and count(parameter)=1 and parameter[1][@type='java.lang.Class&lt;T&gt;']]"
+      name="managedOverride">reabstract</attr>
+  <attr path="/api/package[@name='java.lang.reflect']/interface[@name='AnnotatedType']/method[@name='getAnnotation' and count(parameter)=1 and parameter[1][@type='java.lang.Class&lt;T&gt;']]"
+      name="explicitInterface">IAnnotatedElement</attr>
+  <attr path="/api/package[@name='java.lang.reflect']/interface[@name='AnnotatedType']/method[@name='getAnnotations' and count(parameter)=0]"
+      name="managedOverride">reabstract</attr>
+  <attr path="/api/package[@name='java.lang.reflect']/interface[@name='AnnotatedType']/method[@name='getAnnotations' and count(parameter)=0]"
+      name="explicitInterface">IAnnotatedElement</attr>
+  <attr path="/api/package[@name='java.lang.reflect']/interface[@name='AnnotatedType']/method[@name='getDeclaredAnnotations' and count(parameter)=0]"
+      name="managedOverride">reabstract</attr>
+  <attr path="/api/package[@name='java.lang.reflect']/interface[@name='AnnotatedType']/method[@name='getDeclaredAnnotations' and count(parameter)=0]"
+      name="explicitInterface">IAnnotatedElement</attr>
 </metadata>


### PR DESCRIPTION
Update `<JdkInfo/>` task to emit new `$(Java*MajorVersion)` and `$(JavaApi*DefineConstants)` MSBuild properties.  These are used by `src/Java.Base` so that it knows which JDK version it's binding.

Update `src/Java.Base` to support binding the `java.base.jmod` from JDK 17.

Note: This "JDK-17 Java.Base binding" was a "time limited" effort.

To build against JDK-17:

 1. Install JDK-17.

 2. Prepare and override `$(JdksRoot)`:

        dotnet build -t:Prepare Java.Interop.sln -p:JdksRoot=/Library/Java/JavaVirtualMachines/microsoft-17.jdk/Contents/Home

    will use the Microsoft OpenJDK 17 installation on macOS.

 3. Build:

        dotnet build Java.Interop.sln