### PR TITLE
[ci] Build dotnet release branches and PRs against dotnet release branches.

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -2,14 +2,14 @@
 
 trigger:
   - main
-  - d16-*
+  - release/*
   - d17-*
 
 pr:
   branches:
     include:
     - main
-    - d16-*
+    - release/*
     - d17-*
   paths:
     exclude:


### PR DESCRIPTION
Currently we do not run CI on the `release/*` branches used by the new `dotnet` world order or PRs against those branches.

Add `release/*` to our CI triggers to remedy this.

Additionally, no `d16` branches are currently supported, so remove it from the trigger.