### PR TITLE
[build] Target `net8.0`

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <ProduceReferenceAssemblyInOutDir>true</ProduceReferenceAssemblyInOutDir>
     <!-- Disables the transitive restore of packages like Microsoft.AspNetCore.App.Ref, Microsoft.WindowsDesktop.App.Ref -->
     <DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
-    <DotNetTargetFrameworkVersion>7.0</DotNetTargetFrameworkVersion>
+    <DotNetTargetFrameworkVersion>8.0</DotNetTargetFrameworkVersion>
     <DotNetTargetFramework>net$(DotNetTargetFrameworkVersion)</DotNetTargetFramework>
   </PropertyGroup>
 

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -24,8 +24,8 @@ parameters:
 variables:
   RunningOnCI: true
   Build.Configuration: Release
-  DotNetCoreVersion: 7.x
-  DotNetTargetFramework: net7.0
+  DotNetCoreVersion: 8.x
+  DotNetTargetFramework: net8.0
   NetCoreTargetFrameworkPathSuffix: -$(DotNetTargetFramework)
   1ESWindowsPool: AzurePipelines-EO
   1ESWindowsImage: AzurePipelinesWindows2022compliant


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/pull/1153

*Actually* building *and running* NativeAOT artifacts requires .NET 8.

Update `$(DotNetTargetFramework)` so that .NET 8 is used.