### PR TITLE
[jnimarshalmethod-gen] JavaInterop1 marshal methods

### DIFF
--- a/build-tools/automation/templates/core-tests.yaml
+++ b/build-tools/automation/templates/core-tests.yaml
@@ -147,12 +147,12 @@ steps:
   retryCountOnTaskFailure: 1
 
 - task: DotNetCoreCLI@2
-  displayName: 'jnimarshalmethod-gen Java.Interop.Base-Tests.dll'
+  displayName: 'jnimarshalmethod-gen Java.Base-Tests.dll'
   condition: or(eq('${{ parameters.runNativeDotnetTests }}', 'true'), eq('${{ parameters.runNativeTests }}', 'true'))
   inputs:
     command: custom
     custom: bin/$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/jnimarshalmethod-gen.dll
-    arguments: bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Base-Tests.dll -v -v --keeptemp
+    arguments: bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Base-Tests.dll -v -v --keeptemp
   continueOnError: true
   retryCountOnTaskFailure: 1
 

--- a/build-tools/automation/templates/core-tests.yaml
+++ b/build-tools/automation/templates/core-tests.yaml
@@ -147,6 +147,26 @@ steps:
   retryCountOnTaskFailure: 1
 
 - task: DotNetCoreCLI@2
+  displayName: 'jnimarshalmethod-gen Java.Interop.Base-Tests.dll'
+  condition: or(eq('${{ parameters.runNativeDotnetTests }}', 'true'), eq('${{ parameters.runNativeTests }}', 'true'))
+  inputs:
+    command: custom
+    custom: bin/$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/jnimarshalmethod-gen.dll
+    arguments: bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Base-Tests.dll -v -v --keeptemp
+  continueOnError: true
+  retryCountOnTaskFailure: 1
+
+- task: DotNetCoreCLI@2
+  displayName: 'Tests: Java.Base'
+  condition: or(eq('${{ parameters.runNativeDotnetTests }}', 'true'), eq('${{ parameters.runNativeTests }}', 'true'))
+  inputs:
+    command: test
+    testRunTitle: Java.Base ($(DotNetTargetFramework) - ${{ parameters.platformName }})
+    arguments: bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Base-Tests.dll
+  continueOnError: true
+  retryCountOnTaskFailure: 1
+
+- task: DotNetCoreCLI@2
   displayName: 'Tests: java-source-utils'
   inputs:
     command: build


### PR DESCRIPTION
Fixes: https://github.com/xamarin/java.interop/issues/1159

Context: c93fea090be9bd76f477496d4c9d4ab353ba73f1

`jnimarshalmethod-gen` is intended to generate marshal methods for any type that that:

  * Has `[JavaCallable]` (tested in `Java.Interop.Export-Tests.dll` and c93fea09), or
  * Overrides a `virtual` method which has `[JniMethodSignature]`, or
  * Implements an interface method which has `[JniMethodSignature]`.

Thus, the intention was that it should generate marshal methods for `Java.Base-Tests`:

	% dotnet bin/Debug-net7.0/jnimarshalmethod-gen.dll -v bin/TestDebug-net7.0/Java.Base-Tests.dll
	Unable to read assembly 'bin/TestDebug-net7.0/Java.Base-Tests.dll' with symbols. Retrying to load it without them.
	Preparing marshal method assembly 'Java.Base-Tests-JniMarshalMethods'
	Processing Java.BaseTests.JavaInvoker type
	Processing Java.BaseTests.MyRunnable type
	Processing Java.BaseTests.MyIntConsumer type
	Marshal method assembly 'Java.Base-Tests-JniMarshalMethods' created

Notably missing? No messages stating:

	Adding marshal method for …

Also missing?  `ikdasm bin/TestDebug-net7.0/Java.Base-Tests.dll` showed that there were no `__RegisterNativeMembers()` methods emitted.

The `jnimarshalmethod-gen` invocation was a no-op!

The problems were twofold:

 1. It was only looking for methods with `Android.Runtime.RegisterAttribute`.  This was useful for Xamarin.Android (when we were trying to make it work), but doesn't work with Java.Base.  We need to *also* look for `Java.Interop.JniMethodSignature`.

    Relatedly, the attempt to use `registerAttribute.Constructor.Parameters` to determine parameter names didn't work; the parameter name was always `""`.

 2. A'la c93fea09, we need to ensure that the Java `native` methods we register are consistent with `jcw-gen` output.

Fix these two problems, which allows `jnimarshalmethod-gen` to now emit marshal methods for types within `Java.Base-Tests.dll`.

Additionally, rework the `jnimarshalmethod-gen -f` logic to *remove* the existing `__<$>_jni_marshal_methods` nested type when present.