### PR TITLE
[class-parse] Add Kotlin metadata to `-dump`.

### DIFF
--- a/tools/class-parse/Program.cs
+++ b/tools/class-parse/Program.cs
@@ -163,26 +163,29 @@ namespace Xamarin.Android.Tools {
 			}
 
 			// Output Kotlin metadata if it exists
-			var kotlin_metadata = c.Attributes.OfType<RuntimeVisibleAnnotationsAttribute> ().FirstOrDefault ()?.Annotations.FirstOrDefault (a => a.Type == "Lkotlin/Metadata;");
+			var kotlin_metadata = c.Attributes.OfType<RuntimeVisibleAnnotationsAttribute> ()
+				.FirstOrDefault ()?.Annotations
+				.FirstOrDefault (a => a.Type == "Lkotlin/Metadata;");
 
 			if (kotlin_metadata is not null) {
 				var meta = KotlinMetadata.FromAnnotation (kotlin_metadata);
+				var jopt = new JsonSerializerOptions {
+					ReferenceHandler    = ReferenceHandler.Preserve,
+					WriteIndented       = true,
+				};
 
 				if (meta.AsClassMetadata () is KotlinClass kc) {
-					Console.WriteLine ();
-					Console.WriteLine ($"Kotlin Class Metadata [{meta.MetadataVersion}]:");
-					var json = JsonSerializer.Serialize (kc, new JsonSerializerOptions { ReferenceHandler = ReferenceHandler.Preserve, WriteIndented = true });
-					output.WriteLine (json);
+					output.WriteLine ();
+					var json = JsonSerializer.Serialize (kc, jopt);
+					output.WriteLine ($"Kotlin Class Metadata [{meta.MetadataVersion}]: {json}");
 				} else if (meta.AsFileMetadata () is KotlinFile kf) {
-					Console.WriteLine ();
-					Console.WriteLine ($"Kotlin File Metadata [{meta.MetadataVersion}]:");
-					var json = JsonSerializer.Serialize (kf, new JsonSerializerOptions { ReferenceHandler = ReferenceHandler.Preserve, WriteIndented = true });
-					output.WriteLine (json);
+					output.WriteLine ();
+					var json = JsonSerializer.Serialize (kf, jopt);
+					output.WriteLine ($"Kotlin File Metadata [{meta.MetadataVersion}]: {json}");
 				}
 
-				Console.WriteLine ();
-				Console.WriteLine ("Kotlin Metadata String Table:");
-				output.WriteLine (JsonSerializer.Serialize (meta.Data2, new JsonSerializerOptions { ReferenceHandler = ReferenceHandler.Preserve, WriteIndented = true }));
+				output.WriteLine ();
+				output.WriteLine ($"Kotlin Metadata String Table: {JsonSerializer.Serialize (meta.Data2, jopt)}");
 			}
 		}
 	}


### PR DESCRIPTION
For initial "why did `class-parse` mark this function as `kotlin-internal`" type questions, it would be helpful if `class-parse -dump` could output a parsed Kotlin metadata blob.  

Unfortunately, the Kotlin metadata blob is pretty raw, but if we start adding our logic to it then the output will be incorrect if our assumptions about how the data works are incorrect.  Thus this PR is up for debate if it actually improves the situation or not.

