### PR TITLE
[Java.Interop] suppress one instance of IL2072

### DIFF
--- a/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -882,12 +882,16 @@ namespace Java.Interop
 
 		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState ([MaybeNull]object? value, ParameterAttributes synchronize)
 		{
+			[UnconditionalSuppressMessage ("Trimming", "IL2073", Justification = "This code path is not used in Android projects.")]
+			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.Interfaces)]
+			static Type GetType (object value) => value.GetType ();
+
 			if (value == null)
 				return new JniValueMarshalerState ();
 
 			var jvm     = JniEnvironment.Runtime;
 
-			var vm      = jvm.ValueManager.GetValueMarshaler (value.GetType ());
+			var vm      = jvm.ValueManager.GetValueMarshaler (GetType (value));
 			if (vm != Instance) {
 				var s   = vm.CreateObjectReferenceArgumentState (value, synchronize);
 				return new JniValueMarshalerState (s, vm);


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/8805

When testing new defaults for `TrimMode=full` in xamarin/xamarin-android:

    dotnet new android
    dotnet build -c Release -r android-arm64

Results in a single warning:

    external\Java.Interop\src\Java.Interop\Java.Interop\JniRuntime.JniValueManager.cs(890,4): Trim analysis warning IL2072: Java.Interop.ProxyValueMarshaler.CreateGenericObjectReferenceArgumentState(Object, ParameterAttributes): 'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.Interfaces' in call to 'Java.Interop.JniRuntime.JniValueManager.GetValueMarshaler(Type)'. The return value of method 'System.Object.GetType()' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.

This appears to be a case where the trimmer (ILLink's analyzers) can detect a problem where the Roslyn analyzer could not. It is generally possible for the trimmer to discover some new warning, as it has a complete view of the final code.

This appears to be similar to some other places we used the justification:

    [UnconditionalSuppressMessage ("Trimming", "IL2073", Justification = "This code path is not used in Android projects.")]