### PR TITLE
[jcw-gen, jnimarshalmethod-gen] Native method consistency

### DIFF
--- a/src/Java.Interop.Export/Java.Interop/JavaCallableAttribute.cs
+++ b/src/Java.Interop.Export/Java.Interop/JavaCallableAttribute.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 
 namespace Java.Interop {

--- a/src/Java.Interop.Export/Java.Interop/JavaCallableConstructorAttribute.cs
+++ b/src/Java.Interop.Export/Java.Interop/JavaCallableConstructorAttribute.cs
@@ -1,0 +1,16 @@
+#nullable enable
+using System;
+
+namespace Java.Interop {
+
+	[AttributeUsage (AttributeTargets.Constructor, AllowMultiple=false)]
+	public sealed class JavaCallableConstructorAttribute : Attribute {
+
+		public JavaCallableConstructorAttribute ()
+		{
+		}
+
+		public  string?     SuperConstructorExpression  {get; set;}
+		public  string?     Signature                   {get; set;}
+	}
+}

--- a/src/Java.Interop.Export/Java.Interop/MarshalMemberBuilder.cs
+++ b/src/Java.Interop.Export/Java.Interop/MarshalMemberBuilder.cs
@@ -68,7 +68,7 @@ namespace Java.Interop {
 
 		string GetJniMethodName (JavaCallableAttribute export, MethodInfo method)
 		{
-			return export.Name ?? "n_" + method.Name;
+			return "n_" + method.Name;
 		}
 
 		public string GetJniMethodSignature (JavaCallableAttribute export, MethodInfo method)

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
@@ -412,11 +412,17 @@ namespace Java.Interop {
 			bool TryLoadJniMarshalMethods (JniType nativeClass, Type type, string? methods)
 			{
 				var marshalType = type?.GetNestedType ("__<$>_jni_marshal_methods", BindingFlags.NonPublic);
-				if (marshalType == null)
+				if (marshalType == null) {
 					return false;
+				}
 
-				var registerMethod = marshalType.GetRuntimeMethod ("__RegisterNativeMembers", registerMethodParameters);
-
+				var registerMethod = marshalType.GetMethod (
+						name:           "__RegisterNativeMembers",
+						bindingAttr:    BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public,
+						binder:         null,
+						callConvention: default,
+						types:          registerMethodParameters,
+						modifiers:      null);
 				return TryRegisterNativeMembers (nativeClass, marshalType, methods, registerMethod);
 			}
 
@@ -466,8 +472,10 @@ namespace Java.Interop {
 						continue;
 					}
 
+					var declaringTypeName = methodInfo.DeclaringType?.FullName ?? "<no-decl-type>";
+
 					if ((methodInfo.Attributes & MethodAttributes.Static) != MethodAttributes.Static) {
-						throw new InvalidOperationException ($"The method {methodInfo} marked with {nameof (JniAddNativeMethodRegistrationAttribute)} must be static");
+						throw new InvalidOperationException ($"The method `{declaringTypeName}.{methodInfo}` marked with [{nameof (JniAddNativeMethodRegistrationAttribute)}] must be static!");
 					}
 
 					var register = (Action<JniNativeMethodRegistrationArguments>)methodInfo.CreateDelegate (typeof (Action<JniNativeMethodRegistrationArguments>));

--- a/src/Java.Interop/Java.Interop/JniTypeSignatureAttribute.cs
+++ b/src/Java.Interop/Java.Interop/JniTypeSignatureAttribute.cs
@@ -11,7 +11,9 @@ namespace Java.Interop
 
 		public JniTypeSignatureAttribute (string simpleReference)
 		{
+#if !JCW_ONLY_TYPE_NAMES
 			JniRuntime.JniTypeManager.AssertSimpleReference (simpleReference, nameof (simpleReference));
+#endif  // !JCW_ONLY_TYPE_NAMES
 
 			SimpleReference     = simpleReference;
 		}

--- a/src/Java.Interop/Java.Interop/ManagedPeer.cs
+++ b/src/Java.Interop/Java.Interop/ManagedPeer.cs
@@ -216,7 +216,7 @@ namespace Java.Interop {
 
 			}
 			catch (Exception e) when (JniEnvironment.Runtime.ExceptionShouldTransitionToJni (e)) {
-				Debug.WriteLine (e.ToString ());
+				Debug.WriteLine ($"Exception when trying to register native methods with JNI: {e}");
 				envp.SetPendingException (e);
 			}
 			finally {

--- a/src/Java.Runtime.Environment/Java.Interop/JreTypeManager.cs
+++ b/src/Java.Runtime.Environment/Java.Interop/JreTypeManager.cs
@@ -52,6 +52,10 @@ namespace Java.Interop {
 				registrations.Add (new JniNativeMethodRegistration (name, signature, marshaler!));
 			}
 
+			foreach (var registration in Runtime.MarshalMemberBuilder.GetExportedMemberRegistrations (type)) {
+				registrations.Add (registration);
+			}
+
 			nativeClass.RegisterNativeMethods (registrations.ToArray ());
 		}
 

--- a/tests/Java.Interop.Export-Tests/Java.Interop.Export-Tests.csproj
+++ b/tests/Java.Interop.Export-Tests/Java.Interop.Export-Tests.csproj
@@ -22,19 +22,16 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Java.Interop\Java.Interop.csproj" />
+    <ProjectReference Include="..\..\src\Java.Base\Java.Base.csproj" />
     <ProjectReference Include="..\..\src\Java.Interop.Export\Java.Interop.Export.csproj" />
     <ProjectReference Include="..\..\src\Java.Runtime.Environment\Java.Runtime.Environment.csproj" />
     <ProjectReference Include="..\TestJVM\TestJVM.csproj" />
   </ItemGroup>
   
   <ItemGroup>
-    <JavaExportTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\export\ExportType.java" />
+    <JavaExportTestJar Include="$(MSBuildThisFileDirectory)java\**\*.java" />
   </ItemGroup>
 
-  <Target Name="BuildExportTestJar" BeforeTargets="Build" Inputs="@(JavaExportTestJar)" Outputs="$(OutputPath)export-test.jar">
-    <MakeDir Directories="$(IntermediateOutputPath)et-classes" />
-    <Exec Command="&quot;$(JavaCPath)&quot; -classpath &quot;$(OutputPath)java-interop.jar&quot; $(_JavacSourceOptions) -d &quot;$(IntermediateOutputPath)et-classes&quot; @(JavaExportTestJar->'%(Identity)', ' ')" />
-    <Exec Command="&quot;$(JarPath)&quot; cf &quot;$(OutputPath)export-test.jar&quot; -C &quot;$(IntermediateOutputPath)et-classes&quot; ." />
-  </Target>
+  <Import Project="Java.Interop.Export-Tests.targets" />
 
 </Project>

--- a/tests/Java.Interop.Export-Tests/Java.Interop.Export-Tests.targets
+++ b/tests/Java.Interop.Export-Tests/Java.Interop.Export-Tests.targets
@@ -1,0 +1,53 @@
+﻿<Project>
+
+  <Target Name="_CreateJavaCallableWrappers"
+      Condition=" '$(TargetPath)' != '' "
+      BeforeTargets="BuildExportTestJar"
+      Inputs="$(TargetPath)"
+      Outputs="$(IntermediateOutputPath)java\.stamp">
+    <RemoveDir Directories="$(IntermediateOutputPath)java" />
+    <MakeDir Directories="$(IntermediateOutputPath)java" />
+    <ItemGroup>
+      <!-- I can't find a good way to trim the trailing `\`, so append with `.` so we can sanely quote for $(_Libpath) -->
+      <_RefAsmDirs Include="@(ReferencePathWithRefAssemblies->'%(RootDir)%(Directory).'->Distinct())" />
+    </ItemGroup>
+    <PropertyGroup>
+      <_JcwGen>"$(UtilityOutputFullPath)/jcw-gen.dll"</_JcwGen>
+      <_Target>--codegen-target JavaInterop1</_Target>
+      <_Output>-o "$(IntermediateOutputPath)/java"</_Output>
+      <_Libpath>@(_RefAsmDirs->'-L "%(Identity)"', ' ')</_Libpath>
+    </PropertyGroup>
+    <Exec Command="$(DotnetToolPath) $(_JcwGen) &quot;$(TargetPath)&quot; $(_Target) $(_Output) $(_Libpath)" />
+    <Touch Files="$(IntermediateOutputPath)java\.stamp" AlwaysCreate="True" />
+  </Target>
+
+  <Target Name="BuildExportTestJar"
+      AfterTargets="Build"
+      Inputs="$(TargetPath);@(JavaExportTestJar)"
+      Outputs="$(OutputPath)export-test.jar">
+    <MakeDir Directories="$(IntermediateOutputPath)et-classes" />
+    <ItemGroup>
+      <_JcwSource Include="$(IntermediateOutputPath)java\**\*.java" />
+    </ItemGroup>
+    <ItemGroup>
+      <_Source Include="@(_JcwSource->Replace('%5c', '/'))" />
+      <_Source Include="@(JavaExportTestJar->Replace('%5c', '/'))" />
+    </ItemGroup>
+    <WriteLinesToFile
+        File="$(IntermediateOutputPath)_java_sources.txt"
+        Lines="@(_Source)"
+        Overwrite="True"
+    />
+    <ItemGroup>
+      <_JavacOpt Include="$(_JavacSourceOptions)" />
+      <_JavacOpt Include="-d &quot;$(IntermediateOutputPath)et-classes&quot; " />
+      <_JavacOpt Include="-classpath &quot;$(OutputPath)java-interop.jar&quot; " />
+      <_JavacOpt Include="&quot;@$(IntermediateOutputPath)_java_sources.txt&quot;" />
+      <_JavacOpt Include="-h &quot;$(IntermediateOutputPath)et-classes&quot; " />
+    </ItemGroup>
+    <Exec Command="&quot;$(JavaCPath)&quot; @(_JavacOpt, ' ')" />
+    <Delete Files="$(IntermediateOutputPath)_java_sources.txt" />
+    <Exec Command="&quot;$(JarPath)&quot; cf &quot;$(OutputPath)export-test.jar&quot; -C &quot;$(IntermediateOutputPath)et-classes&quot; ." />
+  </Target>
+
+</Project>

--- a/tests/Java.Interop.Export-Tests/Java.Interop/JavaCallableExample.cs
+++ b/tests/Java.Interop.Export-Tests/Java.Interop/JavaCallableExample.cs
@@ -1,0 +1,23 @@
+using Java.Interop;
+
+namespace Java.InteropTests;
+
+[JniTypeSignature (TypeSignature)]
+class JavaCallableExample : Java.Lang.Object {
+
+	internal const string TypeSignature = "net/dot/jni/test/JavaCallableExample";
+
+	[JavaCallableConstructor(SuperConstructorExpression="")]
+	public JavaCallableExample (int a)
+	{
+		this.a = a;
+	}
+
+	int a;
+
+	[JavaCallable ("getA")]
+	public int GetA ()
+	{
+		return a;
+	}
+}

--- a/tests/Java.Interop.Export-Tests/Java.Interop/JavaCallableExampleTests.cs
+++ b/tests/Java.Interop.Export-Tests/Java.Interop/JavaCallableExampleTests.cs
@@ -1,0 +1,21 @@
+using Java.Interop;
+
+using NUnit.Framework;
+
+namespace Java.InteropTests;
+
+[TestFixture]
+class JavaCallableExampleTest : JavaVMFixture
+{
+	[Test]
+	public void JavaCallableWrappers ()
+	{
+		using var jce = CreateUseJavaCallableExampleType ();
+		var m = jce.GetStaticMethod ("test", "()Z");
+		var z = JniEnvironment.StaticMethods.CallStaticBooleanMethod (jce.PeerReference, m);
+		Assert.IsTrue (z);
+	}
+
+	static JniType CreateUseJavaCallableExampleType () =>
+		new JniType ("net/dot/jni/test/UseJavaCallableExample");
+}

--- a/tests/Java.Interop.Export-Tests/Java.Interop/MarshalMemberBuilderTest.cs
+++ b/tests/Java.Interop.Export-Tests/Java.Interop/MarshalMemberBuilderTest.cs
@@ -24,10 +24,10 @@ namespace Java.InteropTests
 					.ToList ();
 				Assert.AreEqual (11, methods.Count);
 
-				Assert.AreEqual ("action",  methods [0].Name);
-				Assert.AreEqual ("()V",     methods [0].Signature);
+				Assert.AreEqual ("n_InstanceAction",    methods [0].Name);
+				Assert.AreEqual ("()V",                 methods [0].Signature);
 
-				Assert.AreEqual ("staticAction",        methods [1].Name);
+				Assert.AreEqual ("n_StaticAction",      methods [1].Name);
 				Assert.AreEqual ("()V",                 methods [1].Signature);
 
 #if NET

--- a/tests/Java.Interop.Export-Tests/java/com/xamarin/interop/export/ExportType.java
+++ b/tests/Java.Interop.Export-Tests/java/com/xamarin/interop/export/ExportType.java
@@ -25,12 +25,54 @@ public class ExportType
 			throw new Error ("staticFuncMyEnum_MyEnum should return 42!");
 	}
 
-	public static native void staticAction ();
-	public static native void staticActionIJavaObject (Object test);
-	public static native void staticActionInt32String (int i, String s);
-	public static native int  staticFuncMyLegacyColorMyColor_MyColor (int color1, int color2);
+	public  static          void    staticAction () {n_StaticAction ();}
+	private static  native  void    n_StaticAction ();
 
-	public static native boolean staticFuncThisMethodTakesLotsOfParameters (
+	public  static          void    staticActionIJavaObject (Object test) {n_StaticActionIJavaObject(test);}
+	private static  native  void    n_StaticActionIJavaObject (Object test);
+
+	public  static          void    staticActionInt32String (int i, String s) {n_StaticActionInt32String (i, s);}
+	private static  native  void    n_StaticActionInt32String (int i, String s);
+
+	public  static          int     staticFuncMyLegacyColorMyColor_MyColor (int color1, int color2) {return n_StaticFuncMyLegacyColorMyColor_MyColor (color1, color2);}
+	private static  native  int     n_StaticFuncMyLegacyColorMyColor_MyColor (int color1, int color2);
+
+	public static boolean staticFuncThisMethodTakesLotsOfParameters (
+			boolean             a,
+			byte                b,
+			char                c,
+			short               d,
+			int                 e,
+			long                f,
+			float               g,
+			double              h,
+			Object              i,
+			String              j,
+			ArrayList<String>   k,
+			String              l,
+			Object              m,
+			double              n,
+			float               o,
+			long                p) {
+		return n_StaticFuncThisMethodTakesLotsOfParameters (
+				a,
+				b,
+				c,
+				d,
+				e,
+				f,
+				g,
+				h,
+				i,
+				j,
+				k,
+				l,
+				m,
+				n,
+				o,
+				p);
+	}
+	private static native boolean n_StaticFuncThisMethodTakesLotsOfParameters (
 			boolean             a,
 			byte                b,
 			char                c,
@@ -86,12 +128,23 @@ public class ExportType
 			throw new Error ("staticFuncThisMethodTakesLotsOfParameters should return true!");
 	}
 
-	public native void action ();
-	public native void actionIJavaObject (Object test);
-	public native long funcInt64 ();
-	public native Object funcIJavaObject ();
-	public native void staticActionInt (int i);
-	public native void staticActionFloat (float f);
+	public          void    action () {n_InstanceAction ();}
+	private native  void    n_InstanceAction ();
+
+	public          void    actionIJavaObject (Object test) {n_InstanceActionIJavaObject (test);}
+	private native  void    n_InstanceActionIJavaObject (Object test);
+
+	public          long    funcInt64 () {return n_FuncInt64 ();}
+	private native  long    n_FuncInt64 ();
+
+	public          Object  funcIJavaObject () {return n_FuncIJavaObject ();}
+	private native  Object  n_FuncIJavaObject ();
+
+	public          void    staticActionInt (int i) {n_StaticActionInt (i);}
+	private native  void    n_StaticActionInt (int i);
+
+	public          void    staticActionFloat (float f) {n_StaticActionFloat (f);}
+	private native  void    n_StaticActionFloat (float f);
 
 	ArrayList<Object>       managedReferences     = new ArrayList<Object>();
 

--- a/tests/Java.Interop.Export-Tests/java/net/dot/jni/test/UseJavaCallableExample.java
+++ b/tests/Java.Interop.Export-Tests/java/net/dot/jni/test/UseJavaCallableExample.java
@@ -1,0 +1,11 @@
+package net.dot.jni.test;
+
+import net.dot.jni.test.JavaCallableExample;
+
+public class UseJavaCallableExample {
+
+	public static boolean test() {
+		JavaCallableExample e = new JavaCallableExample(42);
+		return e.getA() == 42;
+	}
+}

--- a/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers-Tests.csproj
+++ b/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers-Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>$(DotNetTargetFramework)</TargetFramework>
     <IsPackable>false</IsPackable>
     <DefineConstants>$(DefineConstants);HAVE_CECIL;JCW_ONLY_TYPE_NAMES</DefineConstants>
+    <NoWarn>$(NoWarn);CA1019;CA1813</NoWarn>
   </PropertyGroup>
 
   <Import Project="..\..\TargetFrameworkDependentValues.props" />
@@ -28,5 +29,11 @@
   </ItemGroup>
 
   <Import Project="..\..\src\Java.Interop.NamingCustomAttributes\Java.Interop.NamingCustomAttributes.projitems" Label="Shared" Condition="Exists('..\..\src\Java.Interop.NamingCustomAttributes\Java.Interop.NamingCustomAttributes.projitems')" />
+
+  <ItemGroup>
+    <Compile Include="..\..\src\Java.Interop\Java.Interop\JniTypeSignatureAttribute.cs" />
+    <Compile Include="..\..\src\Java.Interop.Export\Java.Interop\JavaCallableAttribute.cs" />
+    <Compile Include="..\..\src\Java.Interop.Export\Java.Interop\JavaCallableConstructorAttribute.cs" />
+  </ItemGroup>
 
 </Project>

--- a/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGeneratorTests.cs
+++ b/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGeneratorTests.cs
@@ -102,13 +102,14 @@ public class Name
 			Assert.AreEqual (expected, actual);
 		}
 
-		static string Generate (Type type, string applicationJavaClass = null, string monoRuntimeInit = null)
+		static string Generate (Type type, string applicationJavaClass = null, string monoRuntimeInit = null, JavaPeerStyle style = JavaPeerStyle.XAJavaInterop1)
 		{
 			var td  = SupportDeclarations.GetTypeDefinition (type);
 			var g   = new JavaCallableWrapperGenerator (td, log: null, cache: null) {
 				ApplicationJavaClass        = applicationJavaClass,
 				GenerateOnCreateOverrides   = true,
 				MonoRuntimeInitialization   = monoRuntimeInit,
+				CodeGenerationTarget        = style,
 			};
 			var o   = new StringWriter ();
 			var dir = Path.GetDirectoryName (typeof (JavaCallableWrapperGeneratorTests).Assembly.Location);
@@ -449,7 +450,7 @@ public class ExportsConstructors
 	{
 		super (p0);
 		if (getClass () == ExportsConstructors.class) {
-			mono.android.TypeManager.Activate (""Xamarin.Android.ToolsTests.ExportsConstructors, Java.Interop.Tools.JavaCallableWrappers-Tests"", """", this, new java.lang.Object[] { p0 });
+			mono.android.TypeManager.Activate (""Xamarin.Android.ToolsTests.ExportsConstructors, Java.Interop.Tools.JavaCallableWrappers-Tests"", ""System.Int32, System.Private.CoreLib"", this, new java.lang.Object[] { p0 });
 		}
 	}
 
@@ -505,7 +506,7 @@ public class ExportsThrowsConstructors
 	{
 		super (p0);
 		if (getClass () == ExportsThrowsConstructors.class) {
-			mono.android.TypeManager.Activate (""Xamarin.Android.ToolsTests.ExportsThrowsConstructors, Java.Interop.Tools.JavaCallableWrappers-Tests"", """", this, new java.lang.Object[] { p0 });
+			mono.android.TypeManager.Activate (""Xamarin.Android.ToolsTests.ExportsThrowsConstructors, Java.Interop.Tools.JavaCallableWrappers-Tests"", ""System.Int32, System.Private.CoreLib"", this, new java.lang.Object[] { p0 });
 		}
 	}
 
@@ -514,7 +515,7 @@ public class ExportsThrowsConstructors
 	{
 		super (p0);
 		if (getClass () == ExportsThrowsConstructors.class) {
-			mono.android.TypeManager.Activate (""Xamarin.Android.ToolsTests.ExportsThrowsConstructors, Java.Interop.Tools.JavaCallableWrappers-Tests"", """", this, new java.lang.Object[] { p0 });
+			mono.android.TypeManager.Activate (""Xamarin.Android.ToolsTests.ExportsThrowsConstructors, Java.Interop.Tools.JavaCallableWrappers-Tests"", ""System.String, System.Private.CoreLib"", this, new java.lang.Object[] { p0 });
 		}
 	}
 
@@ -618,6 +619,62 @@ public class ExampleInstrumentation
 			refList.clear ();
 	}}
 }}
+";
+			Assert.AreEqual (expected, actual);
+		}
+
+		[Test]
+		public void GenerateJavaInteropExample ()
+		{
+			var actual = Generate (typeof (JavaInteropExample), style: JavaPeerStyle.JavaInterop1);
+			var expected = @"package register;
+
+
+public class JavaInteropExample
+	extends java.lang.Object
+	implements
+		com.xamarin.java_interop.GCUserPeerable
+{
+/** @hide */
+	public static final String __md_methods;
+	static {
+		__md_methods = 
+			""n_Example:()V:__export__\n"" +
+			"""";
+		com.xamarin.java_interop.ManagedPeer.registerNativeMembers (JavaInteropExample.class, ""Xamarin.Android.ToolsTests.JavaInteropExample, Java.Interop.Tools.JavaCallableWrappers-Tests"", __md_methods);
+	}
+
+
+	public JavaInteropExample (int p0, int p1)
+	{
+		super ();
+		if (getClass () == JavaInteropExample.class) {
+			com.xamarin.java_interop.ManagedPeer.construct (this, ""Xamarin.Android.ToolsTests.JavaInteropExample, Java.Interop.Tools.JavaCallableWrappers-Tests"", ""System.Int32, System.Private.CoreLib:System.Int32, System.Private.CoreLib"", new java.lang.Object[] { p0, p1 });
+		}
+	}
+
+
+	public void example ()
+	{
+		n_Example ();
+	}
+
+	private native void n_Example ();
+
+	private java.util.ArrayList refList;
+	public void jiAddManagedReference (java.lang.Object obj)
+	{
+		if (refList == null)
+			refList = new java.util.ArrayList ();
+		refList.add (obj);
+	}
+
+	public void jiClearManagedReferences ()
+	{
+		if (refList != null)
+			refList.clear ();
+	}
+}
 ";
 			Assert.AreEqual (expected, actual);
 		}

--- a/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/SupportDeclarations.cs
+++ b/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/SupportDeclarations.cs
@@ -323,4 +323,15 @@ namespace Xamarin.Android.ToolsTests {
 		[Export (Throws = new Type [0])]
 		public ExportsThrowsConstructors (string value) { }
 	}
+
+	[JniTypeSignature ("register/JavaInteropExample")]
+	class JavaInteropExample : Java.Lang.Object {
+
+
+		[JavaCallableConstructor(SuperConstructorExpression="")]
+		public JavaInteropExample (int a, int b) {}
+
+		[JavaCallable ("example")]
+		public void Example () {}
+	}
 }


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/pull/1153
Context: 4787e0179b349ab5ee0d0dd03d08b694acea4971
Context: 77800dda83c2db4d90b501c00069abc9880caaeb

PR #1153 is exploring the use of [.NET Native AOT][0] to produce a
native library which is used *within* a `java`-originated process:

	% java -cp … com/microsoft/hello_from_jni/App
	# launches NativeAOT-generated native lib, executes C# code…

As NativeAOT has no support for `System.Reflection.Emit`, the only
way for Java code to invoke managed code -- in a Desktop Java.Base
environment! [^0] see 4787e01 -- would be to pre-generate the
required marshal methods via `jnimarshalmethod-gen`.

This in turn requires updating `jcw-gen` to support the pre-existing
`Java.Interop.JavaCallableAttribute`, so that C# code could
reasonably declare methods visible to Java, along with the
introduction of, and support for, a new
`Java.Interop.JavaCallableConstructorAttribute` type.  This allows
straightforward usage:

	[JniTypeSignature ("example/ManagedType")]      // for a nice Java name!
	class ManagedType : Java.Lang.Object {

	    int value;

	    [JavaCallableConstructor(SuperConstructorExpression="")]
	    public ManagedType (int value) {
	        this.value = value;
	    }

	    [JavaCallable ("getString")]
	    public Java.Lang.String GetString () {
	        return new Java.Lang.String ($"Hello from C#, via Java.Interop! Value={value}");
	    }
	}

Run this through `jcw-gen` and `jnimarshalmethod-gen`, run the app,
and nothing worked (?!), because not all pieces were in agreement.

Java `native` method registration is One Of Those Things™ that
involves lots of moving pieces:

  * `generator` emits bindings for Java types, which includes Java
    method names, signatures, and (on .NET Android) the "connector
    method" to use:

        [Register ("toString", "()Ljava/lang/String;", "GetToStringHandler")]   // .NET Android
        [JniMethodSignature ("toString", "()Ljava/lang/String;")]               // Java.Base
        public override unsafe string? ToString () {…}

  * `jcw-gen` uses `generator` output, *prefixing* Java method names
    with `n_` for `native` method declarations, along with a
    method wrapper [^1]

        public String toString() {return n_toString();}
        private native String n_toString();

  * `jnimarshalmethod-gen` emits marshal methods for Java.Base,
    and needs to register the `native` methods declared by `jcw-gen`.
    `jnimarshalmethod-gen` and `jcw-gen` need to be consistent with
    each other.

  * `MarshalMemberbuilder.CreateMarshalToManagedMethodRegistration()`
    creates a `JniNativeMethodRegistration` instance which contains
    the name of the Java `native` method to register, and was
    using a name inconsistent with `jcw-gen`.

Turns Out, `jcw-gen`, `jnimarshalmethod-gen`, and
`MarshalMemberBuilder` were *not* consistent.

The only "real" `jnimarshalmethod-gen` usage (77800dd) is with the
`Java.Interop.Export-Tests` unit test assembly, which *did not use*
`jcw-gen`; it contained only hand-written Java code.  Consequently,
*none* of the Java `native` methods declared within it had an `n_`
prefix, and since this worked with `jnimarshalmethod-gen`, this means
that `jnimarshalmethod-gen` registration logic likewise didn't use
`n_` prefixed method names.

The result is that in the NativeAOT app, it would attempt to register
the `native` Java method `ManagedType.getString()`, while what
`jcw-gen` declared was `ManagedType.n_getString()`!

Java promptly threw an exception, and the app crashed.

Update `Java.Interop.Export-Tests` so that all the methods used with
`MarshalMemberBuilder` are declared with `n_` prefixes, and add
a `Java.Lang.Object` subclass example to the unit tests:

Update `tests/Java.Interop.Tools.JavaCallableWrappers-Tests` to
add a test for `.CodeGenerationTarget==JavaInterop1`.

Add `$(NoWarn)` to
`Java.Interop.Tools.JavaCallableWrappers-Tests.csproj` in order to
"work around" warnings-as-errors:

	…/src/Java.Interop.NamingCustomAttributes/Java.Interop/ExportFieldAttribute.cs(19,63): error CA1019: Remove the property setter from Name or reduce its accessibility because it corresponds to positional argument name
	…/src/Java.Interop.NamingCustomAttributes/Android.Runtime/RegisterAttribute.cs(53,4): error CA1019: Remove the property setter from Name or reduce its accessibility because it corresponds to positional argument name
	…/src/Java.Interop.NamingCustomAttributes/Java.Interop/ExportFieldAttribute.cs(12,16): error CA1813: Avoid unsealed attributes
	…

These are "weird"; the warnings/errors appear to come in because
`Java.Interop.Tools.JavaCallableWrappers-Tests.csproj` now includes:

	<Compile Include="..\..\src\Java.Interop\Java.Interop\JniTypeSignatureAttribute.cs" />

which appears to pull in `src/Java.Interop/.editorconfig`, which makes
CA1019 and CA1813 errors.  (I do not understand what is happening.)

Update `jnimarshalmethod-gen` so that the Java `native` methods it
registers have an `n_` prefix.

Refactor `ExpressionAssemblyBuilder.CreateRegistrationMethod()` to
`ExpressionAssemblyBuilder.AddRegistrationMethod()`, so that
the `EmitConsoleWriteLine()` invocation can provide the *full*
type name of the `__RegisterNativeMembers()` method, which helps
when there is more than one such method running around…

Update `ExpressionAssemblyBuilder` so that the delegate types it
creates for marshal method registration all have
`[UnmanagedFunctionPointer(CallingConvention.Winapi)]`.  (This isn't
needed *here*, but is needed in the context of NativeAOT, as
NativeAOT will only emit "marshal stubs" for delegate types which
have `[UnmanagedFunctionPointer]`.)  Unfortunately, adding
`[UnmanagedFunctionPointer]` broke things:

	error JM4006: jnimarshalmethod-gen: Unable to process assembly '…/Hello-NativeAOTFromJNI.dll'
	Failed to resolve System.Runtime.InteropServices.CallingConvention
	Mono.Cecil.ResolutionException: Failed to resolve System.Runtime.InteropServices.CallingConvention
	   at Mono.Cecil.Mixin.CheckedResolve(TypeReference self)
	   at Mono.Cecil.SignatureWriter.WriteCustomAttributeEnumValue(TypeReference enum_type, Object value)
	   …

The problem is that `CallingConvention` was resolved from
`System.Private.CoreLib`, and when we removed that assembly
reference, the `CallingConvention` couldn't be resolved at all.

We could "fix" this by explicitly adding a reference to
`System.Runtime.InteropServices.dll`, but how many more such corner
cases exist?  The current approach is not viable.

Remove the code from 77800dd which attempts to remove
`System.Private.CoreLib`.  So long as `ExpressionAssemblyBuilder`
output is *only* used in "completed" apps (not distributed in NuGet
packages or some "intermediate" form), referencing
`System.Private.CoreLib` is "fine".

Update `jnimarshalmethod-gen` assembly location probing: in #1153, it
was attempting to resolve the *full assembly name* of `Java.Base`, as
`Java.Base, Version=7.0.0.0, Culture=neutral, PublicKeyToken=null`,
causing it to attempt to load the file
`Java.Base, Version=7.0.0.0, Culture=neutral, PublicKeyToken=null.dll`,
which doesn't exist.  Use `AssemblyName` to parse the string and
extract out the assembly name, so that `Java.Base.dll` is probed for
and found.

Update `JreTypeManager` to *also* register the marshal methods
generated by
`Runtime.MarshalMemberBuilder.GetExportedMemberRegistrations()`.

With all that, the updated `Java.Interop.Export-Tests` test now work
both before and after `jnimarshalmethod-gen` is run:

	% dotnet test --logger "console;verbosity=detailed" bin/TestDebug-net7.0/Java.Interop.Export-Tests.dll &&
	  dotnet bin/Debug-net7.0/jnimarshalmethod-gen.dll  bin/TestDebug-net7.0/Java.Interop.Export-Tests.dll &&
	  dotnet test --logger "console;verbosity=detailed" bin/TestDebug-net7.0/Java.Interop.Export-Tests.dll
	…

TODO:

  * `generator --codegen-target=JavaInterop1` should emit
    JNI method signature information for constructors!
    This would likely remove the need for
    `[JavaCallableConstructor(SuperConstructorExpression="")`.

  * https://github.com/xamarin/java.interop/issues/1159

[0]: https://learn.microsoft.com/dotnet/core/deploying/native-aot

[^0]: In a .NET Android environment, marshal methods are part of
      `generator` output, so things would be more straightforward
      there, though all the `_JniMarshal_*` types that are declared
      would also need to have
      `[UnmanagedFunctionPointer(CallingConvention.Winapi)]`…

[^1]: Why not just declare `toString()` as `native`?  Why have the
      separate `n_`-prefixed version?  To make the
      `#if MONODROID_TIMING` block more consistent within
      `JavaCallableWrapperGenerator.GenerateMethod()`.
      It's likely "too late" to *easily* change this now.