### PR TITLE
[generator] restore `[RegisterAttribute]` for *Implementor types

### DIFF
--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteDuplicateInterfaceEventArgs.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteDuplicateInterfaceEventArgs.txt
@@ -157,6 +157,7 @@ public partial class AnimationEndEventArgs : global::System.EventArgs {
 
 }
 
+[global::Android.Runtime.Register ("mono/java/code/AnimatorListenerImplementor")]
 internal sealed partial class AnimatorListenerImplementor : global::Java.Lang.Object, AnimatorListener {
 
 	object sender;

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteDuplicateInterfaceEventArgs.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteDuplicateInterfaceEventArgs.txt
@@ -47,6 +47,7 @@ public partial class AnimationEndEventArgs : global::System.EventArgs {
 
 }
 
+[global::Android.Runtime.Register ("mono/java/code/AnimatorListenerImplementor")]
 internal sealed partial class AnimatorListenerImplementor : global::Java.Lang.Object, AnimatorListener {
 
 	object? sender;

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteDuplicateInterfaceEventArgs.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteDuplicateInterfaceEventArgs.txt
@@ -157,6 +157,7 @@ public partial class AnimationEndEventArgs : global::System.EventArgs {
 
 }
 
+[global::Android.Runtime.Register ("mono/java/code/AnimatorListenerImplementor")]
 internal sealed partial class AnimatorListenerImplementor : global::Java.Lang.Object, AnimatorListener {
 
 	object sender;

--- a/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Views.View.cs
+++ b/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Views.View.cs
@@ -111,6 +111,7 @@ namespace Android.Views {
 
 		}
 
+		[global::Android.Runtime.Register ("mono/android/view/View_OnClickListenerImplementor")]
 		internal sealed partial class IOnClickListenerImplementor : global::Java.Lang.Object, IOnClickListener {
 			public unsafe IOnClickListenerImplementor () : base (IntPtr.Zero, JniHandleOwnership.DoNotTransfer)
 			{

--- a/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
+++ b/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
@@ -162,6 +162,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 
 	}
 
+	[global::Android.Runtime.Register ("mono/com/google/android/exoplayer/drm/ExoMediaDrm_OnEventListenerImplementor")]
 	internal sealed partial class IExoMediaDrmOnEventListenerImplementor : global::Java.Lang.Object, IExoMediaDrmOnEventListener {
 
 		object sender;

--- a/tools/generator/SourceWriters/InterfaceEventHandlerImplClass.cs
+++ b/tools/generator/SourceWriters/InterfaceEventHandlerImplClass.cs
@@ -27,6 +27,7 @@ namespace generator.SourceWriters
 				type.Nullable = opt.SupportNullableReferenceTypes;
 				Fields.Add (new FieldWriter { Name = "sender", Type = type });
 			}
+			Attributes.Add (new RegisterAttr (jni_class, additionalProperties: iface.AdditionalAttributeString ()) { UseGlobal = true });
 
 			AddConstructor (iface);
 			AddMethods (iface, opt);


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/8337

A customer's app with the code:

    SetContentView(Resource.Layout.activity_main);
    FindViewById<Button>(Resource.Id.asd).Click += MainActivity_Click;

Crashes with `-c Release -p:AndroidLinkMode=r8` with:

    java.lang.RuntimeException: Unable to start activity ComponentInfo{com.companyname.New_folder/crc64abe8cc9139195b67.MainActivity}: java.lang.ClassNotFoundException: android.view.View_IOnClickListenerImplementor
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3644)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3781)
        at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:101)
        at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:138)
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2306)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loopOnce(Looper.java:201)
        at android.os.Looper.loop(Looper.java:288)
        at android.app.ActivityThread.main(ActivityThread.java:7918)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
    Caused by: java.lang.ClassNotFoundException: android.view.View_IOnClickListenerImplementor
        at crc64abe8cc9139195b67.MainActivity.n_onCreate(Native Method)
        at crc64abe8cc9139195b67.MainActivity.onCreate(MainActivity.java:30)
        at android.app.Activity.performCreate(Activity.java:8342)
        at android.app.Activity.performCreate(Activity.java:8321)
        at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1417)
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3625)
        ... 12 more

Which, can be solved by adding your own `proguard` rules like:

    -keep class android.view.View_IOnClickListenerImplementor { *; }

In a91ae7f9, we thought (incorrectly):

> Additionally, stop emitting the `[Register]` attribute for
> `*Implementor` classes:
>
>    [global::Android.Runtime.Register ("mono/android/view/View_OnFocusChangeListenerImplementor")]
>    partial class IOnFocusChangeListenerImplementor {/* … */}
>
> The `[Register]` attribute is not needed, because `*Implementor`
> classes are generated internal implementation details.

`proguard_xamarin.cfg` has the entry:

    -keep class mono.android.** { *; <init>(...); }

So we could do `android.**`, but that would certainly preserve way too much!

For now, let's just restore `[Register]` to revisit this issue at a later date -- maybe .NET 9?