### PR TITLE
[build] introduce `xamarin-android-tools.override.props`

### DIFF
--- a/external/xamarin-android-tools.override.props
+++ b/external/xamarin-android-tools.override.props
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="..\Directory.Build.props" />
+</Project>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/8360

When .NET 8 RC 2 took a dependency on dotnet/runtime 7.0.12 and 6.0.23, we added a `xamarin-android-tools.override.props` with the contents:

    <Project>
      <PropertyGroup>
        <RestoreAdditionalProjectSources>
          https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-26e0f822/nuget/v3/index.json;
          https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-301ba1ee/nuget/v3/index.json;
        </RestoreAdditionalProjectSources>
      </PropertyGroup>
    </Project>

Unfortunately, this still broke for the submodule:

    external/java.interop/external/xamarin-android-tools

This led to the error during the `prepare java.interop Debug` stage:

    external/Java.Interop/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj : error NU1102: Unable to find package Microsoft.NETCore.App.Ref with version (= 6.0.23)
    external/Java.Interop/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj : error NU1102: - Found 86 version(s) in dotnet-public [ Nearest version: 7.0.0-preview.1.22076.8 ]
    external/Java.Interop/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj : error NU1102: - Found 1 version(s) in dotnet-eng [ Nearest version: 5.0.0-alpha.1.19618.1 ]
    external/Java.Interop/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj : error NU1102: Unable to find package Microsoft.NETCore.App.Ref with version (= 6.0.23)
    external/Java.Interop/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj : error NU1102: - Found 86 version(s) in dotnet-public [ Nearest version: 7.0.0-preview.1.22076.8 ]
    external/Java.Interop/external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj : error NU1102: - Found 1 version(s) in dotnet-eng [ Nearest version: 5.0.0-alpha.1.19618.1 ]
    build-tools/scripts/DotNet.targets(19,5): error MSB3073: The command ""bin/Release/dotnet/dotnet" build -t:Prepare Java.Interop.sln -c Debug -p:JdksRoot= -p:DotnetToolPath=bin/Release/dotnet/dotnet -bl:build-tools/scripts/../../bin/BuildDebug/msbuild-20230925T183954-prepare-java-interop.binlog" exited with code 1.
        1 Warning(s)
        7 Error(s)

Introduce a `xamarin-android-tools.override.props` to import `..\Directory.Build.props` and avoid this in the future.