### PR TITLE
Rename com.xamarin.java_interop package to net.dot.jni

### DIFF
--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
@@ -702,7 +702,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 			sw.Write ("\t\t");
 			switch (CodeGenerationTarget) {
 				case JavaPeerStyle.JavaInterop1:
-					sw.Write ("com.xamarin.java_interop.GCUserPeerable");
+					sw.Write ("net.dot.jni.GCUserPeerable");
 					break;
 				default:
 					sw.Write ("mono.android.IGCUserPeer");
@@ -803,7 +803,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 			sw.Write ("\t\t");
 			switch (CodeGenerationTarget) {
 				case JavaPeerStyle.JavaInterop1:
-					sw.Write ("com.xamarin.java_interop.ManagedPeer.registerNativeMembers (");
+					sw.Write ("net.dot.jni.ManagedPeer.registerNativeMembers (");
 					sw.Write (self.name);
 					sw.Write (".class, \"");
 					sw.Write (managedTypeName);
@@ -1004,7 +1004,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 				sw.Write ("\t\t\t");
 				switch (CodeGenerationTarget) {
 					case JavaPeerStyle.JavaInterop1:
-						sw.Write ("com.xamarin.java_interop.ManagedPeer.construct (this, \"");
+						sw.Write ("net.dot.jni.ManagedPeer.construct (this, \"");
 						sw.Write (type.GetPartialAssemblyQualifiedName (cache));
 						sw.Write ("\", \"");
 						sw.Write (ctor.ManagedParameters);

--- a/src/Java.Interop/Java.Interop.targets
+++ b/src/Java.Interop/Java.Interop.targets
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <ItemGroup>
-    <CompileJavaInteropJar Include="java\com\xamarin\java_interop\internal\JavaProxyObject.java" />
-    <CompileJavaInteropJar Include="java\com\xamarin\java_interop\internal\JavaProxyThrowable.java" />
-    <CompileJavaInteropJar Include="java\com\xamarin\java_interop\GCUserPeerable.java" />
-    <CompileJavaInteropJar Include="java\com\xamarin\java_interop\ManagedPeer.java" />
+    <CompileJavaInteropJar Include="java\net\dot\jni\internal\JavaProxyObject.java" />
+    <CompileJavaInteropJar Include="java\net\dot\jni\internal\JavaProxyThrowable.java" />
+    <CompileJavaInteropJar Include="java\net\dot\jni\GCUserPeerable.java" />
+    <CompileJavaInteropJar Include="java\net\dot\jni\ManagedPeer.java" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="$(OutputPath)java-interop.jar">

--- a/src/Java.Interop/Java.Interop/JavaProxyObject.cs
+++ b/src/Java.Interop/Java.Interop/JavaProxyObject.cs
@@ -9,7 +9,7 @@ namespace Java.Interop {
 	[JniTypeSignature (JniTypeName)]
 	sealed class JavaProxyObject : JavaObject, IEquatable<JavaProxyObject>
 	{
-		internal const string JniTypeName = "com/xamarin/java_interop/internal/JavaProxyObject";
+		internal const string JniTypeName = "net/dot/jni/internal/JavaProxyObject";
 
 		static  readonly    JniPeerMembers                                  _members        = new JniPeerMembers (JniTypeName, typeof (JavaProxyObject));
 		static  readonly    ConditionalWeakTable<object, JavaProxyObject>   CachedValues    = new ConditionalWeakTable<object, JavaProxyObject> ();

--- a/src/Java.Interop/Java.Interop/JavaProxyThrowable.cs
+++ b/src/Java.Interop/Java.Interop/JavaProxyThrowable.cs
@@ -7,7 +7,7 @@ namespace Java.Interop {
 	[JniTypeSignature (JniTypeName)]
 	sealed class JavaProxyThrowable : JavaException
 	{
-		new internal    const   string  JniTypeName = "com/xamarin/java_interop/internal/JavaProxyThrowable";
+		new internal    const   string  JniTypeName = "net/dot/jni/internal/JavaProxyThrowable";
 
 		public  Exception   Exception {get; private set;}
 

--- a/src/Java.Interop/Java.Interop/ManagedPeer.cs
+++ b/src/Java.Interop/Java.Interop/ManagedPeer.cs
@@ -14,7 +14,7 @@ namespace Java.Interop {
 	[JniTypeSignature (JniTypeName)]
 	/* static */ sealed class ManagedPeer : JavaObject {
 
-		internal const string JniTypeName = "com/xamarin/java_interop/ManagedPeer";
+		internal const string JniTypeName = "net/dot/jni/ManagedPeer";
 
 
 		static  readonly    JniPeerMembers  _members        = new JniPeerMembers (JniTypeName, typeof (ManagedPeer));

--- a/src/Java.Interop/java/net/dot/jni/GCUserPeerable.java
+++ b/src/Java.Interop/java/net/dot/jni/GCUserPeerable.java
@@ -1,4 +1,4 @@
-package com.xamarin.java_interop;
+package net.dot.jni;
 
 public interface GCUserPeerable {
 

--- a/src/Java.Interop/java/net/dot/jni/ManagedPeer.java
+++ b/src/Java.Interop/java/net/dot/jni/ManagedPeer.java
@@ -1,4 +1,4 @@
-package com.xamarin.java_interop;
+package net.dot.jni;
 
 public /* static */ final class ManagedPeer {
 	private ManagedPeer () {

--- a/src/Java.Interop/java/net/dot/jni/internal/JavaProxyObject.java
+++ b/src/Java.Interop/java/net/dot/jni/internal/JavaProxyObject.java
@@ -1,8 +1,8 @@
-package com.xamarin.java_interop.internal;
+package net.dot.jni.internal;
 
 import java.util.ArrayList;
 
-import com.xamarin.java_interop.GCUserPeerable;
+import net.dot.jni.GCUserPeerable;
 
 /* package */ final class JavaProxyObject
 		extends java.lang.Object
@@ -10,7 +10,7 @@ import com.xamarin.java_interop.GCUserPeerable;
 {
 	static  final   String  assemblyQualifiedName   = "Java.Interop.JavaProxyObject, Java.Interop";
 	static {
-		com.xamarin.java_interop.ManagedPeer.registerNativeMembers (
+		net.dot.jni.ManagedPeer.registerNativeMembers (
 				JavaProxyObject.class,
 				assemblyQualifiedName,
 				"");

--- a/src/Java.Interop/java/net/dot/jni/internal/JavaProxyThrowable.java
+++ b/src/Java.Interop/java/net/dot/jni/internal/JavaProxyThrowable.java
@@ -1,8 +1,8 @@
-package com.xamarin.java_interop.internal;
+package net.dot.jni.internal;
 
 import java.util.ArrayList;
 
-import com.xamarin.java_interop.GCUserPeerable;
+import net.dot.jni.GCUserPeerable;
 
 /* package */ final class JavaProxyThrowable
 		extends java.lang.Error
@@ -10,7 +10,7 @@ import com.xamarin.java_interop.GCUserPeerable;
 {
 	static  final   String  assemblyQualifiedName   = "Java.Interop.JavaProxyThrowable, Java.Interop";
 	static {
-		com.xamarin.java_interop.ManagedPeer.registerNativeMembers (
+		net.dot.jni.ManagedPeer.registerNativeMembers (
 				JavaProxyThrowable.class,
 				assemblyQualifiedName,
 				"");

--- a/src/java-interop/java-interop-gc-bridge-mono.cc
+++ b/src/java-interop/java-interop-gc-bridge-mono.cc
@@ -284,7 +284,7 @@ java_interop_gc_bridge_new (JavaVM *jvm)
 		bridge.WeakReference_class      = static_cast<jclass>(lref_to_gref (env, WeakReference_class));
 	}
 
-	jclass      GCUserPeerable_class    = env->FindClass ("com/xamarin/java_interop/GCUserPeerable");
+	jclass      GCUserPeerable_class    = env->FindClass ("net/dot/jni/GCUserPeerable");
 	if (GCUserPeerable_class) {
 		bridge.GCUserPeerable_add       = env->GetMethodID (GCUserPeerable_class, "jiAddManagedReference",      "(Ljava/lang/Object;)V");
 		bridge.GCUserPeerable_clear     = env->GetMethodID (GCUserPeerable_class, "jiClearManagedReferences",   "()V");

--- a/tests/Java.Interop-Tests/Java.Interop-Tests.csproj
+++ b/tests/Java.Interop-Tests/Java.Interop-Tests.csproj
@@ -33,21 +33,21 @@
   </ItemGroup>
 
   <ItemGroup>
-    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\CrossReferenceBridge.java" />
-    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\CallNonvirtualBase.java" />
-    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\CallNonvirtualDerived.java" />
-    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\CallNonvirtualDerived2.java" />
-    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\CallVirtualFromConstructorBase.java" />
-    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\CallVirtualFromConstructorDerived.java" />
-    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\GetThis.java" />
-    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\ObjectHelper.java" />
-    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\RenameClassBase1.java" />
-    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\RenameClassBase2.java" />
-    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\RenameClassDerived.java" />
-    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\AndroidInterface.java" />
-    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\DesugarAndroidInterface$_CC.java" />
-    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\SelfRegistration.java" />
-    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\com\xamarin\interop\TestType.java" />
+    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\net\dot\jni\test\CrossReferenceBridge.java" />
+    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\net\dot\jni\test\CallNonvirtualBase.java" />
+    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\net\dot\jni\test\CallNonvirtualDerived.java" />
+    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\net\dot\jni\test\CallNonvirtualDerived2.java" />
+    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\net\dot\jni\test\CallVirtualFromConstructorBase.java" />
+    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\net\dot\jni\test\CallVirtualFromConstructorDerived.java" />
+    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\net\dot\jni\test\GetThis.java" />
+    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\net\dot\jni\test\ObjectHelper.java" />
+    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\net\dot\jni\test\RenameClassBase1.java" />
+    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\net\dot\jni\test\RenameClassBase2.java" />
+    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\net\dot\jni\test\RenameClassDerived.java" />
+    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\net\dot\jni\test\AndroidInterface.java" />
+    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\net\dot\jni\test\DesugarAndroidInterface$_CC.java" />
+    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\net\dot\jni\test\SelfRegistration.java" />
+    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\net\dot\jni\test\TestType.java" />
   </ItemGroup>
 
   <Import Project="Java.Interop-Tests.targets" />

--- a/tests/Java.Interop-Tests/Java.Interop/CallNonvirtualBase.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/CallNonvirtualBase.cs
@@ -7,7 +7,7 @@ namespace Java.InteropTests
 	[JniTypeSignature (CallNonvirtualBase.JniTypeName)]
 	public class CallNonvirtualBase : JavaObject
 	{
-		internal const string JniTypeName = "com/xamarin/interop/CallNonvirtualBase";
+		internal const string JniTypeName = "net/dot/jni/test/CallNonvirtualBase";
 
 		readonly static JniPeerMembers _members = new JniPeerMembers (JniTypeName, typeof (CallNonvirtualBase));
 

--- a/tests/Java.Interop-Tests/Java.Interop/CallNonvirtualDerived.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/CallNonvirtualDerived.cs
@@ -7,7 +7,7 @@ namespace Java.InteropTests
 	[JniTypeSignature (CallNonvirtualDerived.JniTypeName)]
 	public class CallNonvirtualDerived : CallNonvirtualBase
 	{
-		internal new const string JniTypeName = "com/xamarin/interop/CallNonvirtualDerived";
+		internal new const string JniTypeName = "net/dot/jni/test/CallNonvirtualDerived";
 
 		readonly static JniPeerMembers _members = new JniPeerMembers (JniTypeName, typeof (CallNonvirtualDerived));
 

--- a/tests/Java.Interop-Tests/Java.Interop/CallNonvirtualDerived2.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/CallNonvirtualDerived2.cs
@@ -7,7 +7,7 @@ namespace Java.InteropTests
 	[JniTypeSignature (CallNonvirtualDerived2.JniTypeName)]
 	public class CallNonvirtualDerived2 : CallNonvirtualDerived
 	{
-		internal new const string JniTypeName = "com/xamarin/interop/CallNonvirtualDerived2";
+		internal new const string JniTypeName = "net/dot/jni/test/CallNonvirtualDerived2";
 
 		public CallNonvirtualDerived2 ()
 		{

--- a/tests/Java.Interop-Tests/Java.Interop/CallVirtualFromConstructorBase.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/CallVirtualFromConstructorBase.cs
@@ -8,7 +8,7 @@ namespace Java.InteropTests {
 	[JniTypeSignature (CallVirtualFromConstructorBase.JniTypeName)]
 	public class CallVirtualFromConstructorBase : JavaObject {
 
-		internal    const   string          JniTypeName = "com/xamarin/interop/CallVirtualFromConstructorBase";
+		internal    const   string          JniTypeName = "net/dot/jni/test/CallVirtualFromConstructorBase";
 		readonly    static  JniPeerMembers  _members    = new JniPeerMembers (JniTypeName, typeof (CallVirtualFromConstructorBase));
 
 		public override JniPeerMembers JniPeerMembers {

--- a/tests/Java.Interop-Tests/Java.Interop/CallVirtualFromConstructorDerived.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/CallVirtualFromConstructorDerived.cs
@@ -6,7 +6,7 @@ namespace Java.InteropTests
 {
 	[JniTypeSignature (CallVirtualFromConstructorDerived.JniTypeName)]
 	public class CallVirtualFromConstructorDerived : CallVirtualFromConstructorBase {
-		new internal    const   string          JniTypeName = "com/xamarin/interop/CallVirtualFromConstructorDerived";
+		new internal    const   string          JniTypeName = "net/dot/jni/test/CallVirtualFromConstructorDerived";
 		static  readonly        JniPeerMembers  _members    = new JniPeerMembers (JniTypeName, typeof (CallVirtualFromConstructorDerived));
 
 		[JniAddNativeMethodRegistrationAttribute]
@@ -53,7 +53,7 @@ namespace Java.InteropTests
 		{
 			JniArgumentValue* args = stackalloc JniArgumentValue [1];
 			args [0]    = new JniArgumentValue (value);
-			var o       = _members.StaticMethods.InvokeObjectMethod ("newInstance.(I)Lcom/xamarin/interop/CallVirtualFromConstructorDerived;", args);
+			var o       = _members.StaticMethods.InvokeObjectMethod ("newInstance.(I)Lnet/dot/jni/test/CallVirtualFromConstructorDerived;", args);
 			return JniEnvironment.Runtime.ValueManager.GetValue<CallVirtualFromConstructorDerived> (ref o, JniObjectReferenceOptions.CopyAndDispose);
 		}
 

--- a/tests/Java.Interop-Tests/Java.Interop/GetThis.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/GetThis.cs
@@ -7,7 +7,7 @@ namespace Java.InteropTests
 	[JniTypeSignature (GetThis.JniTypeName)]
 	public class GetThis : JavaObject
 	{
-		internal const string JniTypeName = "com/xamarin/interop/GetThis";
+		internal const string JniTypeName = "net/dot/jni/test/GetThis";
 
 		bool _isDisposed;
 
@@ -23,7 +23,7 @@ namespace Java.InteropTests
 
 		public unsafe GetThis This {
 			get {
-				var o   = _members.InstanceMethods.InvokeNonvirtualObjectMethod ("getThis.()Lcom/xamarin/interop/GetThis;", this, null);
+				var o   = _members.InstanceMethods.InvokeNonvirtualObjectMethod ("getThis.()Lnet/dot/jni/test/GetThis;", this, null);
 				return JniEnvironment.Runtime.ValueManager.GetValue<GetThis> (ref o, JniObjectReferenceOptions.CopyAndDispose);
 			}
 		}

--- a/tests/Java.Interop-Tests/Java.Interop/JavaManagedGCBridgeTests.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JavaManagedGCBridgeTests.cs
@@ -54,7 +54,7 @@ namespace Java.InteropTests {
 
 	[JniTypeSignature (JniTypeName)]
 	public class CrossReferenceBridge : JavaObject {
-		internal    const    string         JniTypeName = "com/xamarin/interop/CrossReferenceBridge";
+		internal    const    string         JniTypeName = "net/dot/jni/test/CrossReferenceBridge";
 
 		public  string          id;
 		public  List<object>    link        = new List<object> ();

--- a/tests/Java.Interop-Tests/Java.Interop/JavaVMFixture.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JavaVMFixture.cs
@@ -97,7 +97,7 @@ namespace Java.InteropTests {
 		}
 
 		Dictionary<string, string> ReplacmentTypes = new() {
-			["com/xamarin/interop/RenameClassBase1"] = "com/xamarin/interop/RenameClassBase2",
+			["net/dot/jni/test/RenameClassBase1"] = "net/dot/jni/test/RenameClassBase2",
 		};
 
 		protected override string? GetReplacementTypeCore (string jniSimpleReference) =>
@@ -107,12 +107,12 @@ namespace Java.InteropTests {
 
 		Dictionary<(string SourceType, string SourceName, string? SourceSignature), (string? TargetType, string? TargetName, string? TargetSignature, int? ParamCount, bool TurnStatic)> ReplacementMethods = new() {
 			[("java/lang/Object",                       "remappedToToString",       "()Ljava/lang/String;")]    = (null, "toString", null, null, false),
-			[("java/lang/Object",                       "remappedToStaticHashCode", null)]                      = ("com/xamarin/interop/ObjectHelper", "getHashCodeHelper", null, null, true),
+			[("java/lang/Object",                       "remappedToStaticHashCode", null)]                      = ("net/dot/jni/test/ObjectHelper", "getHashCodeHelper", null, null, true),
 			[("java/lang/Runtime",                      "remappedToGetRuntime",     null)]                      = (null, "getRuntime", null, null, false),
 
 			// NOTE: key must use *post-renamed* value, not pre-renamed value
 			// NOTE: SourceSignature lacking return type; "closer in spirit" to what `remapping-config.json` allows
-			[("com/xamarin/interop/RenameClassBase2",   "hashCode",                 "()")]                      = ("com/xamarin/interop/RenameClassBase2", "myNewHashCode", null, null, false),
+			[("net/dot/jni/test/RenameClassBase2",   "hashCode",                 "()")]                      = ("net/dot/jni/test/RenameClassBase2", "myNewHashCode", null, null, false),
 		};
 
 		protected override JniRuntime.ReplacementMethodInfo? GetReplacementMethodInfoCore (string jniSourceType, string jniMethodName, string jniMethodSignature)

--- a/tests/Java.Interop-Tests/Java.Interop/JniInstanceMethodIDTest.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JniInstanceMethodIDTest.cs
@@ -13,8 +13,8 @@ namespace Java.InteropTests
 		[Test]
 		public unsafe void CallNonvirtualVoidMethod_WithBaseMethodIDAndDerivedType ()
 		{
-			using (var b = new JniType ("com/xamarin/interop/CallNonvirtualBase"))
-			using (var d = new JniType ("com/xamarin/interop/CallNonvirtualDerived")) {
+			using (var b = new JniType ("net/dot/jni/test/CallNonvirtualBase"))
+			using (var d = new JniType ("net/dot/jni/test/CallNonvirtualDerived")) {
 				var m = b.GetInstanceMethod ("method", "()V");
 				var f = b.GetInstanceField ("methodInvoked", "Z");
 

--- a/tests/Java.Interop-Tests/Java.Interop/JniTypeManagerTests.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JniTypeManagerTests.cs
@@ -168,7 +168,7 @@ namespace Java.InteropTests
 	}
 
 	class GenericHolder<T> : JavaObject {
-		public  const   string  JniTypeName = "com/xamarin/interop/tests/GenericHolder";
+		public  const   string  JniTypeName = "net/dot/jni/test/tests/GenericHolder";
 
 		public  T   Value   {get; set;}
 	}

--- a/tests/Java.Interop-Tests/Java.Interop/JniTypeTest.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JniTypeTest.cs
@@ -176,7 +176,7 @@ namespace Java.InteropTests
 		[Test]
 		public void RegisterNativeMethods ()
 		{
-			using (var TestType_class = new JniType ("com/xamarin/interop/CallNonvirtualBase")) {
+			using (var TestType_class = new JniType ("net/dot/jni/test/CallNonvirtualBase")) {
 				Assert.AreEqual (JniObjectReferenceType.Global, TestType_class.PeerReference.Type);
 				TestType_class.RegisterNativeMethods ();
 				Assert.AreEqual (JniObjectReferenceType.Global, TestType_class.PeerReference.Type);

--- a/tests/Java.Interop-Tests/Java.Interop/JniValueMarshalerContractTests.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JniValueMarshalerContractTests.cs
@@ -581,7 +581,7 @@ namespace Java.InteropTests {
 
 			// Compare to the default proxy behavior...
 			s       = marshaler.CreateGenericObjectReferenceArgumentState (value);
-			Assert.AreEqual ("com/xamarin/java_interop/internal/JavaProxyObject",   JniEnvironment.Types.GetJniTypeNameFromInstance (s.ReferenceValue));
+			Assert.AreEqual ("net/dot/jni/internal/JavaProxyObject",    JniEnvironment.Types.GetJniTypeNameFromInstance (s.ReferenceValue));
 			marshaler.DestroyGenericArgumentState (value, ref s);
 		}
 	}

--- a/tests/Java.Interop-Tests/Java.Interop/TestType.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/TestType.cs
@@ -12,7 +12,7 @@ namespace Java.InteropTests
 	[JniTypeSignature (TestType.JniTypeName)]
 	public partial class TestType : JavaObject
 	{
-		internal    const    string         JniTypeName = "com/xamarin/interop/TestType";
+		internal    const    string         JniTypeName = "net/dot/jni/test/TestType";
 		static      readonly JniPeerMembers _members    = new JniPeerMembers (JniTypeName, typeof (TestType));
 
 		[JniAddNativeMethodRegistrationAttribute]
@@ -52,13 +52,13 @@ namespace Java.InteropTests
 
 		public static unsafe TestType NewTestType ()
 		{
-			var o   = _members.StaticMethods.InvokeObjectMethod ("newTestType.()Lcom/xamarin/interop/TestType;", null);
+			var o   = _members.StaticMethods.InvokeObjectMethod ("newTestType.()Lnet/dot/jni/test/TestType;", null);
 			return JniEnvironment.Runtime.ValueManager.GetValue<TestType> (ref o, JniObjectReferenceOptions.CopyAndDispose);
 		}
 
 		public static unsafe TestType NewTestTypeWithUnboundConstructor ()
 		{
-			const string id = "newTestTypeWithUnboundConstructor.()Lcom/xamarin/interop/TestType;";
+			const string id = "newTestTypeWithUnboundConstructor.()Lnet/dot/jni/test/TestType;";
 			var o   = _members.StaticMethods.InvokeObjectMethod (id, null);
 			return JniEnvironment.Runtime.ValueManager.GetValue<TestType> (ref o, JniObjectReferenceOptions.CopyAndDispose);
 		}

--- a/tests/Java.Interop-Tests/java/net/dot/jni/test/AndroidInterface.java
+++ b/tests/Java.Interop-Tests/java/net/dot/jni/test/AndroidInterface.java
@@ -1,4 +1,4 @@
-package com.xamarin.interop;
+package net.dot.jni.test;
 
 // When Android Desugaring is enabled -- the default when targeting API-25 and earlier --
 // certain Java constructs result in Java bytecode rewriting.

--- a/tests/Java.Interop-Tests/java/net/dot/jni/test/CallNonvirtualBase.java
+++ b/tests/Java.Interop-Tests/java/net/dot/jni/test/CallNonvirtualBase.java
@@ -1,8 +1,8 @@
-package com.xamarin.interop;
+package net.dot.jni.test;
 
 import java.util.ArrayList;
 
-import com.xamarin.java_interop.GCUserPeerable;
+import net.dot.jni.GCUserPeerable;
 
 public class CallNonvirtualBase implements GCUserPeerable {
 
@@ -12,7 +12,7 @@ public class CallNonvirtualBase implements GCUserPeerable {
 
 	public CallNonvirtualBase () {
 		if (CallNonvirtualBase.class == getClass ()) {
-			com.xamarin.java_interop.ManagedPeer.construct (
+			net.dot.jni.ManagedPeer.construct (
 					this,
 					assemblyQualifiedName,
 					""

--- a/tests/Java.Interop-Tests/java/net/dot/jni/test/CallNonvirtualDerived.java
+++ b/tests/Java.Interop-Tests/java/net/dot/jni/test/CallNonvirtualDerived.java
@@ -1,8 +1,8 @@
-package com.xamarin.interop;
+package net.dot.jni.test;
 
 import java.util.ArrayList;
 
-import com.xamarin.java_interop.GCUserPeerable;
+import net.dot.jni.GCUserPeerable;
 
 public class CallNonvirtualDerived
 		extends CallNonvirtualBase
@@ -14,7 +14,7 @@ public class CallNonvirtualDerived
 
 	public CallNonvirtualDerived () {
 		if (CallNonvirtualDerived.class == getClass ()) {
-			com.xamarin.java_interop.ManagedPeer.construct (
+			net.dot.jni.ManagedPeer.construct (
 					this,
 					assemblyQualifiedName,
 					""

--- a/tests/Java.Interop-Tests/java/net/dot/jni/test/CallNonvirtualDerived2.java
+++ b/tests/Java.Interop-Tests/java/net/dot/jni/test/CallNonvirtualDerived2.java
@@ -1,8 +1,8 @@
-package com.xamarin.interop;
+package net.dot.jni.test;
 
 import java.util.ArrayList;
 
-import com.xamarin.java_interop.GCUserPeerable;
+import net.dot.jni.GCUserPeerable;
 
 public class CallNonvirtualDerived2
 		extends CallNonvirtualDerived
@@ -14,7 +14,7 @@ public class CallNonvirtualDerived2
 
 	public CallNonvirtualDerived2 () {
 		if (CallNonvirtualDerived2.class == getClass ()) {
-			com.xamarin.java_interop.ManagedPeer.construct (
+			net.dot.jni.ManagedPeer.construct (
 					this,
 					assemblyQualifiedName,
 					""

--- a/tests/Java.Interop-Tests/java/net/dot/jni/test/CallVirtualFromConstructorBase.java
+++ b/tests/Java.Interop-Tests/java/net/dot/jni/test/CallVirtualFromConstructorBase.java
@@ -1,8 +1,8 @@
-package com.xamarin.interop;
+package net.dot.jni.test;
 
 import java.util.ArrayList;
 
-import com.xamarin.java_interop.GCUserPeerable;
+import net.dot.jni.GCUserPeerable;
 
 public class CallVirtualFromConstructorBase implements GCUserPeerable {
 
@@ -12,7 +12,7 @@ public class CallVirtualFromConstructorBase implements GCUserPeerable {
 
 	public CallVirtualFromConstructorBase (int value) {
 		if (CallVirtualFromConstructorBase.class == getClass ()) {
-			com.xamarin.java_interop.ManagedPeer.construct (
+			net.dot.jni.ManagedPeer.construct (
 					this,
 					assemblyQualifiedName,
 					"System.Int32",

--- a/tests/Java.Interop-Tests/java/net/dot/jni/test/CallVirtualFromConstructorDerived.java
+++ b/tests/Java.Interop-Tests/java/net/dot/jni/test/CallVirtualFromConstructorDerived.java
@@ -1,8 +1,8 @@
-package com.xamarin.interop;
+package net.dot.jni.test;
 
 import java.util.ArrayList;
 
-import com.xamarin.java_interop.GCUserPeerable;
+import net.dot.jni.GCUserPeerable;
 
 public class CallVirtualFromConstructorDerived
 		extends CallVirtualFromConstructorBase
@@ -10,7 +10,7 @@ public class CallVirtualFromConstructorDerived
 {
 	static  final   String  assemblyQualifiedName   = "Java.InteropTests.CallVirtualFromConstructorDerived, Java.Interop-Tests";
 	static {
-		com.xamarin.java_interop.ManagedPeer.registerNativeMembers (
+		net.dot.jni.ManagedPeer.registerNativeMembers (
 				CallVirtualFromConstructorDerived.class,
 				assemblyQualifiedName,
 				"");
@@ -21,7 +21,7 @@ public class CallVirtualFromConstructorDerived
 	public CallVirtualFromConstructorDerived (int value) {
 		super (value);
 		if (CallVirtualFromConstructorDerived.class == getClass ()) {
-			com.xamarin.java_interop.ManagedPeer.construct (
+			net.dot.jni.ManagedPeer.construct (
 					this,
 					assemblyQualifiedName,
 					"System.Int32",

--- a/tests/Java.Interop-Tests/java/net/dot/jni/test/CrossReferenceBridge.java
+++ b/tests/Java.Interop-Tests/java/net/dot/jni/test/CrossReferenceBridge.java
@@ -1,8 +1,8 @@
-package com.xamarin.interop;
+package net.dot.jni.test;
 
 import java.util.ArrayList;
 
-import com.xamarin.java_interop.GCUserPeerable;
+import net.dot.jni.GCUserPeerable;
 
 public class CrossReferenceBridge implements GCUserPeerable {
 
@@ -12,7 +12,7 @@ public class CrossReferenceBridge implements GCUserPeerable {
 
 	public CrossReferenceBridge () {
 		if (CrossReferenceBridge.class == getClass ()) {
-			com.xamarin.java_interop.ManagedPeer.construct (
+			net.dot.jni.ManagedPeer.construct (
 					this,
 					assemblyQualifiedName,
 					""

--- a/tests/Java.Interop-Tests/java/net/dot/jni/test/DesugarAndroidInterface$_CC.java
+++ b/tests/Java.Interop-Tests/java/net/dot/jni/test/DesugarAndroidInterface$_CC.java
@@ -1,4 +1,4 @@
-package com.xamarin.interop;
+package net.dot.jni.test;
 
 public class DesugarAndroidInterface$_CC {
 

--- a/tests/Java.Interop-Tests/java/net/dot/jni/test/GetThis.java
+++ b/tests/Java.Interop-Tests/java/net/dot/jni/test/GetThis.java
@@ -1,14 +1,14 @@
-package com.xamarin.interop;
+package net.dot.jni.test;
 
 import java.util.ArrayList;
 
-import com.xamarin.java_interop.GCUserPeerable;
+import net.dot.jni.GCUserPeerable;
 
 public class GetThis implements GCUserPeerable {
 
 	static  final   String  assemblyQualifiedName   = "Java.InteropTests.GetThis, Java.Interop-Tests";
 	static {
-		com.xamarin.java_interop.ManagedPeer.registerNativeMembers (
+		net.dot.jni.ManagedPeer.registerNativeMembers (
 				GetThis.class,
 				assemblyQualifiedName,
 				"");
@@ -18,7 +18,7 @@ public class GetThis implements GCUserPeerable {
 
 	public GetThis () {
 		if (GetThis.class == getClass ()) {
-			com.xamarin.java_interop.ManagedPeer.construct (
+			net.dot.jni.ManagedPeer.construct (
 					this,
 					assemblyQualifiedName,
 					""

--- a/tests/Java.Interop-Tests/java/net/dot/jni/test/ObjectHelper.java
+++ b/tests/Java.Interop-Tests/java/net/dot/jni/test/ObjectHelper.java
@@ -1,4 +1,4 @@
-package com.xamarin.interop;
+package net.dot.jni.test;
 
 public class ObjectHelper {
 	private ObjectHelper()

--- a/tests/Java.Interop-Tests/java/net/dot/jni/test/RenameClassBase1.java
+++ b/tests/Java.Interop-Tests/java/net/dot/jni/test/RenameClassBase1.java
@@ -1,8 +1,8 @@
-package com.xamarin.interop;
+package net.dot.jni.test;
 
 import java.util.ArrayList;
 
-import com.xamarin.java_interop.GCUserPeerable;
+import net.dot.jni.GCUserPeerable;
 
 public class RenameClassBase1
 	implements GCUserPeerable
@@ -14,7 +14,7 @@ public class RenameClassBase1
 	public RenameClassBase1 () {
 		System.out.println("RenameClassBase.<init>()");
 		if (RenameClassBase1.class == getClass ()) {
-			com.xamarin.java_interop.ManagedPeer.construct (
+			net.dot.jni.ManagedPeer.construct (
 					this,
 					assemblyQualifiedName,
 					""

--- a/tests/Java.Interop-Tests/java/net/dot/jni/test/RenameClassBase2.java
+++ b/tests/Java.Interop-Tests/java/net/dot/jni/test/RenameClassBase2.java
@@ -1,8 +1,8 @@
-package com.xamarin.interop;
+package net.dot.jni.test;
 
 import java.util.ArrayList;
 
-import com.xamarin.java_interop.GCUserPeerable;
+import net.dot.jni.GCUserPeerable;
 
 public class RenameClassBase2
 	extends RenameClassBase1
@@ -15,7 +15,7 @@ public class RenameClassBase2
 	public RenameClassBase2 () {
 		System.out.println("RenameClassBase.<init>()");
 		if (RenameClassBase2.class == getClass ()) {
-			com.xamarin.java_interop.ManagedPeer.construct (
+			net.dot.jni.ManagedPeer.construct (
 					this,
 					assemblyQualifiedName,
 					""

--- a/tests/Java.Interop-Tests/java/net/dot/jni/test/RenameClassDerived.java
+++ b/tests/Java.Interop-Tests/java/net/dot/jni/test/RenameClassDerived.java
@@ -1,8 +1,8 @@
-package com.xamarin.interop;
+package net.dot.jni.test;
 
 import java.util.ArrayList;
 
-import com.xamarin.java_interop.GCUserPeerable;
+import net.dot.jni.GCUserPeerable;
 
 public class RenameClassDerived
 	extends RenameClassBase2        // Note: does NOT match C# binding!  This is "post Bytecode rewriting"
@@ -15,7 +15,7 @@ public class RenameClassDerived
 	public RenameClassDerived () {
 		System.out.println("RenameClassDerived.<init>()");
 		if (RenameClassDerived.class == getClass ()) {
-			com.xamarin.java_interop.ManagedPeer.construct (
+			net.dot.jni.ManagedPeer.construct (
 					this,
 					assemblyQualifiedName,
 					""

--- a/tests/Java.Interop-Tests/java/net/dot/jni/test/SelfRegistration.java
+++ b/tests/Java.Interop-Tests/java/net/dot/jni/test/SelfRegistration.java
@@ -1,8 +1,8 @@
-package com.xamarin.interop;
+package net.dot.jni.test;
 
 import java.util.ArrayList;
 
-import com.xamarin.java_interop.GCUserPeerable;
+import net.dot.jni.GCUserPeerable;
 
 public class SelfRegistration implements GCUserPeerable {
 
@@ -12,7 +12,7 @@ public class SelfRegistration implements GCUserPeerable {
 
 	public SelfRegistration () {
 		if (SelfRegistration.class == getClass ()) {
-			com.xamarin.java_interop.ManagedPeer.construct (
+			net.dot.jni.ManagedPeer.construct (
 					this,
 					assemblyQualifiedName,
 					""

--- a/tests/Java.Interop-Tests/java/net/dot/jni/test/TestType.java
+++ b/tests/Java.Interop-Tests/java/net/dot/jni/test/TestType.java
@@ -1,14 +1,14 @@
-package com.xamarin.interop;
+package net.dot.jni.test;
 
 import java.util.ArrayList;
 
-import com.xamarin.java_interop.GCUserPeerable;
+import net.dot.jni.GCUserPeerable;
 
 public class TestType implements GCUserPeerable {
 
 	static  final   String  assemblyQualifiedName   = "Java.InteropTests.TestType, Java.Interop-Tests";
 	static {
-		com.xamarin.java_interop.ManagedPeer.registerNativeMembers (
+		net.dot.jni.ManagedPeer.registerNativeMembers (
 				TestType.class,
 				assemblyQualifiedName,
 				"");
@@ -18,7 +18,7 @@ public class TestType implements GCUserPeerable {
 
 	public TestType () {
 		if (TestType.class == getClass ()) {
-			com.xamarin.java_interop.ManagedPeer.construct (
+			net.dot.jni.ManagedPeer.construct (
 					this,
 					assemblyQualifiedName,
 					""
@@ -29,7 +29,7 @@ public class TestType implements GCUserPeerable {
 	// For test purposes; DO NOT provide this constructor in the TestType.cs!
 	public TestType (TestType a, int b) {
 		if (TestType.class == getClass ()) {
-			com.xamarin.java_interop.ManagedPeer.construct (
+			net.dot.jni.ManagedPeer.construct (
 					this,
 					assemblyQualifiedName,
 					assemblyQualifiedName + ":System.Int32",

--- a/tests/Java.Interop.Export-Tests/Java.Interop/ExportTest.cs
+++ b/tests/Java.Interop.Export-Tests/Java.Interop/ExportTest.cs
@@ -30,7 +30,7 @@ delegate bool _JniMarshal_PPZBCSIJFDLLLLLDFJ_Z (
 
 namespace Java.InteropTests
 {
-	[JniTypeSignature ("com/xamarin/interop/export/ExportType")]
+	[JniTypeSignature ("net/dot/jni/test/ExportType")]
 	public class ExportTest : JavaObject
 	{
 		[JniAddNativeMethodRegistrationAttribute]

--- a/tests/Java.Interop.Export-Tests/Java.Interop/MarshalMemberBuilderTest.cs
+++ b/tests/Java.Interop.Export-Tests/Java.Interop/MarshalMemberBuilderTest.cs
@@ -59,7 +59,7 @@ namespace Java.InteropTests
 
 		static JniType CreateExportTestType ()
 		{
-			return new JniType ("com/xamarin/interop/export/ExportType");
+			return new JniType ("net/dot/jni/test/ExportType");
 		}
 
 		static unsafe ExportTest CreateExportTest (JniType type)

--- a/tests/Java.Interop.Export-Tests/java/net/dot/jni/test/ExportType.java
+++ b/tests/Java.Interop.Export-Tests/java/net/dot/jni/test/ExportType.java
@@ -1,8 +1,8 @@
-package com.xamarin.interop.export;
+package net.dot.jni.test;
 
 import java.util.ArrayList;
 
-import com.xamarin.java_interop.GCUserPeerable;
+import net.dot.jni.GCUserPeerable;
 
 public class ExportType
 		implements GCUserPeerable
@@ -10,7 +10,7 @@ public class ExportType
 
 	static  final   String  assemblyQualifiedName   = "Java.InteropTests.ExportTest, Java.Interop.Export-Tests";
 	static {
-		com.xamarin.java_interop.ManagedPeer.registerNativeMembers (
+		net.dot.jni.ManagedPeer.registerNativeMembers (
 				ExportType.class,
 				assemblyQualifiedName,
 				"");

--- a/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGeneratorTests.cs
+++ b/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGeneratorTests.cs
@@ -633,7 +633,7 @@ public class ExampleInstrumentation
 public class JavaInteropExample
 	extends java.lang.Object
 	implements
-		com.xamarin.java_interop.GCUserPeerable
+		net.dot.jni.GCUserPeerable
 {
 /** @hide */
 	public static final String __md_methods;
@@ -641,7 +641,7 @@ public class JavaInteropExample
 		__md_methods = 
 			""n_Example:()V:__export__\n"" +
 			"""";
-		com.xamarin.java_interop.ManagedPeer.registerNativeMembers (JavaInteropExample.class, ""Xamarin.Android.ToolsTests.JavaInteropExample, Java.Interop.Tools.JavaCallableWrappers-Tests"", __md_methods);
+		net.dot.jni.ManagedPeer.registerNativeMembers (JavaInteropExample.class, ""Xamarin.Android.ToolsTests.JavaInteropExample, Java.Interop.Tools.JavaCallableWrappers-Tests"", __md_methods);
 	}
 
 
@@ -649,7 +649,7 @@ public class JavaInteropExample
 	{
 		super ();
 		if (getClass () == JavaInteropExample.class) {
-			com.xamarin.java_interop.ManagedPeer.construct (this, ""Xamarin.Android.ToolsTests.JavaInteropExample, Java.Interop.Tools.JavaCallableWrappers-Tests"", ""System.Int32, System.Private.CoreLib:System.Int32, System.Private.CoreLib"", new java.lang.Object[] { p0, p1 });
+			net.dot.jni.ManagedPeer.construct (this, ""Xamarin.Android.ToolsTests.JavaInteropExample, Java.Interop.Tools.JavaCallableWrappers-Tests"", ""System.Int32, System.Private.CoreLib:System.Int32, System.Private.CoreLib"", new java.lang.Object[] { p0, p1 });
 		}
 	}
 


### PR DESCRIPTION
The eventual plan is to move the xamarin/Java.Interop repo to dotnet/jni (timeline: unspecified), and existing Java code within dotnet/runtime (for use with .NET Android) already uses a `net.dot` package-name prefix.

As "xamarin" is increasingly "persona-non-grata", *and* these types aren't actually used publicly -- .NET Android née Xamarin.Android has it's own set of `mono.android` types -- we can safely rename the `com.xamarin.java_interop` and related packages to instead use a `net.dot.jni` prefix.