### PR TITLE
[Java.Interop] Typemap support for JavaObject & `[JniTypeSignature]`

### DIFF
--- a/src/Java.Interop.Dynamic/Java.Interop.Dynamic/JavaInstanceProxy.cs
+++ b/src/Java.Interop.Dynamic/Java.Interop.Dynamic/JavaInstanceProxy.cs
@@ -13,7 +13,7 @@ using Java.Interop;
 
 namespace Java.Interop.Dynamic {
 
-	[JniTypeSignature ("java/lang/Object")]
+	[JniTypeSignature ("java/lang/Object", GenerateJavaPeer=false)]
 	class JavaInstanceProxy : JavaObject {
 
 		public JavaInstanceProxy (ref JniObjectReference reference, JniObjectReferenceOptions transfer)

--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/TypeDefinitionRocks.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/TypeDefinitionRocks.cs
@@ -92,6 +92,25 @@ namespace Java.Interop.Tools.Cecil {
 			return false;
 		}
 
+		public static bool HasJavaPeer (this TypeDefinition type, IMetadataResolver resolver)
+		{
+			if (type.IsInterface && type.ImplementsInterface ("Java.Interop.IJavaPeerable", resolver))
+				return true;
+
+			foreach (var t in type.GetTypeAndBaseTypes (resolver)) {
+				switch (t.FullName) {
+					case "Java.Lang.Object":
+					case "Java.Lang.Throwable":
+					case "Java.Interop.JavaObject":
+					case "Java.Interop.JavaException":
+						return true;
+					default:
+						break;
+				}
+			}
+			return false;
+		}
+
 		[Obsolete ("Use the TypeDefinitionCache overload for better performance.", error: true)]
 		public static bool ImplementsInterface (this TypeDefinition type, string interfaceName) => throw new NotSupportedException ();
 

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGenerator.cs
@@ -121,7 +121,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers {
 			}
 			children = children ?? new List<JavaCallableWrapperGenerator> ();
 			foreach (TypeDefinition nt in type.NestedTypes) {
-				if (!nt.IsSubclassOf ("Java.Lang.Object", cache))
+				if (!nt.HasJavaPeer (cache))
 					continue;
 				if (!JavaNativeTypeManager.IsNonStaticInnerClass (nt, cache))
 					continue;

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaTypeScanner.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/JavaTypeScanner.cs
@@ -66,10 +66,7 @@ namespace Java.Interop.Tools.JavaCallableWrappers
 
 		void AddJavaTypes (List<TypeDefinition> javaTypes, TypeDefinition type)
 		{
-			if (type.IsSubclassOf ("Java.Lang.Object", cache) ||
-					type.IsSubclassOf ("Java.Lang.Throwable", cache) ||
-					(type.IsInterface && type.ImplementsInterface ("Java.Interop.IJavaPeerable", cache))) {
-				// For subclasses of e.g. Android.App.Activity.
+			if (type.HasJavaPeer (cache)) {
 				javaTypes.Add (type);
 			} else if (type.IsClass && !type.IsSubclassOf ("System.Exception", cache) && type.ImplementsInterface ("Android.Runtime.IJavaObject", cache)) {
 				var level   = ErrorOnCustomJavaObject ? TraceLevel.Error : TraceLevel.Warning;

--- a/src/Java.Interop.Tools.TypeNameMappings/Java.Interop.Tools.TypeNameMappings/JavaNativeTypeManager.cs
+++ b/src/Java.Interop.Tools.TypeNameMappings/Java.Interop.Tools.TypeNameMappings/JavaNativeTypeManager.cs
@@ -717,7 +717,7 @@ namespace Java.Interop.Tools.TypeNameMappings
 			if (!type.IsNested)
 				return false;
 
-			if (!type.DeclaringType.IsSubclassOf ("Java.Lang.Object", cache))
+			if (!type.DeclaringType.HasJavaPeer (cache))
 				return false;
 
 			foreach (var baseType in type.GetBaseTypes (cache)) {

--- a/src/Java.Interop/Java.Interop/JavaException.cs
+++ b/src/Java.Interop/Java.Interop/JavaException.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace Java.Interop
 {
-	[JniTypeSignature (JniTypeName)]
+	[JniTypeSignature (JniTypeName, GenerateJavaPeer=false)]
 	unsafe public class JavaException : Exception, IJavaPeerable
 	{
 		internal    const   string          JniTypeName = "java/lang/Throwable";

--- a/src/Java.Interop/Java.Interop/JavaObject.cs
+++ b/src/Java.Interop/Java.Interop/JavaObject.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace Java.Interop
 {
-	[JniTypeSignature ("java/lang/Object")]
+	[JniTypeSignature ("java/lang/Object", GenerateJavaPeer=false)]
 	unsafe public class JavaObject : IJavaPeerable
 	{
 		readonly static JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (JavaObject));

--- a/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.cs
+++ b/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.cs
@@ -142,7 +142,7 @@ namespace Java.Interop {
 		}
 	}
 
-	[JniTypeSignature ("Z", ArrayRank=1, IsKeyword=true)]
+	[JniTypeSignature ("Z", ArrayRank=1, IsKeyword=true, GenerateJavaPeer=false)]
 	public sealed class JavaBooleanArray : JavaPrimitiveArray<Boolean> {
 
 		internal    static  readonly    ValueMarshaler   ArrayMarshaler     = new ValueMarshaler ();
@@ -337,7 +337,7 @@ namespace Java.Interop {
 		}
 	}
 
-	[JniTypeSignature ("B", ArrayRank=1, IsKeyword=true)]
+	[JniTypeSignature ("B", ArrayRank=1, IsKeyword=true, GenerateJavaPeer=false)]
 	public sealed class JavaSByteArray : JavaPrimitiveArray<SByte> {
 
 		internal    static  readonly    ValueMarshaler   ArrayMarshaler     = new ValueMarshaler ();
@@ -532,7 +532,7 @@ namespace Java.Interop {
 		}
 	}
 
-	[JniTypeSignature ("C", ArrayRank=1, IsKeyword=true)]
+	[JniTypeSignature ("C", ArrayRank=1, IsKeyword=true, GenerateJavaPeer=false)]
 	public sealed class JavaCharArray : JavaPrimitiveArray<Char> {
 
 		internal    static  readonly    ValueMarshaler   ArrayMarshaler     = new ValueMarshaler ();
@@ -727,7 +727,7 @@ namespace Java.Interop {
 		}
 	}
 
-	[JniTypeSignature ("S", ArrayRank=1, IsKeyword=true)]
+	[JniTypeSignature ("S", ArrayRank=1, IsKeyword=true, GenerateJavaPeer=false)]
 	public sealed class JavaInt16Array : JavaPrimitiveArray<Int16> {
 
 		internal    static  readonly    ValueMarshaler   ArrayMarshaler     = new ValueMarshaler ();
@@ -922,7 +922,7 @@ namespace Java.Interop {
 		}
 	}
 
-	[JniTypeSignature ("I", ArrayRank=1, IsKeyword=true)]
+	[JniTypeSignature ("I", ArrayRank=1, IsKeyword=true, GenerateJavaPeer=false)]
 	public sealed class JavaInt32Array : JavaPrimitiveArray<Int32> {
 
 		internal    static  readonly    ValueMarshaler   ArrayMarshaler     = new ValueMarshaler ();
@@ -1117,7 +1117,7 @@ namespace Java.Interop {
 		}
 	}
 
-	[JniTypeSignature ("J", ArrayRank=1, IsKeyword=true)]
+	[JniTypeSignature ("J", ArrayRank=1, IsKeyword=true, GenerateJavaPeer=false)]
 	public sealed class JavaInt64Array : JavaPrimitiveArray<Int64> {
 
 		internal    static  readonly    ValueMarshaler   ArrayMarshaler     = new ValueMarshaler ();
@@ -1312,7 +1312,7 @@ namespace Java.Interop {
 		}
 	}
 
-	[JniTypeSignature ("F", ArrayRank=1, IsKeyword=true)]
+	[JniTypeSignature ("F", ArrayRank=1, IsKeyword=true, GenerateJavaPeer=false)]
 	public sealed class JavaSingleArray : JavaPrimitiveArray<Single> {
 
 		internal    static  readonly    ValueMarshaler   ArrayMarshaler     = new ValueMarshaler ();
@@ -1507,7 +1507,7 @@ namespace Java.Interop {
 		}
 	}
 
-	[JniTypeSignature ("D", ArrayRank=1, IsKeyword=true)]
+	[JniTypeSignature ("D", ArrayRank=1, IsKeyword=true, GenerateJavaPeer=false)]
 	public sealed class JavaDoubleArray : JavaPrimitiveArray<Double> {
 
 		internal    static  readonly    ValueMarshaler   ArrayMarshaler     = new ValueMarshaler ();

--- a/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.tt
+++ b/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.tt
@@ -139,7 +139,7 @@ namespace Java.Interop {
 		}
 	}
 
-	[JniTypeSignature ("<#= info.JniType #>", ArrayRank=1, IsKeyword=true)]
+	[JniTypeSignature ("<#= info.JniType #>", ArrayRank=1, IsKeyword=true, GenerateJavaPeer=false)]
 	public sealed class Java<#= info.TypeModifier #>Array : JavaPrimitiveArray<<#= info.ManagedType #>> {
 
 		internal    static  readonly    ValueMarshaler   ArrayMarshaler     = new ValueMarshaler ();

--- a/src/Java.Interop/Java.Interop/JavaProxyObject.cs
+++ b/src/Java.Interop/Java.Interop/JavaProxyObject.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 
 namespace Java.Interop {
 
-	[JniTypeSignature (JniTypeName)]
+	[JniTypeSignature (JniTypeName, GenerateJavaPeer=false)]
 	sealed class JavaProxyObject : JavaObject, IEquatable<JavaProxyObject>
 	{
 		internal const string JniTypeName = "net/dot/jni/internal/JavaProxyObject";

--- a/src/Java.Interop/Java.Interop/JavaProxyThrowable.cs
+++ b/src/Java.Interop/Java.Interop/JavaProxyThrowable.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace Java.Interop {
 
-	[JniTypeSignature (JniTypeName)]
+	[JniTypeSignature (JniTypeName, GenerateJavaPeer=false)]
 	sealed class JavaProxyThrowable : JavaException
 	{
 		new internal    const   string  JniTypeName = "net/dot/jni/internal/JavaProxyThrowable";

--- a/src/Java.Interop/Java.Interop/ManagedPeer.cs
+++ b/src/Java.Interop/Java.Interop/ManagedPeer.cs
@@ -13,7 +13,7 @@ using System.Text;
 
 namespace Java.Interop {
 
-	[JniTypeSignature (JniTypeName)]
+	[JniTypeSignature (JniTypeName, GenerateJavaPeer=false)]
 	/* static */ sealed class ManagedPeer : JavaObject {
 
 		internal const string JniTypeName = "net/dot/jni/ManagedPeer";

--- a/tests/Java.Interop-PerformanceTests/Java.Interop/JavaTiming.cs
+++ b/tests/Java.Interop-PerformanceTests/Java.Interop/JavaTiming.cs
@@ -7,7 +7,7 @@ using Java.Interop.GenericMarshaler;
 
 namespace Java.Interop.PerformanceTests
 {
-	[JniTypeSignature (JniTypeName)]
+	[JniTypeSignature (JniTypeName, GenerateJavaPeer=false)]
 	public class JavaTiming : JavaObject
 	{
 		protected   const   string          JniTypeName = "com/xamarin/interop/performance/JavaTiming";

--- a/tests/Java.Interop-Tests/Java.Interop-Tests.csproj
+++ b/tests/Java.Interop-Tests/Java.Interop-Tests.csproj
@@ -30,6 +30,7 @@
     <ProjectReference Include="..\..\src\Java.Interop.GenericMarshaler\Java.Interop.GenericMarshaler.csproj" />
     <ProjectReference Include="..\..\src\Java.Runtime.Environment\Java.Runtime.Environment.csproj" />
     <ProjectReference Include="..\TestJVM\TestJVM.csproj" />
+    <ProjectReference Include="..\..\tools\jcw-gen\jcw-gen.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Java.Interop-Tests/Java.Interop-Tests.targets
+++ b/tests/Java.Interop-Tests/Java.Interop-Tests.targets
@@ -1,12 +1,47 @@
 <Project>
 
+  <ItemGroup>
+    <_BuildJavaInteropTestsJarInputs Include="$(TargetPath)" />
+    <_BuildJavaInteropTestsJarInputs Include="$(MSBuildThisFileFullPath)" />
+    <_BuildJavaInteropTestsJarInputs Include="java\**\*.java" />
+  </ItemGroup>
+
+  <Target Name="_CreateJavaCallableWrappers"
+      Condition=" '$(TargetPath)' != '' "
+      AfterTargets="Build"
+      Inputs="@(_BuildJavaInteropTestsJarInputs)"
+      Outputs="$(IntermediateOutputPath)java\.stamp">
+    <RemoveDir Directories="$(IntermediateOutputPath)java" />
+    <MakeDir Directories="$(IntermediateOutputPath)java" />
+    <ItemGroup>
+      <!-- I can't find a good way to trim the trailing `\`, so append with `.` so we can sanely quote for $(_Libpath) -->
+      <_RefAsmDirs Include="@(ReferencePathWithRefAssemblies->'%(RootDir)%(Directory).'->Distinct())" />
+    </ItemGroup>
+    <PropertyGroup>
+      <_JcwGen>"$(UtilityOutputFullPath)/jcw-gen.dll"</_JcwGen>
+      <_Target>--codegen-target JavaInterop1</_Target>
+      <_Output>-o "$(IntermediateOutputPath)/java"</_Output>
+      <_Libpath>@(_RefAsmDirs->'-L "%(Identity)"', ' ')</_Libpath>
+    </PropertyGroup>
+    <Exec Command="$(DotnetToolPath) $(_JcwGen) -v &quot;$(TargetPath)&quot; $(_Target) $(_Output) $(_Libpath)" />
+    <Touch Files="$(IntermediateOutputPath)java\.stamp" AlwaysCreate="True" />
+  </Target>
+
+  <Target Name="_CollectGeneratdJcwSource">
+    <ItemGroup>
+      <_GeneratedJcwSource Include="$(IntermediateOutputPath)java\**\*.java" />
+    </ItemGroup>
+  </Target>
+
   <Target Name="BuildInteropTestJar"
-      BeforeTargets="Build"
-      Inputs="@(JavaInteropTestJar)"
+      AfterTargets="Build"
+      DependsOnTargets="_CreateJavaCallableWrappers;_CollectGeneratdJcwSource"
+      Inputs="@(JavaInteropTestJar);@(_GeneratedJcwSource)"
       Outputs="$(OutputPath)interop-test.jar">
     <MakeDir Directories="$(IntermediateOutputPath)it-classes" />
     <ItemGroup>
       <_Source Include="@(JavaInteropTestJar->Replace('%5c', '/'))" />
+      <_Source Include="@(_GeneratedJcwSource->Replace('%5c', '/'))" />
     </ItemGroup>
     <WriteLinesToFile
         File="$(IntermediateOutputPath)_java_sources.txt"

--- a/tests/Java.Interop-Tests/Java.Interop/CallNonvirtualBase.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/CallNonvirtualBase.cs
@@ -4,7 +4,7 @@ using Java.Interop;
 
 namespace Java.InteropTests
 {
-	[JniTypeSignature (CallNonvirtualBase.JniTypeName)]
+	[JniTypeSignature (CallNonvirtualBase.JniTypeName, GenerateJavaPeer=false)]
 	public class CallNonvirtualBase : JavaObject
 	{
 		internal const string JniTypeName = "net/dot/jni/test/CallNonvirtualBase";

--- a/tests/Java.Interop-Tests/Java.Interop/CallNonvirtualDerived.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/CallNonvirtualDerived.cs
@@ -4,7 +4,7 @@ using Java.Interop;
 
 namespace Java.InteropTests
 {
-	[JniTypeSignature (CallNonvirtualDerived.JniTypeName)]
+	[JniTypeSignature (CallNonvirtualDerived.JniTypeName, GenerateJavaPeer=false)]
 	public class CallNonvirtualDerived : CallNonvirtualBase
 	{
 		internal new const string JniTypeName = "net/dot/jni/test/CallNonvirtualDerived";

--- a/tests/Java.Interop-Tests/Java.Interop/CallNonvirtualDerived2.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/CallNonvirtualDerived2.cs
@@ -4,7 +4,7 @@ using Java.Interop;
 
 namespace Java.InteropTests
 {
-	[JniTypeSignature (CallNonvirtualDerived2.JniTypeName)]
+	[JniTypeSignature (CallNonvirtualDerived2.JniTypeName, GenerateJavaPeer=false)]
 	public class CallNonvirtualDerived2 : CallNonvirtualDerived
 	{
 		internal new const string JniTypeName = "net/dot/jni/test/CallNonvirtualDerived2";

--- a/tests/Java.Interop-Tests/Java.Interop/CallVirtualFromConstructorBase.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/CallVirtualFromConstructorBase.cs
@@ -5,7 +5,7 @@ using Java.Interop.GenericMarshaler;
 
 namespace Java.InteropTests {
 
-	[JniTypeSignature (CallVirtualFromConstructorBase.JniTypeName)]
+	[JniTypeSignature (CallVirtualFromConstructorBase.JniTypeName, GenerateJavaPeer=false)]
 	public class CallVirtualFromConstructorBase : JavaObject {
 
 		internal    const   string          JniTypeName = "net/dot/jni/test/CallVirtualFromConstructorBase";

--- a/tests/Java.Interop-Tests/Java.Interop/CallVirtualFromConstructorDerived.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/CallVirtualFromConstructorDerived.cs
@@ -4,7 +4,7 @@ using Java.Interop;
 
 namespace Java.InteropTests
 {
-	[JniTypeSignature (CallVirtualFromConstructorDerived.JniTypeName)]
+	[JniTypeSignature (CallVirtualFromConstructorDerived.JniTypeName, GenerateJavaPeer=false)]
 	public class CallVirtualFromConstructorDerived : CallVirtualFromConstructorBase {
 		new internal    const   string          JniTypeName = "net/dot/jni/test/CallVirtualFromConstructorDerived";
 		static  readonly        JniPeerMembers  _members    = new JniPeerMembers (JniTypeName, typeof (CallVirtualFromConstructorDerived));

--- a/tests/Java.Interop-Tests/Java.Interop/GetThis.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/GetThis.cs
@@ -4,7 +4,7 @@ using Java.Interop;
 
 namespace Java.InteropTests
 {
-	[JniTypeSignature (GetThis.JniTypeName)]
+	[JniTypeSignature (GetThis.JniTypeName, GenerateJavaPeer=false)]
 	public class GetThis : JavaObject
 	{
 		internal const string JniTypeName = "net/dot/jni/test/GetThis";

--- a/tests/Java.Interop-Tests/Java.Interop/JavaManagedGCBridgeTests.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JavaManagedGCBridgeTests.cs
@@ -52,7 +52,7 @@ namespace Java.InteropTests {
 		}
 	}
 
-	[JniTypeSignature (JniTypeName)]
+	[JniTypeSignature (JniTypeName, GenerateJavaPeer=false)]
 	public class CrossReferenceBridge : JavaObject {
 		internal    const    string         JniTypeName = "net/dot/jni/test/CrossReferenceBridge";
 

--- a/tests/Java.Interop-Tests/Java.Interop/JavaObjectTest.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JavaObjectTest.cs
@@ -204,12 +204,12 @@ namespace Java.InteropTests
 	class JavaObjectWithNoJavaPeer : JavaObject {
 	}
 
-	[JniTypeSignature (JniTypeName)]
+	[JniTypeSignature (JniTypeName, GenerateJavaPeer=false)]
 	class JavaObjectWithMissingJavaPeer : JavaObject {
 		internal    const   string  JniTypeName = "__this__/__type__/__had__/__better__/__not__/__Exist__";
 	}
 
-	[JniTypeSignature ("java/lang/Object")]
+	[JniTypeSignature ("java/lang/Object", GenerateJavaPeer=false)]
 	class JavaDisposedObject : JavaObject {
 
 		public Action   OnDisposed;
@@ -230,7 +230,7 @@ namespace Java.InteropTests
 		}
 	}
 
-	[JniTypeSignature ("java/lang/Object")]
+	[JniTypeSignature ("java/lang/Object", GenerateJavaPeer=false)]
 	class MyDisposableObject : JavaObject {
 		bool _isDisposed;
 

--- a/tests/Java.Interop-Tests/Java.Interop/JavaObjectTest.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JavaObjectTest.cs
@@ -164,11 +164,13 @@ namespace Java.InteropTests
 			var r   = new JniObjectReference ();
 			Assert.Throws<ArgumentException> (() => new JavaObject (ref r, JniObjectReferenceOptions.CopyAndDispose));
 
-			// Note: This may break if/when JavaVM provides "default"
-			Assert.Throws<NotSupportedException> (() => new JavaObjectWithNoJavaPeer ());
 #if __ANDROID__
 			Assert.Throws<Java.Lang.ClassNotFoundException> (() => new JavaObjectWithMissingJavaPeer ()).Dispose ();
 #else   // !__ANDROID__
+			// Note: `JavaObjectWithNoJavaPeer` creation works on Android because tooling provides all
+			// typemap entries.  On desktop, we use the hardcoded cit in JavaVMFixture, which deliberately
+			// *lacks* an  entry for `JavaObjectWithNoJavaPeer`.
+			Assert.Throws<NotSupportedException> (() => new JavaObjectWithNoJavaPeer ());
 			Assert.Throws<JavaException> (() => new JavaObjectWithMissingJavaPeer ()).Dispose ();
 #endif  // !__ANDROID__
 		}
@@ -201,16 +203,20 @@ namespace Java.InteropTests
 		}
 	}
 
+#if !__ANDROID__
 	class JavaObjectWithNoJavaPeer : JavaObject {
 	}
+#endif  // !__ANDROID__
 
 	[JniTypeSignature (JniTypeName, GenerateJavaPeer=false)]
 	class JavaObjectWithMissingJavaPeer : JavaObject {
 		internal    const   string  JniTypeName = "__this__/__type__/__had__/__better__/__not__/__Exist__";
 	}
 
-	[JniTypeSignature ("java/lang/Object", GenerateJavaPeer=false)]
+	[JniTypeSignature (JniTypeName)]
 	class JavaDisposedObject : JavaObject {
+
+		internal    const   string  JniTypeName = "net/dot/jni/test/JavaDisposedObject";
 
 		public Action   OnDisposed;
 		public Action   OnFinalized;
@@ -230,8 +236,10 @@ namespace Java.InteropTests
 		}
 	}
 
-	[JniTypeSignature ("java/lang/Object", GenerateJavaPeer=false)]
+	[JniTypeSignature (JniTypeName)]
 	class MyDisposableObject : JavaObject {
+		internal    const   string  JniTypeName = "net/dot/jni/test/MyDisposableObject";
+
 		bool _isDisposed;
 
 		public MyDisposableObject ()

--- a/tests/Java.Interop-Tests/Java.Interop/JavaObjectTest.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JavaObjectTest.cs
@@ -168,8 +168,8 @@ namespace Java.InteropTests
 			Assert.Throws<Java.Lang.ClassNotFoundException> (() => new JavaObjectWithMissingJavaPeer ()).Dispose ();
 #else   // !__ANDROID__
 			// Note: `JavaObjectWithNoJavaPeer` creation works on Android because tooling provides all
-			// typemap entries.  On desktop, we use the hardcoded cit in JavaVMFixture, which deliberately
-			// *lacks* an  entry for `JavaObjectWithNoJavaPeer`.
+			// typemap entries.  On desktop, we use the hardcoded dictionary in JavaVMFixture, which
+   			// deliberately *lacks* an  entry for `JavaObjectWithNoJavaPeer`.
 			Assert.Throws<NotSupportedException> (() => new JavaObjectWithNoJavaPeer ());
 			Assert.Throws<JavaException> (() => new JavaObjectWithMissingJavaPeer ()).Dispose ();
 #endif  // !__ANDROID__

--- a/tests/Java.Interop-Tests/Java.Interop/JavaVMFixture.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JavaVMFixture.cs
@@ -40,6 +40,9 @@ namespace Java.InteropTests {
 			[CallVirtualFromConstructorBase.JniTypeName]    = typeof (CallVirtualFromConstructorBase),
 			[CallVirtualFromConstructorDerived.JniTypeName] = typeof (CallVirtualFromConstructorDerived),
 			[GetThis.JniTypeName]                           = typeof (GetThis),
+			[JavaDisposedObject.JniTypeName]                = typeof (JavaDisposedObject),
+			[JavaObjectWithMissingJavaPeer.JniTypeName]     = typeof (JavaObjectWithMissingJavaPeer),
+			[MyDisposableObject.JniTypeName]                = typeof (JavaDisposedObject),
 		};
 
 		public JavaVMFixtureTypeManager ()

--- a/tests/Java.Interop-Tests/Java.Interop/JavaVMFixture.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JavaVMFixture.cs
@@ -39,6 +39,7 @@ namespace Java.InteropTests {
 			[RenameClassDerived.JniTypeName]    = typeof (RenameClassDerived),
 			[CallVirtualFromConstructorBase.JniTypeName]    = typeof (CallVirtualFromConstructorBase),
 			[CallVirtualFromConstructorDerived.JniTypeName] = typeof (CallVirtualFromConstructorDerived),
+			[CrossReferenceBridge.JniTypeName]              = typeof (CrossReferenceBridge),
 			[GetThis.JniTypeName]                           = typeof (GetThis),
 			[JavaDisposedObject.JniTypeName]                = typeof (JavaDisposedObject),
 			[JavaObjectWithMissingJavaPeer.JniTypeName]     = typeof (JavaObjectWithMissingJavaPeer),

--- a/tests/Java.Interop-Tests/Java.Interop/JniPeerMembersTests.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JniPeerMembersTests.cs
@@ -161,7 +161,7 @@ namespace Java.InteropTests
 #endif  // NET
 	}
 
-	[JniTypeSignature (JniTypeName)]
+	[JniTypeSignature (JniTypeName, GenerateJavaPeer=false)]
 	class MyString : JavaObject {
 		internal    const   string      JniTypeName = "java/lang/String";
 
@@ -182,7 +182,7 @@ namespace Java.InteropTests
 	}
 
 
-	[JniTypeSignature (JniTypeName)]
+	[JniTypeSignature (JniTypeName, GenerateJavaPeer=false)]
 	class JavaLangRemappingTestObject : JavaObject {
 		internal    const    string         JniTypeName = "java/lang/Object";
 		static      readonly JniPeerMembers _members    = new JniPeerMembers (JniTypeName, typeof (JavaLangRemappingTestObject));
@@ -210,7 +210,7 @@ namespace Java.InteropTests
 		}
 	}
 
-	[JniTypeSignature (JavaLangRemappingTestRuntime.JniTypeName)]
+	[JniTypeSignature (JavaLangRemappingTestRuntime.JniTypeName, GenerateJavaPeer=false)]
 	internal class JavaLangRemappingTestRuntime : JavaObject {
 		internal    const    string         JniTypeName = "java/lang/Runtime";
 		static      readonly JniPeerMembers _members    = new JniPeerMembers (JniTypeName, typeof (JavaLangRemappingTestRuntime));
@@ -228,7 +228,7 @@ namespace Java.InteropTests
 		}
 	}
 
-	[JniTypeSignature (JniTypeName)]
+	[JniTypeSignature (JniTypeName, GenerateJavaPeer=false)]
 	class RenameClassBase : JavaObject {
 		internal    const       string          JniTypeName    = "net/dot/jni/test/RenameClassBase1";
 		static      readonly    JniPeerMembers  _members        = new JniPeerMembers (JniTypeName, typeof (RenameClassBase));
@@ -246,7 +246,7 @@ namespace Java.InteropTests
 		}
 	}
 
-	[JniTypeSignature (JniTypeName)]
+	[JniTypeSignature (JniTypeName, GenerateJavaPeer=false)]
 	class RenameClassDerived : RenameClassBase {
 		internal    new     const       string          JniTypeName    = "net/dot/jni/test/RenameClassDerived";
 		public RenameClassDerived ()
@@ -260,7 +260,7 @@ namespace Java.InteropTests
 	}
 
 #if NET
-	[JniTypeSignature (JniTypeName)]
+	[JniTypeSignature (JniTypeName, GenerateJavaPeer=false)]
 	interface IAndroidInterface : IJavaPeerable {
 		internal            const       string          JniTypeName    = "net/dot/jni/test/AndroidInterface";
 

--- a/tests/Java.Interop-Tests/Java.Interop/JniTypeManagerTests.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JniTypeManagerTests.cs
@@ -197,6 +197,7 @@ namespace Java.InteropTests
 		}
 	}
 
+	[JniTypeSignature (JniTypeName)]
 	class GenericHolder<T> : JavaObject {
 		public  const   string  JniTypeName = "net/dot/jni/test/tests/GenericHolder";
 

--- a/tests/Java.Interop-Tests/Java.Interop/JniTypeManagerTests.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JniTypeManagerTests.cs
@@ -199,7 +199,7 @@ namespace Java.InteropTests
 
 	[JniTypeSignature (JniTypeName)]
 	class GenericHolder<T> : JavaObject {
-		public  const   string  JniTypeName = "net/dot/jni/test/tests/GenericHolder";
+		public  const   string  JniTypeName = "net/dot/jni/test/GenericHolder";
 
 		public  T   Value   {get; set;}
 	}

--- a/tests/Java.Interop-Tests/Java.Interop/TestType.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/TestType.cs
@@ -9,7 +9,7 @@ using NUnit.Framework;
 namespace Java.InteropTests
 {
 #if !NO_MARSHAL_MEMBER_BUILDER_SUPPORT
-	[JniTypeSignature (TestType.JniTypeName)]
+	[JniTypeSignature (TestType.JniTypeName, GenerateJavaPeer=false)]
 	public partial class TestType : JavaObject
 	{
 		internal    const    string         JniTypeName = "net/dot/jni/test/TestType";

--- a/tests/Java.Interop.Export-Tests/Java.Interop/ExportTest.cs
+++ b/tests/Java.Interop.Export-Tests/Java.Interop/ExportTest.cs
@@ -30,7 +30,7 @@ delegate bool _JniMarshal_PPZBCSIJFDLLLLLDFJ_Z (
 
 namespace Java.InteropTests
 {
-	[JniTypeSignature (JniTypeName)]
+	[JniTypeSignature (JniTypeName, GenerateJavaPeer=false)]
 	public class ExportTest : JavaObject
 	{
 		internal const string JniTypeName = "net/dot/jni/test/ExportType";


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/8543
Context: https://github.com/xamarin/xamarin-android/pull/8625
Context: https://github.com/xamarin/java.interop/pull/1168
Context: def5bc0df68a5908fac85e5dd4f02f1e27c75882
Context: 005c914170a0af9069ff18fd4dd9d45463dd5dc6

xamarin/xamarin-android#8543 tested PR #1168, was Totally Green™ -- finding no issues -- and so we merged PR #1168 into 005c9141.

Enter xamarin/xamarin-android#8625, which bumps xamarin-android to use def5bc0d, which includes 005c9141.  xamarin/xamarin-android#8625 contains *failing unit tests* (?!), including
`Java.InteropTests.InvokeVirtualFromConstructorTests()`:

	Java.Lang.LinkageError : net.dot.jni.test.CallVirtualFromConstructorDerived
	----> System.NotSupportedException : Could not find System.Type corresponding to Java type JniTypeSignature(TypeName=net/dot/jni/test/CallVirtualFromConstructorDerived ArrayRank=0 Keyword=False) .
	   at Java.Interop.JniEnvironment.StaticMethods.GetStaticMethodID(JniObjectReference , String , String )
	   at Java.Interop.JniType.GetStaticMethod(String , String )
	   at Java.Interop.JniPeerMembers.JniStaticMethods.GetMethodInfo(String , String )
	   at Java.Interop.JniPeerMembers.JniStaticMethods.GetMethodInfo(String )
	   at Java.Interop.JniPeerMembers.JniStaticMethods.InvokeObjectMethod(String , JniArgumentValue* )
	   at Java.InteropTests.CallVirtualFromConstructorDerived.NewInstance(Int32 value)
	   at Java.InteropTests.InvokeVirtualFromConstructorTests.ActivationConstructor()
	   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
	   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object , BindingFlags )
	  --- End of managed Java.Lang.LinkageError stack trace ---
	java.lang.NoClassDefFoundError: net.dot.jni.test.CallVirtualFromConstructorDerived
		at crc643df67da7b13bb6b1.TestInstrumentation_1.n_onStart(Native Method)
		at crc643df67da7b13bb6b1.TestInstrumentation_1.onStart(TestInstrumentation_1.java:35)
		at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:2189)
	Caused by: android.runtime.JavaProxyThrowable: [System.NotSupportedException]: Could not find System.Type corresponding to Java type JniTypeSignature(TypeName=net/dot/jni/test/CallVirtualFromConstructorDerived ArrayRank=0 Keyword=False) .
		at Java.Interop.ManagedPeer.GetTypeFromSignature(Unknown Source:0)
		at Java.Interop.ManagedPeer.RegisterNativeMembers(Unknown Source:0)
		at net.dot.jni.ManagedPeer.registerNativeMembers(Native Method)
		at net.dot.jni.test.CallVirtualFromConstructorDerived.<clinit>(CallVirtualFromConstructorDerived.java:12)
		... 3 more

	--NotSupportedException
	   at Java.Interop.ManagedPeer.GetTypeFromSignature(JniTypeManager , JniTypeSignature , String )
	   at Java.Interop.ManagedPeer.RegisterNativeMembers(IntPtr jnienv, IntPtr klass, IntPtr n_nativeClass, IntPtr n_methods)

:shocked-pikachu-face: (But xamarin/xamarin-android#8543 was green!)

The problem is twofold:

 1. 005c9141 now requires the presence of typemap entries from e.g. `Java.InteropTests.CallVirtualFromConstructorDerived` to `net.dot.jni.test.CallVirtualFromConstructorDerived`.

 2. `Java.Interop.Tools.JavaCallableWrappers` et al doesn't create typemap entries for `Java.Interop.JavaObject` subclasses which have `[JniTypeSignature]`.

Consequently, our units tests fail (and apparently weren't *run* on xamarin/xamarin-android#8543?!  Still not what happened.)

Fix typemap generation by adding a new `TypeDefinition.HasJavaPeer()` extension method to replace all the `.IsSubclassOf("Java.Lang.Object")` and similar checks, extending it to also check for `Java.Interop.JavaObject` and `Java.Interop.JavaException` base types. (Continuing to use base type checks is done instead of just relying on implementation of `Java.Interop.IJavaPeerable` as a performance optimization, as there could be *lots* of interface types to check.)

Additionally, @jonathanpeppers -- while trying to investigate all this -- ran across a build failure:

	obj\Debug\net9.0-android\android\src\java\lang\Object.java(7,15): javac.exe error JAVAC0000:  error: cyclic inheritance involving Object

This suggests that `Java.Interop.Tools.JavaCallableWrappers` was encountering `Java.Interop.JavaObject` -- or some other type which has `[JniTypeSignature("java/lang/Object")]` -- which is why `java/lang/Object.java` was being generated.

Audit all `[JniTypeSignature]` attributes, and add `GenerateJavaPeer=false` to all types which should *not* hava a Java Callable Wrapper generated for them.  This includes nearly everything within `Java.Interop-Tests.dll`.  (We want the typemaps! We *don't* want generated Java source, as we have hand-written Java peer types for those tests.)

---

Aside: this project includes [T4 Text Templates][0].  To regenerate the output files *without involving Visual Studio*, you can install the [`dotnet-t4`][1] tool:

	$ dotnet tool install --global dotnet-t4

then run it separately for each `.tt` file:

	$HOME/.dotnet/tools/t4 -o src/Java.Interop/Java.Interop/JavaPrimitiveArrays.cs \
	  src/Java.Interop/Java.Interop/JavaPrimitiveArrays.tt

[0]: https://learn.microsoft.com/visualstudio/modeling/code-generation-and-t4-text-templates?view=vs-2022
[1]: https://www.nuget.org/packages/dotnet-t4/