### PR TITLE
[generator] Provide opt-out for obsolete override fixup.

### DIFF
--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
@@ -1138,6 +1138,12 @@ namespace generatortests
 
 			var gens = ParseApiDefinition (xml);
 
+			// Override method should not be marked deprecated because it's: deprecated='not deprecated'
+			Assert.IsNull (gens.Single (g => g.Name == "MyClass").Methods.Single (m => m.Name == "DoStuff").Deprecated);
+
+			options.FixObsoleteOverrides = true;
+			gens = ParseApiDefinition (xml);
+
 			// Override method should be marked deprecated because base method is
 			Assert.AreEqual ("deprecated", gens.Single (g => g.Name == "MyClass").Methods.Single (m => m.Name == "DoStuff").Deprecated);
 		}
@@ -1158,6 +1164,7 @@ namespace generatortests
 			  </package>
 			</api>";
 
+			options.FixObsoleteOverrides = true;
 			var gens = ParseApiDefinition (xml);
 
 			// Override method should match base method's 'deprecated-since'

--- a/tools/generator/CodeGenerationOptions.cs
+++ b/tools/generator/CodeGenerationOptions.cs
@@ -65,6 +65,7 @@ namespace MonoDroid.Generation
 		public bool UseShallowReferencedTypes { get; set; }
 		public bool UseObsoletedOSPlatformAttributes { get; set; }
 		public bool UseRestrictToAttributes { get; set; }
+		public bool FixObsoleteOverrides { get; set; }
 		public bool RemoveConstSugar => BuildingCoreAssembly;
 
 		bool? buildingCoreAssembly;

--- a/tools/generator/CodeGenerator.cs
+++ b/tools/generator/CodeGenerator.cs
@@ -85,6 +85,7 @@ namespace Xamarin.Android.Binder
 				SupportNullableReferenceTypes = options.SupportNullableReferenceTypes,
 				UseObsoletedOSPlatformAttributes = options.UseObsoletedOSPlatformAttributes,
 				UseRestrictToAttributes = options.UseRestrictToAttributes,
+				FixObsoleteOverrides = options.FixObsoleteOverrides,
 			};
 			var resolverCache       = new TypeDefinitionCache ();
 

--- a/tools/generator/CodeGeneratorOptions.cs
+++ b/tools/generator/CodeGeneratorOptions.cs
@@ -53,6 +53,7 @@ namespace Xamarin.Android.Binder
 		public bool		    SupportNestedInterfaceTypes { get; set; }
 		public bool		    SupportNullableReferenceTypes { get; set; }
 		public bool		    UseRestrictToAttributes { get; set; }
+		public bool		    FixObsoleteOverrides { get; set;} = true;
 		public bool		    UseLegacyJavaResolver { get; set; }
 		public bool			UseObsoletedOSPlatformAttributes { get; set; }
 
