### PR TITLE
[Java.Interop.Tools.JavaCallableWrappers] fix net8.0 targeting in XA

### DIFF
--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers.csproj
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers.csproj
@@ -5,9 +5,16 @@
   </PropertyGroup>
   <Import Condition="Exists ('$(XAConfigPath)')" Project="$(XAConfigPath)" />
 
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;$(DotNetTargetFramework)</TargetFrameworks>
+  <PropertyGroup Condition=" '$(XABuild)' == 'true' ">
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(XABuild)' != 'true' ">
+    <TargetFrameworks>netstandard2.0;$(DotNetTargetFramework)</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <LangVersion>11.0</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers.csproj
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers.csproj
@@ -1,20 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <XAConfigPath>..\..\bin\Build$(Configuration)\XAConfig.props</XAConfigPath>
-  </PropertyGroup>
-  <Import Condition="Exists ('$(XAConfigPath)')" Project="$(XAConfigPath)" />
-
-  <PropertyGroup Condition=" '$(XABuild)' == 'true' ">
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(XABuild)' != 'true' ">
     <TargetFrameworks>netstandard2.0;$(DotNetTargetFramework)</TargetFrameworks>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <LangVersion>11.0</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers.csproj
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers.csproj
@@ -13,7 +13,8 @@
 
   <Import Project="..\..\TargetFrameworkDependentValues.props" />
 
-  <PropertyGroup>
+  <!-- Only use $(ToolOutputFullPath) for netstandard2.0 -->
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <OutputPath>$(ToolOutputFullPath)</OutputPath>
   </PropertyGroup>
 


### PR DESCRIPTION
xamarin/xamarin-android's build began failing with:

    (CoreCompile target) ->
    Xamarin.Android.Build.Tasks\Utilities\MamJsonParser.cs(92,43): error CS0122: 'NotNullWhenAttribute' is inaccessible due to its protection level [Xamarin.Android.Build.Tasks\Xamarin.Android.Build.Tasks.csproj]
    Xamarin.Android.Build.Tasks\Utilities\MamJsonParser.cs(92,81): error CS0122: 'NotNullWhenAttribute' is inaccessible due to its protection level [Xamarin.Android.Build.Tasks\Xamarin.Android.Build.Tasks.csproj]
    Xamarin.Android.Build.Tasks\Utilities\MavenExtensions.cs(26,32): error CS0122: 'NotNullWhenAttribute' is inaccessible due to its protection level [Xamarin.Android.Build.Tasks\Xamarin.Android.Build.Tasks.csproj]

This was happening because the `net8.0` build of
`Java.Interop.Tools.JavaCallableWrappers.dll` was being used and should not be: we want the `netstandard2.0` version to be used for MSBuild task assemblies.

To fix this:

* Only set `$(OutputPath)` to `$(ToolOutputFullPath)` for `netstandard2.0`

This solves the build error above.

Other cleanup:

* No need to import `XAConfig.props`, as it no longer exists

* No need to set `$(AppendTargetFrameworkToOutputPath)`, as it is already in `Directory.Build.props`