### PR TITLE
[java.interop] address some "easy" trimmer warnings

### DIFF
--- a/src/Java.Interop/Java.Interop.csproj
+++ b/src/Java.Interop/Java.Interop.csproj
@@ -14,6 +14,10 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
+    <!-- TODO: enable these when all warnings are solved -->
+    <!--<IsTrimmable>true</IsTrimmable>-->
+    <!--<EnableAotAnalyzer>true</EnableAotAnalyzer>-->
     <MSBuildWarningsAsMessages>NU1702</MSBuildWarningsAsMessages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Java.Interop/Java.Interop/JavaArray.cs
+++ b/src/Java.Interop/Java.Interop/JavaArray.cs
@@ -364,7 +364,12 @@ namespace Java.Interop
 		}
 	}
 	
-	public abstract class JavaPrimitiveArray<[DynamicallyAccessedMembers (ConstructorsAndInterfaces)] T> : JavaArray<T> {
+	public abstract class JavaPrimitiveArray<
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			T
+	>
+		: JavaArray<T>
+	{
 
 		internal JavaPrimitiveArray (ref JniObjectReference reference, JniObjectReferenceOptions transfer)
 			: base (ref reference, transfer)

--- a/src/Java.Interop/Java.Interop/JavaArray.cs
+++ b/src/Java.Interop/Java.Interop/JavaArray.cs
@@ -12,8 +12,6 @@ namespace Java.Interop
 {
 	public abstract class JavaArray<T> : JavaObject, IList, IList<T>
 	{
-		internal const DynamicallyAccessedMemberTypes ConstructorsAndInterfaces = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.Interfaces;
-
 		internal delegate TArray ArrayCreator<TArray> (ref JniObjectReference reference, JniObjectReferenceOptions transfer)
 			where TArray : JavaArray<T>;
 

--- a/src/Java.Interop/Java.Interop/JavaArray.cs
+++ b/src/Java.Interop/Java.Interop/JavaArray.cs
@@ -12,6 +12,8 @@ namespace Java.Interop
 {
 	public abstract class JavaArray<T> : JavaObject, IList, IList<T>
 	{
+		internal const DynamicallyAccessedMemberTypes ConstructorsAndInterfaces = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.Interfaces;
+
 		internal delegate TArray ArrayCreator<TArray> (ref JniObjectReference reference, JniObjectReferenceOptions transfer)
 			where TArray : JavaArray<T>;
 
@@ -362,7 +364,7 @@ namespace Java.Interop
 		}
 	}
 	
-	public abstract class JavaPrimitiveArray<T> : JavaArray<T> {
+	public abstract class JavaPrimitiveArray<[DynamicallyAccessedMembers (ConstructorsAndInterfaces)] T> : JavaArray<T> {
 
 		internal JavaPrimitiveArray (ref JniObjectReference reference, JniObjectReferenceOptions transfer)
 			: base (ref reference, transfer)

--- a/src/Java.Interop/Java.Interop/JavaObject.cs
+++ b/src/Java.Interop/Java.Interop/JavaObject.cs
@@ -1,12 +1,15 @@
 #nullable enable
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Java.Interop
 {
 	[JniTypeSignature ("java/lang/Object", GenerateJavaPeer=false)]
 	unsafe public class JavaObject : IJavaPeerable
 	{
+		internal const DynamicallyAccessedMemberTypes ConstructorsAndInterfaces = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.Interfaces;
+
 		readonly static JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (JavaObject));
 
 		public int                  JniIdentityHashCode { get; private set; }

--- a/src/Java.Interop/Java.Interop/JavaObjectArray.cs
+++ b/src/Java.Interop/Java.Interop/JavaObjectArray.cs
@@ -7,7 +7,11 @@ using System.Reflection;
 
 namespace Java.Interop
 {
-	public class JavaObjectArray<[DynamicallyAccessedMembers (ConstructorsAndInterfaces)] T> : JavaArray<T>
+	public class JavaObjectArray<
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			T
+	>
+		: JavaArray<T>
 	{
 		internal    static  readonly    ValueMarshaler   Instance           = new ValueMarshaler ();
 
@@ -164,7 +168,11 @@ namespace Java.Interop
 
 		internal sealed class ValueMarshaler : JniValueMarshaler<IList<T>> {
 
-			public override IList<T> CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+			public override IList<T> CreateGenericValue (
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 			{
 				return JavaArray<T>.CreateValue (ref reference, options, targetType, (ref JniObjectReference h, JniObjectReferenceOptions t) => new JavaObjectArray<T> (ref h, t) {
 					forMarshalCollection    = true,
@@ -194,7 +202,11 @@ namespace Java.Interop
 		[SuppressMessage ("Design", "CA1034", Justification = "https://github.com/xamarin/Java.Interop/commit/bb7ca5d02aa3fc2b447ad57af1256e74e5f954fa")]
 		partial class Arrays {
 
-			public static JavaObjectArray<T>? CreateMarshalObjectArray<[DynamicallyAccessedMembers (JavaArray<T>.ConstructorsAndInterfaces)] T> (IEnumerable<T>? value)
+			public static JavaObjectArray<T>? CreateMarshalObjectArray<
+					[DynamicallyAccessedMembers (JavaArray<T>.ConstructorsAndInterfaces)]
+					T
+			> (
+					IEnumerable<T>? value)
 			{
 				if (value == null) {
 					return null;

--- a/src/Java.Interop/Java.Interop/JavaObjectArray.cs
+++ b/src/Java.Interop/Java.Interop/JavaObjectArray.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -7,7 +7,7 @@ using System.Reflection;
 
 namespace Java.Interop
 {
-	public class JavaObjectArray<T> : JavaArray<T>
+	public class JavaObjectArray<[DynamicallyAccessedMembers (ConstructorsAndInterfaces)] T> : JavaArray<T>
 	{
 		internal    static  readonly    ValueMarshaler   Instance           = new ValueMarshaler ();
 
@@ -164,7 +164,7 @@ namespace Java.Interop
 
 		internal sealed class ValueMarshaler : JniValueMarshaler<IList<T>> {
 
-			public override IList<T> CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+			public override IList<T> CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 			{
 				return JavaArray<T>.CreateValue (ref reference, options, targetType, (ref JniObjectReference h, JniObjectReferenceOptions t) => new JavaObjectArray<T> (ref h, t) {
 					forMarshalCollection    = true,
@@ -194,7 +194,7 @@ namespace Java.Interop
 		[SuppressMessage ("Design", "CA1034", Justification = "https://github.com/xamarin/Java.Interop/commit/bb7ca5d02aa3fc2b447ad57af1256e74e5f954fa")]
 		partial class Arrays {
 
-			public static JavaObjectArray<T>? CreateMarshalObjectArray<T> (IEnumerable<T>? value)
+			public static JavaObjectArray<T>? CreateMarshalObjectArray<[DynamicallyAccessedMembers (JavaArray<T>.ConstructorsAndInterfaces)] T> (IEnumerable<T>? value)
 			{
 				if (value == null) {
 					return null;

--- a/src/Java.Interop/Java.Interop/JavaObjectArray.cs
+++ b/src/Java.Interop/Java.Interop/JavaObjectArray.cs
@@ -203,7 +203,7 @@ namespace Java.Interop
 		partial class Arrays {
 
 			public static JavaObjectArray<T>? CreateMarshalObjectArray<
-					[DynamicallyAccessedMembers (JavaArray<T>.ConstructorsAndInterfaces)]
+					[DynamicallyAccessedMembers (JavaObject.ConstructorsAndInterfaces)]
 					T
 			> (
 					IEnumerable<T>? value)

--- a/src/Java.Interop/Java.Interop/JavaObjectArray.cs
+++ b/src/Java.Interop/Java.Interop/JavaObjectArray.cs
@@ -169,10 +169,10 @@ namespace Java.Interop
 		internal sealed class ValueMarshaler : JniValueMarshaler<IList<T>> {
 
 			public override IList<T> CreateGenericValue (
-				ref JniObjectReference reference,
-				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-				Type? targetType)
+					ref JniObjectReference reference,
+					JniObjectReferenceOptions options,
+					[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+					Type? targetType)
 			{
 				return JavaArray<T>.CreateValue (ref reference, options, targetType, (ref JniObjectReference h, JniObjectReferenceOptions t) => new JavaObjectArray<T> (ref h, t) {
 					forMarshalCollection    = true,

--- a/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.cs
+++ b/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.cs
@@ -244,14 +244,14 @@ namespace Java.Interop {
 				typeof (JavaBooleanArray) == targetType;
 		}
 
-		public static object? CreateMarshaledValue (IntPtr handle, Type? targetType)
+		public static object? CreateMarshaledValue (IntPtr handle, [DynamicallyAccessedMembers(JniValueMarshaler.ConstructorsAndInterfaces)] Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
 		}
 
 		internal sealed class ValueMarshaler : JniValueMarshaler<IList<Boolean>> {
 
-			public override IList<Boolean> CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+			public override IList<Boolean> CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 			{
 				return JavaArray<Boolean>.CreateValue (
 						ref reference,
@@ -276,6 +276,7 @@ namespace Java.Interop {
 				JavaArray<Boolean>.DestroyArgumentState<JavaBooleanArray> (value, ref state, synchronize);
 			}
 
+			[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize = 0, Type? targetType = null)
 			{
 				Func<IntPtr, Type?, object?>  m = JavaBooleanArray.CreateMarshaledValue;
@@ -439,14 +440,14 @@ namespace Java.Interop {
 				typeof (JavaSByteArray) == targetType;
 		}
 
-		public static object? CreateMarshaledValue (IntPtr handle, Type? targetType)
+		public static object? CreateMarshaledValue (IntPtr handle, [DynamicallyAccessedMembers (JniValueMarshaler.ConstructorsAndInterfaces)] Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
 		}
 
 		internal sealed class ValueMarshaler : JniValueMarshaler<IList<SByte>> {
 
-			public override IList<SByte> CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+			public override IList<SByte> CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 			{
 				return JavaArray<SByte>.CreateValue (
 						ref reference,
@@ -471,6 +472,7 @@ namespace Java.Interop {
 				JavaArray<SByte>.DestroyArgumentState<JavaSByteArray> (value, ref state, synchronize);
 			}
 
+			[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize = 0, Type? targetType = null)
 			{
 				Func<IntPtr, Type?, object?>  m = JavaSByteArray.CreateMarshaledValue;
@@ -634,14 +636,14 @@ namespace Java.Interop {
 				typeof (JavaCharArray) == targetType;
 		}
 
-		public static object? CreateMarshaledValue (IntPtr handle, Type? targetType)
+		public static object? CreateMarshaledValue (IntPtr handle, [DynamicallyAccessedMembers (JniValueMarshaler.ConstructorsAndInterfaces)] Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
 		}
 
 		internal sealed class ValueMarshaler : JniValueMarshaler<IList<Char>> {
 
-			public override IList<Char> CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+			public override IList<Char> CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 			{
 				return JavaArray<Char>.CreateValue (
 						ref reference,
@@ -666,6 +668,7 @@ namespace Java.Interop {
 				JavaArray<Char>.DestroyArgumentState<JavaCharArray> (value, ref state, synchronize);
 			}
 
+			[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize = 0, Type? targetType = null)
 			{
 				Func<IntPtr, Type?, object?>  m = JavaCharArray.CreateMarshaledValue;
@@ -829,14 +832,14 @@ namespace Java.Interop {
 				typeof (JavaInt16Array) == targetType;
 		}
 
-		public static object? CreateMarshaledValue (IntPtr handle, Type? targetType)
+		public static object? CreateMarshaledValue (IntPtr handle, [DynamicallyAccessedMembers (JniValueMarshaler.ConstructorsAndInterfaces)] Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
 		}
 
 		internal sealed class ValueMarshaler : JniValueMarshaler<IList<Int16>> {
 
-			public override IList<Int16> CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+			public override IList<Int16> CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 			{
 				return JavaArray<Int16>.CreateValue (
 						ref reference,
@@ -861,6 +864,7 @@ namespace Java.Interop {
 				JavaArray<Int16>.DestroyArgumentState<JavaInt16Array> (value, ref state, synchronize);
 			}
 
+			[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize = 0, Type? targetType = null)
 			{
 				Func<IntPtr, Type?, object?>  m = JavaInt16Array.CreateMarshaledValue;
@@ -1024,14 +1028,14 @@ namespace Java.Interop {
 				typeof (JavaInt32Array) == targetType;
 		}
 
-		public static object? CreateMarshaledValue (IntPtr handle, Type? targetType)
+		public static object? CreateMarshaledValue (IntPtr handle, [DynamicallyAccessedMembers (JniValueMarshaler.ConstructorsAndInterfaces)] Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
 		}
 
 		internal sealed class ValueMarshaler : JniValueMarshaler<IList<Int32>> {
 
-			public override IList<Int32> CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+			public override IList<Int32> CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 			{
 				return JavaArray<Int32>.CreateValue (
 						ref reference,
@@ -1056,6 +1060,7 @@ namespace Java.Interop {
 				JavaArray<Int32>.DestroyArgumentState<JavaInt32Array> (value, ref state, synchronize);
 			}
 
+			[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize = 0, Type? targetType = null)
 			{
 				Func<IntPtr, Type?, object?>  m = JavaInt32Array.CreateMarshaledValue;
@@ -1219,14 +1224,14 @@ namespace Java.Interop {
 				typeof (JavaInt64Array) == targetType;
 		}
 
-		public static object? CreateMarshaledValue (IntPtr handle, Type? targetType)
+		public static object? CreateMarshaledValue (IntPtr handle, [DynamicallyAccessedMembers (JniValueMarshaler.ConstructorsAndInterfaces)] Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
 		}
 
 		internal sealed class ValueMarshaler : JniValueMarshaler<IList<Int64>> {
 
-			public override IList<Int64> CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+			public override IList<Int64> CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 			{
 				return JavaArray<Int64>.CreateValue (
 						ref reference,
@@ -1251,6 +1256,7 @@ namespace Java.Interop {
 				JavaArray<Int64>.DestroyArgumentState<JavaInt64Array> (value, ref state, synchronize);
 			}
 
+			[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize = 0, Type? targetType = null)
 			{
 				Func<IntPtr, Type?, object?>  m = JavaInt64Array.CreateMarshaledValue;
@@ -1414,14 +1420,14 @@ namespace Java.Interop {
 				typeof (JavaSingleArray) == targetType;
 		}
 
-		public static object? CreateMarshaledValue (IntPtr handle, Type? targetType)
+		public static object? CreateMarshaledValue (IntPtr handle, [DynamicallyAccessedMembers (JniValueMarshaler.ConstructorsAndInterfaces)] Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
 		}
 
 		internal sealed class ValueMarshaler : JniValueMarshaler<IList<Single>> {
 
-			public override IList<Single> CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+			public override IList<Single> CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 			{
 				return JavaArray<Single>.CreateValue (
 						ref reference,
@@ -1446,6 +1452,7 @@ namespace Java.Interop {
 				JavaArray<Single>.DestroyArgumentState<JavaSingleArray> (value, ref state, synchronize);
 			}
 
+			[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize = 0, Type? targetType = null)
 			{
 				Func<IntPtr, Type?, object?>  m = JavaSingleArray.CreateMarshaledValue;
@@ -1609,14 +1616,14 @@ namespace Java.Interop {
 				typeof (JavaDoubleArray) == targetType;
 		}
 
-		public static object? CreateMarshaledValue (IntPtr handle, Type? targetType)
+		public static object? CreateMarshaledValue (IntPtr handle, [DynamicallyAccessedMembers (JniValueMarshaler.ConstructorsAndInterfaces)] Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
 		}
 
 		internal sealed class ValueMarshaler : JniValueMarshaler<IList<Double>> {
 
-			public override IList<Double> CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+			public override IList<Double> CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 			{
 				return JavaArray<Double>.CreateValue (
 						ref reference,
@@ -1641,6 +1648,7 @@ namespace Java.Interop {
 				JavaArray<Double>.DestroyArgumentState<JavaDoubleArray> (value, ref state, synchronize);
 			}
 
+			[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize = 0, Type? targetType = null)
 			{
 				Func<IntPtr, Type?, object?>  m = JavaDoubleArray.CreateMarshaledValue;

--- a/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.cs
+++ b/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.cs
@@ -251,7 +251,11 @@ namespace Java.Interop {
 
 		internal sealed class ValueMarshaler : JniValueMarshaler<IList<Boolean>> {
 
-			public override IList<Boolean> CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+			public override IList<Boolean> CreateGenericValue (
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 			{
 				return JavaArray<Boolean>.CreateValue (
 						ref reference,
@@ -447,7 +451,11 @@ namespace Java.Interop {
 
 		internal sealed class ValueMarshaler : JniValueMarshaler<IList<SByte>> {
 
-			public override IList<SByte> CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+			public override IList<SByte> CreateGenericValue (
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 			{
 				return JavaArray<SByte>.CreateValue (
 						ref reference,
@@ -643,7 +651,11 @@ namespace Java.Interop {
 
 		internal sealed class ValueMarshaler : JniValueMarshaler<IList<Char>> {
 
-			public override IList<Char> CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+			public override IList<Char> CreateGenericValue (
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 			{
 				return JavaArray<Char>.CreateValue (
 						ref reference,
@@ -839,7 +851,11 @@ namespace Java.Interop {
 
 		internal sealed class ValueMarshaler : JniValueMarshaler<IList<Int16>> {
 
-			public override IList<Int16> CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+			public override IList<Int16> CreateGenericValue (
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 			{
 				return JavaArray<Int16>.CreateValue (
 						ref reference,
@@ -1035,7 +1051,11 @@ namespace Java.Interop {
 
 		internal sealed class ValueMarshaler : JniValueMarshaler<IList<Int32>> {
 
-			public override IList<Int32> CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+			public override IList<Int32> CreateGenericValue (
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 			{
 				return JavaArray<Int32>.CreateValue (
 						ref reference,
@@ -1231,7 +1251,11 @@ namespace Java.Interop {
 
 		internal sealed class ValueMarshaler : JniValueMarshaler<IList<Int64>> {
 
-			public override IList<Int64> CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+			public override IList<Int64> CreateGenericValue (
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 			{
 				return JavaArray<Int64>.CreateValue (
 						ref reference,
@@ -1427,7 +1451,11 @@ namespace Java.Interop {
 
 		internal sealed class ValueMarshaler : JniValueMarshaler<IList<Single>> {
 
-			public override IList<Single> CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+			public override IList<Single> CreateGenericValue (
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 			{
 				return JavaArray<Single>.CreateValue (
 						ref reference,
@@ -1623,7 +1651,11 @@ namespace Java.Interop {
 
 		internal sealed class ValueMarshaler : JniValueMarshaler<IList<Double>> {
 
-			public override IList<Double> CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+			public override IList<Double> CreateGenericValue (
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 			{
 				return JavaArray<Double>.CreateValue (
 						ref reference,

--- a/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.cs
+++ b/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.cs
@@ -244,7 +244,10 @@ namespace Java.Interop {
 				typeof (JavaBooleanArray) == targetType;
 		}
 
-		public static object? CreateMarshaledValue (IntPtr handle, [DynamicallyAccessedMembers(JniValueMarshaler.ConstructorsAndInterfaces)] Type? targetType)
+		public static object? CreateMarshaledValue (
+			IntPtr handle,
+			[DynamicallyAccessedMembers(JniValueMarshaler.ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
 		}
@@ -444,7 +447,10 @@ namespace Java.Interop {
 				typeof (JavaSByteArray) == targetType;
 		}
 
-		public static object? CreateMarshaledValue (IntPtr handle, [DynamicallyAccessedMembers (JniValueMarshaler.ConstructorsAndInterfaces)] Type? targetType)
+		public static object? CreateMarshaledValue (
+			IntPtr handle,
+			[DynamicallyAccessedMembers (JniValueMarshaler.ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
 		}
@@ -644,7 +650,10 @@ namespace Java.Interop {
 				typeof (JavaCharArray) == targetType;
 		}
 
-		public static object? CreateMarshaledValue (IntPtr handle, [DynamicallyAccessedMembers (JniValueMarshaler.ConstructorsAndInterfaces)] Type? targetType)
+		public static object? CreateMarshaledValue (
+			IntPtr handle,
+			[DynamicallyAccessedMembers (JniValueMarshaler.ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
 		}
@@ -844,7 +853,10 @@ namespace Java.Interop {
 				typeof (JavaInt16Array) == targetType;
 		}
 
-		public static object? CreateMarshaledValue (IntPtr handle, [DynamicallyAccessedMembers (JniValueMarshaler.ConstructorsAndInterfaces)] Type? targetType)
+		public static object? CreateMarshaledValue (
+			IntPtr handle,
+			[DynamicallyAccessedMembers (JniValueMarshaler.ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
 		}
@@ -1044,7 +1056,10 @@ namespace Java.Interop {
 				typeof (JavaInt32Array) == targetType;
 		}
 
-		public static object? CreateMarshaledValue (IntPtr handle, [DynamicallyAccessedMembers (JniValueMarshaler.ConstructorsAndInterfaces)] Type? targetType)
+		public static object? CreateMarshaledValue (
+			IntPtr handle,
+			[DynamicallyAccessedMembers (JniValueMarshaler.ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
 		}
@@ -1244,7 +1259,10 @@ namespace Java.Interop {
 				typeof (JavaInt64Array) == targetType;
 		}
 
-		public static object? CreateMarshaledValue (IntPtr handle, [DynamicallyAccessedMembers (JniValueMarshaler.ConstructorsAndInterfaces)] Type? targetType)
+		public static object? CreateMarshaledValue (
+			IntPtr handle,
+			[DynamicallyAccessedMembers (JniValueMarshaler.ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
 		}
@@ -1444,7 +1462,10 @@ namespace Java.Interop {
 				typeof (JavaSingleArray) == targetType;
 		}
 
-		public static object? CreateMarshaledValue (IntPtr handle, [DynamicallyAccessedMembers (JniValueMarshaler.ConstructorsAndInterfaces)] Type? targetType)
+		public static object? CreateMarshaledValue (
+			IntPtr handle,
+			[DynamicallyAccessedMembers (JniValueMarshaler.ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
 		}
@@ -1644,7 +1665,10 @@ namespace Java.Interop {
 				typeof (JavaDoubleArray) == targetType;
 		}
 
-		public static object? CreateMarshaledValue (IntPtr handle, [DynamicallyAccessedMembers (JniValueMarshaler.ConstructorsAndInterfaces)] Type? targetType)
+		public static object? CreateMarshaledValue (
+			IntPtr handle,
+			[DynamicallyAccessedMembers (JniValueMarshaler.ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
 		}

--- a/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.cs
+++ b/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.cs
@@ -245,9 +245,9 @@ namespace Java.Interop {
 		}
 
 		public static object? CreateMarshaledValue (
-			IntPtr handle,
-			[DynamicallyAccessedMembers(JniValueMarshaler.ConstructorsAndInterfaces)]
-			Type? targetType)
+				IntPtr handle,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
 		}
@@ -255,10 +255,10 @@ namespace Java.Interop {
 		internal sealed class ValueMarshaler : JniValueMarshaler<IList<Boolean>> {
 
 			public override IList<Boolean> CreateGenericValue (
-				ref JniObjectReference reference,
-				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-				Type? targetType)
+					ref JniObjectReference reference,
+					JniObjectReferenceOptions options,
+					[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+					Type? targetType)
 			{
 				return JavaArray<Boolean>.CreateValue (
 						ref reference,
@@ -283,7 +283,6 @@ namespace Java.Interop {
 				JavaArray<Boolean>.DestroyArgumentState<JavaBooleanArray> (value, ref state, synchronize);
 			}
 
-			[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize = 0, Type? targetType = null)
 			{
 				Func<IntPtr, Type?, object?>  m = JavaBooleanArray.CreateMarshaledValue;
@@ -448,9 +447,9 @@ namespace Java.Interop {
 		}
 
 		public static object? CreateMarshaledValue (
-			IntPtr handle,
-			[DynamicallyAccessedMembers (JniValueMarshaler.ConstructorsAndInterfaces)]
-			Type? targetType)
+				IntPtr handle,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
 		}
@@ -458,10 +457,10 @@ namespace Java.Interop {
 		internal sealed class ValueMarshaler : JniValueMarshaler<IList<SByte>> {
 
 			public override IList<SByte> CreateGenericValue (
-				ref JniObjectReference reference,
-				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-				Type? targetType)
+					ref JniObjectReference reference,
+					JniObjectReferenceOptions options,
+					[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+					Type? targetType)
 			{
 				return JavaArray<SByte>.CreateValue (
 						ref reference,
@@ -486,7 +485,6 @@ namespace Java.Interop {
 				JavaArray<SByte>.DestroyArgumentState<JavaSByteArray> (value, ref state, synchronize);
 			}
 
-			[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize = 0, Type? targetType = null)
 			{
 				Func<IntPtr, Type?, object?>  m = JavaSByteArray.CreateMarshaledValue;
@@ -651,9 +649,9 @@ namespace Java.Interop {
 		}
 
 		public static object? CreateMarshaledValue (
-			IntPtr handle,
-			[DynamicallyAccessedMembers (JniValueMarshaler.ConstructorsAndInterfaces)]
-			Type? targetType)
+				IntPtr handle,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
 		}
@@ -661,10 +659,10 @@ namespace Java.Interop {
 		internal sealed class ValueMarshaler : JniValueMarshaler<IList<Char>> {
 
 			public override IList<Char> CreateGenericValue (
-				ref JniObjectReference reference,
-				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-				Type? targetType)
+					ref JniObjectReference reference,
+					JniObjectReferenceOptions options,
+					[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+					Type? targetType)
 			{
 				return JavaArray<Char>.CreateValue (
 						ref reference,
@@ -689,7 +687,6 @@ namespace Java.Interop {
 				JavaArray<Char>.DestroyArgumentState<JavaCharArray> (value, ref state, synchronize);
 			}
 
-			[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize = 0, Type? targetType = null)
 			{
 				Func<IntPtr, Type?, object?>  m = JavaCharArray.CreateMarshaledValue;
@@ -854,9 +851,9 @@ namespace Java.Interop {
 		}
 
 		public static object? CreateMarshaledValue (
-			IntPtr handle,
-			[DynamicallyAccessedMembers (JniValueMarshaler.ConstructorsAndInterfaces)]
-			Type? targetType)
+				IntPtr handle,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
 		}
@@ -864,10 +861,10 @@ namespace Java.Interop {
 		internal sealed class ValueMarshaler : JniValueMarshaler<IList<Int16>> {
 
 			public override IList<Int16> CreateGenericValue (
-				ref JniObjectReference reference,
-				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-				Type? targetType)
+					ref JniObjectReference reference,
+					JniObjectReferenceOptions options,
+					[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+					Type? targetType)
 			{
 				return JavaArray<Int16>.CreateValue (
 						ref reference,
@@ -892,7 +889,6 @@ namespace Java.Interop {
 				JavaArray<Int16>.DestroyArgumentState<JavaInt16Array> (value, ref state, synchronize);
 			}
 
-			[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize = 0, Type? targetType = null)
 			{
 				Func<IntPtr, Type?, object?>  m = JavaInt16Array.CreateMarshaledValue;
@@ -1057,9 +1053,9 @@ namespace Java.Interop {
 		}
 
 		public static object? CreateMarshaledValue (
-			IntPtr handle,
-			[DynamicallyAccessedMembers (JniValueMarshaler.ConstructorsAndInterfaces)]
-			Type? targetType)
+				IntPtr handle,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
 		}
@@ -1067,10 +1063,10 @@ namespace Java.Interop {
 		internal sealed class ValueMarshaler : JniValueMarshaler<IList<Int32>> {
 
 			public override IList<Int32> CreateGenericValue (
-				ref JniObjectReference reference,
-				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-				Type? targetType)
+					ref JniObjectReference reference,
+					JniObjectReferenceOptions options,
+					[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+					Type? targetType)
 			{
 				return JavaArray<Int32>.CreateValue (
 						ref reference,
@@ -1095,7 +1091,6 @@ namespace Java.Interop {
 				JavaArray<Int32>.DestroyArgumentState<JavaInt32Array> (value, ref state, synchronize);
 			}
 
-			[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize = 0, Type? targetType = null)
 			{
 				Func<IntPtr, Type?, object?>  m = JavaInt32Array.CreateMarshaledValue;
@@ -1260,9 +1255,9 @@ namespace Java.Interop {
 		}
 
 		public static object? CreateMarshaledValue (
-			IntPtr handle,
-			[DynamicallyAccessedMembers (JniValueMarshaler.ConstructorsAndInterfaces)]
-			Type? targetType)
+				IntPtr handle,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
 		}
@@ -1270,10 +1265,10 @@ namespace Java.Interop {
 		internal sealed class ValueMarshaler : JniValueMarshaler<IList<Int64>> {
 
 			public override IList<Int64> CreateGenericValue (
-				ref JniObjectReference reference,
-				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-				Type? targetType)
+					ref JniObjectReference reference,
+					JniObjectReferenceOptions options,
+					[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+					Type? targetType)
 			{
 				return JavaArray<Int64>.CreateValue (
 						ref reference,
@@ -1298,7 +1293,6 @@ namespace Java.Interop {
 				JavaArray<Int64>.DestroyArgumentState<JavaInt64Array> (value, ref state, synchronize);
 			}
 
-			[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize = 0, Type? targetType = null)
 			{
 				Func<IntPtr, Type?, object?>  m = JavaInt64Array.CreateMarshaledValue;
@@ -1463,9 +1457,9 @@ namespace Java.Interop {
 		}
 
 		public static object? CreateMarshaledValue (
-			IntPtr handle,
-			[DynamicallyAccessedMembers (JniValueMarshaler.ConstructorsAndInterfaces)]
-			Type? targetType)
+				IntPtr handle,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
 		}
@@ -1473,10 +1467,10 @@ namespace Java.Interop {
 		internal sealed class ValueMarshaler : JniValueMarshaler<IList<Single>> {
 
 			public override IList<Single> CreateGenericValue (
-				ref JniObjectReference reference,
-				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-				Type? targetType)
+					ref JniObjectReference reference,
+					JniObjectReferenceOptions options,
+					[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+					Type? targetType)
 			{
 				return JavaArray<Single>.CreateValue (
 						ref reference,
@@ -1501,7 +1495,6 @@ namespace Java.Interop {
 				JavaArray<Single>.DestroyArgumentState<JavaSingleArray> (value, ref state, synchronize);
 			}
 
-			[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize = 0, Type? targetType = null)
 			{
 				Func<IntPtr, Type?, object?>  m = JavaSingleArray.CreateMarshaledValue;
@@ -1666,9 +1659,9 @@ namespace Java.Interop {
 		}
 
 		public static object? CreateMarshaledValue (
-			IntPtr handle,
-			[DynamicallyAccessedMembers (JniValueMarshaler.ConstructorsAndInterfaces)]
-			Type? targetType)
+				IntPtr handle,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
 		}
@@ -1676,10 +1669,10 @@ namespace Java.Interop {
 		internal sealed class ValueMarshaler : JniValueMarshaler<IList<Double>> {
 
 			public override IList<Double> CreateGenericValue (
-				ref JniObjectReference reference,
-				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-				Type? targetType)
+					ref JniObjectReference reference,
+					JniObjectReferenceOptions options,
+					[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+					Type? targetType)
 			{
 				return JavaArray<Double>.CreateValue (
 						ref reference,
@@ -1704,7 +1697,6 @@ namespace Java.Interop {
 				JavaArray<Double>.DestroyArgumentState<JavaDoubleArray> (value, ref state, synchronize);
 			}
 
-			[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize = 0, Type? targetType = null)
 			{
 				Func<IntPtr, Type?, object?>  m = JavaDoubleArray.CreateMarshaledValue;

--- a/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.cs
+++ b/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.cs
@@ -283,6 +283,7 @@ namespace Java.Interop {
 				JavaArray<Boolean>.DestroyArgumentState<JavaBooleanArray> (value, ref state, synchronize);
 			}
 
+			[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize = 0, Type? targetType = null)
 			{
 				Func<IntPtr, Type?, object?>  m = JavaBooleanArray.CreateMarshaledValue;
@@ -485,6 +486,7 @@ namespace Java.Interop {
 				JavaArray<SByte>.DestroyArgumentState<JavaSByteArray> (value, ref state, synchronize);
 			}
 
+			[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize = 0, Type? targetType = null)
 			{
 				Func<IntPtr, Type?, object?>  m = JavaSByteArray.CreateMarshaledValue;
@@ -687,6 +689,7 @@ namespace Java.Interop {
 				JavaArray<Char>.DestroyArgumentState<JavaCharArray> (value, ref state, synchronize);
 			}
 
+			[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize = 0, Type? targetType = null)
 			{
 				Func<IntPtr, Type?, object?>  m = JavaCharArray.CreateMarshaledValue;
@@ -889,6 +892,7 @@ namespace Java.Interop {
 				JavaArray<Int16>.DestroyArgumentState<JavaInt16Array> (value, ref state, synchronize);
 			}
 
+			[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize = 0, Type? targetType = null)
 			{
 				Func<IntPtr, Type?, object?>  m = JavaInt16Array.CreateMarshaledValue;
@@ -1091,6 +1095,7 @@ namespace Java.Interop {
 				JavaArray<Int32>.DestroyArgumentState<JavaInt32Array> (value, ref state, synchronize);
 			}
 
+			[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize = 0, Type? targetType = null)
 			{
 				Func<IntPtr, Type?, object?>  m = JavaInt32Array.CreateMarshaledValue;
@@ -1293,6 +1298,7 @@ namespace Java.Interop {
 				JavaArray<Int64>.DestroyArgumentState<JavaInt64Array> (value, ref state, synchronize);
 			}
 
+			[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize = 0, Type? targetType = null)
 			{
 				Func<IntPtr, Type?, object?>  m = JavaInt64Array.CreateMarshaledValue;
@@ -1495,6 +1501,7 @@ namespace Java.Interop {
 				JavaArray<Single>.DestroyArgumentState<JavaSingleArray> (value, ref state, synchronize);
 			}
 
+			[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize = 0, Type? targetType = null)
 			{
 				Func<IntPtr, Type?, object?>  m = JavaSingleArray.CreateMarshaledValue;
@@ -1697,6 +1704,7 @@ namespace Java.Interop {
 				JavaArray<Double>.DestroyArgumentState<JavaDoubleArray> (value, ref state, synchronize);
 			}
 
+			[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize = 0, Type? targetType = null)
 			{
 				Func<IntPtr, Type?, object?>  m = JavaDoubleArray.CreateMarshaledValue;

--- a/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.tt
+++ b/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.tt
@@ -242,9 +242,9 @@ namespace Java.Interop {
 		}
 
 		public static object? CreateMarshaledValue (
-			IntPtr handle,
-			[DynamicallyAccessedMembers (JniValueMarshaler.ConstructorsAndInterfaces)]
-			Type? targetType)
+				IntPtr handle,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
 		}
@@ -252,10 +252,10 @@ namespace Java.Interop {
 		internal sealed class ValueMarshaler : JniValueMarshaler<IList<<#= info.TypeModifier #>>> {
 
 			public override IList<<#= info.TypeModifier #>> CreateGenericValue (
-				ref JniObjectReference reference,
-				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-				Type? targetType)
+					ref JniObjectReference reference,
+					JniObjectReferenceOptions options,
+					[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+					Type? targetType)
 			{
 				return JavaArray<<#= info.TypeModifier #>>.CreateValue (
 						ref reference,

--- a/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.tt
+++ b/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.tt
@@ -241,7 +241,10 @@ namespace Java.Interop {
 				typeof (Java<#= info.TypeModifier #>Array) == targetType;
 		}
 
-		public static object? CreateMarshaledValue (IntPtr handle, Type? targetType)
+		public static object? CreateMarshaledValue (
+			IntPtr handle,
+			[DynamicallyAccessedMembers (JniValueMarshaler.ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
 		}

--- a/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.tt
+++ b/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.tt
@@ -280,6 +280,7 @@ namespace Java.Interop {
 				JavaArray<<#= info.ManagedType #>>.DestroyArgumentState<Java<#= info.TypeModifier #>Array> (value, ref state, synchronize);
 			}
 
+			[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 			public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize = 0, Type? targetType = null)
 			{
 				Func<IntPtr, Type?, object?>  m = Java<#= info.TypeModifier #>Array.CreateMarshaledValue;

--- a/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.tt
+++ b/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.tt
@@ -248,7 +248,7 @@ namespace Java.Interop {
 
 		internal sealed class ValueMarshaler : JniValueMarshaler<IList<<#= info.TypeModifier #>>> {
 
-			public override IList<<#= info.TypeModifier #>> CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+			public override IList<<#= info.TypeModifier #>> CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 			{
 				return JavaArray<<#= info.TypeModifier #>>.CreateValue (
 						ref reference,

--- a/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.tt
+++ b/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.tt
@@ -248,7 +248,11 @@ namespace Java.Interop {
 
 		internal sealed class ValueMarshaler : JniValueMarshaler<IList<<#= info.TypeModifier #>>> {
 
-			public override IList<<#= info.TypeModifier #>> CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+			public override IList<<#= info.TypeModifier #>> CreateGenericValue (
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 			{
 				return JavaArray<<#= info.TypeModifier #>>.CreateValue (
 						ref reference,

--- a/src/Java.Interop/Java.Interop/JniBuiltinMarshalers.cs
+++ b/src/Java.Interop/Java.Interop/JniBuiltinMarshalers.cs
@@ -4,11 +4,11 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 
 using Java.Interop.Expressions;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Java.Interop {
 
@@ -224,10 +224,10 @@ namespace Java.Interop {
 		}
 
 		public override object? CreateValue (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-			Type? targetType)
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
@@ -235,10 +235,10 @@ namespace Java.Interop {
 		}
 
 		public override Boolean CreateGenericValue (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-			Type? targetType)
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			if (!reference.IsValid)
 				return default (Boolean);
@@ -271,19 +271,19 @@ namespace Java.Interop {
 			state   = new JniValueMarshalerState ();
 		}
 
-		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
 		{
 		    return sourceValue;
 		}
 
-		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize)
 		{
 			return sourceValue;
 		}
 
-		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateReturnValueFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue)
 		{
 			return sourceValue;
@@ -295,10 +295,10 @@ namespace Java.Interop {
 		internal    static  readonly    JniNullableBooleanValueMarshaler   Instance    = new JniNullableBooleanValueMarshaler ();
 
 		public override Boolean? CreateGenericValue (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-			Type? targetType)
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
@@ -366,10 +366,10 @@ namespace Java.Interop {
 		}
 
 		public override object? CreateValue (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-			Type? targetType)
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
@@ -377,10 +377,10 @@ namespace Java.Interop {
 		}
 
 		public override SByte CreateGenericValue (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-			Type? targetType)
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			if (!reference.IsValid)
 				return default (SByte);
@@ -413,19 +413,19 @@ namespace Java.Interop {
 			state   = new JniValueMarshalerState ();
 		}
 
-		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
 		{
 		    return sourceValue;
 		}
 
-		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize)
 		{
 			return sourceValue;
 		}
 
-		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateReturnValueFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue)
 		{
 			return sourceValue;
@@ -437,10 +437,10 @@ namespace Java.Interop {
 		internal    static  readonly    JniNullableSByteValueMarshaler   Instance    = new JniNullableSByteValueMarshaler ();
 
 		public override SByte? CreateGenericValue (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-			Type? targetType)
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
@@ -508,10 +508,10 @@ namespace Java.Interop {
 		}
 
 		public override object? CreateValue (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-			Type? targetType)
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
@@ -519,10 +519,10 @@ namespace Java.Interop {
 		}
 
 		public override Char CreateGenericValue (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-			Type? targetType)
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			if (!reference.IsValid)
 				return default (Char);
@@ -555,19 +555,19 @@ namespace Java.Interop {
 			state   = new JniValueMarshalerState ();
 		}
 
-		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
 		{
 		    return sourceValue;
 		}
 
-		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize)
 		{
 			return sourceValue;
 		}
 
-		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateReturnValueFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue)
 		{
 			return sourceValue;
@@ -579,10 +579,10 @@ namespace Java.Interop {
 		internal    static  readonly    JniNullableCharValueMarshaler   Instance    = new JniNullableCharValueMarshaler ();
 
 		public override Char? CreateGenericValue (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-			Type? targetType)
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
@@ -650,10 +650,10 @@ namespace Java.Interop {
 		}
 
 		public override object? CreateValue (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-			Type? targetType)
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
@@ -661,10 +661,10 @@ namespace Java.Interop {
 		}
 
 		public override Int16 CreateGenericValue (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-			Type? targetType)
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			if (!reference.IsValid)
 				return default (Int16);
@@ -697,19 +697,19 @@ namespace Java.Interop {
 			state   = new JniValueMarshalerState ();
 		}
 
-		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
 		{
 		    return sourceValue;
 		}
 
-		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize)
 		{
 			return sourceValue;
 		}
 
-		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateReturnValueFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue)
 		{
 			return sourceValue;
@@ -721,10 +721,10 @@ namespace Java.Interop {
 		internal    static  readonly    JniNullableInt16ValueMarshaler   Instance    = new JniNullableInt16ValueMarshaler ();
 
 		public override Int16? CreateGenericValue (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-			Type? targetType)
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
@@ -792,10 +792,10 @@ namespace Java.Interop {
 		}
 
 		public override object? CreateValue (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-			Type? targetType)
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
@@ -803,10 +803,10 @@ namespace Java.Interop {
 		}
 
 		public override Int32 CreateGenericValue (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-			Type? targetType)
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			if (!reference.IsValid)
 				return default (Int32);
@@ -839,19 +839,19 @@ namespace Java.Interop {
 			state   = new JniValueMarshalerState ();
 		}
 
-		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
 		{
 		    return sourceValue;
 		}
 
-		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize)
 		{
 			return sourceValue;
 		}
 
-		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateReturnValueFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue)
 		{
 			return sourceValue;
@@ -863,10 +863,10 @@ namespace Java.Interop {
 		internal    static  readonly    JniNullableInt32ValueMarshaler   Instance    = new JniNullableInt32ValueMarshaler ();
 
 		public override Int32? CreateGenericValue (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-			Type? targetType)
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
@@ -934,10 +934,10 @@ namespace Java.Interop {
 		}
 
 		public override object? CreateValue (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-			Type? targetType)
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
@@ -945,10 +945,10 @@ namespace Java.Interop {
 		}
 
 		public override Int64 CreateGenericValue (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-			Type? targetType)
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			if (!reference.IsValid)
 				return default (Int64);
@@ -981,19 +981,19 @@ namespace Java.Interop {
 			state   = new JniValueMarshalerState ();
 		}
 
-		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
 		{
 		    return sourceValue;
 		}
 
-		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize)
 		{
 			return sourceValue;
 		}
 
-		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateReturnValueFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue)
 		{
 			return sourceValue;
@@ -1005,10 +1005,10 @@ namespace Java.Interop {
 		internal    static  readonly    JniNullableInt64ValueMarshaler   Instance    = new JniNullableInt64ValueMarshaler ();
 
 		public override Int64? CreateGenericValue (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-			Type? targetType)
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
@@ -1076,10 +1076,10 @@ namespace Java.Interop {
 		}
 
 		public override object? CreateValue (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-			Type? targetType)
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
@@ -1087,10 +1087,10 @@ namespace Java.Interop {
 		}
 
 		public override Single CreateGenericValue (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-			Type? targetType)
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			if (!reference.IsValid)
 				return default (Single);
@@ -1123,19 +1123,19 @@ namespace Java.Interop {
 			state   = new JniValueMarshalerState ();
 		}
 
-		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
 		{
 		    return sourceValue;
 		}
 
-		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize)
 		{
 			return sourceValue;
 		}
 
-		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateReturnValueFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue)
 		{
 			return sourceValue;
@@ -1147,10 +1147,10 @@ namespace Java.Interop {
 		internal    static  readonly    JniNullableSingleValueMarshaler   Instance    = new JniNullableSingleValueMarshaler ();
 
 		public override Single? CreateGenericValue (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-			Type? targetType)
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
@@ -1218,10 +1218,10 @@ namespace Java.Interop {
 		}
 
 		public override object? CreateValue (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-			Type? targetType)
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
@@ -1229,10 +1229,10 @@ namespace Java.Interop {
 		}
 
 		public override Double CreateGenericValue (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-			Type? targetType)
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			if (!reference.IsValid)
 				return default (Double);
@@ -1265,19 +1265,19 @@ namespace Java.Interop {
 			state   = new JniValueMarshalerState ();
 		}
 
-		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
 		{
 		    return sourceValue;
 		}
 
-		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize)
 		{
 			return sourceValue;
 		}
 
-		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateReturnValueFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue)
 		{
 			return sourceValue;
@@ -1289,10 +1289,10 @@ namespace Java.Interop {
 		internal    static  readonly    JniNullableDoubleValueMarshaler   Instance    = new JniNullableDoubleValueMarshaler ();
 
 		public override Double? CreateGenericValue (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-			Type? targetType)
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;

--- a/src/Java.Interop/Java.Interop/JniBuiltinMarshalers.cs
+++ b/src/Java.Interop/Java.Interop/JniBuiltinMarshalers.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -223,14 +223,14 @@ namespace Java.Interop {
 		    get {return typeof (Boolean);}
 		}
 
-		public override object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+		public override object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
 			return CreateGenericValue (ref reference, options, targetType);
 		}
 
-		public override Boolean CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+		public override Boolean CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 		{
 			if (!reference.IsValid)
 				return default (Boolean);
@@ -263,16 +263,19 @@ namespace Java.Interop {
 			state   = new JniValueMarshalerState ();
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
 		{
 		    return sourceValue;
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize)
 		{
 			return sourceValue;
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateReturnValueFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue)
 		{
 			return sourceValue;
@@ -283,7 +286,7 @@ namespace Java.Interop {
 
 		internal    static  readonly    JniNullableBooleanValueMarshaler   Instance    = new JniNullableBooleanValueMarshaler ();
 
-		public override Boolean? CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+		public override Boolean? CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
@@ -350,14 +353,14 @@ namespace Java.Interop {
 		    get {return typeof (SByte);}
 		}
 
-		public override object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+		public override object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
 			return CreateGenericValue (ref reference, options, targetType);
 		}
 
-		public override SByte CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+		public override SByte CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 		{
 			if (!reference.IsValid)
 				return default (SByte);
@@ -390,16 +393,19 @@ namespace Java.Interop {
 			state   = new JniValueMarshalerState ();
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
 		{
 		    return sourceValue;
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize)
 		{
 			return sourceValue;
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateReturnValueFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue)
 		{
 			return sourceValue;
@@ -410,7 +416,7 @@ namespace Java.Interop {
 
 		internal    static  readonly    JniNullableSByteValueMarshaler   Instance    = new JniNullableSByteValueMarshaler ();
 
-		public override SByte? CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+		public override SByte? CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
@@ -477,14 +483,14 @@ namespace Java.Interop {
 		    get {return typeof (Char);}
 		}
 
-		public override object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+		public override object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
 			return CreateGenericValue (ref reference, options, targetType);
 		}
 
-		public override Char CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+		public override Char CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 		{
 			if (!reference.IsValid)
 				return default (Char);
@@ -517,16 +523,19 @@ namespace Java.Interop {
 			state   = new JniValueMarshalerState ();
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
 		{
 		    return sourceValue;
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize)
 		{
 			return sourceValue;
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateReturnValueFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue)
 		{
 			return sourceValue;
@@ -537,7 +546,7 @@ namespace Java.Interop {
 
 		internal    static  readonly    JniNullableCharValueMarshaler   Instance    = new JniNullableCharValueMarshaler ();
 
-		public override Char? CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+		public override Char? CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
@@ -604,14 +613,14 @@ namespace Java.Interop {
 		    get {return typeof (Int16);}
 		}
 
-		public override object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+		public override object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
 			return CreateGenericValue (ref reference, options, targetType);
 		}
 
-		public override Int16 CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+		public override Int16 CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 		{
 			if (!reference.IsValid)
 				return default (Int16);
@@ -644,16 +653,19 @@ namespace Java.Interop {
 			state   = new JniValueMarshalerState ();
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
 		{
 		    return sourceValue;
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize)
 		{
 			return sourceValue;
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateReturnValueFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue)
 		{
 			return sourceValue;
@@ -664,7 +676,7 @@ namespace Java.Interop {
 
 		internal    static  readonly    JniNullableInt16ValueMarshaler   Instance    = new JniNullableInt16ValueMarshaler ();
 
-		public override Int16? CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+		public override Int16? CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
@@ -731,14 +743,14 @@ namespace Java.Interop {
 		    get {return typeof (Int32);}
 		}
 
-		public override object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+		public override object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
 			return CreateGenericValue (ref reference, options, targetType);
 		}
 
-		public override Int32 CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+		public override Int32 CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 		{
 			if (!reference.IsValid)
 				return default (Int32);
@@ -771,16 +783,19 @@ namespace Java.Interop {
 			state   = new JniValueMarshalerState ();
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
 		{
 		    return sourceValue;
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize)
 		{
 			return sourceValue;
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateReturnValueFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue)
 		{
 			return sourceValue;
@@ -791,7 +806,7 @@ namespace Java.Interop {
 
 		internal    static  readonly    JniNullableInt32ValueMarshaler   Instance    = new JniNullableInt32ValueMarshaler ();
 
-		public override Int32? CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+		public override Int32? CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
@@ -858,14 +873,14 @@ namespace Java.Interop {
 		    get {return typeof (Int64);}
 		}
 
-		public override object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+		public override object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
 			return CreateGenericValue (ref reference, options, targetType);
 		}
 
-		public override Int64 CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+		public override Int64 CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 		{
 			if (!reference.IsValid)
 				return default (Int64);
@@ -898,16 +913,19 @@ namespace Java.Interop {
 			state   = new JniValueMarshalerState ();
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
 		{
 		    return sourceValue;
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize)
 		{
 			return sourceValue;
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateReturnValueFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue)
 		{
 			return sourceValue;
@@ -918,7 +936,7 @@ namespace Java.Interop {
 
 		internal    static  readonly    JniNullableInt64ValueMarshaler   Instance    = new JniNullableInt64ValueMarshaler ();
 
-		public override Int64? CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+		public override Int64? CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
@@ -985,14 +1003,14 @@ namespace Java.Interop {
 		    get {return typeof (Single);}
 		}
 
-		public override object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+		public override object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
 			return CreateGenericValue (ref reference, options, targetType);
 		}
 
-		public override Single CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+		public override Single CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 		{
 			if (!reference.IsValid)
 				return default (Single);
@@ -1025,16 +1043,19 @@ namespace Java.Interop {
 			state   = new JniValueMarshalerState ();
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
 		{
 		    return sourceValue;
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize)
 		{
 			return sourceValue;
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateReturnValueFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue)
 		{
 			return sourceValue;
@@ -1045,7 +1066,7 @@ namespace Java.Interop {
 
 		internal    static  readonly    JniNullableSingleValueMarshaler   Instance    = new JniNullableSingleValueMarshaler ();
 
-		public override Single? CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+		public override Single? CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
@@ -1112,14 +1133,14 @@ namespace Java.Interop {
 		    get {return typeof (Double);}
 		}
 
-		public override object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+		public override object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
 			return CreateGenericValue (ref reference, options, targetType);
 		}
 
-		public override Double CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+		public override Double CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 		{
 			if (!reference.IsValid)
 				return default (Double);
@@ -1152,16 +1173,19 @@ namespace Java.Interop {
 			state   = new JniValueMarshalerState ();
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
 		{
 		    return sourceValue;
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize)
 		{
 			return sourceValue;
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateReturnValueFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue)
 		{
 			return sourceValue;
@@ -1172,7 +1196,7 @@ namespace Java.Interop {
 
 		internal    static  readonly    JniNullableDoubleValueMarshaler   Instance    = new JniNullableDoubleValueMarshaler ();
 
-		public override Double? CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+		public override Double? CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;

--- a/src/Java.Interop/Java.Interop/JniBuiltinMarshalers.cs
+++ b/src/Java.Interop/Java.Interop/JniBuiltinMarshalers.cs
@@ -223,14 +223,22 @@ namespace Java.Interop {
 		    get {return typeof (Boolean);}
 		}
 
-		public override object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+		public override object? CreateValue (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions options,
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
 			return CreateGenericValue (ref reference, options, targetType);
 		}
 
-		public override Boolean CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+		public override Boolean CreateGenericValue (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions options,
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			if (!reference.IsValid)
 				return default (Boolean);
@@ -286,7 +294,11 @@ namespace Java.Interop {
 
 		internal    static  readonly    JniNullableBooleanValueMarshaler   Instance    = new JniNullableBooleanValueMarshaler ();
 
-		public override Boolean? CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+		public override Boolean? CreateGenericValue (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions options,
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
@@ -353,14 +365,22 @@ namespace Java.Interop {
 		    get {return typeof (SByte);}
 		}
 
-		public override object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+		public override object? CreateValue (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions options,
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
 			return CreateGenericValue (ref reference, options, targetType);
 		}
 
-		public override SByte CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+		public override SByte CreateGenericValue (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions options,
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			if (!reference.IsValid)
 				return default (SByte);
@@ -416,7 +436,11 @@ namespace Java.Interop {
 
 		internal    static  readonly    JniNullableSByteValueMarshaler   Instance    = new JniNullableSByteValueMarshaler ();
 
-		public override SByte? CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+		public override SByte? CreateGenericValue (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions options,
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
@@ -483,14 +507,22 @@ namespace Java.Interop {
 		    get {return typeof (Char);}
 		}
 
-		public override object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+		public override object? CreateValue (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions options,
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
 			return CreateGenericValue (ref reference, options, targetType);
 		}
 
-		public override Char CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+		public override Char CreateGenericValue (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions options,
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			if (!reference.IsValid)
 				return default (Char);
@@ -546,7 +578,11 @@ namespace Java.Interop {
 
 		internal    static  readonly    JniNullableCharValueMarshaler   Instance    = new JniNullableCharValueMarshaler ();
 
-		public override Char? CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+		public override Char? CreateGenericValue (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions options,
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
@@ -613,14 +649,22 @@ namespace Java.Interop {
 		    get {return typeof (Int16);}
 		}
 
-		public override object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+		public override object? CreateValue (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions options,
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
 			return CreateGenericValue (ref reference, options, targetType);
 		}
 
-		public override Int16 CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+		public override Int16 CreateGenericValue (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions options,
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			if (!reference.IsValid)
 				return default (Int16);
@@ -676,7 +720,11 @@ namespace Java.Interop {
 
 		internal    static  readonly    JniNullableInt16ValueMarshaler   Instance    = new JniNullableInt16ValueMarshaler ();
 
-		public override Int16? CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+		public override Int16? CreateGenericValue (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions options,
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
@@ -743,14 +791,22 @@ namespace Java.Interop {
 		    get {return typeof (Int32);}
 		}
 
-		public override object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+		public override object? CreateValue (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions options,
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
 			return CreateGenericValue (ref reference, options, targetType);
 		}
 
-		public override Int32 CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+		public override Int32 CreateGenericValue (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions options,
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			if (!reference.IsValid)
 				return default (Int32);
@@ -806,7 +862,11 @@ namespace Java.Interop {
 
 		internal    static  readonly    JniNullableInt32ValueMarshaler   Instance    = new JniNullableInt32ValueMarshaler ();
 
-		public override Int32? CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+		public override Int32? CreateGenericValue (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions options,
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
@@ -873,14 +933,22 @@ namespace Java.Interop {
 		    get {return typeof (Int64);}
 		}
 
-		public override object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+		public override object? CreateValue (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions options,
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
 			return CreateGenericValue (ref reference, options, targetType);
 		}
 
-		public override Int64 CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+		public override Int64 CreateGenericValue (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions options,
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			if (!reference.IsValid)
 				return default (Int64);
@@ -936,7 +1004,11 @@ namespace Java.Interop {
 
 		internal    static  readonly    JniNullableInt64ValueMarshaler   Instance    = new JniNullableInt64ValueMarshaler ();
 
-		public override Int64? CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+		public override Int64? CreateGenericValue (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions options,
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
@@ -1003,14 +1075,22 @@ namespace Java.Interop {
 		    get {return typeof (Single);}
 		}
 
-		public override object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+		public override object? CreateValue (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions options,
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
 			return CreateGenericValue (ref reference, options, targetType);
 		}
 
-		public override Single CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+		public override Single CreateGenericValue (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions options,
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			if (!reference.IsValid)
 				return default (Single);
@@ -1066,7 +1146,11 @@ namespace Java.Interop {
 
 		internal    static  readonly    JniNullableSingleValueMarshaler   Instance    = new JniNullableSingleValueMarshaler ();
 
-		public override Single? CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+		public override Single? CreateGenericValue (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions options,
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
@@ -1133,14 +1217,22 @@ namespace Java.Interop {
 		    get {return typeof (Double);}
 		}
 
-		public override object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+		public override object? CreateValue (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions options,
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
 			return CreateGenericValue (ref reference, options, targetType);
 		}
 
-		public override Double CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+		public override Double CreateGenericValue (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions options,
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			if (!reference.IsValid)
 				return default (Double);
@@ -1196,7 +1288,11 @@ namespace Java.Interop {
 
 		internal    static  readonly    JniNullableDoubleValueMarshaler   Instance    = new JniNullableDoubleValueMarshaler ();
 
-		public override Double? CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+		public override Double? CreateGenericValue (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions options,
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;

--- a/src/Java.Interop/Java.Interop/JniBuiltinMarshalers.cs
+++ b/src/Java.Interop/Java.Interop/JniBuiltinMarshalers.cs
@@ -271,19 +271,19 @@ namespace Java.Interop {
 			state   = new JniValueMarshalerState ();
 		}
 
-		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
 		{
 		    return sourceValue;
 		}
 
-		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize)
 		{
 			return sourceValue;
 		}
 
-		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateReturnValueFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue)
 		{
 			return sourceValue;
@@ -413,19 +413,19 @@ namespace Java.Interop {
 			state   = new JniValueMarshalerState ();
 		}
 
-		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
 		{
 		    return sourceValue;
 		}
 
-		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize)
 		{
 			return sourceValue;
 		}
 
-		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateReturnValueFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue)
 		{
 			return sourceValue;
@@ -555,19 +555,19 @@ namespace Java.Interop {
 			state   = new JniValueMarshalerState ();
 		}
 
-		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
 		{
 		    return sourceValue;
 		}
 
-		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize)
 		{
 			return sourceValue;
 		}
 
-		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateReturnValueFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue)
 		{
 			return sourceValue;
@@ -697,19 +697,19 @@ namespace Java.Interop {
 			state   = new JniValueMarshalerState ();
 		}
 
-		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
 		{
 		    return sourceValue;
 		}
 
-		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize)
 		{
 			return sourceValue;
 		}
 
-		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateReturnValueFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue)
 		{
 			return sourceValue;
@@ -839,19 +839,19 @@ namespace Java.Interop {
 			state   = new JniValueMarshalerState ();
 		}
 
-		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
 		{
 		    return sourceValue;
 		}
 
-		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize)
 		{
 			return sourceValue;
 		}
 
-		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateReturnValueFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue)
 		{
 			return sourceValue;
@@ -981,19 +981,19 @@ namespace Java.Interop {
 			state   = new JniValueMarshalerState ();
 		}
 
-		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
 		{
 		    return sourceValue;
 		}
 
-		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize)
 		{
 			return sourceValue;
 		}
 
-		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateReturnValueFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue)
 		{
 			return sourceValue;
@@ -1123,19 +1123,19 @@ namespace Java.Interop {
 			state   = new JniValueMarshalerState ();
 		}
 
-		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
 		{
 		    return sourceValue;
 		}
 
-		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize)
 		{
 			return sourceValue;
 		}
 
-		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateReturnValueFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue)
 		{
 			return sourceValue;
@@ -1265,19 +1265,19 @@ namespace Java.Interop {
 			state   = new JniValueMarshalerState ();
 		}
 
-		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
 		{
 		    return sourceValue;
 		}
 
-		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize)
 		{
 			return sourceValue;
 		}
 
-		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateReturnValueFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue)
 		{
 			return sourceValue;

--- a/src/Java.Interop/Java.Interop/JniBuiltinMarshalers.tt
+++ b/src/Java.Interop/Java.Interop/JniBuiltinMarshalers.tt
@@ -230,19 +230,19 @@ namespace Java.Interop {
 			state   = new JniValueMarshalerState ();
 		}
 
-		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
 		{
 		    return sourceValue;
 		}
 
-		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize)
 		{
 			return sourceValue;
 		}
 
-		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateReturnValueFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue)
 		{
 			return sourceValue;

--- a/src/Java.Interop/Java.Interop/JniBuiltinMarshalers.tt
+++ b/src/Java.Interop/Java.Interop/JniBuiltinMarshalers.tt
@@ -1,4 +1,4 @@
-﻿<#@ template  language="C#" #>
+<#@ template  language="C#" #>
 <#@ assembly  name="System.Core" #>
 <#@ import    namespace="System.Collections.Generic" #>
 <#@ import    namespace="System.Linq" #>
@@ -181,14 +181,22 @@ namespace Java.Interop {
 		    get {return typeof (<#= type.Type #>);}
 		}
 
-		public override object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+		public override object? CreateValue (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions options,
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
 			return CreateGenericValue (ref reference, options, targetType);
 		}
 
-		public override <#= type.Type #> CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+		public override <#= type.Type #> CreateGenericValue (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions options,
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			if (!reference.IsValid)
 				return default (<#= type.Type #>);
@@ -241,7 +249,11 @@ namespace Java.Interop {
 
 		internal    static  readonly    JniNullable<#= type.Type #>ValueMarshaler   Instance    = new JniNullable<#= type.Type #>ValueMarshaler ();
 
-		public override <#= type.Type #>? CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+		public override <#= type.Type #>? CreateGenericValue (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions options,
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;

--- a/src/Java.Interop/Java.Interop/JniBuiltinMarshalers.tt
+++ b/src/Java.Interop/Java.Interop/JniBuiltinMarshalers.tt
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 
@@ -182,10 +183,10 @@ namespace Java.Interop {
 		}
 
 		public override object? CreateValue (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-			Type? targetType)
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
@@ -193,10 +194,10 @@ namespace Java.Interop {
 		}
 
 		public override <#= type.Type #> CreateGenericValue (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-			Type? targetType)
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			if (!reference.IsValid)
 				return default (<#= type.Type #>);
@@ -204,12 +205,12 @@ namespace Java.Interop {
 			return Jni<#= type.Name #>.GetValueFromJni (ref reference, options, targetType);
 		}
 
-		public override JniValueMarshalerState CreateGenericArgumentState (<#= type.Type #> value, ParameterAttributes synchronize = ParameterAttributes.In)
+		public override JniValueMarshalerState CreateGenericArgumentState ([MaybeNull] <#= type.Type #> value, ParameterAttributes synchronize = ParameterAttributes.In)
 		{
 			return new JniValueMarshalerState (new JniArgumentValue (value));
 		}
 
-		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState (<#= type.Type #> value, ParameterAttributes synchronize)
+		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState ([MaybeNull] <#= type.Type #> value, ParameterAttributes synchronize)
 		{
 			var r = Jni<#= type.Name #>.CreateLocalRef (value);
 			return new JniValueMarshalerState (r);
@@ -229,16 +230,19 @@ namespace Java.Interop {
 			state   = new JniValueMarshalerState ();
 		}
 
+		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
 		{
 		    return sourceValue;
 		}
 
+		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize)
 		{
 			return sourceValue;
 		}
 
+		[RequiresUnreferencedCode (JniValueMarshaler.ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateReturnValueFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue)
 		{
 			return sourceValue;
@@ -250,10 +254,10 @@ namespace Java.Interop {
 		internal    static  readonly    JniNullable<#= type.Type #>ValueMarshaler   Instance    = new JniNullable<#= type.Type #>ValueMarshaler ();
 
 		public override <#= type.Type #>? CreateGenericValue (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-			Type? targetType)
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			if (!reference.IsValid)
 				return null;
@@ -261,7 +265,7 @@ namespace Java.Interop {
 			return Jni<#= type.Name #>.GetValueFromJni (ref reference, options, targetType: null);
 		}
 
-		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState (<#= type.Type #>? value, ParameterAttributes synchronize)
+		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState ([MaybeNull] <#= type.Type #>? value, ParameterAttributes synchronize)
 		{
 		    if (!value.HasValue)
 		        return new JniValueMarshalerState ();

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniMarshalMemberBuilder.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniMarshalMemberBuilder.cs
@@ -200,19 +200,19 @@ namespace Java.Interop {
 
 
 		public override object? CreateValue (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-			Type? targetType)
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			throw new NotSupportedException ();
 		}
 
 		public override IntPtr CreateGenericValue (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-			Type? targetType)
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			throw new NotSupportedException ();
 		}

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniMarshalMemberBuilder.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniMarshalMemberBuilder.cs
@@ -199,12 +199,20 @@ namespace Java.Interop {
 		}
 
 
-		public override object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+		public override object? CreateValue (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions options,
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			throw new NotSupportedException ();
 		}
 
-		public override IntPtr CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+		public override IntPtr CreateGenericValue (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions options,
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			throw new NotSupportedException ();
 		}

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniMarshalMemberBuilder.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniMarshalMemberBuilder.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -31,6 +31,7 @@ namespace Java.Interop {
 #if NET
 		[DynamicDependency (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, "Java.Interop.MarshalMemberBuilder", "Java.Interop.Export")]
 		[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "DynamicDependency should preserve the constructor.")]
+		[UnconditionalSuppressMessage ("Trimming", "IL2072", Justification = "DynamicDependency should preserve the constructor.")]
 		[UnconditionalSuppressMessage ("Trimming", "IL2035", Justification = "Java.Interop.Export.dll is not always present.")]
 #endif
 		partial void SetMarshalMemberBuilder (CreationOptions options)
@@ -179,28 +180,31 @@ namespace Java.Interop {
 	sealed class IntPtrValueMarshaler : JniValueMarshaler<IntPtr> {
 		internal    static  IntPtrValueMarshaler Instance = new IntPtrValueMarshaler ();
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterFromManagedExpression (Java.Interop.Expressions.JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize)
 		{
 			return sourceValue;
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterToManagedExpression (Java.Interop.Expressions.JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
 		{
 			return sourceValue;
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateReturnValueFromManagedExpression (Java.Interop.Expressions.JniValueMarshalerContext context, ParameterExpression sourceValue)
 		{
 			return sourceValue;
 		}
 
 
-		public override object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+		public override object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 		{
 			throw new NotSupportedException ();
 		}
 
-		public override IntPtr CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+		public override IntPtr CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 		{
 			throw new NotSupportedException ();
 		}

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
@@ -409,12 +409,20 @@ namespace Java.Interop {
 
 			protected virtual ReplacementMethodInfo? GetReplacementMethodInfoCore (string jniSimpleReference, string jniMethodName, string jniMethodSignature) => null;
 
-			public virtual void RegisterNativeMembers (JniType nativeClass, [DynamicallyAccessedMembers (MethodsAndPrivateNested)] Type type, ReadOnlySpan<char> methods)
+			public virtual void RegisterNativeMembers (
+					JniType nativeClass,
+					[DynamicallyAccessedMembers (MethodsAndPrivateNested)]
+					Type type,
+					ReadOnlySpan<char> methods)
 			{
 				TryRegisterNativeMembers (nativeClass, type, methods);
 			}
 
-			protected bool TryRegisterNativeMembers (JniType nativeClass, [DynamicallyAccessedMembers (MethodsAndPrivateNested)] Type type, ReadOnlySpan<char> methods)
+			protected bool TryRegisterNativeMembers (
+					JniType nativeClass,
+					[DynamicallyAccessedMembers (MethodsAndPrivateNested)]
+					Type type,
+					ReadOnlySpan<char> methods)
 			{
 				AssertValid ();
 
@@ -429,7 +437,11 @@ namespace Java.Interop {
 #if NET
 			[Obsolete ("Use RegisterNativeMembers(JniType, Type, ReadOnlySpan<char>)")]
 #endif  // NET
-			public virtual void RegisterNativeMembers (JniType nativeClass, [DynamicallyAccessedMembers (MethodsAndPrivateNested)] Type type, string? methods)
+			public virtual void RegisterNativeMembers (
+					JniType nativeClass,
+					[DynamicallyAccessedMembers (MethodsAndPrivateNested)]
+					Type type,
+					string? methods)
 			{
 				TryRegisterNativeMembers (nativeClass, type, methods);
 			}
@@ -437,7 +449,11 @@ namespace Java.Interop {
 #if NET
 			[Obsolete ("Use RegisterNativeMembers(JniType, Type, ReadOnlySpan<char>)")]
 #endif  // NET
-			protected bool TryRegisterNativeMembers (JniType nativeClass, [DynamicallyAccessedMembers (MethodsAndPrivateNested)] Type type, string? methods)
+			protected bool TryRegisterNativeMembers (
+					JniType nativeClass,
+					[DynamicallyAccessedMembers (MethodsAndPrivateNested)]
+					Type type,
+					string? methods)
 			{
 				AssertValid ();
 
@@ -446,7 +462,11 @@ namespace Java.Interop {
 
 			static Type [] registerMethodParameters = new Type [] { typeof (JniNativeMethodRegistrationArguments) };
 
-			bool TryLoadJniMarshalMethods (JniType nativeClass, [DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicNestedTypes)] Type type, string? methods)
+			bool TryLoadJniMarshalMethods (
+					JniType nativeClass,
+					[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicNestedTypes)]
+					Type type,
+					string? methods)
 			{
 				var marshalType = type?.GetNestedType ("__<$>_jni_marshal_methods", BindingFlags.NonPublic);
 				if (marshalType == null) {
@@ -465,7 +485,12 @@ namespace Java.Interop {
 
 			static List<JniNativeMethodRegistration> sharedRegistrations = new List<JniNativeMethodRegistration> ();
 
-			bool TryRegisterNativeMembers (JniType nativeClass, [DynamicallyAccessedMembers (Methods)] Type marshalType, string? methods, MethodInfo? registerMethod)
+			bool TryRegisterNativeMembers (
+					JniType nativeClass,
+					[DynamicallyAccessedMembers (Methods)]
+					Type marshalType,
+					string? methods,
+					MethodInfo? registerMethod)
 			{
 				bool lockTaken = false;
 				bool rv = false;
@@ -497,7 +522,10 @@ namespace Java.Interop {
 				return rv;
 			}
 
-			bool FindAndCallRegisterMethod ([DynamicallyAccessedMembers (Methods)] Type marshalType, JniNativeMethodRegistrationArguments arguments)
+			bool FindAndCallRegisterMethod (
+					[DynamicallyAccessedMembers (Methods)]
+					Type marshalType,
+					JniNativeMethodRegistrationArguments arguments)
 			{
 				if (!Runtime.JniAddNativeMethodRegistrationAttributePresent)
 					return false;

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -80,6 +80,10 @@ namespace Java.Interop {
 #endif  // NET
 
 		public partial class JniTypeManager : IDisposable, ISetRuntime {
+
+			internal const DynamicallyAccessedMemberTypes Methods = DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods;
+			internal const DynamicallyAccessedMemberTypes MethodsAndPrivateNested = Methods | DynamicallyAccessedMemberTypes.NonPublicNestedTypes;
+			internal const DynamicallyAccessedMemberTypes MethodsConstructorsInterfaces = MethodsAndPrivateNested | DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.Interfaces;
 
 			JniRuntime?             runtime;
 			bool                    disposed;
@@ -267,7 +271,7 @@ namespace Java.Interop {
 			static  readonly    Type[]      EmptyTypeArray      = Array.Empty<Type> ();
 
 
-			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+			[return: DynamicallyAccessedMembers (MethodsConstructorsInterfaces)]
 			public  Type?    GetType (JniTypeSignature typeSignature)
 			{
 				AssertValid ();
@@ -405,12 +409,12 @@ namespace Java.Interop {
 
 			protected virtual ReplacementMethodInfo? GetReplacementMethodInfoCore (string jniSimpleReference, string jniMethodName, string jniMethodSignature) => null;
 
-			public virtual void RegisterNativeMembers (JniType nativeClass, Type type, ReadOnlySpan<char> methods)
+			public virtual void RegisterNativeMembers (JniType nativeClass, [DynamicallyAccessedMembers (MethodsAndPrivateNested)] Type type, ReadOnlySpan<char> methods)
 			{
 				TryRegisterNativeMembers (nativeClass, type, methods);
 			}
 
-			protected bool TryRegisterNativeMembers (JniType nativeClass, Type type, ReadOnlySpan<char> methods)
+			protected bool TryRegisterNativeMembers (JniType nativeClass, [DynamicallyAccessedMembers (MethodsAndPrivateNested)] Type type, ReadOnlySpan<char> methods)
 			{
 				AssertValid ();
 
@@ -425,7 +429,7 @@ namespace Java.Interop {
 #if NET
 			[Obsolete ("Use RegisterNativeMembers(JniType, Type, ReadOnlySpan<char>)")]
 #endif  // NET
-			public virtual void RegisterNativeMembers (JniType nativeClass, Type type, string? methods)
+			public virtual void RegisterNativeMembers (JniType nativeClass, [DynamicallyAccessedMembers (MethodsAndPrivateNested)] Type type, string? methods)
 			{
 				TryRegisterNativeMembers (nativeClass, type, methods);
 			}
@@ -433,7 +437,7 @@ namespace Java.Interop {
 #if NET
 			[Obsolete ("Use RegisterNativeMembers(JniType, Type, ReadOnlySpan<char>)")]
 #endif  // NET
-			protected bool TryRegisterNativeMembers (JniType nativeClass, Type type, string? methods)
+			protected bool TryRegisterNativeMembers (JniType nativeClass, [DynamicallyAccessedMembers (MethodsAndPrivateNested)] Type type, string? methods)
 			{
 				AssertValid ();
 
@@ -442,7 +446,7 @@ namespace Java.Interop {
 
 			static Type [] registerMethodParameters = new Type [] { typeof (JniNativeMethodRegistrationArguments) };
 
-			bool TryLoadJniMarshalMethods (JniType nativeClass, Type type, string? methods)
+			bool TryLoadJniMarshalMethods (JniType nativeClass, [DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicNestedTypes)] Type type, string? methods)
 			{
 				var marshalType = type?.GetNestedType ("__<$>_jni_marshal_methods", BindingFlags.NonPublic);
 				if (marshalType == null) {
@@ -461,7 +465,7 @@ namespace Java.Interop {
 
 			static List<JniNativeMethodRegistration> sharedRegistrations = new List<JniNativeMethodRegistration> ();
 
-			bool TryRegisterNativeMembers (JniType nativeClass, Type marshalType, string? methods, MethodInfo? registerMethod)
+			bool TryRegisterNativeMembers (JniType nativeClass, [DynamicallyAccessedMembers (Methods)] Type marshalType, string? methods, MethodInfo? registerMethod)
 			{
 				bool lockTaken = false;
 				bool rv = false;
@@ -493,7 +497,7 @@ namespace Java.Interop {
 				return rv;
 			}
 
-			bool FindAndCallRegisterMethod (Type marshalType, JniNativeMethodRegistrationArguments arguments)
+			bool FindAndCallRegisterMethod ([DynamicallyAccessedMembers (Methods)] Type marshalType, JniNativeMethodRegistrationArguments arguments)
 			{
 				if (!Runtime.JniAddNativeMethodRegistrationAttributePresent)
 					return false;

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -49,6 +49,9 @@ namespace Java.Interop
 
 		public abstract partial class JniValueManager : ISetRuntime, IDisposable {
 
+			internal const DynamicallyAccessedMemberTypes Constructors = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
+			internal const DynamicallyAccessedMemberTypes ConstructorsAndInterfaces = Constructors | DynamicallyAccessedMemberTypes.Interfaces;
+
 			JniRuntime?             runtime;
 			bool                    disposed;
 			public      JniRuntime  Runtime {
@@ -252,22 +255,19 @@ namespace Java.Interop
 					: null;
 			}
 
-			static  readonly    KeyValuePair<Type, Type>[]      PeerTypeMappings = new []{
-				new KeyValuePair<Type, Type>(typeof (object),           typeof (JavaObject)),
-				new KeyValuePair<Type, Type>(typeof (IJavaPeerable),    typeof (JavaObject)),
-				new KeyValuePair<Type, Type>(typeof (Exception),        typeof (JavaException)),
-			};
-
-			static Type GetPeerType (Type type)
+			[return: DynamicallyAccessedMembers (Constructors)]
+			static Type GetPeerType ([DynamicallyAccessedMembers (Constructors)] Type type)
 			{
-				foreach (var m in PeerTypeMappings) {
-					if (m.Key == type)
-						return m.Value;
-				}
+				if (type == typeof (object))
+					return typeof (JavaObject);
+				if (type == typeof (IJavaPeerable))
+					return typeof (JavaObject);
+				if (type == typeof (Exception))
+					return typeof (JavaException);
 				return type;
 			}
 
-			public virtual IJavaPeerable? CreatePeer (ref JniObjectReference reference, JniObjectReferenceOptions transfer, Type? targetType)
+			public virtual IJavaPeerable? CreatePeer (ref JniObjectReference reference, JniObjectReferenceOptions transfer, [DynamicallyAccessedMembers (Constructors)] Type? targetType)
 			{
 				if (disposed)
 					throw new ObjectDisposedException (GetType ().Name);
@@ -298,7 +298,7 @@ namespace Java.Interop
 
 			static  readonly    Type    ByRefJniObjectReference = typeof (JniObjectReference).MakeByRefType ();
 
-			ConstructorInfo? GetPeerConstructor (JniObjectReference instance, Type fallbackType)
+			ConstructorInfo? GetPeerConstructor (JniObjectReference instance, [DynamicallyAccessedMembers (Constructors)] Type fallbackType)
 			{
 				var klass       = JniEnvironment.Types.GetObjectClass (instance);
 				var jniTypeName = JniEnvironment.Types.GetJniTypeNameFromClass (klass);
@@ -333,7 +333,7 @@ namespace Java.Interop
 				return GetActivationConstructor (fallbackType);
 			}
 
-			static ConstructorInfo? GetActivationConstructor (Type type)
+			static ConstructorInfo? GetActivationConstructor ([DynamicallyAccessedMembers (Constructors)] Type type)
 			{
 				if (type.IsAbstract || type.IsInterface) {
 					type = GetInvokerType (type) ?? type;
@@ -346,6 +346,7 @@ namespace Java.Interop
 				return null;
 			}
 
+			[return: DynamicallyAccessedMembers (Constructors)]
 			static Type? GetInvokerType (Type type)
 			{
 				const string suffix = "Invoker";
@@ -363,7 +364,7 @@ namespace Java.Interop
 				return suffixDefinition.MakeGenericType (arguments);
 			}
 
-			public object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType = null)
+			public object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType = null)
 			{
 				if (disposed)
 					throw new ObjectDisposedException (GetType ().Name);
@@ -393,7 +394,14 @@ namespace Java.Interop
 			}
 
 			[return: MaybeNull]
-			public T CreateValue<T> (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType = null)
+			public T CreateValue<
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				T
+			> (
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType = null)
 			{
 				if (disposed)
 					throw new ObjectDisposedException (GetType ().Name);
@@ -430,6 +438,7 @@ namespace Java.Interop
 				return marshaler.CreateGenericValue (ref reference, options, targetType);
 			}
 
+			[return: DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
 			internal Type? GetRuntimeType (JniObjectReference reference)
 			{
 				if (!reference.IsValid)
@@ -440,7 +449,7 @@ namespace Java.Interop
 				return Runtime.TypeManager.GetType (signature);
 			}
 
-			public object? GetValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType = null)
+			public object? GetValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType = null)
 			{
 				if (disposed)
 					throw new ObjectDisposedException (GetType ().Name);
@@ -468,14 +477,21 @@ namespace Java.Interop
 			}
 
 			[return: MaybeNull]
-			public T GetValue<T> (IntPtr handle)
+			public T GetValue<[DynamicallyAccessedMembers (ConstructorsAndInterfaces)] T> (IntPtr handle)
 			{
 				var r   = new JniObjectReference (handle);
 				return GetValue<T> (ref r, JniObjectReferenceOptions.Copy);
 			}
 
 			[return: MaybeNull]
-			public T GetValue<T> (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType = null)
+			public T GetValue<
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				T
+			> (
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType = null)
 			{
 				if (!reference.IsValid) {
 #pragma warning disable 8653
@@ -511,7 +527,7 @@ namespace Java.Interop
 
 			Dictionary<Type, JniValueMarshaler> Marshalers = new Dictionary<Type, JniValueMarshaler> ();
 
-			public JniValueMarshaler<T> GetValueMarshaler<T>()
+			public JniValueMarshaler<T> GetValueMarshaler<[DynamicallyAccessedMembers (ConstructorsAndInterfaces)] T>()
 			{
 				if (disposed)
 					throw new ObjectDisposedException (GetType ().Name);
@@ -527,7 +543,7 @@ namespace Java.Interop
 				}
 			}
 
-			public JniValueMarshaler GetValueMarshaler (Type type)
+			public JniValueMarshaler GetValueMarshaler ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.Interfaces)] Type type)
 			{
 				if (disposed)
 					throw new ObjectDisposedException (GetType ().Name);
@@ -599,7 +615,7 @@ namespace Java.Interop
 				return direct ();
 			}
 
-			static JniValueMarshaler GetObjectArrayMarshalerHelper<T> ()
+			static JniValueMarshaler GetObjectArrayMarshalerHelper<[DynamicallyAccessedMembers (ConstructorsAndInterfaces)] T> ()
 			{
 				return JavaObjectArray<T>.Instance;
 			}
@@ -619,7 +635,7 @@ namespace Java.Interop
 			get {return typeof (void);}
 		}
 
-		public override object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+		public override object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 		{
 			throw new NotSupportedException ();
 		}
@@ -640,7 +656,7 @@ namespace Java.Interop
 		internal    static  JavaPeerableValueMarshaler      Instance    = new JavaPeerableValueMarshaler ();
 
 		[return: MaybeNull]
-		public override IJavaPeerable? CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+		public override IJavaPeerable? CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 		{
 			var jvm         = JniEnvironment.Runtime;
 			var marshaler   = jvm.ValueManager.GetValueMarshaler (targetType ?? typeof(IJavaPeerable));
@@ -664,6 +680,7 @@ namespace Java.Interop
 			state   = new JniValueMarshalerState ();
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize)
 		{
 			var r = CreateIntermediaryExpressionFromManagedExpression (context, sourceValue);
@@ -674,6 +691,7 @@ namespace Java.Interop
 			return h;
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		Expression CreateIntermediaryExpressionFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue)
 		{
 			var r   = Expression.Variable (typeof (JniObjectReference), sourceValue.Name + "_ref");
@@ -687,11 +705,13 @@ namespace Java.Interop
 			return r;
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateReturnValueFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue)
 		{
 			return ReturnObjectReferenceToJni (context, sourceValue.Name, CreateIntermediaryExpressionFromManagedExpression (context, sourceValue));
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
 		{
 			targetType ??= typeof (object);
@@ -709,7 +729,7 @@ namespace Java.Interop
 		}
 	}
 
-	sealed class DelegatingValueMarshaler<T> : JniValueMarshaler<T> {
+	sealed class DelegatingValueMarshaler<[DynamicallyAccessedMembers (ConstructorsAndInterfaces)] T> : JniValueMarshaler<T> {
 
 		JniValueMarshaler   ValueMarshaler;
 
@@ -719,7 +739,7 @@ namespace Java.Interop
 		}
 
 		[return: MaybeNull]
-		public override T CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+		public override T CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 		{
 			return (T) ValueMarshaler.CreateValue (ref reference, options, targetType ?? typeof (T))!;
 		}
@@ -734,16 +754,19 @@ namespace Java.Interop
 			ValueMarshaler.DestroyArgumentState (value, ref state, synchronize);
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize)
 		{
 			return ValueMarshaler.CreateParameterFromManagedExpression (context, sourceValue, synchronize);
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
 		{
 			return ValueMarshaler.CreateParameterToManagedExpression (context, sourceValue, synchronize, targetType);
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateReturnValueFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue)
 		{
 			return ValueMarshaler.CreateReturnValueFromManagedExpression (context, sourceValue);
@@ -755,7 +778,7 @@ namespace Java.Interop
 		internal    static  ProxyValueMarshaler     Instance    = new ProxyValueMarshaler ();
 
 		[return: MaybeNull]
-		public override object? CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+		public override object? CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 		{
 			var jvm     = JniEnvironment.Runtime;
 

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -477,7 +477,11 @@ namespace Java.Interop
 			}
 
 			[return: MaybeNull]
-			public T GetValue<[DynamicallyAccessedMembers (ConstructorsAndInterfaces)] T> (IntPtr handle)
+			public T GetValue<
+					[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+					T
+			> (
+					IntPtr handle)
 			{
 				var r   = new JniObjectReference (handle);
 				return GetValue<T> (ref r, JniObjectReferenceOptions.Copy);
@@ -527,7 +531,10 @@ namespace Java.Interop
 
 			Dictionary<Type, JniValueMarshaler> Marshalers = new Dictionary<Type, JniValueMarshaler> ();
 
-			public JniValueMarshaler<T> GetValueMarshaler<[DynamicallyAccessedMembers (ConstructorsAndInterfaces)] T>()
+			public JniValueMarshaler<T> GetValueMarshaler<
+					[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+					T>
+			()
 			{
 				if (disposed)
 					throw new ObjectDisposedException (GetType ().Name);
@@ -615,7 +622,10 @@ namespace Java.Interop
 				return direct ();
 			}
 
-			static JniValueMarshaler GetObjectArrayMarshalerHelper<[DynamicallyAccessedMembers (ConstructorsAndInterfaces)] T> ()
+			static JniValueMarshaler GetObjectArrayMarshalerHelper<
+					[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+					T
+			> ()
 			{
 				return JavaObjectArray<T>.Instance;
 			}
@@ -635,7 +645,11 @@ namespace Java.Interop
 			get {return typeof (void);}
 		}
 
-		public override object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+		public override object? CreateValue (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions options,
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			throw new NotSupportedException ();
 		}
@@ -656,7 +670,11 @@ namespace Java.Interop
 		internal    static  JavaPeerableValueMarshaler      Instance    = new JavaPeerableValueMarshaler ();
 
 		[return: MaybeNull]
-		public override IJavaPeerable? CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+		public override IJavaPeerable? CreateGenericValue (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions options,
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			var jvm         = JniEnvironment.Runtime;
 			var marshaler   = jvm.ValueManager.GetValueMarshaler (targetType ?? typeof(IJavaPeerable));
@@ -729,7 +747,12 @@ namespace Java.Interop
 		}
 	}
 
-	sealed class DelegatingValueMarshaler<[DynamicallyAccessedMembers (ConstructorsAndInterfaces)] T> : JniValueMarshaler<T> {
+	sealed class DelegatingValueMarshaler<
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			T
+	>
+		: JniValueMarshaler<T>
+	{
 
 		JniValueMarshaler   ValueMarshaler;
 
@@ -739,7 +762,11 @@ namespace Java.Interop
 		}
 
 		[return: MaybeNull]
-		public override T CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+		public override T CreateGenericValue (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions options,
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			return (T) ValueMarshaler.CreateValue (ref reference, options, targetType ?? typeof (T))!;
 		}
@@ -778,7 +805,11 @@ namespace Java.Interop
 		internal    static  ProxyValueMarshaler     Instance    = new ProxyValueMarshaler ();
 
 		[return: MaybeNull]
-		public override object? CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+		public override object? CreateGenericValue (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions options,
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			var jvm     = JniEnvironment.Runtime;
 

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -550,8 +550,8 @@ namespace Java.Interop
 
 			public JniValueMarshaler<T> GetValueMarshaler<
 					[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-					T>
-			()
+					T
+			> ()
 			{
 				if (disposed)
 					throw new ObjectDisposedException (GetType ().Name);

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -267,7 +267,11 @@ namespace Java.Interop
 				return type;
 			}
 
-			public virtual IJavaPeerable? CreatePeer (ref JniObjectReference reference, JniObjectReferenceOptions transfer, [DynamicallyAccessedMembers (Constructors)] Type? targetType)
+			public virtual IJavaPeerable? CreatePeer (
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions transfer,
+				[DynamicallyAccessedMembers (Constructors)]
+				Type? targetType)
 			{
 				if (disposed)
 					throw new ObjectDisposedException (GetType ().Name);
@@ -298,7 +302,10 @@ namespace Java.Interop
 
 			static  readonly    Type    ByRefJniObjectReference = typeof (JniObjectReference).MakeByRefType ();
 
-			ConstructorInfo? GetPeerConstructor (JniObjectReference instance, [DynamicallyAccessedMembers (Constructors)] Type fallbackType)
+			ConstructorInfo? GetPeerConstructor (
+				JniObjectReference instance,
+				[DynamicallyAccessedMembers (Constructors)]
+				Type fallbackType)
 			{
 				var klass       = JniEnvironment.Types.GetObjectClass (instance);
 				var jniTypeName = JniEnvironment.Types.GetJniTypeNameFromClass (klass);
@@ -333,7 +340,9 @@ namespace Java.Interop
 				return GetActivationConstructor (fallbackType);
 			}
 
-			static ConstructorInfo? GetActivationConstructor ([DynamicallyAccessedMembers (Constructors)] Type type)
+			static ConstructorInfo? GetActivationConstructor (
+				[DynamicallyAccessedMembers (Constructors)]
+				Type type)
 			{
 				if (type.IsAbstract || type.IsInterface) {
 					type = GetInvokerType (type) ?? type;
@@ -364,7 +373,11 @@ namespace Java.Interop
 				return suffixDefinition.MakeGenericType (arguments);
 			}
 
-			public object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType = null)
+			public object? CreateValue (
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType = null)
 			{
 				if (disposed)
 					throw new ObjectDisposedException (GetType ().Name);
@@ -449,7 +462,11 @@ namespace Java.Interop
 				return Runtime.TypeManager.GetType (signature);
 			}
 
-			public object? GetValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType = null)
+			public object? GetValue (
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType = null)
 			{
 				if (disposed)
 					throw new ObjectDisposedException (GetType ().Name);
@@ -550,7 +567,9 @@ namespace Java.Interop
 				}
 			}
 
-			public JniValueMarshaler GetValueMarshaler ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.Interfaces)] Type type)
+			public JniValueMarshaler GetValueMarshaler (
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.Interfaces)]
+				Type type)
 			{
 				if (disposed)
 					throw new ObjectDisposedException (GetType ().Name);

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -268,10 +268,10 @@ namespace Java.Interop
 			}
 
 			public virtual IJavaPeerable? CreatePeer (
-				ref JniObjectReference reference,
-				JniObjectReferenceOptions transfer,
-				[DynamicallyAccessedMembers (Constructors)]
-				Type? targetType)
+					ref JniObjectReference reference,
+					JniObjectReferenceOptions transfer,
+					[DynamicallyAccessedMembers (Constructors)]
+					Type? targetType)
 			{
 				if (disposed)
 					throw new ObjectDisposedException (GetType ().Name);
@@ -303,9 +303,9 @@ namespace Java.Interop
 			static  readonly    Type    ByRefJniObjectReference = typeof (JniObjectReference).MakeByRefType ();
 
 			ConstructorInfo? GetPeerConstructor (
-				JniObjectReference instance,
-				[DynamicallyAccessedMembers (Constructors)]
-				Type fallbackType)
+					JniObjectReference instance,
+					[DynamicallyAccessedMembers (Constructors)]
+					Type fallbackType)
 			{
 				var klass       = JniEnvironment.Types.GetObjectClass (instance);
 				var jniTypeName = JniEnvironment.Types.GetJniTypeNameFromClass (klass);
@@ -341,8 +341,8 @@ namespace Java.Interop
 			}
 
 			static ConstructorInfo? GetActivationConstructor (
-				[DynamicallyAccessedMembers (Constructors)]
-				Type type)
+					[DynamicallyAccessedMembers (Constructors)]
+					Type type)
 			{
 				if (type.IsAbstract || type.IsInterface) {
 					type = GetInvokerType (type) ?? type;
@@ -374,10 +374,10 @@ namespace Java.Interop
 			}
 
 			public object? CreateValue (
-				ref JniObjectReference reference,
-				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-				Type? targetType = null)
+					ref JniObjectReference reference,
+					JniObjectReferenceOptions options,
+					[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+					Type? targetType = null)
 			{
 				if (disposed)
 					throw new ObjectDisposedException (GetType ().Name);
@@ -408,13 +408,13 @@ namespace Java.Interop
 
 			[return: MaybeNull]
 			public T CreateValue<
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-				T
+					[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+					T
 			> (
-				ref JniObjectReference reference,
-				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-				Type? targetType = null)
+					ref JniObjectReference reference,
+					JniObjectReferenceOptions options,
+					[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+					Type? targetType = null)
 			{
 				if (disposed)
 					throw new ObjectDisposedException (GetType ().Name);
@@ -463,10 +463,10 @@ namespace Java.Interop
 			}
 
 			public object? GetValue (
-				ref JniObjectReference reference,
-				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-				Type? targetType = null)
+					ref JniObjectReference reference,
+					JniObjectReferenceOptions options,
+					[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+					Type? targetType = null)
 			{
 				if (disposed)
 					throw new ObjectDisposedException (GetType ().Name);
@@ -506,13 +506,13 @@ namespace Java.Interop
 
 			[return: MaybeNull]
 			public T GetValue<
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-				T
+					[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+					T
 			> (
-				ref JniObjectReference reference,
-				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-				Type? targetType = null)
+					ref JniObjectReference reference,
+					JniObjectReferenceOptions options,
+					[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+					Type? targetType = null)
 			{
 				if (!reference.IsValid) {
 #pragma warning disable 8653
@@ -568,8 +568,8 @@ namespace Java.Interop
 			}
 
 			public JniValueMarshaler GetValueMarshaler (
-				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.Interfaces)]
-				Type type)
+					[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.Interfaces)]
+					Type type)
 			{
 				if (disposed)
 					throw new ObjectDisposedException (GetType ().Name);
@@ -665,10 +665,10 @@ namespace Java.Interop
 		}
 
 		public override object? CreateValue (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-			Type? targetType)
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			throw new NotSupportedException ();
 		}
@@ -690,10 +690,10 @@ namespace Java.Interop
 
 		[return: MaybeNull]
 		public override IJavaPeerable? CreateGenericValue (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-			Type? targetType)
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			var jvm         = JniEnvironment.Runtime;
 			var marshaler   = jvm.ValueManager.GetValueMarshaler (targetType ?? typeof(IJavaPeerable));
@@ -782,10 +782,10 @@ namespace Java.Interop
 
 		[return: MaybeNull]
 		public override T CreateGenericValue (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-			Type? targetType)
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			return (T) ValueMarshaler.CreateValue (ref reference, options, targetType ?? typeof (T))!;
 		}
@@ -825,10 +825,10 @@ namespace Java.Interop
 
 		[return: MaybeNull]
 		public override object? CreateGenericValue (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-			Type? targetType)
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			var jvm     = JniEnvironment.Runtime;
 

--- a/src/Java.Interop/Java.Interop/JniRuntime.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.cs
@@ -271,7 +271,7 @@ namespace Java.Interop
 		static unsafe JavaVMInterface CreateInvoker (IntPtr handle)
 		{
 			IntPtr p = Marshal.ReadIntPtr (handle);
-			return (JavaVMInterface) Marshal.PtrToStructure (p, typeof (JavaVMInterface))!;
+			return (JavaVMInterface) Marshal.PtrToStructure<JavaVMInterface> (p)!;
 		}
 
 		~JniRuntime ()

--- a/src/Java.Interop/Java.Interop/JniStringValueMarshaler.cs
+++ b/src/Java.Interop/Java.Interop/JniStringValueMarshaler.cs
@@ -15,10 +15,10 @@ namespace Java.Interop {
 		internal    static  readonly    JniStringValueMarshaler     Instance    = new JniStringValueMarshaler ();
 
 		public override string? CreateGenericValue (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-			Type? targetType)
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			return JniEnvironment.Strings.ToString (ref reference, options, targetType ?? typeof (string));
 		}

--- a/src/Java.Interop/Java.Interop/JniStringValueMarshaler.cs
+++ b/src/Java.Interop/Java.Interop/JniStringValueMarshaler.cs
@@ -14,7 +14,7 @@ namespace Java.Interop {
 
 		internal    static  readonly    JniStringValueMarshaler     Instance    = new JniStringValueMarshaler ();
 
-		public override string? CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType)
+		public override string? CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 		{
 			return JniEnvironment.Strings.ToString (ref reference, options, targetType ?? typeof (string));
 		}
@@ -32,6 +32,7 @@ namespace Java.Interop {
 			state   = new JniValueMarshalerState ();
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize)
 		{
 			Func<string, JniObjectReference>    m   = JniEnvironment.Strings.NewString;
@@ -46,6 +47,7 @@ namespace Java.Interop {
 			return hdl;
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateReturnValueFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue)
 		{
 			Func<string, JniObjectReference>    m   = JniEnvironment.Strings.NewString;
@@ -57,6 +59,7 @@ namespace Java.Interop {
 			return ReturnObjectReferenceToJni (context, sourceValue.Name, obj);
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public override Expression CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize, Type? targetType)
 		{
 			Func<IntPtr, string?>   m   = JniEnvironment.Strings.ToString;

--- a/src/Java.Interop/Java.Interop/JniStringValueMarshaler.cs
+++ b/src/Java.Interop/Java.Interop/JniStringValueMarshaler.cs
@@ -14,7 +14,11 @@ namespace Java.Interop {
 
 		internal    static  readonly    JniStringValueMarshaler     Instance    = new JniStringValueMarshaler ();
 
-		public override string? CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+		public override string? CreateGenericValue (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions options,
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			Type? targetType)
 		{
 			return JniEnvironment.Strings.ToString (ref reference, options, targetType ?? typeof (string));
 		}

--- a/src/Java.Interop/Java.Interop/JniValueMarshaler.cs
+++ b/src/Java.Interop/Java.Interop/JniValueMarshaler.cs
@@ -120,6 +120,9 @@ namespace Java.Interop {
 
 	public abstract class JniValueMarshaler {
 
+		internal const DynamicallyAccessedMemberTypes ConstructorsAndInterfaces = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.Interfaces;
+		internal const string ExpressionRequiresUnreferencedCode = "System.Linq.Expression usage may trim away required code.";
+
 		public  virtual     bool                    IsJniValueType {
 			get {return false;}
 		}
@@ -129,7 +132,7 @@ namespace Java.Interop {
 			get {return IntPtr_type;}
 		}
 
-		public  abstract    object?                 CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType = null);
+		public  abstract    object?                 CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType = null);
 
 		public  virtual     JniValueMarshalerState  CreateArgumentState (object? value, ParameterAttributes synchronize = 0)
 		{
@@ -139,12 +142,13 @@ namespace Java.Interop {
 		public  abstract    JniValueMarshalerState  CreateObjectReferenceArgumentState (object? value, ParameterAttributes synchronize = 0);
 		public  abstract    void                    DestroyArgumentState (object? value, ref JniValueMarshalerState state, ParameterAttributes synchronize = 0);
 
-		internal object? CreateValue (IntPtr handle, Type? targetType)
+		internal object? CreateValue (IntPtr handle, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
 		{
 			var r = new JniObjectReference (handle);
 			return CreateValue (ref r, JniObjectReferenceOptions.Copy, targetType);
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public  virtual     Expression              CreateParameterToManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize = 0, Type? targetType = null)
 		{
 			Func<IntPtr, Type, object?> m   = CreateValue;
@@ -165,6 +169,7 @@ namespace Java.Interop {
 			return self;
 		}
 
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public  virtual     Expression              CreateReturnValueFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue)
 		{
 			CreateParameterFromManagedExpression (context, sourceValue, 0);
@@ -186,6 +191,8 @@ namespace Java.Interop {
 		}
 
 		delegate void DestroyArgumentStateCb (object value, ref JniValueMarshalerState state, ParameterAttributes synchronize);
+
+		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		public  virtual     Expression              CreateParameterFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue, ParameterAttributes synchronize)
 		{
 			Func<object, ParameterAttributes, JniValueMarshalerState>   c   = CreateArgumentState;
@@ -216,10 +223,10 @@ namespace Java.Interop {
 		}
 	}
 
-	public abstract class JniValueMarshaler<T> : JniValueMarshaler {
+	public abstract class JniValueMarshaler<[DynamicallyAccessedMembers (ConstructorsAndInterfaces)] T> : JniValueMarshaler {
 
 		[return: MaybeNull]
-		public  abstract    T                       CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType = null);
+		public  abstract    T                       CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType = null);
 
 		public  virtual     JniValueMarshalerState  CreateGenericArgumentState ([MaybeNull] T value, ParameterAttributes synchronize = 0)
 		{
@@ -229,7 +236,7 @@ namespace Java.Interop {
 		public  abstract    JniValueMarshalerState  CreateGenericObjectReferenceArgumentState ([MaybeNull] T value, ParameterAttributes synchronize = 0);
 		public  abstract    void                    DestroyGenericArgumentState ([AllowNull] T value, ref JniValueMarshalerState state, ParameterAttributes synchronize = 0);
 
-		public override object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, Type? targetType = null)
+		public override object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType = null)
 		{
 			return CreateGenericValue (ref reference, options, targetType ?? typeof (T));
 		}

--- a/src/Java.Interop/Java.Interop/JniValueMarshaler.cs
+++ b/src/Java.Interop/Java.Interop/JniValueMarshaler.cs
@@ -132,7 +132,11 @@ namespace Java.Interop {
 			get {return IntPtr_type;}
 		}
 
-		public  abstract    object?                 CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType = null);
+		public  abstract    object?                 CreateValue (
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType = null);
 
 		public  virtual     JniValueMarshalerState  CreateArgumentState (object? value, ParameterAttributes synchronize = 0)
 		{
@@ -142,7 +146,10 @@ namespace Java.Interop {
 		public  abstract    JniValueMarshalerState  CreateObjectReferenceArgumentState (object? value, ParameterAttributes synchronize = 0);
 		public  abstract    void                    DestroyArgumentState (object? value, ref JniValueMarshalerState state, ParameterAttributes synchronize = 0);
 
-		internal object? CreateValue (IntPtr handle, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType)
+		internal object? CreateValue (
+				IntPtr handle,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType)
 		{
 			var r = new JniObjectReference (handle);
 			return CreateValue (ref r, JniObjectReferenceOptions.Copy, targetType);
@@ -231,7 +238,11 @@ namespace Java.Interop {
 	{
 
 		[return: MaybeNull]
-		public  abstract    T                       CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType = null);
+		public  abstract    T                       CreateGenericValue (
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType = null);
 
 		public  virtual     JniValueMarshalerState  CreateGenericArgumentState ([MaybeNull] T value, ParameterAttributes synchronize = 0)
 		{
@@ -242,10 +253,10 @@ namespace Java.Interop {
 		public  abstract    void                    DestroyGenericArgumentState ([AllowNull] T value, ref JniValueMarshalerState state, ParameterAttributes synchronize = 0);
 
 		public override object? CreateValue (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
-			Type? targetType = null)
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
+				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				Type? targetType = null)
 		{
 			return CreateGenericValue (ref reference, options, targetType ?? typeof (T));
 		}

--- a/src/Java.Interop/Java.Interop/JniValueMarshaler.cs
+++ b/src/Java.Interop/Java.Interop/JniValueMarshaler.cs
@@ -223,7 +223,12 @@ namespace Java.Interop {
 		}
 	}
 
-	public abstract class JniValueMarshaler<[DynamicallyAccessedMembers (ConstructorsAndInterfaces)] T> : JniValueMarshaler {
+	public abstract class JniValueMarshaler<
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			T
+	>
+		: JniValueMarshaler
+	{
 
 		[return: MaybeNull]
 		public  abstract    T                       CreateGenericValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType = null);
@@ -236,7 +241,11 @@ namespace Java.Interop {
 		public  abstract    JniValueMarshalerState  CreateGenericObjectReferenceArgumentState ([MaybeNull] T value, ParameterAttributes synchronize = 0);
 		public  abstract    void                    DestroyGenericArgumentState ([AllowNull] T value, ref JniValueMarshalerState state, ParameterAttributes synchronize = 0);
 
-		public override object? CreateValue (ref JniObjectReference reference, JniObjectReferenceOptions options, [DynamicallyAccessedMembers (ConstructorsAndInterfaces)] Type? targetType = null)
+		public override object? CreateValue (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions options,
+			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			Type? targetType = null)
 		{
 			return CreateGenericValue (ref reference, options, targetType ?? typeof (T));
 		}

--- a/src/Java.Interop/Java.Interop/JniValueMarshalerAttribute.cs
+++ b/src/Java.Interop/Java.Interop/JniValueMarshalerAttribute.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace Java.Interop {
@@ -25,7 +26,10 @@ namespace Java.Interop {
 			MarshalerType   = marshalerType;
 		}
 
-		public  Type    MarshalerType   {get;}
+		public  Type    MarshalerType   {
+			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+			get;
+		}
 	}
 }
 

--- a/src/Java.Interop/Java.Interop/ManagedPeer.cs
+++ b/src/Java.Interop/Java.Interop/ManagedPeer.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -17,6 +17,8 @@ namespace Java.Interop {
 	/* static */ sealed class ManagedPeer : JavaObject {
 
 		internal const string JniTypeName = "net/dot/jni/ManagedPeer";
+		internal const DynamicallyAccessedMemberTypes Constructors = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
+		internal const DynamicallyAccessedMemberTypes ConstructorsMethodsNestedTypes = Constructors | DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods | DynamicallyAccessedMemberTypes.NonPublicNestedTypes;
 
 
 		static  readonly    JniPeerMembers  _members        = new JniPeerMembers (JniTypeName, typeof (ManagedPeer));
@@ -140,7 +142,7 @@ namespace Java.Interop {
 
 		static Dictionary<string, ConstructorInfo?> ConstructorCache    = new Dictionary<string, ConstructorInfo?> ();
 
-		static ConstructorInfo? GetConstructor (Type type, string jniTypeName, string signature)
+		static ConstructorInfo? GetConstructor ([DynamicallyAccessedMembers (Constructors)] Type type, string jniTypeName, string signature)
 		{
 			var ctorCacheKey    = jniTypeName + "." + signature;
 			lock (ConstructorCache) {
@@ -290,7 +292,7 @@ namespace Java.Interop {
 			}
 		}
 
-		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+		[return: DynamicallyAccessedMembers (ConstructorsMethodsNestedTypes)]
 		static Type GetTypeFromSignature (JniRuntime.JniTypeManager typeManager, JniTypeSignature typeSignature, string? context = null)
 		{
 			return typeManager.GetType (typeSignature) ??

--- a/src/Java.Interop/Java.Interop/ManagedPeer.cs
+++ b/src/Java.Interop/Java.Interop/ManagedPeer.cs
@@ -142,7 +142,11 @@ namespace Java.Interop {
 
 		static Dictionary<string, ConstructorInfo?> ConstructorCache    = new Dictionary<string, ConstructorInfo?> ();
 
-		static ConstructorInfo? GetConstructor ([DynamicallyAccessedMembers (Constructors)] Type type, string jniTypeName, string signature)
+		static ConstructorInfo? GetConstructor (
+				[DynamicallyAccessedMembers (Constructors)]
+				Type type,
+				string jniTypeName,
+				string signature)
 		{
 			var ctorCacheKey    = jniTypeName + "." + signature;
 			lock (ConstructorCache) {


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/issues/1157

On the path to enabling `IsAotCompatible`, we can enable some settings
to get started:

    <IsTrimmable>true</IsTrimmable>
    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
    <EnableAotAnalyzer>true</EnableAotAnalyzer>

This opts into the analyzers without declaring the assembly is fully AOT-compatible.

Starting out, I got 33 warnings: this is an attempt to address the ones that don't require too much thinking. Unfortunately, solving 1 warning likely will create dozens more -- as you have to update all callers.

This results in 24 warnings remaining. Since `Release` builds have `$(TreatWarningsAsErrors)`, I will wait to enable the analyzers until all warnings are addressed.

### Example Warnings ###

`System.Linq.Expression` usage:

    src\Java.Interop\Java.Interop\JniRuntime.JniValueManager.cs(672,58):
    warning IL2026: Using member 'System.Linq.Expressions.Expression.Property(Expression, String)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Creating Expressions requires unreferenced code because the members being referenced by the Expression may be trimmed.

I decorated this one with:

    [RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]

`Type.GetNestedType()` usage:

    src\Java.Interop\Java.Interop\JniRuntime.JniTypeManager.cs(447,28):
    warning IL2070: 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.NonPublicNestedTypes' in call to 'System.Type.GetNestedType(String, BindingFlags)'. The parameter 'type' of method 'Java.Interop.JniRuntime.JniTypeManager.TryLoadJniMarshalMethods(JniType, Type, String)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.

Added:

    [DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicNestedTypes)]

`Activator.CreateInstance()` usage:

    src\Java.Interop\Java.Interop\JniRuntime.JniValueManager.cs(542,33): warning IL2072: 'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicParameterlessConstructor' in call to 'System.Activator.CreateInstance(Type)'. The return value of method 'Java.Interop.JniValueMarshalerAttribute.MarshalerType.get' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.

Added:

    [return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]

### Code that Actually Changed ###

As I enabled more attributes, these snowball into more and more warnings! I eventually had to make `GetPeerType()` look like:

    [return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
    static Type GetPeerType ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] Type type)

The analyzer was not able to understand code like:

    static  readonly    KeyValuePair<Type, Type>[]      PeerTypeMappings = new []{
        new KeyValuePair<Type, Type>(typeof (object),           typeof (JavaObject)),
        new KeyValuePair<Type, Type>(typeof (IJavaPeerable),    typeof (JavaObject)),
        new KeyValuePair<Type, Type>(typeof (Exception),        typeof (JavaException)),
    };
    //...
    foreach (var m in PeerTypeMappings) {
        if (m.Key == type)
            return m.Value;
    }

Simply removing the `PeerTypeMappings` array and using `if` statements solved the warnings. This may be the only real code change if any.