@@ -104,7 +105,7 @@ namespace Xamarin.Android.Binder
 					"SDK Platform {VERSION}/API level.",
 					v => opts.ApiLevel = v },
 				{ "lang-features=",
-					"For internal use. (Flags: interface-constants,default-interface-methods,nested-interface-types,nullable-reference-types,obsoleted-platform-attributes,restrict-to-attributes)",
+					"For internal use. (Flags: interface-constants,default-interface-methods,nested-interface-types,nullable-reference-types,obsoleted-platform-attributes,restrict-to-attributes,dont-fix-obsolete-overrides)",
 					v => {
 						opts.SupportInterfaceConstants = v?.Contains ("interface-constants") == true;
 						opts.SupportDefaultInterfaceMethods = v?.Contains ("default-interface-methods") == true;
@@ -112,6 +113,7 @@ namespace Xamarin.Android.Binder
 						opts.SupportNullableReferenceTypes = v?.Contains ("nullable-reference-types") == true;
 						opts.UseObsoletedOSPlatformAttributes = v?.Contains ("obsoleted-platform-attributes") == true;
 						opts.UseRestrictToAttributes = v?.Contains ("restrict-to-attributes") == true;
+						opts.FixObsoleteOverrides = v?.Contains ("dont-fix-obsolete-overrides") == false;
 						}},
 				{ "preserve-enums",
 					"For internal use.",

--- a/tools/generator/CodeGeneratorOptions.cs
+++ b/tools/generator/CodeGeneratorOptions.cs
@@ -105,7 +105,7 @@ namespace Xamarin.Android.Binder
 					"SDK Platform {VERSION}/API level.",
 					v => opts.ApiLevel = v },
 				{ "lang-features=",
-					"For internal use. (Flags: interface-constants,default-interface-methods,nested-interface-types,nullable-reference-types,obsoleted-platform-attributes,restrict-to-attributes,dont-fix-obsolete-overrides)",
+					"For internal use. (Flags: interface-constants,default-interface-methods,nested-interface-types,nullable-reference-types,obsoleted-platform-attributes,restrict-to-attributes,do-not-fix-obsolete-overrides)",
 					v => {
 						opts.SupportInterfaceConstants = v?.Contains ("interface-constants") == true;
 						opts.SupportDefaultInterfaceMethods = v?.Contains ("default-interface-methods") == true;
@@ -113,7 +113,7 @@ namespace Xamarin.Android.Binder
 						opts.SupportNullableReferenceTypes = v?.Contains ("nullable-reference-types") == true;
 						opts.UseObsoletedOSPlatformAttributes = v?.Contains ("obsoleted-platform-attributes") == true;
 						opts.UseRestrictToAttributes = v?.Contains ("restrict-to-attributes") == true;
-						opts.FixObsoleteOverrides = v?.Contains ("dont-fix-obsolete-overrides") == false;
+						opts.FixObsoleteOverrides = v?.Contains ("do-not-fix-obsolete-overrides") == false;
 						}},
 				{ "preserve-enums",
 					"For internal use.",

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
@@ -311,13 +311,15 @@ namespace MonoDroid.Generation
 					if (bm != null && bm.RetVal.FullName == m.RetVal.FullName) { // if return type is different, it could be still "new", not "override".
 						m.IsOverride = true;
 
-						// If method overrides a deprecated method, it also needs to be marked as deprecated
-						if (bm.Deprecated.HasValue () && !m.Deprecated.HasValue ())
-							m.Deprecated = bm.Deprecated;
+						if (opt.FixObsoleteOverrides) {
+							// If method overrides a deprecated method, it also needs to be marked as deprecated
+							if (bm.Deprecated.HasValue () && !m.Deprecated.HasValue ())
+								m.Deprecated = bm.Deprecated;
 
-						// Fix issue when base method was deprecated before the overriding method, set both both to base method value
-						if (bm.DeprecatedSince.GetValueOrDefault (0) < m.DeprecatedSince.GetValueOrDefault (0))
-							m.DeprecatedSince = bm.DeprecatedSince;
+							// Fix issue when base method was deprecated before the overriding method, set both both to base method value
+							if (bm.DeprecatedSince.GetValueOrDefault (0) < m.DeprecatedSince.GetValueOrDefault (0))
+								m.DeprecatedSince = bm.DeprecatedSince;
+						}
 
 						break;
 					}


### PR DESCRIPTION
Fixes: https://github.com/xamarin/java.interop/issues/1142
Context: https://github.com/xamarin/java.interop/pull/1130

In https://github.com/xamarin/java.interop/pull/1130 we added a feature to automatically mark a method as "deprecated" if it overrides a "deprecated" method.

However, there can be instances where this is undesirable for a user, and there is currently no way to opt out on a global or `metadata` level.

Add a global opt-out for this feature, usable via:
```
--lang-features=do-not-fix-obsolete-overrides
```

This will be made available to users via an MSBuild property in an additional PR.