### PR TITLE
[JavaTypeSystem] Add JavaFieldModel.ToString ().

### DIFF
--- a/src/Java.Interop.Tools.JavaTypeSystem/JavaModels/JavaFieldModel.cs
+++ b/src/Java.Interop.Tools.JavaTypeSystem/JavaModels/JavaFieldModel.cs
@@ -43,5 +43,13 @@ namespace Java.Interop.Tools.JavaTypeSystem.Models
 				return;
 			}
 		}
+
+		public override string ToString ()
+		{
+			if (DeclaringType != null)
+				return $"[Field] {DeclaringType.FullName}.{Name}";
+
+			return $"[Field] {Name}";
+		}
 	}
 }


### PR DESCRIPTION
Context: https://discord.com/channels/732297728826277939/732297837953679412/1151531791069499524

A user reported the following output in their `java-resolution-report.log`:

```
The field 'Java.Interop.Tools.JavaTypeSystem.Models.JavaFieldModel' was removed because its name contains a dollar sign.
The class '[Class] com.google.android.libraries.navigation.internal.aac.ad' was removed because the Java base type 'com.google.android.libraries.navigation.internal.aad.ar<com.google.android.libraries.navigation.internal.aac.af<K, V>>' could not be found.
```

We should be providing the user with the name of the removed field rather than the `JavaFieldModel` type name.  To do this, add an appropriate `JavaFieldModel.ToString ()`.