### PR TITLE
[Java.Interop.Tools.JavaCallableWrappers] [Export]+params

### DIFF
--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
@@ -295,7 +295,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 					if (!string.IsNullOrEmpty (eattr.Name)) {
 						// Diagnostic.Warning (log, "Use of ExportAttribute.Name property is invalid on constructors");
 					}
-					ctors.Add (new Signature (ctor, eattr, cache));
+					ctors.Add (new Signature (ctor, eattr, managedParameters, cache));
 					curCtors.Add (ctor);
 					return;
 				}
@@ -481,7 +481,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 				if (type.HasGenericParameters)
 					Diagnostic.Error (4206, LookupSource (implementedMethod), Localization.Resources.JavaCallableWrappers_XA4206);
 
-				var msig = new Signature (implementedMethod, attr, cache);
+				var msig = new Signature (implementedMethod, attr, managedParameters: null, cache: cache);
 				if (!string.IsNullOrEmpty (attr.SuperArgumentsString)) {
 					// Diagnostic.Warning (log, "Use of ExportAttribute.SuperArgumentsString property is invalid on methods");
 				}
@@ -834,7 +834,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 				IsDynamicallyRegistered = shouldBeDynamicallyRegistered;
 			}
 
-			public Signature (MethodDefinition method, ExportAttribute export, IMetadataResolver cache)
+			public Signature (MethodDefinition method, ExportAttribute export, string? managedParameters, IMetadataResolver cache)
 				: this (method.Name, GetJniSignature (method, cache), "__export__", null, null, export.SuperArgumentsString)
 			{
 				IsExport = true;
@@ -842,6 +842,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 				JavaAccess = JavaCallableWrapperGenerator.GetJavaAccess (method.Attributes & MethodAttributes.MemberAccessMask);
 				ThrownTypeNames = export.ThrownNames;
 				JavaNameOverride = export.Name;
+				ManagedParameters = managedParameters;
 				Annotations = JavaCallableWrapperGenerator.GetAnnotationsString ("\t", method.CustomAttributes, cache);
 			}
 

--- a/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGeneratorTests.cs
+++ b/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGeneratorTests.cs
@@ -449,7 +449,7 @@ public class ExportsConstructors
 	{
 		super (p0);
 		if (getClass () == ExportsConstructors.class) {
-			mono.android.TypeManager.Activate (""Xamarin.Android.ToolsTests.ExportsConstructors, Java.Interop.Tools.JavaCallableWrappers-Tests"", """", this, new java.lang.Object[] { p0 });
+			mono.android.TypeManager.Activate (""Xamarin.Android.ToolsTests.ExportsConstructors, Java.Interop.Tools.JavaCallableWrappers-Tests"", ""System.Int32, System.Private.CoreLib"", this, new java.lang.Object[] { p0 });
 		}
 	}
 
@@ -505,7 +505,7 @@ public class ExportsThrowsConstructors
 	{
 		super (p0);
 		if (getClass () == ExportsThrowsConstructors.class) {
-			mono.android.TypeManager.Activate (""Xamarin.Android.ToolsTests.ExportsThrowsConstructors, Java.Interop.Tools.JavaCallableWrappers-Tests"", """", this, new java.lang.Object[] { p0 });
+			mono.android.TypeManager.Activate (""Xamarin.Android.ToolsTests.ExportsThrowsConstructors, Java.Interop.Tools.JavaCallableWrappers-Tests"", ""System.Int32, System.Private.CoreLib"", this, new java.lang.Object[] { p0 });
 		}
 	}
 
@@ -514,7 +514,7 @@ public class ExportsThrowsConstructors
 	{
 		super (p0);
 		if (getClass () == ExportsThrowsConstructors.class) {
-			mono.android.TypeManager.Activate (""Xamarin.Android.ToolsTests.ExportsThrowsConstructors, Java.Interop.Tools.JavaCallableWrappers-Tests"", """", this, new java.lang.Object[] { p0 });
+			mono.android.TypeManager.Activate (""Xamarin.Android.ToolsTests.ExportsThrowsConstructors, Java.Interop.Tools.JavaCallableWrappers-Tests"", ""System.String, System.Private.CoreLib"", this, new java.lang.Object[] { p0 });
 		}
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/7554

Placing `[Export]` on a constructor with parameters did not work as expected.  Consider:

	public class Example : Java.Lang.Object
	{
	    [Export(SuperArgumentsString = "")]
	    public Example (int value)
	    {
	        this.value = value;
	    }

	    int value;
	}

This *does* generate a Java Callable Wrapper with the desired constructor, but it *doesn't* invoke the correct C# constructor, because of the `TypeManager.Activate()` invocation:

	// Java JCW
	/* partial */ class Example extends java.lang.Object {
	    public Example(int p0) {
	        super ();
	        if (getClass () == Example.class) {
	            mono.android.TypeManager.Activate (
	                    /* typeName */      "Namespace.Example, Assembly",
	                    /* signature */     "",
	                    /* instance */      this,
	                    /* parameterList */ new java.lang.Object[] { p0 });
	        }
	    }
	}

In particular, because `signature` is the empty string, `TypeManager.Activate()` will lookup and invoke the *default* constructor, rather than the `Example(int)` constructor. (This despite the fact that `parameterList` contains arguments!)

Consequently, when Java invokes the `Example(int)` constructor, an exception is thrown, as the default constructor it wants doesn't exist:

	Could not activate JNI Handle 0x7ffd2bd94e50 (key_handle 0x65d856e) of Java type 'namespace/Example' as managed type 'Namespace.Example'.
	Java.Interop.JavaLocationException: Exception of type 'Java.Interop.JavaLocationException' was thrown.
	Java.Lang.Error: Exception of type 'Java.Lang.Error' was thrown.

	  --- End of managed Java.Lang.Error stack trace ---
	java.lang.Error: Java callstack:
		at mono.android.TypeManager.n_activate(Native Method)
		at mono.android.TypeManager.Activate(TypeManager.java:7)
		at namespace.Example.<init>(Example.java:0)
		…

Update `JavaCallableWrapperGenerator.AddConstructor()` so that the `managedParameters` value is provided to the `Signature` instance for the `[Export]` constructor.  This value is then inserted as the `signature` parameter value, which will allow the correct constructor to be invoked:

	// Fixed Java JCW
	/* partial */ class Example extends java.lang.Object {
	    public Example(int p0) {
	        super ();
	        if (getClass () == Example.class) {
	            mono.android.TypeManager.Activate (
	                    /* typeName */      "Namespace.Example, Assembly",
	                    /* signature */     "System.Int32, System.Runtime",
	                    /* instance */      this,
	                    /* parameterList */ new java.lang.Object[] { p0 });
	        }
	    }
	}