### PR TITLE
[ci] Add API Scan job

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -16,6 +16,10 @@ pr:
     - README.md
     - Documentation/*
 
+parameters:
+- name: ApiScanSourceBranch
+  default: 'refs/heads/main'
+
 # Global variables
 variables:
   RunningOnCI: true
@@ -57,19 +61,11 @@ jobs:
 
   - template: templates\fail-on-issue.yaml
 
-  - task: ArchiveFiles@2
-    displayName: 'Archive build outputs'
-    inputs:
-      rootFolderOrFile: 'bin'
-      archiveType: 'zip'
-      archiveFile: '$(Build.ArtifactStagingDirectory)/bin-dotnet.zip'
-      replaceExistingArchive: true
-    condition: succeededOrFailed()
-
   - task: PublishBuildArtifacts@1
-    displayName: 'Publish Artifact: debug'
+    displayName: Publish build artifacts
     inputs:
-      ArtifactName: debug
+      artifactName: artifacts
+      targetPath: bin
     condition: succeededOrFailed()
 
 - job: mac_dotnet_build
@@ -94,6 +90,64 @@ jobs:
       platformName: .NET - MacOS
 
   - template: templates\fail-on-issue.yaml
+
+
+- job: api_scan
+  displayName: API Scan
+  dependsOn: windows_dotnet_build
+  pool:
+    name: Azure Pipelines
+    vmImage: windows-2022
+  timeoutInMinutes: 480
+  workspace:
+    clean: all
+  variables:
+  - name: ApiScan.Enabled
+    value: true
+  steps:
+  - task: DownloadPipelineArtifact@2
+    displayName: Download build artifacts
+    inputs:
+      artifactName: artifacts
+      downloadPath: $(Build.StagingDirectory)
+
+  - task: APIScan@2
+    displayName: Run APIScan
+    inputs:
+      softwareFolder: $(Build.StagingDirectory)
+      symbolsFolder: 'SRV*http://symweb;$(Build.StagingDirectory)'
+      softwareName: $(ApiScanName)
+      softwareVersionNum: $(Build.SourceBranchName)-$(Build.SourceVersion)$(System.JobAttempt)
+      isLargeApp: true
+      toolVersion: Latest
+    condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
+    env:
+      AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(ApiScanSecret)
+
+  - task: SdtReport@2
+    displayName: Guardian Export - Security Report
+    inputs:
+      GdnExportAllTools: false
+      GdnExportGdnToolApiScan: true
+      GdnExportOutputSuppressionFile: source.gdnsuppress
+    condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
+
+  - task: PublishSecurityAnalysisLogs@3
+    displayName: Publish Guardian Artifacts
+    inputs:
+      ArtifactName: APIScan Logs
+      ArtifactType: Container
+      AllTools: false
+      APIScan: true
+      ToolLogsNotFoundAction: Warning
+    condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
+
+  - task: PostAnalysis@2
+    displayName: Fail Build on Guardian Issues
+    inputs:
+      GdnBreakAllTools: false
+      GdnBreakGdnToolApiScan: true
+    condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
 
 
 - job: OneLocBuild

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -107,13 +107,27 @@ jobs:
     displayName: Download build artifacts
     inputs:
       artifactName: artifacts
-      downloadPath: $(Build.StagingDirectory)
+      downloadPath: $(Build.SourcesDirectory)
+
+    ### Copy .dll, .exe, .pdb files for APIScan
+  - task: CopyFiles@2
+    displayName: Collect Files for APIScan
+    inputs:
+      Contents: |
+        $(Build.SourcesDirectory)\$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)\**\?(*.dll|*.exe|*.pdb)
+        !$(Build.SourcesDirectory)\**\jnimarshalmethod-gen.*
+        !$(Build.SourcesDirectory)\**\Mono.CSharp.dll
+        !$(Build.SourcesDirectory)\**\SgmlReader.exe
+        !$(Build.SourcesDirectory)\**\win-*\java-interop.dll
+      TargetFolder: $(Build.StagingDirectory)\apiscan
+      OverWrite: true
+      flattenFolders: true
 
   - task: APIScan@2
     displayName: Run APIScan
     inputs:
-      softwareFolder: $(Build.StagingDirectory)
-      symbolsFolder: 'SRV*http://symweb;$(Build.StagingDirectory)'
+      softwareFolder: $(Build.StagingDirectory)\apiscan
+      symbolsFolder: 'SRV*http://symweb;$(Build.StagingDirectory)\apiscan'
       softwareName: $(ApiScanName)
       softwareVersionNum: $(Build.SourceBranchName)-$(Build.SourceVersion)$(System.JobAttempt)
       isLargeApp: true

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -61,7 +61,7 @@ jobs:
 
   - template: templates\fail-on-issue.yaml
 
-  - task: PublishBuildArtifacts@1
+  - task: PublishPipelineArtifact@1
     displayName: Publish build artifacts
     inputs:
       artifactName: artifacts
@@ -95,15 +95,13 @@ jobs:
 - job: api_scan
   displayName: API Scan
   dependsOn: windows_dotnet_build
+  condition: and(eq(dependencies.windows_dotnet_build.result, 'Succeeded'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
   pool:
     name: Azure Pipelines
     vmImage: windows-2022
   timeoutInMinutes: 480
   workspace:
     clean: all
-  variables:
-  - name: ApiScan.Enabled
-    value: true
   steps:
   - task: DownloadPipelineArtifact@2
     displayName: Download build artifacts
@@ -120,7 +118,6 @@ jobs:
       softwareVersionNum: $(Build.SourceBranchName)-$(Build.SourceVersion)$(System.JobAttempt)
       isLargeApp: true
       toolVersion: Latest
-    condition: and(succeeded(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
     env:
       AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(ApiScanSecret)
 
@@ -130,7 +127,6 @@ jobs:
       GdnExportAllTools: false
       GdnExportGdnToolApiScan: true
       GdnExportOutputSuppressionFile: source.gdnsuppress
-    condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
 
   - task: PublishSecurityAnalysisLogs@3
     displayName: Publish Guardian Artifacts
@@ -140,14 +136,12 @@ jobs:
       AllTools: false
       APIScan: true
       ToolLogsNotFoundAction: Warning
-    condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
 
   - task: PostAnalysis@2
     displayName: Fail Build on Guardian Issues
     inputs:
       GdnBreakAllTools: false
       GdnBreakGdnToolApiScan: true
-    condition: and(succeededOrFailed(), eq(variables['ApiScan.Enabled'], 'true'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
 
 
 - job: OneLocBuild


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/25351/APIScan-step-by-step-guide-to-setting-up-a-Pipeline

The ApiScan task has been added to pipeline runs against `main`.  This
task should help us identify related issues earlier, rather than having
to wait for a full scan of VS.