Example:
```
class-parse -dump EmojiPickerView.class

--- cut normal content ---

Kotlin Class Metadata [1.8.0]:
{
  "$id": "1",
  "CompanionObjectName": "Companion",
  "Constructors": { ... },
  "EnumEntries": {
    "$id": "14",
    "$values": []
  },
  "Flags": 6,
  "FullyQualifiedName": null,
  "Inheritability": 0,
  "NestedClassNames": {
    "$id": "15",
    "$values": [
      "Companion"
    ]
  },
  "ObjectType": 0,
  "SealedSubclassFullyQualifiedNames": null,
  "SuperTypeIds": null,
  "SuperTypes": {
    "$id": "16",
    "$values": [
      {
        "$id": "17",
        "Arguments": {
          "$id": "18",
          "$values": []
        },
        "Nullable": false,
        "FlexibleTypeCapabilitiesId": null,
        "FlexibleUpperBound": null,
        "FlexibleUpperBoundId": 0,
        "ClassName": "android/widget/FrameLayout;",
        "TypeParameter": null,
        "TypeParameterName": null,
        "TypeAliasName": null,
        "OuterType": null,
        "OuterTypeId": null,
        "AbbreviatedType": null,
        "AbbreviatedTypeId": null,
        "Flags": 0
      }
    ]
  },
  "TypeParameters": {
    "$id": "19",
    "$values": []
  },
  "VersionRequirements": null,
  "Visibility": 3,
  "Functions": {
    "$id": "20",
    "$values": [
      ...
      {
        "$id": "145",
        "Name": "setOnEmojiPickedListener",
        "JvmName": "setOnEmojiPickedListener",
        "JvmSignature": null,
        "Flags": 6,
        "ReturnType": {
          "$id": "146",
          "Arguments": {
            "$id": "147",
            "$values": []
          },
          "Nullable": false,
          "FlexibleTypeCapabilitiesId": null,
          "FlexibleUpperBound": null,
          "FlexibleUpperBoundId": 0,
          "ClassName": "kotlin/Unit",
          "TypeParameter": null,
          "TypeParameterName": null,
          "TypeAliasName": null,
          "OuterType": null,
          "OuterTypeId": null,
          "AbbreviatedType": null,
          "AbbreviatedTypeId": null,
          "Flags": 0
        },
        "ReturnTypeId": 0,
        "TypeParameters": {
          "$id": "148",
          "$values": []
        },
        "ReceiverType": null,
        "ReceiverTypeId": 0,
        "TypeTable": null,
        "Contract": null,
        "ValueParameters": {
          "$id": "149",
          "$values": [
            {
              "$id": "150",
              "Flags": 0,
              "Name": "onEmojiPickedListener",
              "Type": {
                "$id": "151",
                "Arguments": {
                  "$id": "152",
                  "$values": [
                    {
                      "$id": "153",
                      "Projection": 2,
                      "Type": {
                        "$id": "154",
                        "Arguments": {
                          "$id": "155",
                          "$values": []
                        },
                        "Nullable": false,
                        "FlexibleTypeCapabilitiesId": null,
                        "FlexibleUpperBound": null,
                        "FlexibleUpperBoundId": 0,
                        "ClassName": "androidx/emoji2/emojipicker/EmojiViewItem;",
                        "TypeParameter": null,
                        "TypeParameterName": null,
                        "TypeAliasName": null,
                        "OuterType": null,
                        "OuterTypeId": null,
                        "AbbreviatedType": null,
                        "AbbreviatedTypeId": null,
                        "Flags": 0
                      },
                      "TypeId": 0
                    }
                  ]
                },
                "Nullable": true,
                "FlexibleTypeCapabilitiesId": null,
                "FlexibleUpperBound": null,
                "FlexibleUpperBoundId": 0,
                "ClassName": "androidx/core/util/Consumer;",
                "TypeParameter": null,
                "TypeParameterName": null,
                "TypeAliasName": null,
                "OuterType": null,
                "OuterTypeId": null,
                "AbbreviatedType": null,
                "AbbreviatedTypeId": null,
                "Flags": 0
              },
              "TypeId": 0,
              "VarArgElementType": null,
              "VarArgElementTypeId": 0
            }
          ]
        },
        "VersionRequirements": null
      },
  ...
  },
  "Properties": {... },
  "TypeAliases": {
    "$id": "230",
    "$values": []
  },
  "TypeTable": null,
  "VersionRequirementTable": {
    "$id": "231",
    "Requirements": {
      "$id": "232",
      "$values": [
        {
          "$id": "233",
          "Version": 25,
          "VersionFull": 0,
          "Level": 1,
          "ErrorCode": 0,
          "Message": 0,
          "VersionKind": 0
        }
      ]
    }
  }
}

Kotlin Metadata String Table:
[
  "Landroidx/emoji2/emojipicker/EmojiPickerView;",
  "Landroid/widget/FrameLayout;",
  "context",
  "Landroid/content/Context;",
  "attrs",
  "Landroid/util/AttributeSet;",
  "defStyleAttr",
  "",
  "(Landroid/content/Context;Landroid/util/AttributeSet;I)V",
  "_emojiGridRows",
  "",
  "Ljava/lang/Float;",
  "bodyAdapter",
  "Landroidx/emoji2/emojipicker/EmojiPickerBodyAdapter;",
  "value",
  "emojiGridColumns",
  "getEmojiGridColumns",
  "()I",
  "setEmojiGridColumns",
  "(I)V",
  "emojiGridRows",
  "getEmojiGridRows",
  "()F",
  "setEmojiGridRows",
  "(F)V",
  "emojiPickerItems",
  "Landroidx/emoji2/emojipicker/EmojiPickerItems;",
  "onEmojiPickedListener",
  "Landroidx/core/util/Consumer;",
  "Landroidx/emoji2/emojipicker/EmojiViewItem;",
  "recentEmojiProvider",
  "Landroidx/emoji2/emojipicker/RecentEmojiProvider;",
  "recentItemGroup",
  "Landroidx/emoji2/emojipicker/ItemGroup;",
  "recentItems",
  "",
  "Landroidx/emoji2/emojipicker/EmojiViewData;",
  "recentNeedsRefreshing",
  "",
  "scope",
  "Lkotlinx/coroutines/CoroutineScope;",
  "stickyVariantProvider",
  "Landroidx/emoji2/emojipicker/StickyVariantProvider;",
  "addView",
  "",
  "child",
  "Landroid/view/View;",
  "params",
  "Landroid/view/ViewGroup$LayoutParams;",
  "index",
  "width",
  "height",
  "buildEmojiPickerItems",
  "buildEmojiPickerItems$emoji2_emojipicker_release",
  "createEmojiPickerBodyAdapter",
  "refreshRecent",
  "refreshRecent$emoji2_emojipicker_release",
  "(Lkotlin/coroutines/Continuation;)Ljava/lang/Object;",
  "removeAllViews",
  "removeView",
  "removeViewAt",
  "removeViewInLayout",
  "removeViews",
  "start",
  "count",
  "removeViewsInLayout",
  "setOnEmojiPickedListener",
  "setRecentEmojiProvider",
  "showEmojiPickerView",
  "Companion",
  "emoji2-emojipicker_release"
]
```