### PR TITLE
[generator] `[JniConstructorSignature]` on bound constructors

### DIFF
--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
@@ -391,6 +391,19 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 			return r;
 		}
 
+		internal static RegisterAttribute? RegisterFromJniConstructorSignatureAttribute (CustomAttribute attr)
+		{
+			// attr.Resolve ();
+			RegisterAttribute? r = null;
+			if (attr.ConstructorArguments.Count == 1)
+				r = new RegisterAttribute (
+					name:             ".ctor",
+					signature:        (string) attr.ConstructorArguments [0].Value,
+					connector:        "",
+					originAttribute:  attr);
+			return r;
+		}
+
 		internal static RegisterAttribute? RegisterFromJniMethodSignatureAttribute (CustomAttribute attr)
 		{
 			// attr.Resolve ();
@@ -460,6 +473,13 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 		{
 			foreach (var a in GetAttributes<RegisterAttribute> (p, a => ToRegisterAttribute (a))) {
 				yield return a;
+			}
+			foreach (var c in p.GetCustomAttributes ("Java.Interop.JniConstructorSignatureAttribute")) {
+				var r = RegisterFromJniConstructorSignatureAttribute (c);
+				if (r == null) {
+					continue;
+				}
+				yield return r;
 			}
 			foreach (var c in p.GetCustomAttributes ("Java.Interop.JniMethodSignatureAttribute")) {
 				var r = RegisterFromJniMethodSignatureAttribute (c);

--- a/src/Java.Interop/Java.Interop/JniConstructorSignatureAttribute.cs
+++ b/src/Java.Interop/Java.Interop/JniConstructorSignatureAttribute.cs
@@ -1,0 +1,20 @@
+#nullable enable
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+#if NET
+
+namespace Java.Interop
+{
+	[AttributeUsage (AttributeTargets.Constructor, AllowMultiple = false)]
+	public sealed class JniConstructorSignatureAttribute : JniMemberSignatureAttribute {
+
+		public JniConstructorSignatureAttribute (string memberSignature)
+			: base (".ctor", memberSignature)
+		{
+		}
+	}
+}
+
+#endif  // NET

--- a/tests/Java.Base-Tests/Java.Base-Tests.targets
+++ b/tests/Java.Base-Tests/Java.Base-Tests.targets
@@ -24,7 +24,7 @@
       <_Output>-o "$(IntermediateOutputPath)/java"</_Output>
       <_Libpath>@(_RefAsmDirs->'-L "%(Identity)"', ' ')</_Libpath>
     </PropertyGroup>
-    <Exec Command="$(DotnetToolPath) $(_JcwGen) &quot;$(TargetPath)&quot; $(_Target) $(_Output) $(_Libpath)" />
+    <Exec Command="$(DotnetToolPath) $(_JcwGen) -v &quot;$(TargetPath)&quot; $(_Target) $(_Output) $(_Libpath)" />
     <Touch Files="$(IntermediateOutputPath)java\.stamp" AlwaysCreate="True" />
   </Target>
 

--- a/tests/Java.Interop.Export-Tests/Java.Interop/JavaCallableExampleTests.cs
+++ b/tests/Java.Interop.Export-Tests/Java.Interop/JavaCallableExampleTests.cs
@@ -16,6 +16,12 @@ class JavaCallableExampleTest : JavaVMFixture
 		Assert.IsTrue (z);
 	}
 
+	[Test]
+	public void ManagedCtorInvokesJavaDefaultCtor ()
+	{
+		using var o = new JavaCallableExample (42);
+	}
+
 	static JniType CreateUseJavaCallableExampleType () =>
 		new JniType ("net/dot/jni/test/UseJavaCallableExample");
 }

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteClass.txt
@@ -8,6 +8,7 @@ public partial class MyClass {
 	}
 
 	// Metadata.xml XPath constructor reference: path="/api/package[@name='java.code']/class[@name='MyClass']/constructor[@name='MyClass' and count(parameter)=0]"
+	[global::Java.Interop.JniConstructorSignature ("()V")]
 	unsafe MyClass () : base (ref *InvalidJniObjectReference, JniObjectReferenceOptions.None)
 	{
 		const string __id = "()V";
@@ -24,6 +25,7 @@ public partial class MyClass {
 	}
 
 	// Metadata.xml XPath constructor reference: path="/api/package[@name='java.code']/class[@name='MyClass']/constructor[@name='MyClass' and count(parameter)=1 and parameter[1][@type='java.lang.String']]"
+	[global::Java.Interop.JniConstructorSignature ("(Ljava/lang/String;)V")]
 	unsafe MyClass (string? p0) : base (ref *InvalidJniObjectReference, JniObjectReferenceOptions.None)
 	{
 		const string __id = "(Ljava/lang/String;)V";

--- a/tests/generator-Tests/expected.ji/AccessModifiers/Xamarin.Test.ExtendPublicClass.cs
+++ b/tests/generator-Tests/expected.ji/AccessModifiers/Xamarin.Test.ExtendPublicClass.cs
@@ -30,6 +30,7 @@ namespace Xamarin.Test {
 		}
 
 		// Metadata.xml XPath constructor reference: path="/api/package[@name='xamarin.test']/class[@name='ExtendPublicClass']/constructor[@name='ExtendPublicClass' and count(parameter)=0]"
+		[global::Java.Interop.JniConstructorSignature ("()V")]
 		public unsafe ExtendPublicClass () : base (ref *InvalidJniObjectReference, JniObjectReferenceOptions.None)
 		{
 			const string __id = "()V";

--- a/tests/generator-Tests/expected.ji/AccessModifiers/Xamarin.Test.PublicClass.cs
+++ b/tests/generator-Tests/expected.ji/AccessModifiers/Xamarin.Test.PublicClass.cs
@@ -64,6 +64,7 @@ namespace Xamarin.Test {
 		}
 
 		// Metadata.xml XPath constructor reference: path="/api/package[@name='xamarin.test']/class[@name='PublicClass']/constructor[@name='PublicClass' and count(parameter)=0]"
+		[global::Java.Interop.JniConstructorSignature ("()V")]
 		public unsafe PublicClass () : base (ref *InvalidJniObjectReference, JniObjectReferenceOptions.None)
 		{
 			const string __id = "()V";

--- a/tests/generator-Tests/expected.ji/AccessModifiers/Xamarin.Test.TestClass.cs
+++ b/tests/generator-Tests/expected.ji/AccessModifiers/Xamarin.Test.TestClass.cs
@@ -30,6 +30,7 @@ namespace Xamarin.Test {
 		}
 
 		// Metadata.xml XPath constructor reference: path="/api/package[@name='xamarin.test']/class[@name='TestClass']/constructor[@name='TestClass' and count(parameter)=0]"
+		[global::Java.Interop.JniConstructorSignature ("()V")]
 		public unsafe TestClass () : base (ref *InvalidJniObjectReference, JniObjectReferenceOptions.None)
 		{
 			const string __id = "()V";

--- a/tests/generator-Tests/expected.ji/Constructors/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/Constructors/Xamarin.Test.SomeObject.cs
@@ -30,6 +30,7 @@ namespace Xamarin.Test {
 		}
 
 		// Metadata.xml XPath constructor reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/constructor[@name='SomeObject' and count(parameter)=0]"
+		[global::Java.Interop.JniConstructorSignature ("()V")]
 		[global::System.Obsolete (@"deprecated")]
 		public unsafe SomeObject () : base (ref *InvalidJniObjectReference, JniObjectReferenceOptions.None)
 		{
@@ -47,6 +48,7 @@ namespace Xamarin.Test {
 		}
 
 		// Metadata.xml XPath constructor reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/constructor[@name='SomeObject' and count(parameter)=1 and parameter[1][@type='int']]"
+		[global::Java.Interop.JniConstructorSignature ("(I)V")]
 		public unsafe SomeObject (int aint) : base (ref *InvalidJniObjectReference, JniObjectReferenceOptions.None)
 		{
 			const string __id = "(I)V";

--- a/tests/generator-Tests/expected.ji/Constructors/Xamarin.Test.SomeObject2.cs
+++ b/tests/generator-Tests/expected.ji/Constructors/Xamarin.Test.SomeObject2.cs
@@ -30,6 +30,7 @@ namespace Xamarin.Test {
 		}
 
 		// Metadata.xml XPath constructor reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject2']/constructor[@name='SomeObject2' and count(parameter)=1 and parameter[1][@type='int']]"
+		[global::Java.Interop.JniConstructorSignature ("(I)V")]
 		public unsafe SomeObject2 (int aint) : base (ref *InvalidJniObjectReference, JniObjectReferenceOptions.None)
 		{
 			const string __id = "(I)V";

--- a/tests/generator-Tests/expected.ji/Streams/Java.IO.FilterOutputStream.cs
+++ b/tests/generator-Tests/expected.ji/Streams/Java.IO.FilterOutputStream.cs
@@ -30,6 +30,7 @@ namespace Java.IO {
 		}
 
 		// Metadata.xml XPath constructor reference: path="/api/package[@name='java.io']/class[@name='FilterOutputStream']/constructor[@name='FilterOutputStream' and count(parameter)=1 and parameter[1][@type='java.io.OutputStream']]"
+		[global::Java.Interop.JniConstructorSignature ("(Ljava/io/OutputStream;)V")]
 		public unsafe FilterOutputStream (global::Java.IO.OutputStream @out) : base (ref *InvalidJniObjectReference, JniObjectReferenceOptions.None)
 		{
 			const string __id = "(Ljava/io/OutputStream;)V";

--- a/tests/generator-Tests/expected.ji/Streams/Java.IO.InputStream.cs
+++ b/tests/generator-Tests/expected.ji/Streams/Java.IO.InputStream.cs
@@ -30,6 +30,7 @@ namespace Java.IO {
 		}
 
 		// Metadata.xml XPath constructor reference: path="/api/package[@name='java.io']/class[@name='InputStream']/constructor[@name='InputStream' and count(parameter)=0]"
+		[global::Java.Interop.JniConstructorSignature ("()V")]
 		public unsafe InputStream () : base (ref *InvalidJniObjectReference, JniObjectReferenceOptions.None)
 		{
 			const string __id = "()V";

--- a/tests/generator-Tests/expected.ji/Streams/Java.IO.OutputStream.cs
+++ b/tests/generator-Tests/expected.ji/Streams/Java.IO.OutputStream.cs
@@ -30,6 +30,7 @@ namespace Java.IO {
 		}
 
 		// Metadata.xml XPath constructor reference: path="/api/package[@name='java.io']/class[@name='OutputStream']/constructor[@name='OutputStream' and count(parameter)=0]"
+		[global::Java.Interop.JniConstructorSignature ("()V")]
 		public unsafe OutputStream () : base (ref *InvalidJniObjectReference, JniObjectReferenceOptions.None)
 		{
 			const string __id = "()V";

--- a/tests/generator-Tests/expected.ji/TestInterface/ClassWithoutNamespace.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/ClassWithoutNamespace.cs
@@ -28,6 +28,7 @@ public abstract partial class ClassWithoutNamespace : global::Java.Lang.Object, 
 	}
 
 	// Metadata.xml XPath constructor reference: path="/api/package[@name='']/class[@name='ClassWithoutNamespace']/constructor[@name='ClassWithoutNamespace' and count(parameter)=0]"
+	[global::Java.Interop.JniConstructorSignature ("()V")]
 	public unsafe ClassWithoutNamespace () : base (ref *InvalidJniObjectReference, JniObjectReferenceOptions.None)
 	{
 		const string __id = "()V";

--- a/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericImplementation.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericImplementation.cs
@@ -30,6 +30,7 @@ namespace Test.ME {
 		}
 
 		// Metadata.xml XPath constructor reference: path="/api/package[@name='test.me']/class[@name='GenericImplementation']/constructor[@name='GenericImplementation' and count(parameter)=0]"
+		[global::Java.Interop.JniConstructorSignature ("()V")]
 		public unsafe GenericImplementation () : base (ref *InvalidJniObjectReference, JniObjectReferenceOptions.None)
 		{
 			const string __id = "()V";

--- a/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericObjectPropertyImplementation.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericObjectPropertyImplementation.cs
@@ -30,6 +30,7 @@ namespace Test.ME {
 		}
 
 		// Metadata.xml XPath constructor reference: path="/api/package[@name='test.me']/class[@name='GenericObjectPropertyImplementation']/constructor[@name='GenericObjectPropertyImplementation' and count(parameter)=0]"
+		[global::Java.Interop.JniConstructorSignature ("()V")]
 		public unsafe GenericObjectPropertyImplementation () : base (ref *InvalidJniObjectReference, JniObjectReferenceOptions.None)
 		{
 			const string __id = "()V";

--- a/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericStringImplementation.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericStringImplementation.cs
@@ -30,6 +30,7 @@ namespace Test.ME {
 		}
 
 		// Metadata.xml XPath constructor reference: path="/api/package[@name='test.me']/class[@name='GenericStringImplementation']/constructor[@name='GenericStringImplementation' and count(parameter)=0]"
+		[global::Java.Interop.JniConstructorSignature ("()V")]
 		public unsafe GenericStringImplementation () : base (ref *InvalidJniObjectReference, JniObjectReferenceOptions.None)
 		{
 			const string __id = "()V";

--- a/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericStringPropertyImplementation.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Test.ME.GenericStringPropertyImplementation.cs
@@ -30,6 +30,7 @@ namespace Test.ME {
 		}
 
 		// Metadata.xml XPath constructor reference: path="/api/package[@name='test.me']/class[@name='GenericStringPropertyImplementation']/constructor[@name='GenericStringPropertyImplementation' and count(parameter)=0]"
+		[global::Java.Interop.JniConstructorSignature ("()V")]
 		public unsafe GenericStringPropertyImplementation () : base (ref *InvalidJniObjectReference, JniObjectReferenceOptions.None)
 		{
 			const string __id = "()V";

--- a/tests/generator-Tests/expected.ji/TestInterface/Test.ME.TestInterfaceImplementation.cs
+++ b/tests/generator-Tests/expected.ji/TestInterface/Test.ME.TestInterfaceImplementation.cs
@@ -49,6 +49,7 @@ namespace Test.ME {
 		}
 
 		// Metadata.xml XPath constructor reference: path="/api/package[@name='test.me']/class[@name='TestInterfaceImplementation']/constructor[@name='TestInterfaceImplementation' and count(parameter)=0]"
+		[global::Java.Interop.JniConstructorSignature ("()V")]
 		public unsafe TestInterfaceImplementation () : base (ref *InvalidJniObjectReference, JniObjectReferenceOptions.None)
 		{
 			const string __id = "()V";

--- a/tools/generator/SourceWriters/Attributes/RegisterAttr.cs
+++ b/tools/generator/SourceWriters/Attributes/RegisterAttr.cs
@@ -66,6 +66,9 @@ namespace generator.SourceWriters
 				case MemberTypes.TypeInfo:
 					writer.WriteLine ($"[global::Java.Interop.JniTypeSignature (\"{Name}\", GenerateJavaPeer={(DoNotGenerateAcw ? "false" : "true")})]");
 					break;
+				case MemberTypes.Constructor:
+					writer.WriteLine ($"[global::Java.Interop.JniConstructorSignature (\"{Signature}\")]");
+					break;
 				case MemberTypes.Method:
 					writer.WriteLine ($"[global::Java.Interop.JniMethodSignature (\"{Name}\", \"{Signature}\")]");
 					break;

--- a/tools/generator/SourceWriters/BoundConstructor.cs
+++ b/tools/generator/SourceWriters/BoundConstructor.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using MonoDroid.Generation;
@@ -29,9 +30,9 @@ namespace generator.SourceWriters
 
 			SourceWriterExtensions.AddSupportedOSPlatform (Attributes, constructor, opt);
 
-			if (opt.CodeGenerationTarget != CodeGenerationTarget.JavaInterop1) {
-				Attributes.Add (new RegisterAttr (".ctor", constructor.JniSignature, string.Empty, additionalProperties: constructor.AdditionalAttributeString ()));
-			}
+			Attributes.Add (new RegisterAttr (".ctor", constructor.JniSignature, string.Empty, additionalProperties: constructor.AdditionalAttributeString ()) {
+				MemberType	    = opt.CodeGenerationTarget != CodeGenerationTarget.JavaInterop1 ? null : (MemberTypes?) MemberTypes.Constructor,
+			});
 
 			SourceWriterExtensions.AddObsolete (Attributes, constructor.Deprecated, opt, deprecatedSince: constructor.DeprecatedSince);
 			SourceWriterExtensions.AddRestrictToWarning (Attributes, constructor.AnnotatedVisibility, false, opt);


### PR DESCRIPTION
Context: 3043d890239cf53eb42633430faa417c140c8952

Constructors, how do they work?

Commit 3043d890 goes into some details about the interaction between Java constructors and managed-side constructors when the Java constructor is invoked first.

What happens when the managed-side constructor is invoked first?

	class JavaInteropExample : Java.Lang.Object {
	    [JavaCallableConstructor(SuperConstructorExpression="")]
	    public JavaInteropExample (int a, int b) {}
	}

*Before* that code runs (ideally), `jcw-gen` (or equivalent) will run, creating a Java Callable Wrapper for `JavaInteropExample`, and that Java Callable Wrapper (JCW) will contain a constructor:

	// JCW
	/* partial */ class JavaInteropExample extends java.lang.Object {
	    public JavaInteropExample(int p0, int p1) {
	        super ();
	        if (getClass () == JavaInteropExample.class) {
	            ManagedPeer.construct (…);
	        }
	    }
	}

Then someone tries:

	// C#
	var o = new JavaInteropExample(42);

What happens is:

 1. `JavaInteropExample(int, int)` constructor begins execution, *immediately* executes (implicit) base constructor invocation `: base()`.

 2. `Java.Lang.Object` default constructor executes, which invokes `JavaObject(ref JniObjectReference, JniObjectReferenceOptions)` constructor, which is a no-op as the `JniObjectReference` is invalid.

 3. `Java.Lang.Object` default constructor continues, hitting:

        var peer = JniPeerMembers.InstanceMethods.StartCreateInstance ("()V", GetType (), null);

    which looks up the Java peer, and invokes the default constructor on the Java peer.

 4. `JavaObject.PeerReference` (eventually) is `peer.NewGlobalRef()`, and the `JavaInteropExample` constructor can *now* begin executing.

If the JCW doesn't contain a default constructor, then things fail:

	Error Message:
	 Java.Interop.JavaException : Lnet/dot/jni/test/JavaCallableExample;.<init>()V
	Stack Trace:
	   at Java.Interop.JniEnvironment.InstanceMethods.GetMethodID(JniObjectReference type, String name, String signature) in /Users/jon/Developer/src/xamarin/java.interop/src/Java.Interop/obj/Debug/net7.0/JniEnvironment.g.cs:line 19947
	 at Java.Interop.JniType.GetConstructor(String signature) in /Users/jon/Developer/src/xamarin/java.interop/src/Java.Interop/Java.Interop/JniType.cs:line 182
	 at Java.Interop.JniPeerMembers.JniInstanceMethods.GetConstructor(String signature) in /Users/jon/Developer/src/xamarin/java.interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods.cs:line 63
	 at Java.Interop.JniPeerMembers.JniInstanceMethods.FinishCreateInstance(String constructorSignature, IJavaPeerable self, JniArgumentValue* parameters) in /Users/jon/Developer/src/xamarin/java.interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods.cs:line 173
	 at Java.Lang.Object..ctor() in /Users/jon/Developer/src/xamarin/java.interop/src/Java.Base/obj/Debug-net7.0/mcw/Java.Lang.Object.cs:line 33
	 at Java.InteropTests.JavaCallableExample..ctor(Int32 a) in /Users/jon/Developer/src/xamarin/java.interop/tests/Java.Interop.Export-Tests/Java.Interop/JavaCallableExample.cs:line 11
	 at Java.InteropTests.JavaCallableExampleTest.ManagedCtorInvokesJavaDefaultCtor() in /Users/jon/Developer/src/xamarin/java.interop/tests/Java.Interop.Export-Tests/Java.Interop/JavaCallableExampleTests.cs:line 22
	 at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
	 at System.Reflection.MethodInvoker.Invoke(Object obj, IntPtr* args, BindingFlags invokeAttr)
	--- End of managed Java.Interop.JavaException stack trace ---
	java.lang.NoSuchMethodError: Lnet/dot/jni/test/JavaCallableExample;.<init>()V

But why would the JCW for `JavaInteropExample` contain a default constructor at all?

In .NET Android, bound constructors have `[Register]`, and `jcw-gen` will emit *all* "current context" [TODO] constructors based on `[Register]` for constructors in the "current type".  This ensures that we get *at least one* constructor that exists in Java, which the C# derived types will need to invoke.

TODO: does xamarin/monodroid have a good commit message to crib?

`generator --codegen-target=JavaInterop1`-style bindings didn't previously emit anything for bound constructors, preventing `jcw-gen` from performing this same logic.  Consequently, the JCW for `JavaInteropExample` *didn't* have a default constructor.

Add a new `Java.Interop.JniConstructorSignatureAttribute` type, and update `generator` to emit this attribute on bound constructors.

Update `jcw-gen` to support `JniConstructorSignatureAttribute`.

This adds a default constructor to `JavaInteropExample`:

	// JCW
	/* partial */ class JavaInteropExample extends java.lang.Object {
	    public JavaInteropExample() {
	        super ();
	        if (getClass () == JavaInteropExample.class) {
	            ManagedPeer.construct (…);
	        }
	    }

	    public JavaInteropExample(int p0, int p1) {
	        super ();
	        if (getClass () == JavaInteropExample.class) {
	            ManagedPeer.construct (…);
	        }
	    }
	}

Note: while there is a public default constructor on the JCW, Java code cannot call it.  If it attempts to do so, an exception will be thrown because the C#-side type doesn't have a default constructor.