### PR TITLE
Automatically add NullableAttributes support to netstandard2.0 projects that enable NRT.

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,6 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
 
+  <!-- Automatically add NRT attribute support for netstandard2.0 projects using NRT -->
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' AND '$(Nullable)' == 'enable' ">
+    <Compile Include="$(MSBuildThisFileDirectory)src\utils\NullableAttributes.cs" Visible="false" />
+  </ItemGroup>
+  
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' AND '$(Nullable)' == 'enable' ">
+    <DefineConstants>$(DefineConstants);INTERNAL_NULLABLE_ATTRIBUTES</DefineConstants>
+  </PropertyGroup>
+
   <!-- Add Roslyn analyzers NuGet to all projects -->
   <ItemGroup Condition=" '$(DisableRoslynAnalyzers)' != 'True' ">
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">

--- a/src/Java.Interop.Localization/Java.Interop.Localization.csproj
+++ b/src/Java.Interop.Localization/Java.Interop.Localization.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-    <DefineConstants>INTERNAL_NULLABLE_ATTRIBUTES</DefineConstants>
     <NeutralLanguage>en</NeutralLanguage>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
@@ -18,10 +17,6 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Include="..\utils\NullableAttributes.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil.csproj
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-    <DefineConstants>INTERNAL_NULLABLE_ATTRIBUTES</DefineConstants>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
@@ -16,10 +15,6 @@
   </PropertyGroup>
 
   <Import Project="..\..\build-tools\scripts\cecil.projitems" />
-
-  <ItemGroup>
-    <Compile Include="..\utils\NullableAttributes.cs" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Java.Interop.Localization\Java.Interop.Localization.csproj" />

--- a/src/Java.Interop.Tools.Diagnostics/Java.Interop.Tools.Diagnostics.csproj
+++ b/src/Java.Interop.Tools.Diagnostics/Java.Interop.Tools.Diagnostics.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-    <DefineConstants>INTERNAL_NULLABLE_ATTRIBUTES</DefineConstants>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
@@ -16,10 +15,6 @@
   </PropertyGroup>
 
   <Import Project="..\..\build-tools\scripts\cecil.projitems" />
-
-  <ItemGroup>
-    <Compile Include="..\utils\NullableAttributes.cs" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers.csproj
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers.csproj
@@ -23,9 +23,6 @@
     <Compile Include="..\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings\JavaNativeTypeManager.cs">
       <Link>JavaNativeTypeManager.cs</Link>
     </Compile>
-    <Compile Include="..\utils\NullableAttributes.cs">
-      <Link>NullableAttributes.cs</Link>
-    </Compile>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Java.Interop.Tools.Maven/Java.Interop.Tools.Maven.csproj
+++ b/src/Java.Interop.Tools.Maven/Java.Interop.Tools.Maven.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>11.0</LangVersion>
     <Nullable>enable</Nullable>
-    <DefineConstants>INTERNAL_NULLABLE_ATTRIBUTES</DefineConstants>
     <Nullable>enable</Nullable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
@@ -15,10 +14,6 @@
   <PropertyGroup>
     <OutputPath>$(UtilityOutputFullPath)</OutputPath>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Compile Include="..\utils\NullableAttributes.cs" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />

--- a/src/Java.Interop/Java.Interop.csproj
+++ b/src/Java.Interop/Java.Interop.csproj
@@ -24,7 +24,7 @@
   </PropertyGroup>
   <Import Project="..\..\TargetFrameworkDependentValues.props" />
   <PropertyGroup>
-    <DefineConstants>INTEROP;FEATURE_JNIOBJECTREFERENCE_INTPTRS;INTERNAL_NULLABLE_ATTRIBUTES;$(JavaInteropDefineConstants)</DefineConstants>
+    <DefineConstants>INTEROP;FEATURE_JNIOBJECTREFERENCE_INTPTRS;$(JavaInteropDefineConstants)</DefineConstants>
     <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(Configuration)\$(TargetFramework.ToLowerInvariant())\</IntermediateOutputPath>
     <OutputPath>$(ToolOutputFullPath)</OutputPath>
     <DocumentationFile>$(ToolOutputFullPath)Java.Interop.xml</DocumentationFile>
@@ -42,7 +42,6 @@
     <DefineConstants>FEATURE_JNIENVIRONMENT_JI_PINVOKES;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Condition=" '$(TargetFramework)' == 'netstandard2.0' " Include="..\utils\NullableAttributes.cs" />
     <Compile Remove="Java.Interop\JniLocationException.cs" />
   </ItemGroup>
   <PropertyGroup>


### PR DESCRIPTION
`netstandard2.0` doesn't have "built-in" compiler support for NRT attributes.  Thus when we enable NRT on `netstandard2.0` projects we are responsible for providing the attributes ourselves.

Rather than manually repeat this info in each `netstandard2.0` `.csproj`, we can use `Directory.Build.targets` to automatically set the attributes up in projects that need it.

Additionally, we can mark it as `Visible="false"` so the file doesn't show up in Visual Studio Solution Explorer, just like the "real" "built-in" attributes.