### PR TITLE
[ci] Use managed identity for API Scan

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -99,8 +99,8 @@ jobs:
   dependsOn: windows_dotnet_build
   condition: and(eq(dependencies.windows_dotnet_build.result, 'Succeeded'), eq(variables['Build.SourceBranch'], '${{ parameters.ApiScanSourceBranch }}'))
   pool:
-    name: Azure Pipelines
-    vmImage: windows-2022
+    name: MAUI-1ESPT
+    demands: ImageOverride -equals 1ESPT-Windows2022
   timeoutInMinutes: 480
   workspace:
     clean: all
@@ -135,7 +135,7 @@ jobs:
       isLargeApp: true
       toolVersion: Latest
     env:
-      AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(ApiScanSecret)
+      AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanMAUI1ESPTManagedId)
 
   - task: SdtReport@2
     displayName: Guardian Export - Security Report


### PR DESCRIPTION
I've configured a new [managed identity][0] (MSI) for API Scan, which
allows us to enable a more modern authentication approach when running
API Scan on the `MAUI-1ESPT` agent pool.

A new `$(ApiScanMAUI1ESPTManagedId)` variable has been configured in the
pipeline settings to pass the app ID for this MSI to the API Scan task.

[0]: https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/cd4829e2-e38b-43d2-8316-2f2009f36f97/resourcegroups/1esobjects/providers/microsoft.managedidentity/userassignedidentities/maui1esptapiscanidentity/overview