### PR TITLE
[Java.Interop.Tools.TypeNameMappings] introduce project for net8.0

### DIFF
--- a/Java.Interop.sln
+++ b/Java.Interop.sln
@@ -115,7 +115,9 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Java.Interop.Tools.Expressi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hello-NativeAOTFromJNI", "samples\Hello-NativeAOTFromJNI\Hello-NativeAOTFromJNI.csproj", "{8DB3842B-73D7-491C-96F9-EBC863E2C917}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Java.Interop.Tools.TypeNameMappings", "src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.csproj", "{421B9ECE-2393-41C5-AF65-A3BE2B632A83}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{40B3CE2F-B8DE-45CD-A43A-0F1A89BDB803}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Java.Interop.Tools.TypeNameMappings", "src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.csproj", "{C2AF6ACF-04F6-4B41-95EA-97A372C075F9}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -328,10 +330,10 @@ Global
 		{8DB3842B-73D7-491C-96F9-EBC863E2C917}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8DB3842B-73D7-491C-96F9-EBC863E2C917}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8DB3842B-73D7-491C-96F9-EBC863E2C917}.Release|Any CPU.Build.0 = Release|Any CPU
-		{421B9ECE-2393-41C5-AF65-A3BE2B632A83}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{421B9ECE-2393-41C5-AF65-A3BE2B632A83}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{421B9ECE-2393-41C5-AF65-A3BE2B632A83}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{421B9ECE-2393-41C5-AF65-A3BE2B632A83}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C2AF6ACF-04F6-4B41-95EA-97A372C075F9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C2AF6ACF-04F6-4B41-95EA-97A372C075F9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C2AF6ACF-04F6-4B41-95EA-97A372C075F9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C2AF6ACF-04F6-4B41-95EA-97A372C075F9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -387,7 +389,7 @@ Global
 		{1A0262FE-3CDB-4AF2-AAD8-65C59524FE8A} = {0998E45F-8BCE-4791-A944-962CD54E2D80}
 		{211BAA88-66B1-41B2-88B2-530DBD8DF702} = {271C9F30-F679-4793-942B-0D9527CB3E2F}
 		{8DB3842B-73D7-491C-96F9-EBC863E2C917} = {D5A93398-AEB1-49F3-89DC-3904A47DB0C7}
-		{421B9ECE-2393-41C5-AF65-A3BE2B632A83} = {F8FEE1C4-3F99-4229-8C94-3883036A744B}
+		{C2AF6ACF-04F6-4B41-95EA-97A372C075F9} = {40B3CE2F-B8DE-45CD-A43A-0F1A89BDB803}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {29204E0C-382A-49A0-A814-AD7FBF9774A5}

--- a/Java.Interop.sln
+++ b/Java.Interop.sln
@@ -115,6 +115,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Java.Interop.Tools.Expressi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hello-NativeAOTFromJNI", "samples\Hello-NativeAOTFromJNI\Hello-NativeAOTFromJNI.csproj", "{8DB3842B-73D7-491C-96F9-EBC863E2C917}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Java.Interop.Tools.TypeNameMappings", "src\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings.csproj", "{421B9ECE-2393-41C5-AF65-A3BE2B632A83}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Java.Interop.NamingCustomAttributes\Java.Interop.NamingCustomAttributes.projitems*{58b564a1-570d-4da2-b02d-25bddb1a9f4f}*SharedItemsImports = 5
@@ -326,6 +328,10 @@ Global
 		{8DB3842B-73D7-491C-96F9-EBC863E2C917}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8DB3842B-73D7-491C-96F9-EBC863E2C917}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8DB3842B-73D7-491C-96F9-EBC863E2C917}.Release|Any CPU.Build.0 = Release|Any CPU
+		{421B9ECE-2393-41C5-AF65-A3BE2B632A83}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{421B9ECE-2393-41C5-AF65-A3BE2B632A83}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{421B9ECE-2393-41C5-AF65-A3BE2B632A83}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{421B9ECE-2393-41C5-AF65-A3BE2B632A83}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -381,6 +387,7 @@ Global
 		{1A0262FE-3CDB-4AF2-AAD8-65C59524FE8A} = {0998E45F-8BCE-4791-A944-962CD54E2D80}
 		{211BAA88-66B1-41B2-88B2-530DBD8DF702} = {271C9F30-F679-4793-942B-0D9527CB3E2F}
 		{8DB3842B-73D7-491C-96F9-EBC863E2C917} = {D5A93398-AEB1-49F3-89DC-3904A47DB0C7}
