### PR TITLE
[java-source-utils] Ignore CodeQL SM00697 java/path-injection-local

### DIFF
--- a/tools/java-source-utils/src/main/java/com/microsoft/android/JavaSourceUtilsOptions.java
+++ b/tools/java-source-utils/src/main/java/com/microsoft/android/JavaSourceUtilsOptions.java
@@ -167,7 +167,7 @@ public class JavaSourceUtilsOptions implements AutoCloseable {
 					final   String          bootClassPath   = getNextOptionValue(args, arg);
 					final   ArrayList<File> files           = new ArrayList<File>();
 					for (final String cp : bootClassPath.split(File.pathSeparator)) {
-						final   File    file    = new File(cp); // lgtm [java/path-injection-local] java-source-utils.jar is a command-line app, and is useless if it doesn't support command-line args.
+						final   File    file    = new File(cp); // CodeQL [SM00697] java-source-utils.jar is a command-line app, and is useless if it doesn't support command-line args.
 						if (!file.exists()) {
 							System.err.println(App.APP_NAME + ": warning: invalid file path for option `-bootclasspath`: " + cp);
 							continue;
@@ -253,7 +253,7 @@ public class JavaSourceUtilsOptions implements AutoCloseable {
 					if (arg.startsWith("@")) {
 						// response file?
 						final   String  responseFileName = arg.substring(1);
-						final   File    responseFile     = new File(responseFileName);  // lgtm [java/path-injection-local] java-source-utils.jar is a command-line app, and is useless if it doesn't support command-line args.
+						final   File    responseFile     = new File(responseFileName);  // CodeQL [SM00697] java-source-utils.jar is a command-line app, and is useless if it doesn't support command-line args.
 						if (responseFile.exists()) {
 							final   Iterator<String>        lines   =
 								Files.readAllLines(responseFile.toPath())
@@ -267,7 +267,7 @@ public class JavaSourceUtilsOptions implements AutoCloseable {
 							break;
 						}
 					}
-					final   File    file        = new File(arg);    // lgtm [java/path-injection-local] java-source-utils.jar is a command-line app, and is useless if it doesn't support command-line args.
+					final   File    file        = new File(arg);    // CodeQL [SM00697] java-source-utils.jar is a command-line app, and is useless if it doesn't support command-line args.
 					if (!file.exists()) {
 						System.err.println(App.APP_NAME + ": warning: invalid file path for option `FILES`: " + arg);
 						break;
@@ -347,7 +347,7 @@ public class JavaSourceUtilsOptions implements AutoCloseable {
 			throw new IllegalArgumentException(
 					"Expected required value for option `" + option + "`.");
 		final   String  fileName    = args.next();
-		final   File    file        = new File(fileName);   // lgtm [java/path-injection-local] java-source-utils.jar is a command-line app, and is useless if it doesn't support command-line args.
+		final   File    file        = new File(fileName);   // CodeQL [SM00697] java-source-utils.jar is a command-line app, and is useless if it doesn't support command-line args.
 		if (!file.exists()) {
 			System.err.println(App.APP_NAME + ": warning: invalid file path for option `" + option + "`: " + fileName);
 			return null;

--- a/tools/java-source-utils/src/main/java/com/microsoft/android/JavadocXmlGenerator.java
+++ b/tools/java-source-utils/src/main/java/com/microsoft/android/JavadocXmlGenerator.java
@@ -39,7 +39,7 @@ public final class JavadocXmlGenerator implements AutoCloseable {
 		if (output == null)
 			this.output = System.out;
 		else {
-			final File file     = new File(output);     // lgtm [java/path-injection-local] java-source-utils.jar is a command-line app, and is useless if it doesn't support command-line args.
+			final File file     = new File(output);     // CodeQL [SM00697] java-source-utils.jar is a command-line app, and is useless if it doesn't support command-line args.
 			final File parent   = file.getParentFile();
 			if (parent != null) {
 				parent.mkdirs();
@@ -86,7 +86,7 @@ public final class JavadocXmlGenerator implements AutoCloseable {
 			final   Element    blurb    = document.createElement("copyright");
 			final   NodeList   contents = readXmlFile(copyright);
 			if (contents == null) {
-				final byte[]   data     = Files.readAllBytes(copyright.toPath());
+				final byte[]   data     = Files.readAllBytes(copyright.toPath());   // CodeQL [SM00697] java-source-utils.jar is a command-line app, and is useless if it doesn't support command-line args.
 				blurb.appendChild(document.createCDATASection(new String(data, StandardCharsets.UTF_8)));
 			} else {
 				final int len = contents.getLength();


### PR DESCRIPTION
Fixes: https://codeql.microsoft.com/issues/5011e9f8-1b9e-4735-b9c5-89d78d9c04b2
Fixes: https://codeql.microsoft.com/issues/a9013ebf-d97c-41d8-aa62-92da7f8ea1c7
Fixes: https://codeql.microsoft.com/issues/b42d4728-2ce4-4599-b5cb-4d2affb86985
Fixes: https://codeql.microsoft.com/issues/bafce9a0-95ae-4aac-95e0-5ba8af1f3944
Fixes: https://codeql.microsoft.com/issues/bcc73986-161f-40b4-96a4-1c7e52959941
Fixes: https://codeql.microsoft.com/issues/dd199e97-a989-4f18-9fc7-a23a497eba32
Fixes: https://codeql.microsoft.com/issues/e844028d-77d8-4e04-9bfd-24005727ea84

Context: 5fa7ac458ec225cf58396d015ebb9aa6a538062d
Context: https://codeql.microsoft.com/issues/repository?Uri=https%3A%2F%2Fgithub.com%2Fxamarin%2Fjava.interop#
Context: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/codeql-semmle#guidance-on-suppressions

Commit 5fa7ac45 "addressed" numerous LGTM warnings around "path injection".

We're now using CodeQL, and even though CodeQL *started as* LGTM, it (apparently) no longer supports the previous `// lgtm` comments. It instead wants `// CodeQL` comments, updated to use an "Opaque Id".

Update the comments to silence the CodeQL warnings.