### PR TITLE
[Java.Interop] Allow JniRuntime init from JavaVM* and JNIEnv*

### DIFF
--- a/src/Java.Runtime.Environment/Java.Interop/JreRuntime.cs
+++ b/src/Java.Runtime.Environment/Java.Interop/JreRuntime.cs
@@ -39,11 +39,7 @@ namespace Java.Interop {
 		public JreRuntimeOptions ()
 		{
 			JniVersion  = JniVersion.v1_2;
-			ClassPath   = new Collection<string> () {
-				Path.Combine (
-					Path.GetDirectoryName (typeof (JreRuntimeOptions).Assembly.Location) ?? throw new NotSupportedException (),
-					"java-interop.jar"),
-			};
+			ClassPath   = new Collection<string> ();
 		}
 
 		public JreRuntimeOptions AddOption (string option)
@@ -80,7 +76,9 @@ namespace Java.Interop {
 		{
 			if (builder == null)
 				throw new ArgumentNullException ("builder");
-			if (string.IsNullOrEmpty (builder.JvmLibraryPath))
+			if (builder.InvocationPointer == IntPtr.Zero &&
+					builder.EnvironmentPointer == IntPtr.Zero &&
+					string.IsNullOrEmpty (builder.JvmLibraryPath))
 				throw new InvalidOperationException ($"Member `{nameof (JreRuntimeOptions)}.{nameof (JreRuntimeOptions.JvmLibraryPath)}` must be set.");
 
 			builder.LibraryHandler  = JvmLibraryHandler.Create ();
@@ -99,10 +97,20 @@ namespace Java.Interop {
 				builder.ObjectReferenceManager  = builder.ObjectReferenceManager    ?? new ManagedObjectReferenceManager (builder.JniGlobalReferenceLogWriter, builder.JniLocalReferenceLogWriter);
 			}
 
-			if (builder.InvocationPointer != IntPtr.Zero)
+			if (builder.InvocationPointer != IntPtr.Zero || builder.EnvironmentPointer != IntPtr.Zero)
 				return builder;
 
 			builder.LibraryHandler.LoadJvmLibrary (builder.JvmLibraryPath!);
+
+			if (!builder.ClassPath.Any (p => p.EndsWith ("java-interop.jar", StringComparison.OrdinalIgnoreCase))) {
+				var loc = typeof (JreRuntimeOptions).Assembly.Location;
+				var dir = string.IsNullOrEmpty (loc) ? null : Path.GetDirectoryName (loc);
+				var jij = string.IsNullOrEmpty (dir) ? null : Path.Combine (dir, "java-interop.jar");
+				if (!File.Exists (jij)) {
+					throw new InvalidOperationException ($"`java-interop.jar` is required.  Please add to `JreRuntimeOptions.ClassPath`.  Tried to find it in `{jij}`.");
+				}
+				builder.ClassPath.Add (jij);
+			}
 
 			var args = new JavaVMInitArgs () {
 				version             = builder.JniVersion,

--- a/src/Java.Runtime.Environment/Java.Interop/JreRuntime.cs
+++ b/src/Java.Runtime.Environment/Java.Interop/JreRuntime.cs
@@ -107,7 +107,7 @@ namespace Java.Interop {
 				var dir = string.IsNullOrEmpty (loc) ? null : Path.GetDirectoryName (loc);
 				var jij = string.IsNullOrEmpty (dir) ? null : Path.Combine (dir, "java-interop.jar");
 				if (!File.Exists (jij)) {
-					throw new InvalidOperationException ($"`java-interop.jar` is required.  Please add to `JreRuntimeOptions.ClassPath`.  Tried to find it in `{jij}`.");
+					throw new FileNotFoundException ($"`java-interop.jar` is required.  Please add to `JreRuntimeOptions.ClassPath`.  Tried to find it in `{jij}`.");
 				}
 				builder.ClassPath.Add (jij);
 			}

--- a/tests/Java.Interop-Tests/Java.Interop/JniRuntimeTest.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JniRuntimeTest.cs
@@ -36,6 +36,25 @@ namespace Java.InteropTests
 				Assert.Fail ("Expected NotSupportedException; got: {0}", e);
 			}
 		}
+
+		[Test]
+		public void UseInvocationPointerOnNewThread ()
+		{
+			var InvocationPointer = JniRuntime.CurrentRuntime.InvocationPointer;
+
+			var t = new Thread (() => {
+				try {
+					var second = new JreRuntimeOptions () {
+						InvocationPointer   = InvocationPointer,
+					}.CreateJreVM ();
+				}
+				catch (Exception e) {
+					Assert.Fail ("Expected no exception, got: {0}", e);
+				}
+			});
+			t.Start ();
+			t.Join ();
+		}
 #endif  // !__ANDROID__
 
 		[Test]


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/pull/1153

[JNI][0] supports *two* modes of operation:

 1. Native code creates the JVM, e.g. via [`JNI_CreateJavaVM()`][1]

 2. The JVM already exists, and when Java code calls [`System.loadLibrary()`][3], the JVM calls the [`JNI_OnLoad()`][2] function on the specified library.

Java.Interop samples and unit tests rely on the first approach, e.g. `TestJVM` subclasses `JreRuntime`, which is responsible for calling `JNI_CreateJavaVM()` so that Java code can be used.

PR #1153 is exploring the use of [.NET Native AOT][4] to produce a native library which is used with Java-originated initialization.

In order to make Java-originated initialization *work*, we need to be able to initialize `JniRuntime` and `JreRuntime` around existing JVM-provided pointers:

  * The `JavaVM*` provided to `JNI_OnLoad()`, which can be used to set `JniRuntime.CreationOptions.InvocationPointer`:

        [UnmanagedCallersOnly(EntryPoint="JNI_OnLoad")]
        int JNI_OnLoad(IntPtr vm, IntPtr reserved)
        {
            var options = new JreRuntimeOptions {
                InvocationPointer = vm,
            };
            var runtime = options.CreateJreVM ();
            return runtime.JniVersion;
            return JNI_VERSION_1_6;
        }

  * The [`JNIEnv*` value provided to Java `native` methods][5] when they are invoked, which can be used to set `JniRuntime.CreationOptions.EnvironmentPointer`:

        [UnmanagedCallersOnly(EntryPoint="Java_example_Whatever_init")]
        void Whatever_init(IntPtr jnienv, IntPtr Whatever_class)
        {
            var options = new JreRuntimeOptions {
                EnvironmentPointer = jnienv,
            };
            var runtime = options.CreateJreVM ();
        }

Update `JniRuntime` and `JreRuntime` to support these Java-originated initialization strategies.  In particular, don't require that `JreRuntimeOptions.JvmLibraryPath` be set, avoiding:

	System.InvalidOperationException: Member `JreRuntimeOptions.JvmLibraryPath` must be set.
	   at Java.Interop.JreRuntime.CreateJreVM(JreRuntimeOptions builder)
	   at Java.Interop.JreRuntime..ctor(JreRuntimeOptions builder)
	   at Java.Interop.JreRuntimeOptions.CreateJreVM()

[0]: https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/jniTOC.html
[1]: https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/invocation.html#creating_the_vm
[2]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Runtime.html#loadLibrary(java.lang.String)
[3]: https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/invocation.html#JNJI_OnLoad
[4]: https://learn.microsoft.com/dotnet/core/deploying/native-aot/
[5]: https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/design.html#native_method_arguments