### PR TITLE
[generator] Extend `skipInvokerMethods` support to interfaces.

### DIFF
--- a/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
@@ -117,10 +117,6 @@ namespace MonoDroid.Generation
 					 !options.SupportNestedInterfaceTypes
 			};
 
-			if (elem.Attribute ("skipInvokerMethods")?.Value is string skip)
-				foreach (var m in skip.Split (new char [] { ',', ' ', '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries))
-					klass.SkippedInvokerMethods.Add (m);
-
 			FillApiSince (klass, pkg, elem);
 			SetLineInfo (klass, elem, options);
 
@@ -263,6 +259,10 @@ namespace MonoDroid.Generation
 				PackageName = pkg.XGetAttribute ("name"),
 				Visibility = elem.XGetAttribute ("visibility")
 			};
+
+			if (elem.Attribute ("skipInvokerMethods")?.Value is string skip)
+				foreach (var m in skip.Split (new char [] { ',', ' ', '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries))
+					support.SkippedInvokerMethods.Add (m);
 
 			if (support.IsDeprecated) {
 				support.DeprecatedComment = elem.XGetAttribute ("deprecated");

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ClassGen.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ClassGen.cs
@@ -11,7 +11,6 @@ namespace MonoDroid.Generation
 	public class ClassGen : GenBase
 	{
 		bool fill_explicit_implementation_started;
-		HashSet<string> skipped_invoker_methods;
 
 		public List<Ctor> Ctors { get; private set; } = new List<Ctor> ();
 
@@ -355,8 +354,6 @@ namespace MonoDroid.Generation
 			validated = false;
 			base.ResetValidation ();
 		}
-
-		public HashSet<string> SkippedInvokerMethods => skipped_invoker_methods ??= new HashSet<string> ();
 
 		public override string ToNative (CodeGenerationOptions opt, string varname, Dictionary<string, string> mappings = null)
 		{

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
@@ -854,6 +854,8 @@ namespace MonoDroid.Generation
 
 		public bool ShouldGenerateAnnotationAttribute => IsAnnotation;
 
+		public HashSet<string> SkippedInvokerMethods => support.SkippedInvokerMethods;
+
 		public void StripNonBindables (CodeGenerationOptions opt)
 		{
 			// Strip out default interface methods if not desired

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBaseSupport.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBaseSupport.cs
@@ -1,9 +1,12 @@
 using System;
+using System.Collections.Generic;
 
 namespace MonoDroid.Generation
 {
 	public class GenBaseSupport
 	{
+		HashSet<string> skipped_invoker_methods;
+
 		public string AnnotatedVisibility { get; set; }
 		public bool IsAcw { get; set; }
 		public bool IsDeprecated { get; set; }
@@ -20,6 +23,8 @@ namespace MonoDroid.Generation
 		public string TypeNamePrefix { get; set; } = string.Empty;
 		public string Visibility { get; set; }
 		public GenericParameterDefinitionList TypeParameters { get; set; }
+
+		public HashSet<string> SkippedInvokerMethods => skipped_invoker_methods ??= new HashSet<string> ();
 
 		public virtual bool OnValidate (CodeGenerationOptions opt)
 		{

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Method.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Method.cs
@@ -193,6 +193,8 @@ namespace MonoDroid.Generation
 
 		public string GetSignature () => $"n_{JavaName}:{JniSignature}:{ConnectorName}";
 
+		public string GetSkipInvokerSignature () => $"{DeclaringType.RawJniName}.{JavaName}{JniSignature}";
+
 		public bool IsEventHandlerWithHandledProperty => RetVal.JavaName == "boolean" && EventName != "";
 
 		public override bool IsGeneric => base.IsGeneric || RetVal.IsGeneric;

--- a/tools/generator/SourceWriters/ClassInvokerClass.cs
+++ b/tools/generator/SourceWriters/ClassInvokerClass.cs
@@ -103,7 +103,7 @@ namespace generator.SourceWriters
 		void AddMethodInvokers (ClassGen klass, IEnumerable<Method> methods, HashSet<string> members, HashSet<string> skipInvokers, InterfaceGen gen, CodeGenerationOptions opt)
 		{
 			foreach (var m in methods) {
-				if (skipInvokers.Contains ($"{m.DeclaringType.RawJniName}.{m.JavaName}{m.JniSignature}"))
+				if (skipInvokers.Contains (m.GetSkipInvokerSignature ()))
 					continue;
 
 				var sig = m.GetSignature ();


### PR DESCRIPTION
Context: https://github.com/xamarin/java.interop/pull/1086

https://github.com/xamarin/java.interop/pull/1086 added the metadata attribute `skipInvokerMethods` to allow us to suppress generation of invoker methods for a class.

The [AndroidX Media3 binding](https://github.com/xamarin/AndroidX/pull/779) hits an issue where we generate incorrect generics in an invoker type.  However this is an invoker type for an `interface` instead of a `class`.

Extend our `skipInvokerMethods` support to cover interfaces as well.