### PR TITLE
[Xamarin.Android.Tools.Bytecode] add `org.jspecify.annotations.NonNull`

### DIFF
--- a/src/Xamarin.Android.Tools.Bytecode/XmlClassDeclarationBuilder.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/XmlClassDeclarationBuilder.cs
@@ -499,15 +499,20 @@ namespace Xamarin.Android.Tools.Bytecode {
 		{
 			// Android ones plus the list from here:
 			// https://stackoverflow.com/questions/4963300/which-notnull-java-annotation-should-i-use
+			// https://github.com/JetBrains/kotlin/blob/03360c0108797b2a98b6608e2bddfacd5f4e87ce/core/compiler.common.jvm/src/org/jetbrains/kotlin/load/java/JvmAnnotationNames.kt#L64-L91
 			switch (annotation.Type) {
 				case "Landroid/annotation/NonNull;":
 				case "Landroid/support/annotation/NonNull;":
 				case "Landroidx/annotation/NonNull;":
 				case "Landroidx/annotation/RecentlyNonNull;":
+				case "Lcom/android/annotations/NonNull;":
 				case "Ledu/umd/cs/findbugs/annotations/NonNull;":
+				case "Ljakarta/annotation/Nonnull;":
 				case "Ljavax/annotation/Nonnull;":
 				case "Ljavax/validation/constraints/NotNull;":
 				case "Llombok/NonNull;":
+				case "Lorg/checkerframework/checker/nullness/compatqual/NonNullDecl;":
+				case "Lorg/checkerframework/checker/nullness/qual/NonNull;":
 				case "Lorg/eclipse/jdt/annotation/NonNull;":
 				case "Lorg/jetbrains/annotations/NotNull;":
 				case "Lorg/jspecify/annotations/NonNull;":


### PR DESCRIPTION
Context: https://mvnrepository.com/artifact/org.jspecify/jspecify
Context: https://mvnrepository.com/artifact/org.jspecify/jspecify/1.0.0/usages

It appears that some newer AndroidX/GPS libraries are now using:

```diff
--androidx.annotation.NonNull
++org.jspecify.annotations.NonNull
```

I can see versions of guava and androidx.core taking a dependency on `org.jspecify:jspecify:1.0.0`, which provides the
`org.jspecify.annotations.NonNull` annotation type.

I sorted the list of annotation types alphabetically, and added the `org.jspecify.annotations.NonNull` annotation type to the list of recognized annotations in `XmlClassDeclarationBuilder.cs`.