### PR TITLE
[Java.Interop] suppress IL3050 with `#pragma`

### DIFF
--- a/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
@@ -271,14 +271,18 @@ namespace Java.Interop {
 			static  readonly    Type[]      EmptyTypeArray      = Array.Empty<Type> ();
 			const string NotUsedInAndroid = "This code path is not used in Android projects.";
 
-			// FIXME: https://github.com/xamarin/java.interop/issues/1192
-			[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = NotUsedInAndroid)]
-			static Type MakeArrayType (Type type) => type.MakeArrayType ();
+			static Type MakeArrayType (Type type) =>
+				// FIXME: https://github.com/xamarin/java.interop/issues/1192
+				#pragma warning disable IL3050
+				type.MakeArrayType ();
+				#pragma warning restore IL3050
 
-			// FIXME: https://github.com/xamarin/java.interop/issues/1192
 			[UnconditionalSuppressMessage ("Trimming", "IL2055", Justification = NotUsedInAndroid)]
-			[UnconditionalSuppressMessage ("AOT",      "IL3050", Justification = NotUsedInAndroid)]
-			static Type MakeGenericType (Type type, Type arrayType) => type.MakeGenericType (arrayType);
+			static Type MakeGenericType (Type type, Type arrayType) =>
+				// FIXME: https://github.com/xamarin/java.interop/issues/1192
+				#pragma warning disable IL3050
+				type.MakeGenericType (arrayType);
+				#pragma warning restore IL3050
 
 			[UnconditionalSuppressMessage ("Trimming", "IL2073", Justification = "Types returned here should be preserved via other means.")]
 			[return: DynamicallyAccessedMembers (MethodsConstructorsInterfaces)]

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -370,15 +370,16 @@ namespace Java.Interop
 				static Type? AssemblyGetType (Assembly assembly, string typeName) =>
 					assembly.GetType (typeName);
 
-				// FIXME: https://github.com/xamarin/java.interop/issues/1192
 				[UnconditionalSuppressMessage ("Trimming", "IL2055", Justification = makeGenericTypeMessage)]
-				[UnconditionalSuppressMessage ("AOT",      "IL3050", Justification = makeGenericTypeMessage)]
 				[return: DynamicallyAccessedMembers (Constructors)]
 				static Type MakeGenericType (
 						[DynamicallyAccessedMembers (Constructors)]
 						Type type,
 						Type [] arguments) =>
+					// FIXME: https://github.com/xamarin/java.interop/issues/1192
+					#pragma warning disable IL3050
 					type.MakeGenericType (arguments);
+					#pragma warning restore IL3050
 
 				Type[] arguments = type.GetGenericArguments ();
 				if (arguments.Length == 0)
@@ -657,11 +658,12 @@ namespace Java.Interop
 			{
 				const string makeGenericMethodMessage = "This code path is not used in Android projects.";
 
-				// FIXME: https://github.com/xamarin/java.interop/issues/1192
 				[UnconditionalSuppressMessage ("Trimming", "IL2060", Justification = makeGenericMethodMessage)]
-				[UnconditionalSuppressMessage ("AOT",      "IL3050", Justification = makeGenericMethodMessage)]
 				static MethodInfo MakeGenericMethod (MethodInfo method, Type type) =>
+					// FIXME: https://github.com/xamarin/java.interop/issues/1192
+					#pragma warning disable IL3050
 					method.MakeGenericMethod (type);
+					#pragma warning restore IL3050
 
 				Func<JniValueMarshaler> indirect = GetObjectArrayMarshalerHelper<object>;
 				var reifiedMethodInfo = MakeGenericMethod (


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/8758#discussion_r1503086757
Context: https://github.com/xamarin/java.interop/issues/1192

In 7d1e7057 and b8f6f8884, we suppressed IL3050, an AOT-related warning with:

    // FIXME: https://github.com/xamarin/java.interop/issues/1192
    [UnconditionalSuppressMessage ("AOT", "IL3050")]
    // Problematic code here

We don't immediately *plan* to support NativeAOT on Android in .NET 9, so it would be nice if we could suppress the warning *for now*. But if anyone tried to use this code in a NativeAOT context, they could get a warning.

So instead we should use:

    // FIXME: https://github.com/xamarin/java.interop/issues/1192
    #pragma warning disable IL3050
    // Problematic code here
    #pragma warning restore IL3050

This will prevent us from introducing new `IL3050` and related warnings, but if anyone consumes `Java.Interop.dll` from NativeAOT -- they will see the warning.