### PR TITLE
[Java.Interop] ignore remaining trimming warnings

### DIFF
--- a/src/Java.Interop/Java.Interop.csproj
+++ b/src/Java.Interop/Java.Interop.csproj
@@ -15,9 +15,8 @@
     <Nullable>enable</Nullable>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
-    <!-- TODO: enable these when all warnings are solved -->
-    <!--<IsTrimmable>true</IsTrimmable>-->
-    <!--<EnableAotAnalyzer>true</EnableAotAnalyzer>-->
+    <IsTrimmable>true</IsTrimmable>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
     <MSBuildWarningsAsMessages>NU1702</MSBuildWarningsAsMessages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniMarshalMemberBuilder.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniMarshalMemberBuilder.cs
@@ -150,6 +150,7 @@ namespace Java.Interop {
 				throw new NotSupportedException ("Don't know how to determine JNI signature for parameter type: " + p.ParameterType.FullName + ".");
 			}
 
+			[UnconditionalSuppressMessage ("Trimming", "IL2072", Justification = "Method parameter types should be preserved via other means.")]
 			public JniValueMarshaler GetParameterMarshaler (ParameterInfo parameter)
 			{
 				if (parameter.ParameterType == typeof (IntPtr))

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
@@ -472,7 +472,8 @@ namespace Java.Interop {
 
 			static Type [] registerMethodParameters = new Type [] { typeof (JniNativeMethodRegistrationArguments) };
 
-			const string MarshalMethods = "'jni_marshal_methods' should be preserved via other means.";
+			// https://github.com/xamarin/xamarin-android/blob/5472eec991cc075e4b0c09cd98a2331fb93aa0f3/src/Microsoft.Android.Sdk.ILLink/PreserveRegistrations.cs#L85
+			const string MarshalMethods = "'jni_marshal_methods' is preserved by the PreserveRegistrations trimmer step.";
 
 			[UnconditionalSuppressMessage ("Trimming", "IL2072", Justification = MarshalMethods)]
 			[UnconditionalSuppressMessage ("Trimming", "IL2075", Justification = MarshalMethods)]

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
@@ -269,14 +269,15 @@ namespace Java.Interop {
 
 			static  readonly    string[]    EmptyStringArray    = Array.Empty<string> ();
 			static  readonly    Type[]      EmptyTypeArray      = Array.Empty<Type> ();
+			const string NotUsedInAndroid = "This code path is not used in Android projects.";
 
 			// FIXME: https://github.com/xamarin/java.interop/issues/1192
-			[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "This code path is not used in Android projects")]
+			[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = NotUsedInAndroid)]
 			static Type MakeArrayType (Type type) => type.MakeArrayType ();
 
 			// FIXME: https://github.com/xamarin/java.interop/issues/1192
-			[UnconditionalSuppressMessage ("Trimming", "IL2055", Justification = "This code path is not used in Android projects")]
-			[UnconditionalSuppressMessage ("AOT",      "IL3050", Justification = "This code path is not used in Android projects")]
+			[UnconditionalSuppressMessage ("Trimming", "IL2055", Justification = NotUsedInAndroid)]
+			[UnconditionalSuppressMessage ("AOT",      "IL3050", Justification = NotUsedInAndroid)]
 			static Type MakeGenericType (Type type, Type arrayType) => type.MakeGenericType (arrayType);
 
 

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
@@ -271,6 +271,7 @@ namespace Java.Interop {
 			static  readonly    Type[]      EmptyTypeArray      = Array.Empty<Type> ();
 
 
+			[UnconditionalSuppressMessage ("Trimming", "IL2073", Justification = "Types returned here should be preserved via other means.")]
 			[return: DynamicallyAccessedMembers (MethodsConstructorsInterfaces)]
 			public  Type?    GetType (JniTypeSignature typeSignature)
 			{
@@ -288,6 +289,8 @@ namespace Java.Interop {
 				return CreateGetTypesEnumerator (typeSignature);
 			}
 
+			[UnconditionalSuppressMessage ("Trimming", "IL2075", Justification = "JavaObjectArray<T> types should be preserved via other means.")]
+			[UnconditionalSuppressMessage ("AOT",      "IL3050", Justification = "Array types should be preserved via other means.")]
 			IEnumerable<Type> CreateGetTypesEnumerator (JniTypeSignature typeSignature)
 			{
 				if (!typeSignature.IsValid)
@@ -325,6 +328,8 @@ namespace Java.Interop {
 				}
 			}
 
+			[UnconditionalSuppressMessage ("Trimming", "IL2075", Justification = "JavaObjectArray<T> types should be preserved via other means.")]
+			[UnconditionalSuppressMessage ("AOT",      "IL3050", Justification = "Array types should be preserved via other means.")]
 			IEnumerable<Type> GetPrimitiveArrayTypesForSimpleReference (JniTypeSignature typeSignature, Type type)
 			{
 				int index   = -1;
@@ -462,6 +467,10 @@ namespace Java.Interop {
 
 			static Type [] registerMethodParameters = new Type [] { typeof (JniNativeMethodRegistrationArguments) };
 
+			const string MarshalMethods = "'jni_marshal_methods' should be preserved via other means.";
+
+			[UnconditionalSuppressMessage ("Trimming", "IL2072", Justification = MarshalMethods)]
+			[UnconditionalSuppressMessage ("Trimming", "IL2075", Justification = MarshalMethods)]
 			bool TryLoadJniMarshalMethods (
 					JniType nativeClass,
 					[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.NonPublicNestedTypes)]

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
@@ -270,6 +270,15 @@ namespace Java.Interop {
 			static  readonly    string[]    EmptyStringArray    = Array.Empty<string> ();
 			static  readonly    Type[]      EmptyTypeArray      = Array.Empty<Type> ();
 
+			// FIXME: https://github.com/xamarin/java.interop/issues/1192
+			[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "This code path is not used in Android projects")]
+			static Type MakeArrayType (Type type) => type.MakeArrayType ();
+
+			// FIXME: https://github.com/xamarin/java.interop/issues/1192
+			[UnconditionalSuppressMessage ("Trimming", "IL2055", Justification = "This code path is not used in Android projects")]
+			[UnconditionalSuppressMessage ("AOT",      "IL3050", Justification = "This code path is not used in Android projects")]
+			static Type MakeGenericType (Type type, Type arrayType) => type.MakeGenericType (arrayType);
+
 
 			[UnconditionalSuppressMessage ("Trimming", "IL2073", Justification = "Types returned here should be preserved via other means.")]
 			[return: DynamicallyAccessedMembers (MethodsConstructorsInterfaces)]
@@ -289,8 +298,6 @@ namespace Java.Interop {
 				return CreateGetTypesEnumerator (typeSignature);
 			}
 
-			[UnconditionalSuppressMessage ("Trimming", "IL2075", Justification = "JavaObjectArray<T> types should be preserved via other means.")]
-			[UnconditionalSuppressMessage ("AOT",      "IL3050", Justification = "Array types should be preserved via other means.")]
 			IEnumerable<Type> CreateGetTypesEnumerator (JniTypeSignature typeSignature)
 			{
 				if (!typeSignature.IsValid)
@@ -312,7 +319,7 @@ namespace Java.Interop {
 						var rank        = typeSignature.ArrayRank;
 						var arrayType   = type;
 						while (rank-- > 0) {
-							arrayType   = typeof (JavaObjectArray<>).MakeGenericType (arrayType);
+							arrayType   = MakeGenericType(typeof(JavaObjectArray<>), arrayType);
 						}
 						yield return arrayType;
 					}
@@ -321,15 +328,13 @@ namespace Java.Interop {
 						var rank        = typeSignature.ArrayRank;
 						var arrayType   = type;
 						while (rank-- > 0) {
-							arrayType   = arrayType.MakeArrayType ();
+							arrayType   = MakeArrayType (arrayType);
 						}
 						yield return arrayType;
 					}
 				}
 			}
 
-			[UnconditionalSuppressMessage ("Trimming", "IL2075", Justification = "JavaObjectArray<T> types should be preserved via other means.")]
-			[UnconditionalSuppressMessage ("AOT",      "IL3050", Justification = "Array types should be preserved via other means.")]
 			IEnumerable<Type> GetPrimitiveArrayTypesForSimpleReference (JniTypeSignature typeSignature, Type type)
 			{
 				int index   = -1;
@@ -346,14 +351,14 @@ namespace Java.Interop {
 					var rank        = typeSignature.ArrayRank-1;
 					var arrayType   = t;
 					while (rank-- > 0) {
-						arrayType   = typeof (JavaObjectArray<>).MakeGenericType (arrayType);
+						arrayType   = MakeGenericType (typeof (JavaObjectArray<>), arrayType);
 					}
 					yield return arrayType;
 
 					rank            = typeSignature.ArrayRank-1;
 					arrayType       = t;
 					while (rank-- > 0) {
-						arrayType   = arrayType.MakeArrayType ();
+						arrayType   = MakeArrayType (arrayType);
 					}
 					yield return arrayType;
 				}

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
@@ -319,7 +319,7 @@ namespace Java.Interop {
 						var rank        = typeSignature.ArrayRank;
 						var arrayType   = type;
 						while (rank-- > 0) {
-							arrayType   = MakeGenericType(typeof(JavaObjectArray<>), arrayType);
+							arrayType   = MakeGenericType (typeof (JavaObjectArray<>), arrayType);
 						}
 						yield return arrayType;
 					}

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
@@ -280,7 +280,6 @@ namespace Java.Interop {
 			[UnconditionalSuppressMessage ("AOT",      "IL3050", Justification = NotUsedInAndroid)]
 			static Type MakeGenericType (Type type, Type arrayType) => type.MakeGenericType (arrayType);
 
-
 			[UnconditionalSuppressMessage ("Trimming", "IL2073", Justification = "Types returned here should be preserved via other means.")]
 			[return: DynamicallyAccessedMembers (MethodsConstructorsInterfaces)]
 			public  Type?    GetType (JniTypeSignature typeSignature)

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -355,29 +355,40 @@ namespace Java.Interop
 				return null;
 			}
 
-			const string AssemblyGetType = "'Invoker' types are preserved via other means.";
-			const string MakeGenericType = "Generic 'Invoker' types are preserved via other means.";
-
 			[return: DynamicallyAccessedMembers (Constructors)]
-			[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = AssemblyGetType)]
-			[UnconditionalSuppressMessage ("Trimming", "IL2073", Justification = AssemblyGetType)]
-			[UnconditionalSuppressMessage ("Trimming", "IL2055", Justification = MakeGenericType)]
-			[UnconditionalSuppressMessage ("AOT",      "IL3050", Justification = MakeGenericType)]
 			static Type? GetInvokerType (Type type)
 			{
 				const string suffix = "Invoker";
+
+				// https://github.com/xamarin/xamarin-android/blob/5472eec991cc075e4b0c09cd98a2331fb93aa0f3/src/Microsoft.Android.Sdk.ILLink/MarkJavaObjects.cs#L176-L186
+				const string assemblyGetTypeMessage = "'Invoker' types are preserved by the MarkJavaObjects trimmer step.";
+				const string makeGenericTypeMessage = "Generic 'Invoker' types are preserved by the MarkJavaObjects trimmer step.";
+
+				[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = assemblyGetTypeMessage)]
+				[UnconditionalSuppressMessage ("Trimming", "IL2073", Justification = assemblyGetTypeMessage)]
+				[return: DynamicallyAccessedMembers (Constructors)]
+				static Type? AssemblyGetType(Assembly assembly, string typeName) =>
+					assembly.GetType (typeName);
+
+				[UnconditionalSuppressMessage ("Trimming", "IL2055", Justification = makeGenericTypeMessage)]
+				// FIXME: https://github.com/xamarin/java.interop/issues/1192
+				[UnconditionalSuppressMessage ("AOT",      "IL3050", Justification = makeGenericTypeMessage)]
+				[return: DynamicallyAccessedMembers (Constructors)]
+				static Type MakeGenericType (Type type, Type [] arguments) =>
+					type.MakeGenericType (arguments);
+
 				Type[] arguments = type.GetGenericArguments ();
 				if (arguments.Length == 0)
-					return type.Assembly.GetType (type + suffix);
+					return AssemblyGetType (type.Assembly, type + suffix);
 				Type definition = type.GetGenericTypeDefinition ();
 				int bt = definition.FullName!.IndexOf ("`", StringComparison.Ordinal);
 				if (bt == -1)
 					throw new NotSupportedException ("Generic type doesn't follow generic type naming convention! " + type.FullName);
-				Type? suffixDefinition = definition.Assembly.GetType (
+				Type? suffixDefinition = AssemblyGetType (definition.Assembly,
 						definition.FullName.Substring (0, bt) + suffix + definition.FullName.Substring (bt));
 				if (suffixDefinition == null)
 					return null;
-				return suffixDefinition.MakeGenericType (arguments);
+				return MakeGenericType (suffixDefinition, arguments);
 			}
 
 			public object? CreateValue (

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -367,7 +367,7 @@ namespace Java.Interop
 				[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = assemblyGetTypeMessage)]
 				[UnconditionalSuppressMessage ("Trimming", "IL2073", Justification = assemblyGetTypeMessage)]
 				[return: DynamicallyAccessedMembers (Constructors)]
-				static Type? AssemblyGetType(Assembly assembly, string typeName) =>
+				static Type? AssemblyGetType (Assembly assembly, string typeName) =>
 					assembly.GetType (typeName);
 
 				// FIXME: https://github.com/xamarin/java.interop/issues/1192

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -370,8 +370,8 @@ namespace Java.Interop
 				static Type? AssemblyGetType(Assembly assembly, string typeName) =>
 					assembly.GetType (typeName);
 
-				[UnconditionalSuppressMessage ("Trimming", "IL2055", Justification = makeGenericTypeMessage)]
 				// FIXME: https://github.com/xamarin/java.interop/issues/1192
+				[UnconditionalSuppressMessage ("Trimming", "IL2055", Justification = makeGenericTypeMessage)]
 				[UnconditionalSuppressMessage ("AOT",      "IL3050", Justification = makeGenericTypeMessage)]
 				[return: DynamicallyAccessedMembers (Constructors)]
 				static Type MakeGenericType (Type type, Type [] arguments) =>
@@ -650,15 +650,19 @@ namespace Java.Interop
 				return GetValueMarshalerCore (type);
 			}
 
-			const string MakeGenericMethod = "Generic methods used here, should be preserved via other means.";
-
-			[UnconditionalSuppressMessage ("Trimming", "IL2060", Justification = MakeGenericMethod)]
-			[UnconditionalSuppressMessage ("AOT",      "IL3050", Justification = MakeGenericMethod)]
 			static JniValueMarshaler GetObjectArrayMarshaler (Type elementType)
 			{
+				const string makeGenericMethodMessage = "This code path is not used in Android projects.";
+
+				// FIXME: https://github.com/xamarin/java.interop/issues/1192
+				[UnconditionalSuppressMessage ("Trimming", "IL2060", Justification = makeGenericMethodMessage)]
+				[UnconditionalSuppressMessage ("AOT",      "IL3050", Justification = makeGenericMethodMessage)]
+				static MethodInfo MakeGenericMethod (MethodInfo method, Type type) =>
+					method.MakeGenericMethod (type);
+
 				Func<JniValueMarshaler> indirect = GetObjectArrayMarshalerHelper<object>;
-				var reifiedMethodInfo = indirect.Method.GetGenericMethodDefinition ()
-					.MakeGenericMethod (elementType);
+				var reifiedMethodInfo = MakeGenericMethod (
+						indirect.Method.GetGenericMethodDefinition (), elementType);
 				Func<JniValueMarshaler> direct = (Func<JniValueMarshaler>) Delegate.CreateDelegate (typeof (Func<JniValueMarshaler>), reifiedMethodInfo);
 				return direct ();
 			}

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -355,7 +355,14 @@ namespace Java.Interop
 				return null;
 			}
 
+			const string AssemblyGetType = "'Invoker' types are preserved via other means.";
+			const string MakeGenericType = "Generic 'Invoker' types are preserved via other means.";
+
 			[return: DynamicallyAccessedMembers (Constructors)]
+			[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = AssemblyGetType)]
+			[UnconditionalSuppressMessage ("Trimming", "IL2073", Justification = AssemblyGetType)]
+			[UnconditionalSuppressMessage ("Trimming", "IL2055", Justification = MakeGenericType)]
+			[UnconditionalSuppressMessage ("AOT",      "IL3050", Justification = MakeGenericType)]
 			static Type? GetInvokerType (Type type)
 			{
 				const string suffix = "Invoker";
@@ -632,6 +639,10 @@ namespace Java.Interop
 				return GetValueMarshalerCore (type);
 			}
 
+			const string MakeGenericMethod = "Generic methods used here, should be preserved via other means.";
+
+			[UnconditionalSuppressMessage ("Trimming", "IL2060", Justification = MakeGenericMethod)]
+			[UnconditionalSuppressMessage ("AOT",      "IL3050", Justification = MakeGenericMethod)]
 			static JniValueMarshaler GetObjectArrayMarshaler (Type elementType)
 			{
 				Func<JniValueMarshaler> indirect = GetObjectArrayMarshalerHelper<object>;

--- a/src/Java.Interop/Java.Interop/JniValueMarshalerAttribute.cs
+++ b/src/Java.Interop/Java.Interop/JniValueMarshalerAttribute.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System;
 using System.Diagnostics.CodeAnalysis;
@@ -8,13 +8,16 @@ namespace Java.Interop {
 
 	[AttributeUsage (Targets, AllowMultiple=false)]
 	public class JniValueMarshalerAttribute : Attribute {
+		const DynamicallyAccessedMemberTypes ParameterlessConstructorsInterfaces = DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.Interfaces;
 
 		const   AttributeTargets    Targets =
 			AttributeTargets.Class | AttributeTargets.Enum |
 			AttributeTargets.Interface | AttributeTargets.Struct |
 			AttributeTargets.Parameter | AttributeTargets.ReturnValue;
 
-		public JniValueMarshalerAttribute (Type marshalerType)
+		public JniValueMarshalerAttribute (
+				[DynamicallyAccessedMembers (ParameterlessConstructorsInterfaces)]
+				Type marshalerType)
 		{
 			if (marshalerType == null)
 				throw new ArgumentNullException (nameof (marshalerType));
@@ -27,7 +30,7 @@ namespace Java.Interop {
 		}
 
 		public  Type    MarshalerType   {
-			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+			[return: DynamicallyAccessedMembers (ParameterlessConstructorsInterfaces)]
 			get;
 		}
 	}

--- a/src/Java.Interop/Java.Interop/ManagedPeer.cs
+++ b/src/Java.Interop/Java.Interop/ManagedPeer.cs
@@ -231,7 +231,7 @@ namespace Java.Interop {
 		{
 			// https://github.com/xamarin/xamarin-android/blob/5472eec991cc075e4b0c09cd98a2331fb93aa0f3/src/Microsoft.Android.Sdk.ILLink/MarkJavaObjects.cs#L51-L132
 			[UnconditionalSuppressMessage ("Trimming", "IL2072", Justification = "Constructors are preserved by the MarkJavaObjects trimmer step.")]
-			static object? ValueManagerGetValue(JniRuntime runtime, ref JniObjectReference value, ParameterInfo parameter) =>
+			static object? ValueManagerGetValue (JniRuntime runtime, ref JniObjectReference value, ParameterInfo parameter) =>
 				runtime.ValueManager.GetValue (ref value, JniObjectReferenceOptions.CopyAndDispose, parameter.ParameterType);
 
 			if (!values.IsValid)

--- a/src/Java.Interop/Java.Interop/ManagedPeer.cs
+++ b/src/Java.Interop/Java.Interop/ManagedPeer.cs
@@ -227,9 +227,13 @@ namespace Java.Interop {
 			return candidateParameterTypes;
 		}
 
-		[UnconditionalSuppressMessage ("Trimming", "IL2072", Justification = "Constructor parameter types should be preserved via other means.")]
 		static object?[]? GetValues (JniRuntime runtime, JniObjectReference values, ConstructorInfo cinfo)
 		{
+			// https://github.com/xamarin/xamarin-android/blob/5472eec991cc075e4b0c09cd98a2331fb93aa0f3/src/Microsoft.Android.Sdk.ILLink/MarkJavaObjects.cs#L51-L132
+			[UnconditionalSuppressMessage ("Trimming", "IL2072", Justification = "Constructors are preserved by the MarkJavaObjects trimmer step.")]
+			static object? ValueManagerGetValue(JniRuntime runtime, ref JniObjectReference value, ParameterInfo parameter) =>
+				runtime.ValueManager.GetValue (ref value, JniObjectReferenceOptions.CopyAndDispose, parameter.ParameterType);
+
 			if (!values.IsValid)
 				return null;
 
@@ -241,7 +245,7 @@ namespace Java.Interop {
 			var pvalues = new object? [len];
 			for (int i = 0; i < len; ++i) {
 				var n_value = JniEnvironment.Arrays.GetObjectArrayElement (values, i);
-				var value   = runtime.ValueManager.GetValue (ref n_value, JniObjectReferenceOptions.CopyAndDispose, parameters [i].ParameterType);
+				var value   = ValueManagerGetValue (runtime, ref n_value, parameters [i]);
 				pvalues [i] = value;
 			}
 

--- a/src/Java.Interop/Java.Interop/ManagedPeer.cs
+++ b/src/Java.Interop/Java.Interop/ManagedPeer.cs
@@ -227,6 +227,7 @@ namespace Java.Interop {
 			return candidateParameterTypes;
 		}
 
+		[UnconditionalSuppressMessage ("Trimming", "IL2072", Justification = "Constructor parameter types should be preserved via other means.")]
 		static object?[]? GetValues (JniRuntime runtime, JniObjectReference values, ConstructorInfo cinfo)
 		{
 			if (!values.IsValid)

--- a/src/Java.Interop/Properties/AssemblyInfo.cs
+++ b/src/Java.Interop/Properties/AssemblyInfo.cs
@@ -6,7 +6,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription ("")]
 [assembly: AssemblyCulture ("")]
 [assembly: AssemblyTrademark ("Microsoft Corporation")]
-[assembly: AssemblyMetadata ("IsTrimmable", "True")]
 
 [assembly: InternalsVisibleTo (
 	"Java.Interop.GenericMarshaler, PublicKey=" +


### PR DESCRIPTION
Fixes: https://github.com/xamarin/java.interop/issues/1157

The remaining trimmer warnings are around usage of System.Reflection such as:

* Create an `Invoker` type from an original type via `Type.Assembly.GetType()`

* Create a `Type` based on a `ParameterInfo.ParameterType` and/or create instances

* Use `Type.MakeGenericType()`

* Use `Type.MakeArrayType()`

The trimming warnings themselves all indicate that these types "might be trimmed", in that nothing explicitly preserves them. However, we have a plethora of custom trimmer steps that work to preserve these types involved in Java interop, such as:

* https://github.com/xamarin/xamarin-android/blob/main/src/Microsoft.Android.Sdk.ILLink/PreserveApplications.cs
* https://github.com/xamarin/xamarin-android/blob/main/src/Microsoft.Android.Sdk.ILLink/PreserveExportedTypes.cs
* https://github.com/xamarin/xamarin-android/blob/main/src/Microsoft.Android.Sdk.ILLink/PreserveJavaExceptions.cs
* https://github.com/xamarin/xamarin-android/blob/main/src/Microsoft.Android.Sdk.ILLink/PreserveJavaInterfaces.cs
* https://github.com/xamarin/xamarin-android/blob/main/src/Microsoft.Android.Sdk.ILLink/PreserveRegistrations.cs

One day, in a perfect world, we could remove these trimmer steps and completely rely on the trimmer's warnings & attributing mechanisms. That day doesn't have to be today -- as our goal is begin surfacing trimmer warnings to users in their own code and dependencies.

With these warnings ignored, we can fully enable analyzers with:

    <IsTrimmable>true</IsTrimmable>
    <EnableAotAnalyzer>true</EnableAotAnalyzer>

We can then remove:

    [assembly: AssemblyMetadata ("IsTrimmable", "True")]

As the MSBuild property does this for us, in addition to enabling analyzers.

I don't think we should enable `$(IsAotCompatible)` quite yet, as `Java.Interop.dll` likely *won't work* yet on NativeAOT, and this places metadata that says an assembly is supported. We should just use the `$(EnableAotAnalyzer)` analyzers for now, so we don't introduce new issues.