+		{421B9ECE-2393-41C5-AF65-A3BE2B632A83} = {F8FEE1C4-3F99-4229-8C94-3883036A744B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {29204E0C-382A-49A0-A814-AD7FBF9774A5}

--- a/src/Java.Interop.Tools.TypeNameMappings/Java.Interop.Tools.TypeNameMappings.csproj
+++ b/src/Java.Interop.Tools.TypeNameMappings/Java.Interop.Tools.TypeNameMappings.csproj
@@ -1,32 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>11.0</LangVersion>
+    <TargetFramework>$(DotNetTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <SignAssembly>true</SignAssembly>
-    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
-    <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
+    <IsTrimmable>true</IsTrimmable>
+    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
     <DefineConstants>$(DefineConstants);JCW_ONLY_TYPE_NAMES;HAVE_CECIL</DefineConstants>
   </PropertyGroup>
 
   <Import Project="..\..\TargetFrameworkDependentValues.props" />
-
-  <PropertyGroup>
-    <OutputPath>$(ToolOutputFullPath)</OutputPath>
-  </PropertyGroup>
-
   <Import Project="..\..\build-tools\scripts\cecil.projitems" />
-
-  <ItemGroup>
-    <Compile Include="..\Java.Interop.Tools.TypeNameMappings\Java.Interop.Tools.TypeNameMappings\JavaNativeTypeManager.cs">
-      <Link>JavaNativeTypeManager.cs</Link>
-    </Compile>
-    <Compile Include="..\utils\NullableAttributes.cs">
-      <Link>NullableAttributes.cs</Link>
-    </Compile>
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Java.Interop.Localization\Java.Interop.Localization.csproj" />
@@ -35,7 +19,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+    <Compile Include="..\Java.Interop.Tools.JavaCallableWrappers\Java.Interop.Tools.JavaCallableWrappers\Crc64.cs" />
+    <Compile Include="..\Java.Interop.Tools.JavaCallableWrappers\Java.Interop.Tools.JavaCallableWrappers\Crc64.Table.cs" />
+    <Compile Include="..\Java.Interop.Tools.JavaCallableWrappers\Java.Interop.Tools.JavaCallableWrappers\Crc64Helper.cs" />
   </ItemGroup>
 
   <Import Project="..\Java.Interop.NamingCustomAttributes\Java.Interop.NamingCustomAttributes.projitems" Label="Shared" Condition="Exists('..\Java.Interop.NamingCustomAttributes\Java.Interop.NamingCustomAttributes.projitems')" />


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=9137456&view=logs&j=96fd57f5-f69e-53c7-3d47-f67e6cf9b93e&s=1afc3bfe-122c-538b-e9ad-2a86c2efcfef&t=38f83f46-bc21-5edd-1614-e44f20babf10&l=29658

xamarin/xamarin-android now has a random build failure:

    "Xamarin.Android.sln" (default target) (1:2) ->
    "src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj" (default target) (28:9) ->
    (CoreCompile target) ->
        src/Xamarin.Android.Build.Tasks/Utilities/MamJsonParser.cs(92,43): error CS0122: 'NotNullWhenAttribute' is inaccessible due to its protection level [src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj]
        src/Xamarin.Android.Build.Tasks/Utilities/MamJsonParser.cs(92,81): error CS0122: 'NotNullWhenAttribute' is inaccessible due to its protection level [src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj]
        src/Xamarin.Android.Build.Tasks/Utilities/MavenExtensions.cs(26,32): error CS0122: 'NotNullWhenAttribute' is inaccessible due to its protection level [src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj]

It happens some percentage of the time... It appears the cause is the `net8.0` `Java.Interop.Tools.JavaCallableWrappers.dll` is being used when the `netstandard2.0` version should be used.

To fix this:

* Don't build `Java.Interop.Tools.JavaCallableWrappers.csproj` for `net8.0` anymore.

* Introduce a new `net8.0` `Java.Interop.Tools.TypeNameMappings.csproj` that isn't shipped or used. It can check trimmer warnings, though.

This partially reverts 67c079c and 56b7eeb.