### PR TITLE
[generator] Extend `skipInvokerMethods` support to interfaces. (#1202)

### DIFF
--- a/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
@@ -117,10 +117,6 @@ namespace MonoDroid.Generation
 					 !options.SupportNestedInterfaceTypes
 			};
 
-			if (elem.Attribute ("skipInvokerMethods")?.Value is string skip)
-				foreach (var m in skip.Split (new char [] { ',', ' ', '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries))
-					klass.SkippedInvokerMethods.Add (m);
-
 			FillApiSince (klass, pkg, elem);
 			SetLineInfo (klass, elem, options);
 
@@ -263,6 +259,10 @@ namespace MonoDroid.Generation
 				PackageName = pkg.XGetAttribute ("name"),
 				Visibility = elem.XGetAttribute ("visibility")
 			};
+
+			if (elem.Attribute ("skipInvokerMethods")?.Value is string skip)
+				foreach (var m in skip.Split (new char [] { ',', ' ', '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries))
+					support.SkippedInvokerMethods.Add (m);
 
 			if (support.IsDeprecated) {
 				support.DeprecatedComment = elem.XGetAttribute ("deprecated");

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ClassGen.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ClassGen.cs
@@ -11,7 +11,6 @@ namespace MonoDroid.Generation
 	public class ClassGen : GenBase
 	{
 		bool fill_explicit_implementation_started;
-		HashSet<string> skipped_invoker_methods;
 
 		public List<Ctor> Ctors { get; private set; } = new List<Ctor> ();
 
@@ -355,8 +354,6 @@ namespace MonoDroid.Generation
 			validated = false;
 			base.ResetValidation ();
 		}
-
-		public HashSet<string> SkippedInvokerMethods => skipped_invoker_methods ??= new HashSet<string> ();
 
 		public override string ToNative (CodeGenerationOptions opt, string varname, Dictionary<string, string> mappings = null)
 		{

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
@@ -833,6 +833,8 @@ namespace MonoDroid.Generation
 
 		public bool ShouldGenerateAnnotationAttribute => IsAnnotation;
 
+		public HashSet<string> SkippedInvokerMethods => support.SkippedInvokerMethods;
+
 		public void StripNonBindables (CodeGenerationOptions opt)
 		{
 			// Strip out default interface methods if not desired

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBaseSupport.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBaseSupport.cs
@@ -1,9 +1,12 @@
 using System;
+using System.Collections.Generic;
 
 namespace MonoDroid.Generation
 {
 	public class GenBaseSupport
 	{
+		HashSet<string> skipped_invoker_methods;
+
 		public string AnnotatedVisibility { get; set; }
 		public bool IsAcw { get; set; }
 		public bool IsDeprecated { get; set; }
@@ -20,6 +23,8 @@ namespace MonoDroid.Generation
 		public string TypeNamePrefix { get; set; } = string.Empty;
 		public string Visibility { get; set; }
 		public GenericParameterDefinitionList TypeParameters { get; set; }
+
+		public HashSet<string> SkippedInvokerMethods => skipped_invoker_methods ??= new HashSet<string> ();
 
 		public virtual bool OnValidate (CodeGenerationOptions opt)
 		{

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Method.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Method.cs
@@ -193,6 +193,8 @@ namespace MonoDroid.Generation
 
 		public string GetSignature () => $"n_{JavaName}:{JniSignature}:{ConnectorName}";
 
+		public string GetSkipInvokerSignature () => $"{DeclaringType.RawJniName}.{JavaName}{JniSignature}";
+
 		public bool IsEventHandlerWithHandledProperty => RetVal.JavaName == "boolean" && EventName != "";
 
 		public override bool IsGeneric => base.IsGeneric || RetVal.IsGeneric;

--- a/tools/generator/SourceWriters/ClassInvokerClass.cs
+++ b/tools/generator/SourceWriters/ClassInvokerClass.cs
@@ -103,7 +103,7 @@ namespace generator.SourceWriters
 		void AddMethodInvokers (ClassGen klass, IEnumerable<Method> methods, HashSet<string> members, HashSet<string> skipInvokers, InterfaceGen gen, CodeGenerationOptions opt)
 		{
 			foreach (var m in methods) {
-				if (skipInvokers.Contains ($"{m.DeclaringType.RawJniName}.{m.JavaName}{m.JniSignature}"))
+				if (skipInvokers.Contains (m.GetSkipInvokerSignature ()))
 					continue;
 
 				var sig = m.GetSignature ();

--- a/tools/generator/SourceWriters/InterfaceInvokerClass.cs
+++ b/tools/generator/SourceWriters/InterfaceInvokerClass.cs
@@ -55,18 +55,18 @@ namespace generator.SourceWriters
 
 			Constructors.Add (new InterfaceInvokerConstructor (opt, iface, context));
 
-			AddMemberInvokers (iface, new HashSet<string> (), opt, context);
+			AddMemberInvokers (iface, new HashSet<string> (), iface.SkippedInvokerMethods, opt, context);
 		}
 
 		void AddMemberInvokers (InterfaceGen iface, HashSet<string> members, CodeGenerationOptions opt, CodeGeneratorContext context)
 		{
 			AddPropertyInvokers (iface, iface.Properties.Where (p => !p.Getter.IsStatic && !p.Getter.IsInterfaceDefaultMethod), members, opt, context);
-			AddMethodInvokers (iface, iface.Methods.Where (m => !m.IsStatic && !m.IsInterfaceDefaultMethod), members, opt, context);
+			AddMethodInvokers (iface, iface.Methods.Where (m => !m.IsStatic && !m.IsInterfaceDefaultMethod), members, skipInvokers, opt, context);
 			AddCharSequenceEnumerators (iface);
 
 			foreach (var i in iface.GetAllDerivedInterfaces ()) {
 				AddPropertyInvokers (iface, i.Properties.Where (p => !p.Getter.IsStatic && !p.Getter.IsInterfaceDefaultMethod), members, opt, context);
-				AddMethodInvokers (iface, i.Methods.Where (m => !m.IsStatic && !m.IsInterfaceDefaultMethod && !iface.IsCovariantMethod (m) && !(i.FullName.StartsWith ("Java.Lang.ICharSequence", StringComparison.Ordinal) && m.Name.EndsWith ("Formatted", StringComparison.Ordinal))), members, opt, context);
+				AddMethodInvokers (iface, i.Methods.Where (m => !m.IsStatic && !m.IsInterfaceDefaultMethod && !iface.IsCovariantMethod (m) && !(i.FullName.StartsWith ("Java.Lang.ICharSequence", StringComparison.Ordinal) && m.Name.EndsWith ("Formatted", StringComparison.Ordinal))), members, skipInvokers, opt, context);
 				AddCharSequenceEnumerators (i);
 			}
 		}
@@ -90,10 +90,13 @@ namespace generator.SourceWriters
 				Properties.Add (new InterfaceInvokerProperty (iface, prop, opt, context));
 			}
 		}
-
-		void AddMethodInvokers (InterfaceGen iface, IEnumerable<Method> methods, HashSet<string> members, CodeGenerationOptions opt, CodeGeneratorContext context)
+		
+		void AddMethodInvokers (InterfaceGen iface, IEnumerable<Method> methods, HashSet<string> members, HashSet<string> skipInvokers, CodeGenerationOptions opt, CodeGeneratorContext context)
 		{
 			foreach (var m in methods) {
+				if (skipInvokers.Contains (m.GetSkipInvokerSignature ()))
+					continue;
+
 				var sig = m.GetSignature ();
 
 				if (members.Contains (sig))

--- a/tools/generator/SourceWriters/InterfaceInvokerClass.cs
+++ b/tools/generator/SourceWriters/InterfaceInvokerClass.cs
@@ -58,7 +58,7 @@ namespace generator.SourceWriters
 			AddMemberInvokers (iface, new HashSet<string> (), iface.SkippedInvokerMethods, opt, context);
 		}
 
-		void AddMemberInvokers (InterfaceGen iface, HashSet<string> members, CodeGenerationOptions opt, CodeGeneratorContext context)
+		void AddMemberInvokers (InterfaceGen iface, HashSet<string> members, HashSet<string> skipInvokers, CodeGenerationOptions opt, CodeGeneratorContext context)
 		{
 			AddPropertyInvokers (iface, iface.Properties.Where (p => !p.Getter.IsStatic && !p.Getter.IsInterfaceDefaultMethod), members, opt, context);
 			AddMethodInvokers (iface, iface.Methods.Where (m => !m.IsStatic && !m.IsInterfaceDefaultMethod), members, skipInvokers, opt, context);


### PR DESCRIPTION
Context: 73ebad2496a0d6df251fd24e216248da70e3fea9
Context: https://github.com/xamarin/AndroidX/pull/779

Commit 73ebad24 added support for the metadata attribute `//class[@skipInvokerMethods]`, which allowed us to suppress generation of invoker methods for a class.

The AndroidX Media3 binding in xamarin/AndroidX#779 hits a similar issue wherein we generate incorrect generics on an invoker type. However, this is an invoker type for an *`interface`*, not a `class`.

Extend our `skipInvokerMethods` support so that it can be used as `//interface[@skipInvokerMethods]` as well.