### PR TITLE
Add Ability to write out the list of files generated.

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,9 +4,22 @@
     "version": "2.0.0",
     "tasks": [
         {
+            "label": "Prepare Java.Interop",
+            "type": "shell",
+            "command": "dotnet build Java.Interop.sln -t:Prepare",
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            },
+            "problemMatcher": [
+                "$msCompile"
+            ]
+        },
+        {
             "label": "Build Java.Interop",
             "type": "shell",
-            "command": "msbuild Java.Interop.sln /restore /t:Build",
+            "command": "dotnet build Java.Interop.sln",
+            "dependsOn": [ "Prepare Java.Interop" ],
             "group": {
                 "kind": "build",
                 "isDefault": true
@@ -18,10 +31,10 @@
         {
             "label": "Clean Java.Interop",
             "type": "shell",
-            "command": "msbuild Java.Interop.sln /restore /t:Clean",
+            "command": "dotnet build Java.Interop.sln -t:Clean",
             "group": {
                 "kind": "build",
-                "isDefault": true
+                "isDefault": false
             },
             "problemMatcher": [
                 "$msCompile"
@@ -30,10 +43,10 @@
         {
             "label": "Build Generator",
             "type": "shell",
-            "command": "msbuild tools/generator/generator.sln /restore /t:Build",
+            "command": "dotnet build tools/generator/generator.csproj",
             "group": {
                 "kind": "build",
-                "isDefault": true
+                "isDefault": false
             },
             "problemMatcher": [
                 "$msCompile"
@@ -42,26 +55,14 @@
         {
             "label": "Clean Generator",
             "type": "shell",
-            "command": "msbuild tools/generator/generator.sln /restore /t:Clean",
+            "command": "dotnet build tools/generator/generator.csproj -t:Clean",
             "group": {
                 "kind": "build",
-                "isDefault": true
+                "isDefault": false
             },
             "problemMatcher": [
                 "$msCompile"
             ]
         },
-        {
-            "label": "Run Generator Unit Tests",
-            "type": "shell",
-            "command": "msbuild tools/generator/generator.sln /restore /t:RunNunitTests",
-            "group": {
-                "kind": "test",
-                "isDefault": true
-            },
-            "problemMatcher": [
-                "$msCompile"
-            ]
-        }
     ]
 }

--- a/tools/generator/CodeGenerationOptions.cs
+++ b/tools/generator/CodeGenerationOptions.cs
@@ -66,6 +66,7 @@ namespace MonoDroid.Generation
 		public bool UseObsoletedOSPlatformAttributes { get; set; }
 		public bool UseRestrictToAttributes { get; set; }
 		public bool RemoveConstSugar => BuildingCoreAssembly;
+		public string GeneratedFilesOutputFile { get; set; }
 
 		bool? buildingCoreAssembly;
 		// Basically this means "Are we building Mono.Android.dll?"

--- a/tools/generator/CodeGenerator.cs
+++ b/tools/generator/CodeGenerator.cs
@@ -71,6 +71,7 @@ namespace Xamarin.Android.Binder
 			string mapping_file     = options.MappingReportFile;
 			bool only_xml_adjuster  = options.OnlyRunApiXmlAdjuster;
 			string api_xml_adjuster_output = options.ApiXmlAdjusterOutput;
+			string generatedFilesOutputFile = options.GeneratedFilesOutputFile;
 			var apiSource           = "";
 			var opt                 = new CodeGenerationOptions () {
 				ApiXmlFile            = options.ApiDescriptionFile,
@@ -255,6 +256,7 @@ namespace Xamarin.Android.Binder
 				: enummap.WriteEnumerations (enumdir, enums, FlattenNestedTypes (gens).ToArray (), opt);
 
 			gen_info.GenerateLibraryProjectFile (options, enumFiles);
+			gen_info.GenerateFileList (options, generatedFilesOutputFile);
 		}
 
 		static void AddTypeToTable (CodeGenerationOptions opt, GenBase gb)

--- a/tools/generator/CodeGeneratorOptions.cs
+++ b/tools/generator/CodeGeneratorOptions.cs
@@ -55,6 +55,7 @@ namespace Xamarin.Android.Binder
 		public bool		    UseRestrictToAttributes { get; set; }
 		public bool		    UseLegacyJavaResolver { get; set; }
 		public bool			UseObsoletedOSPlatformAttributes { get; set; }
+		public string		GeneratedFilesOutputFile { get; set; }
 
 		public XmldocStyle		    XmldocStyle { get; set; } = XmldocStyle.IntelliSense;
 
@@ -134,6 +135,9 @@ namespace Xamarin.Android.Binder
 				{ "xml-adjuster-output=",
 					"specify API XML adjuster output XML for class-parse input.",
 					v => opts.ApiXmlAdjusterOutput = v },
+				{ "generated-files-output-file=",
+					"specify the path to write the list of generated files",
+					v => opts.GeneratedFilesOutputFile = v },
 				{ "h|?|help",
 					"Show this message and exit.",
 					v => show_help = v != null },

--- a/tools/generator/GenerationInfo.cs
+++ b/tools/generator/GenerationInfo.cs
@@ -37,6 +37,22 @@ namespace MonoDroid.Generation {
 			return sw;
 		}
 
+		internal void GenerateFileList (CodeGeneratorOptions options, string path = null)
+		{
+			if (path == null) {
+				var     name    = Assembly ?? "GeneratedFiles";
+				int     idx     = name.IndexOf (',');
+				name            = idx < 0 ? name : name.Substring (0, idx);
+				path            = Path.Combine (CSharpDir, name + ".FileList.txt");
+			}
+			var sb = new StringBuilder ();
+			foreach (var file in GeneratedFiles
+						.OrderBy (f => f, StringComparer.OrdinalIgnoreCase)) {
+				sb.AppendLine (file);
+			}
+			File.WriteAllText (path, sb.ToString ());
+		}
+
 		internal void GenerateLibraryProjectFile (CodeGeneratorOptions options, IEnumerable<string> enumFiles, string path = null)
 		{
 			if (path == null) {


### PR DESCRIPTION
Currently if a user removes a file for a binding the generated C# code file is NOT removed until the end of the build. This is because the Incremental Clean does not happen until the end of the build process. So
we end up with old unused code in the assembly.

That this PR does is to add the ability for the generator to write a list of the files it generated during this run. This can then be compared by the calling app
with the list of current files and the deleted ones can then be removed.

This will be useful for supporting incremental build support for bindings.

This never was a problem, but now with binding happening inside the application project via `AndroidLibrary` or `AndroidJavaSource` it is important to make sure we do not include code that is no longer being generated. Especially for intellisense.

The simple text file format was chosen because all we need is a list of files. This can be loaded by MSBuild and compared directly against the results of

```
<ItemGroup>
    <Foo Include="obj\Debug\generated\src\*.cs" />
</ItemGroup>
```

If we used the existing `.projitems` file there would be some additional work as we would need to parse the xml data.

### Additional Fixes

Fixed up some of the vscode tasks which no longer worked.