### PR TITLE
Proof of Concept: Map Java object to single best managed type

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -47,7 +47,7 @@
     <!-- Workaround: https://github.com/dotnet/runtime/issues/55992 -->
     <UseAppHost>False</UseAppHost>
     <AppendTargetFrameworkToOutputPath Condition=" '$(AppendTargetFrameworkToOutputPath)' == '' ">False</AppendTargetFrameworkToOutputPath>
-    <BaseIntermediateOutputPath Condition=" '$(BaseIntermediateOutputPath)' == '' ">obj\</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath Condition=" '$(BaseIntermediateOutputPath)' == '' ">$(MSBuildProjectDirectory)\obj\</BaseIntermediateOutputPath>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -285,7 +285,7 @@ namespace Java.Interop
 					ref JniObjectReference reference,
 					JniObjectReferenceOptions transfer,
 					[DynamicallyAccessedMembers (Constructors)]
-					Type? targetType = null)
+					Type? targetType)
 			{
 				if (disposed)
 					throw new ObjectDisposedException (GetType ().Name);

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -323,7 +323,7 @@ namespace Java.Interop
 
 				JniObjectReference.Dispose (ref targetClass);
 
-				var peer = CreatePeerInstance (ref refClass, ref reference, transfer);
+				var peer = CreatePeerInstance (ref refClass, targetType, ref reference, transfer);
 				if (peer == null) {
 					throw new NotSupportedException (string.Format ("Could not find an appropriate constructable wrapper type for Java type '{0}', targetType='{1}'.",
 							JniEnvironment.Types.GetJniTypeNameFromInstance (reference), targetType));
@@ -334,6 +334,8 @@ namespace Java.Interop
 
 			IJavaPeerable? CreatePeerInstance (
 					ref JniObjectReference klass,
+					[DynamicallyAccessedMembers (Constructors)]
+					Type targetType,
 					ref JniObjectReference reference,
 					JniObjectReferenceOptions transfer)
 			{
@@ -364,8 +366,9 @@ namespace Java.Interop
 				}
 				JniObjectReference.Dispose (ref klass, JniObjectReferenceOptions.CopyAndDispose);
 
-				// Instance has no mapped type
-				return null;
+				// If we have nothing in the hierarchy, assume caller knows best and create targetType
+				return TryCreatePeerInstance (ref reference, transfer, targetType);
+
 
 				[UnconditionalSuppressMessage ("Trimming", "IL2073", Justification = "Types returned here should be preserved via other means.")]
 				[return: DynamicallyAccessedMembers (Constructors)]

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -369,7 +369,7 @@ namespace Java.Interop
 
 				[UnconditionalSuppressMessage ("Trimming", "IL2073", Justification = "Types returned here should be preserved via other means.")]
 				[return: DynamicallyAccessedMembers (Constructors)]
-				Type? GetTypeAssignableTo (JniTypeSignature sig)
+				Type? GetBestTypeForSignature (JniTypeSignature sig)
 				{
 					string[] sdkAssemblyNames = ["Mono.Android", "Java.Base", "Java.Interop"];
 					// Find single best instance

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -360,7 +360,7 @@ namespace Java.Interop
 						return null;
 
 					Type? type = GetBestTypeForSignature (sig);
-					if (type != null) {
+					if (type != null && type.IsAssignableTo(targetType)) {
 						var peer = TryCreatePeerInstance (ref reference, transfer, type);
 
 						if (peer != null) {

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -259,6 +259,18 @@ namespace Java.Interop
 					: null;
 			}
 
+			[return: DynamicallyAccessedMembers (Constructors)]
+			static Type GetPeerType ([DynamicallyAccessedMembers (Constructors)] Type type)
+			{
+				if (type == typeof (object))
+					return typeof (JavaObject);
+				if (type == typeof (IJavaPeerable))
+					return typeof (JavaObject);
+				if (type == typeof (Exception))
+					return typeof (JavaException);
+				return type;
+			}
+
 			public IJavaPeerable? GetPeer (
 					JniObjectReference reference,
 					[DynamicallyAccessedMembers (Constructors)]
@@ -295,6 +307,7 @@ namespace Java.Interop
 				}
 
 				targetType  = targetType ?? typeof (JavaObject);
+				targetType = GetPeerType(targetType);
 
 				if (!typeof (IJavaPeerable).IsAssignableFrom (targetType))
 					throw new ArgumentException ($"targetType `{targetType.AssemblyQualifiedName}` must implement IJavaPeerable!", nameof (targetType));

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -14,46 +14,49 @@ using Java.Interop.Expressions;
 
 namespace Java.Interop
 {
-	public class JniSurfacedPeerInfo {
+	public class JniSurfacedPeerInfo
+	{
 
-		public  int                             JniIdentityHashCode     {get; private set;}
-		public  WeakReference<IJavaPeerable>    SurfacedPeer            {get; private set;}
+		public int JniIdentityHashCode { get; private set; }
+		public WeakReference<IJavaPeerable> SurfacedPeer { get; private set; }
 
 		public JniSurfacedPeerInfo (int jniIdentityHashCode, WeakReference<IJavaPeerable> surfacedPeer)
 		{
-			JniIdentityHashCode     = jniIdentityHashCode;
-			SurfacedPeer            = surfacedPeer;
+			JniIdentityHashCode = jniIdentityHashCode;
+			SurfacedPeer = surfacedPeer;
 		}
 	}
 
 	partial class JniRuntime
 	{
-		partial class CreationOptions {
-			public  JniValueManager?        ValueManager                {get; set;}
+		partial class CreationOptions
+		{
+			public JniValueManager? ValueManager { get; set; }
 		}
 
-		internal    JniValueManager?        valueManager;
-		public  JniValueManager             ValueManager                {
+		internal JniValueManager? valueManager;
+		public JniValueManager ValueManager {
 			get => valueManager ?? throw new NotSupportedException ();
 		}
 
 		partial void SetValueManager (CreationOptions options)
 		{
-			var manager     = options.ValueManager;
+			var manager = options.ValueManager;
 			if (manager == null)
 				throw new ArgumentException (
 						"No JniValueManager specified in JniRuntime.CreationOptions.ValueManager.",
 						nameof (options));
-			valueManager    = SetRuntime (manager);
+			valueManager = SetRuntime (manager);
 		}
 
-		public abstract partial class JniValueManager : ISetRuntime, IDisposable {
+		public abstract partial class JniValueManager : ISetRuntime, IDisposable
+		{
 
 			internal const DynamicallyAccessedMemberTypes Constructors = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
 
-			JniRuntime?             runtime;
-			bool                    disposed;
-			public      JniRuntime  Runtime {
+			JniRuntime? runtime;
+			bool disposed;
+			public JniRuntime Runtime {
 				get => runtime ?? throw new NotSupportedException ();
 			}
 
@@ -86,7 +89,7 @@ namespace Java.Interop
 
 			public abstract void FinalizePeer (IJavaPeerable value);
 
-			public abstract List<JniSurfacedPeerInfo>   GetSurfacedPeers ();
+			public abstract List<JniSurfacedPeerInfo> GetSurfacedPeers ();
 
 			public abstract void ActivatePeer (IJavaPeerable? self, JniObjectReference reference, ConstructorInfo cinfo, object? []? argumentValues);
 
@@ -95,7 +98,7 @@ namespace Java.Interop
 				if (peer == null)
 					throw new ArgumentNullException (nameof (peer));
 
-				var newRef  = peer.PeerReference;
+				var newRef = peer.PeerReference;
 				if (newRef.IsValid) {
 					JniObjectReference.Dispose (ref reference, options);
 
@@ -105,17 +108,17 @@ namespace Java.Interop
 						return;
 					}
 					JniObjectReference.Dispose (ref reference, options);
-					newRef   = newRef.NewGlobalRef ();
+					newRef = newRef.NewGlobalRef ();
 				} else if (options == JniObjectReferenceOptions.None) {
 					// `reference` is likely *InvalidJniObjectReference, and can't be touched
 					return;
 				} else if (!reference.IsValid) {
 					throw new ArgumentException ("JNI Object Reference is invalid.", nameof (reference));
 				} else {
-					newRef  = reference;
+					newRef = reference;
 
 					if ((options & JniObjectReferenceOptions.Copy) == JniObjectReferenceOptions.Copy) {
-						newRef  = reference.NewGlobalRef ();
+						newRef = reference.NewGlobalRef ();
 					}
 
 					JniObjectReference.Dispose (ref reference, options);
@@ -222,7 +225,7 @@ namespace Java.Interop
 				if (!reference.IsValid)
 					return null;
 
-				var t   = PeekPeer (reference);
+				var t = PeekPeer (reference);
 				if (t == null)
 					return t;
 
@@ -234,15 +237,15 @@ namespace Java.Interop
 
 			protected virtual bool TryUnboxPeerObject (IJavaPeerable value, [NotNullWhen (true)] out object? result)
 			{
-				result  = null;
-				var p   = value as JavaProxyObject;
+				result = null;
+				var p = value as JavaProxyObject;
 				if (p != null) {
-					result  = p.Value;
+					result = p.Value;
 					return true;
 				}
-				var x   = value as JavaProxyThrowable;
+				var x = value as JavaProxyThrowable;
 				if (x != null) {
-					result  = x.Exception;
+					result = x.Exception;
 					return true;
 				}
 				return false;
@@ -250,7 +253,7 @@ namespace Java.Interop
 
 			object? PeekBoxedObject (JniObjectReference reference)
 			{
-				var t   = PeekPeer (reference);
+				var t = PeekPeer (reference);
 				if (t == null)
 					return null;
 				object? r;
@@ -284,7 +287,7 @@ namespace Java.Interop
 					return null;
 				}
 
-				var peeked  = PeekPeer (reference);
+				var peeked = PeekPeer (reference);
 				if (peeked != null &&
 						(targetType == null ||
 						 targetType.IsAssignableFrom (peeked.GetType ()))) {
@@ -292,7 +295,72 @@ namespace Java.Interop
 				}
 				return CreatePeer (ref reference, JniObjectReferenceOptions.Copy, targetType);
 			}
+#if false
+			class AndroidTypeMapUniverse { }
+			public IJavaPeerable? CreatePeer(
+					ref JniObjectReference reference,
+					JniObjectReferenceOptions options,
+					[DynamicallyAccessedMembers (Constructors)]
+					Type? targetType)
+			{
+				if (disposed)
+					throw new ObjectDisposedException (GetType ().Name);
 
+				if (!reference.IsValid) {
+					return null;
+				}
+
+				targetType  = targetType ?? typeof (JavaObject);
+				targetType  = GetPeerType (targetType);
+				if (!typeof (IJavaPeerable).IsAssignableFrom (targetType))
+					throw new ArgumentException ($"targetType `{targetType.AssemblyQualifiedName}` must implement IJavaPeerable!", nameof (targetType));
+				IReadOnlyDictionary<string, Type> typemap = System.Runtime.InteropServices.TypeMapping.GetOrCreateExternalTypeMapping<AndroidTypeMapUniverse>();
+				string? className;
+				JniObjectReference refClass;
+				Type? mappedType = null;
+				do {
+					refClass = JniEnvironment.Types.GetObjectClass (reference);
+					className = JniEnvironment.Types.GetJniTypeNameFromClass (refClass);
+					if (className is not null && typemap.TryGetValue (className, out mappedType)) {
+						JniObjectReference.Dispose (ref refClass);
+						break;
+					}
+					var oldClass = refClass;
+					refClass = JniEnvironment.Types.GetSuperclass (refClass);
+					JniObjectReference.Dispose (ref oldClass);
+				}
+				while (refClass.IsValid);
+
+				if (mappedType is null) {
+					throw new InvalidOperationException ("Java object type does not have mapping to .NET type.");
+				}
+				if (!mappedType.IsAssignableTo(targetType)) {
+					throw new InvalidOperationException("Mapped .NET type is not assignable to target type.");
+				}
+
+				var managedObject = GetUninitializedObject (mappedType);
+				var constructed = false;
+				try {
+					constructed = TryConstructPeer (managedObject, ref reference, options, mappedType);
+				} finally {
+					if (!constructed) {
+						GC.SuppressFinalize (managedObject);
+						managedObject    = null;
+					}
+				}
+				return managedObject;
+
+				static IJavaPeerable GetUninitializedObject (
+						[DynamicallyAccessedMembers (Constructors)]
+						Type type)
+				{
+					var v   = (IJavaPeerable) System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject (type);
+					v.SetJniManagedPeerState (JniManagedPeerStates.Replaceable | JniManagedPeerStates.Activatable);
+					return v;
+				}
+
+			}
+#else
 			public virtual IJavaPeerable? CreatePeer (
 					ref JniObjectReference reference,
 					JniObjectReferenceOptions transfer,
@@ -306,18 +374,18 @@ namespace Java.Interop
 					return null;
 				}
 
-				targetType  = targetType ?? typeof (JavaObject);
-				targetType  = GetPeerType (targetType);
+				targetType = targetType ?? typeof (JavaObject);
+				targetType = GetPeerType (targetType);
 
 				if (!typeof (IJavaPeerable).IsAssignableFrom (targetType))
 					throw new ArgumentException ($"targetType `{targetType.AssemblyQualifiedName}` must implement IJavaPeerable!", nameof (targetType));
 
-				var targetSig  = Runtime.TypeManager.GetTypeSignature (targetType);
+				var targetSig = Runtime.TypeManager.GetTypeSignature (targetType);
 				if (!targetSig.IsValid || targetSig.SimpleReference == null) {
 					throw new ArgumentException ($"Could not determine Java type corresponding to `{targetType.AssemblyQualifiedName}`.", nameof (targetType));
 				}
 
-				var refClass    = JniEnvironment.Types.GetObjectClass (reference);
+				var refClass = JniEnvironment.Types.GetObjectClass (reference);
 				JniObjectReference targetClass;
 				try {
 					targetClass = JniEnvironment.Types.FindClass (targetSig.SimpleReference);
@@ -369,13 +437,13 @@ namespace Java.Interop
 						}
 					}
 
-					var super   = JniEnvironment.Types.GetSuperclass (klass);
+					var super = JniEnvironment.Types.GetSuperclass (klass);
 					jniTypeName = super.IsValid
 						? JniEnvironment.Types.GetJniTypeNameFromClass (super)
 						: null;
 
 					JniObjectReference.Dispose (ref klass, JniObjectReferenceOptions.CopyAndDispose);
-					klass      = super;
+					klass = super;
 				}
 				JniObjectReference.Dispose (ref klass, JniObjectReferenceOptions.CopyAndDispose);
 
@@ -385,12 +453,54 @@ namespace Java.Interop
 				[return: DynamicallyAccessedMembers (Constructors)]
 				Type? GetTypeAssignableTo (JniTypeSignature sig, Type targetType)
 				{
-					foreach (var t in Runtime.TypeManager.GetTypes (sig)) {
-						if (targetType.IsAssignableFrom (t)) {
-							return t;
+					string[] sdkAssemblyNames = ["Mono.Android", "Java.Base", "Java.Runtime", "Java.Interop"];
+					// Find single best instance
+					Type? best = null;
+					foreach (Type type in Runtime.TypeManager.GetTypes (sig)) {
+						if (best is null) {
+							best = type;
+							continue;
+						}
+						if (type == best)
+							continue;
+						// Types in sdk assemblies should be first in the list
+						if ((uint)Array.IndexOf(sdkAssemblyNames, best.Module.Assembly.GetName ().Name) >
+								(uint)Array.IndexOf(sdkAssemblyNames, type.Module.Assembly.GetName ().Name)) {
+							best = type;
+							continue;
+						}
+						// We found the `Invoker` type *before* the declared type
+						// Fix things up so the abstract type is first, and the `Invoker` is considered a duplicate.
+						if ((type.IsAbstract || type.IsInterface) &&
+								!best.IsAbstract &&
+								!best.IsInterface &&
+								type.IsAssignableFrom (best)) {
+							best = type;
+							continue;
+						}
+
+						// If the type is a derived type of the current best, then it is better
+						if (type.IsAssignableTo(best))
+						{
+							best = type;
+							continue;
+						}
+
+						// we found a generic subclass of a non-generic type
+						if (type.IsGenericType &&
+								!best.IsGenericType &&
+								type.IsAssignableTo (best)) {
+							best = type;
+							continue;
 						}
 					}
+					if (best is not null && best.IsAssignableTo (targetType))
+						return best;
 					return null;
+					//throw new InvalidOperationException (
+					//	$"Best type for instance of Java class '{sig.Name}' is '{best.FullName}', "
+					//	+ $"which is not assignable to target type '{targetType.FullName}'."
+					//	+ $"\nOther mapped types:\n{string.Join("\n", Runtime.TypeManager.GetTypes(sig).Select(t => t.FullName))}");
 				}
 			}
 
@@ -400,16 +510,16 @@ namespace Java.Interop
 					[DynamicallyAccessedMembers (Constructors)]
 					Type type)
 			{
-				type    = Runtime.TypeManager.GetInvokerType (type) ?? type;
+				type = Runtime.TypeManager.GetInvokerType (type) ?? type;
 
-				var self        = GetUninitializedObject (type);
+				var self = GetUninitializedObject (type);
 				var constructed = false;
 				try {
 					constructed = TryConstructPeer (self, ref reference, options, type);
 				} finally {
 					if (!constructed) {
 						GC.SuppressFinalize (self);
-						self    = null;
+						self = null;
 					}
 				}
 				return self;
@@ -418,15 +528,16 @@ namespace Java.Interop
 						[DynamicallyAccessedMembers (Constructors)]
 						Type type)
 				{
-					var v   = (IJavaPeerable) System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject (type);
+					var v = (IJavaPeerable) System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject (type);
 					v.SetJniManagedPeerState (JniManagedPeerStates.Replaceable | JniManagedPeerStates.Activatable);
 					return v;
 				}
 			}
+#endif
 
-			const               BindingFlags    ActivationConstructorBindingFlags   = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
-			static  readonly    Type            ByRefJniObjectReference = typeof (JniObjectReference).MakeByRefType ();
-			static  readonly    Type[]          JIConstructorSignature  = new Type [] { ByRefJniObjectReference, typeof (JniObjectReferenceOptions) };
+			const BindingFlags ActivationConstructorBindingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+			static readonly Type ByRefJniObjectReference = typeof (JniObjectReference).MakeByRefType ();
+			static readonly Type [] JIConstructorSignature = new Type [] { ByRefJniObjectReference, typeof (JniObjectReferenceOptions) };
 
 
 			protected virtual bool TryConstructPeer (
@@ -438,12 +549,12 @@ namespace Java.Interop
 			{
 				var c = type.GetConstructor (ActivationConstructorBindingFlags, null, JIConstructorSignature, null);
 				if (c != null) {
-					var args = new object[] {
+					var args = new object [] {
 						reference,
 						options,
 					};
 					c.Invoke (self, args);
-					reference   = (JniObjectReference) args [0];
+					reference = (JniObjectReference) args [0];
 					return true;
 				}
 				return false;
@@ -465,7 +576,7 @@ namespace Java.Interop
 					return JavaPeerableValueMarshaler.Instance.CreateGenericValue (ref reference, options, targetType);
 				}
 
-				var boxed   = PeekBoxedObject (reference);
+				var boxed = PeekBoxedObject (reference);
 				if (boxed != null) {
 					JniObjectReference.Dispose (ref reference, options);
 					if (targetType != null)
@@ -478,14 +589,14 @@ namespace Java.Interop
 					// Let's hope this is an IJavaPeerable!
 					return JavaPeerableValueMarshaler.Instance.CreateGenericValue (ref reference, options, targetType);
 				}
-				var marshaler   = GetValueMarshaler (targetType);
+				var marshaler = GetValueMarshaler (targetType);
 				return marshaler.CreateValue (ref reference, options, targetType);
 			}
 
 			[return: MaybeNull]
 			public T CreateValue<
 					[DynamicallyAccessedMembers (Constructors)]
-					T
+			T
 			> (
 					ref JniObjectReference reference,
 					JniObjectReferenceOptions options,
@@ -509,21 +620,21 @@ namespace Java.Interop
 								typeof (T)),
 							nameof (targetType));
 
-				var boxed   = PeekBoxedObject (reference);
+				var boxed = PeekBoxedObject (reference);
 				if (boxed != null) {
 					JniObjectReference.Dispose (ref reference, options);
 					return (T) Convert.ChangeType (boxed, targetType ?? typeof (T));
 				}
 
-				targetType  = targetType ?? typeof (T);
+				targetType = targetType ?? typeof (T);
 
 				if (typeof (IJavaPeerable).IsAssignableFrom (targetType)) {
-#pragma warning disable CS8600,CS8601 // Possible null reference assignment.
+#pragma warning disable CS8600, CS8601 // Possible null reference assignment.
 					return (T) JavaPeerableValueMarshaler.Instance.CreateGenericValue (ref reference, options, targetType);
-#pragma warning restore CS8600,CS8601 // Possible null reference assignment.
+#pragma warning restore CS8600, CS8601 // Possible null reference assignment.
 				}
 
-				var marshaler   = GetValueMarshaler<T> ();
+				var marshaler = GetValueMarshaler<T> ();
 				return marshaler.CreateGenericValue (ref reference, options, targetType);
 			}
 
@@ -565,25 +676,25 @@ namespace Java.Interop
 					// Let's hope this is an IJavaPeerable!
 					return JavaPeerableValueMarshaler.Instance.CreateGenericValue (ref reference, options, targetType);
 				}
-				var marshaler   = GetValueMarshaler (targetType);
+				var marshaler = GetValueMarshaler (targetType);
 				return marshaler.CreateValue (ref reference, options, targetType);
 			}
 
 			[return: MaybeNull]
 			public T GetValue<
 					[DynamicallyAccessedMembers (Constructors)]
-					T
+			T
 			> (
 					IntPtr handle)
 			{
-				var r   = new JniObjectReference (handle);
+				var r = new JniObjectReference (handle);
 				return GetValue<T> (ref r, JniObjectReferenceOptions.Copy);
 			}
 
 			[return: MaybeNull]
 			public T GetValue<
 					[DynamicallyAccessedMembers (Constructors)]
-					T
+			T
 			> (
 					ref JniObjectReference reference,
 					JniObjectReferenceOptions options,
@@ -604,7 +715,7 @@ namespace Java.Interop
 								typeof (T)),
 							nameof (targetType));
 
-				targetType  = targetType ?? typeof (T);
+				targetType = targetType ?? typeof (T);
 
 				var existing = PeekValue (reference);
 				if (existing != null && (targetType == null || targetType.IsAssignableFrom (existing.GetType ()))) {
@@ -613,12 +724,12 @@ namespace Java.Interop
 				}
 
 				if (typeof (IJavaPeerable).IsAssignableFrom (targetType)) {
-#pragma warning disable CS8600,CS8601 // Possible null reference assignment.
+#pragma warning disable CS8600, CS8601 // Possible null reference assignment.
 					return (T) JavaPeerableValueMarshaler.Instance.CreateGenericValue (ref reference, options, targetType);
-#pragma warning restore CS8600,CS8601 // Possible null reference assignment.
+#pragma warning restore CS8600, CS8601 // Possible null reference assignment.
 				}
 
-				var marshaler   = GetValueMarshaler<T> ();
+				var marshaler = GetValueMarshaler<T> ();
 				return marshaler.CreateGenericValue (ref reference, options, targetType);
 			}
 
@@ -626,14 +737,14 @@ namespace Java.Interop
 
 			public JniValueMarshaler<T> GetValueMarshaler<
 					[DynamicallyAccessedMembers (Constructors)]
-					T
+			T
 			> ()
 			{
 				if (disposed)
 					throw new ObjectDisposedException (GetType ().Name);
 
-				var m   = GetValueMarshaler (typeof (T));
-				var r   = m as JniValueMarshaler<T>;
+				var m = GetValueMarshaler (typeof (T));
+				var r = m as JniValueMarshaler<T>;
 				if (r != null)
 					return r;
 				lock (Marshalers) {
@@ -653,7 +764,7 @@ namespace Java.Interop
 				if (type.ContainsGenericParameters)
 					throw new ArgumentException ("Generic type definitions are not supported.", nameof (type));
 
-				var marshalerAttr   = type.GetCustomAttribute<JniValueMarshalerAttribute> ();
+				var marshalerAttr = type.GetCustomAttribute<JniValueMarshalerAttribute> ();
 				if (marshalerAttr != null)
 					return (JniValueMarshaler) Activator.CreateInstance (marshalerAttr.MarshalerType)!;
 
@@ -669,7 +780,7 @@ namespace Java.Interop
 				}
 
 
-				var listType    = GetListType (type);
+				var listType = GetListType (type);
 				if (listType != null) {
 					var elementType = listType.GenericTypeArguments [0];
 					if (elementType.IsValueType) {
@@ -689,7 +800,7 @@ namespace Java.Interop
 				return GetValueMarshalerCore (type);
 			}
 
-			static Type? GetListType(Type type)
+			static Type? GetListType (Type type)
 			{
 				foreach (var iface in GetInterfaces (type).Concat (new [] { type })) {
 					if (typeof (IList<>).IsAssignableFrom (iface.IsGenericType ? iface.GetGenericTypeDefinition () : iface))
@@ -721,7 +832,7 @@ namespace Java.Interop
 
 			static JniValueMarshaler GetObjectArrayMarshalerHelper<
 					[DynamicallyAccessedMembers (Constructors)]
-					T
+			T
 			> ()
 			{
 				return JavaObjectArray<T>.Instance;
@@ -734,12 +845,13 @@ namespace Java.Interop
 		}
 	}
 
-	sealed class VoidValueMarshaler : JniValueMarshaler {
+	sealed class VoidValueMarshaler : JniValueMarshaler
+	{
 
-		internal    static  VoidValueMarshaler              Instance    = new VoidValueMarshaler ();
+		internal static VoidValueMarshaler Instance = new VoidValueMarshaler ();
 
 		public override Type MarshalType {
-			get {return typeof (void);}
+			get { return typeof (void); }
 		}
 
 		public override object? CreateValue (
@@ -762,9 +874,10 @@ namespace Java.Interop
 		}
 	}
 
-	sealed class JavaPeerableValueMarshaler : JniValueMarshaler<IJavaPeerable?> {
+	sealed class JavaPeerableValueMarshaler : JniValueMarshaler<IJavaPeerable?>
+	{
 
-		internal    static  JavaPeerableValueMarshaler      Instance    = new JavaPeerableValueMarshaler ();
+		internal static JavaPeerableValueMarshaler Instance = new JavaPeerableValueMarshaler ();
 
 		[return: MaybeNull]
 		public override IJavaPeerable? CreateGenericValue (
@@ -773,26 +886,26 @@ namespace Java.Interop
 				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
-			var jvm         = JniEnvironment.Runtime;
-			var marshaler   = jvm.ValueManager.GetValueMarshaler (targetType ?? typeof(IJavaPeerable));
+			var jvm = JniEnvironment.Runtime;
+			var marshaler = jvm.ValueManager.GetValueMarshaler (targetType ?? typeof (IJavaPeerable));
 			if (marshaler != Instance)
 				return (IJavaPeerable) marshaler.CreateValue (ref reference, options, targetType)!;
 			return jvm.ValueManager.CreatePeer (ref reference, options, targetType);
 		}
 
-		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState ([MaybeNull]IJavaPeerable? value, ParameterAttributes synchronize)
+		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState ([MaybeNull] IJavaPeerable? value, ParameterAttributes synchronize)
 		{
 			if (value == null || !value.PeerReference.IsValid)
 				return new JniValueMarshalerState ();
-			var r   = value.PeerReference.NewLocalRef ();
+			var r = value.PeerReference.NewLocalRef ();
 			return new JniValueMarshalerState (r);
 		}
 
-		public override void DestroyGenericArgumentState ([MaybeNull]IJavaPeerable? value, ref JniValueMarshalerState state, ParameterAttributes synchronize)
+		public override void DestroyGenericArgumentState ([MaybeNull] IJavaPeerable? value, ref JniValueMarshalerState state, ParameterAttributes synchronize)
 		{
-			var r   = state.ReferenceValue;
+			var r = state.ReferenceValue;
 			JniObjectReference.Dispose (ref r);
-			state   = new JniValueMarshalerState ();
+			state = new JniValueMarshalerState ();
 		}
 
 		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
@@ -809,13 +922,13 @@ namespace Java.Interop
 		[RequiresUnreferencedCode (ExpressionRequiresUnreferencedCode)]
 		Expression CreateIntermediaryExpressionFromManagedExpression (JniValueMarshalerContext context, ParameterExpression sourceValue)
 		{
-			var r   = Expression.Variable (typeof (JniObjectReference), sourceValue.Name + "_ref");
+			var r = Expression.Variable (typeof (JniObjectReference), sourceValue.Name + "_ref");
 			context.LocalVariables.Add (r);
 			context.CreationStatements.Add (
 					Expression.IfThenElse (
-						test:       Expression.Equal (Expression.Constant (null), sourceValue),
-						ifTrue:     Expression.Assign (r, Expression.New (typeof (JniObjectReference))),
-						ifFalse:    Expression.Assign (r, Expression.Property (Expression.Convert (sourceValue, typeof (IJavaPeerable)), "PeerReference"))));
+						test: Expression.Equal (Expression.Constant (null), sourceValue),
+						ifTrue: Expression.Assign (r, Expression.New (typeof (JniObjectReference))),
+						ifFalse: Expression.Assign (r, Expression.Property (Expression.Convert (sourceValue, typeof (IJavaPeerable)), "PeerReference"))));
 
 			return r;
 		}
@@ -833,14 +946,14 @@ namespace Java.Interop
 		{
 			targetType ??= typeof (object);
 
-			var r   = Expression.Variable (targetType, sourceValue.Name + "_val");
+			var r = Expression.Variable (targetType, sourceValue.Name + "_val");
 			context.LocalVariables.Add (r);
 			context.CreationStatements.Add (
 					Expression.Assign (r,
 						Expression.Call (
 							context.ValueManager ?? Expression.Property (context.Runtime, "ValueManager"),
 							"GetValue",
-							new[]{targetType},
+							new [] { targetType },
 							sourceValue)));
 			return r;
 		}
@@ -848,16 +961,16 @@ namespace Java.Interop
 
 	sealed class DelegatingValueMarshaler<
 			[DynamicallyAccessedMembers (Constructors)]
-			T
+	T
 	>
 		: JniValueMarshaler<T>
 	{
 
-		JniValueMarshaler   ValueMarshaler;
+		JniValueMarshaler ValueMarshaler;
 
 		public DelegatingValueMarshaler (JniValueMarshaler valueMarshaler)
 		{
-			ValueMarshaler  = valueMarshaler;
+			ValueMarshaler = valueMarshaler;
 		}
 
 		[return: MaybeNull]
@@ -870,12 +983,12 @@ namespace Java.Interop
 			return (T) ValueMarshaler.CreateValue (ref reference, options, targetType ?? typeof (T))!;
 		}
 
-		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState ([MaybeNull]T value, ParameterAttributes synchronize)
+		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState ([MaybeNull] T value, ParameterAttributes synchronize)
 		{
 			return ValueMarshaler.CreateObjectReferenceArgumentState (value, synchronize);
 		}
 
-		public override void DestroyGenericArgumentState ([AllowNull]T value, ref JniValueMarshalerState state, ParameterAttributes synchronize)
+		public override void DestroyGenericArgumentState ([AllowNull] T value, ref JniValueMarshalerState state, ParameterAttributes synchronize)
 		{
 			ValueMarshaler.DestroyArgumentState (value, ref state, synchronize);
 		}
@@ -901,9 +1014,10 @@ namespace Java.Interop
 		}
 	}
 
-	sealed class ProxyValueMarshaler : JniValueMarshaler<object?> {
+	sealed class ProxyValueMarshaler : JniValueMarshaler<object?>
+	{
 
-		internal    static  ProxyValueMarshaler     Instance    = new ProxyValueMarshaler ();
+		internal static ProxyValueMarshaler Instance = new ProxyValueMarshaler ();
 
 		[return: MaybeNull]
 		public override object? CreateGenericValue (
@@ -912,19 +1026,19 @@ namespace Java.Interop
 				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
-			var jvm     = JniEnvironment.Runtime;
+			var jvm = JniEnvironment.Runtime;
 
 			if (targetType == null || targetType == typeof (object)) {
-				targetType      = jvm.ValueManager.GetRuntimeType (reference);
+				targetType = jvm.ValueManager.GetRuntimeType (reference);
 			}
 			if (targetType != null) {
-				var vm  = jvm.ValueManager.GetValueMarshaler (targetType);
+				var vm = jvm.ValueManager.GetValueMarshaler (targetType);
 				if (vm != Instance) {
 					return vm.CreateValue (ref reference, options, targetType)!;
 				}
 			}
 
-			var target  = jvm.ValueManager.PeekValue (reference);
+			var target = jvm.ValueManager.PeekValue (reference);
 			if (target != null) {
 				JniObjectReference.Dispose (ref reference, options);
 				return target;
@@ -933,31 +1047,31 @@ namespace Java.Interop
 			return jvm.ValueManager.CreatePeer (ref reference, options, targetType);
 		}
 
-		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState ([MaybeNull]object? value, ParameterAttributes synchronize)
+		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState ([MaybeNull] object? value, ParameterAttributes synchronize)
 		{
 			if (value == null)
 				return new JniValueMarshalerState ();
 
-			var jvm     = JniEnvironment.Runtime;
+			var jvm = JniEnvironment.Runtime;
 
-			var vm      = jvm.ValueManager.GetValueMarshaler (value.GetType ());
+			var vm = jvm.ValueManager.GetValueMarshaler (value.GetType ());
 			if (vm != Instance) {
-				var s   = vm.CreateObjectReferenceArgumentState (value, synchronize);
+				var s = vm.CreateObjectReferenceArgumentState (value, synchronize);
 				return new JniValueMarshalerState (s, vm);
 			}
 
-			var p   = JavaProxyObject.GetProxy (value);
+			var p = JavaProxyObject.GetProxy (value);
 			return new JniValueMarshalerState (p!.PeerReference.NewLocalRef ());
 		}
 
 		public override void DestroyGenericArgumentState (object? value, ref JniValueMarshalerState state, ParameterAttributes synchronize)
 		{
-			var vm  = state.Extra as JniValueMarshaler;
+			var vm = state.Extra as JniValueMarshaler;
 			if (vm != null) {
 				vm.DestroyArgumentState (value, ref state, synchronize);
 				return;
 			}
-			var r   = state.ReferenceValue;
+			var r = state.ReferenceValue;
 			JniObjectReference.Dispose (ref r);
 			state = new JniValueMarshalerState ();
 		}

--- a/src/java-interop/java-interop.targets
+++ b/src/java-interop/java-interop.targets
@@ -35,13 +35,13 @@
     </PropertyGroup>
 
     <PropertyGroup>
-      <_MonoNativePath>$(NuGetPackageRoot)microsoft.netcore.app.runtime.mono.$(NETCoreSdkRuntimeIdentifier)/$(DotNetRuntimePacksVersion)/runtimes/$(NETCoreSdkRuntimeIdentifier)/native/</_MonoNativePath>
+      <_MonoNativePath>$(NuGetPackageRoot)\microsoft.netcore.app.runtime.mono.$(NETCoreSdkRuntimeIdentifier)/$(DotNetRuntimePacksVersion)/runtimes/$(NETCoreSdkRuntimeIdentifier)/native/</_MonoNativePath>
       <_MonoIncludePath>$(_MonoNativePath)include/mono-2.0</_MonoIncludePath>
       <_DEnableMono>-DENABLE_MONO_INTEGRATION=ON</_DEnableMono>
       <_DEnableOsxArchitectures Condition=" $([MSBuild]::IsOSPlatform ('osx')) ">"-DENABLE_OSX_ARCHITECTURES=$(_CmakeOsxArch)"</_DEnableOsxArchitectures>
       <_DMonoDirs>"-DMONO_INCLUDE_LIST=$(_MonoIncludePath)"</_DMonoDirs>
       <_DJdkDirs>"-DJDK_INCLUDE_LIST=@(JdkIncludePath, ';')"</_DJdkDirs>
-      <_DJni_c>"-DJNI_C_PATH=$(MSBuildThisFileDirectory)$(IntermediateOutputPath)jni.c"</_DJni_c>
+      <_DJni_c>"-DJNI_C_PATH=$(IntermediateOutputPath)jni.c"</_DJni_c>
       <_MonoLinkFlags Condition=" $([MSBuild]::IsOSPlatform ('windows')) " >$(MSBuildThisFileDirectory)coreclr.lib</_MonoLinkFlags>
       <_MonoLinkFlags Condition=" !$([MSBuild]::IsOSPlatform ('windows')) ">-L $(_MonoNativePath) -lcoreclr</_MonoLinkFlags>
       <_DMonoLinkFlags>"-DMONO_LINK_FLAGS=$(_MonoLinkFlags)"</_DMonoLinkFlags>
@@ -71,7 +71,7 @@
       <_Cmake Include="CmakePath=$(CmakePath)" />
       <_Cmake Include="CmakeGenerator=$(CmakeGenerator)" />
       <_Cmake Include="CmakeSourceDir=$(MSBuildThisFileDirectory)" />
-      <_Cmake Include="CmakeBuildDir=$(MSBuildThisFileDirectory)$(IntermediateOutputPath)" />
+      <_Cmake Include="CmakeBuildDir=$(IntermediateOutputPath)" />
       <_Cmake Include="CmakeExtraArgs=$(_ExtraArgs)" />
     </ItemGroup>
     <MSBuild
@@ -86,9 +86,9 @@
 
   <Target Name="_UpdateCoreCLRLib"
       Condition="  $([MSBuild]::IsOSPlatform ('windows'))  And '$(NativeToolchainSupported)' == 'True' "
-      Inputs="coreclr.def"
-      Outputs="corclr.lib">
-    <Exec Command="lib /def:coreclr.def /out:coreclr.lib /machine:X64" />
+      Inputs="$(MSBuildThisFileDirectory)coreclr.def"
+      Outputs="$(MSBuildThisFileDirectory)coreclr.lib">
+    <Exec Command="'C:\Program Files\Microsoft Visual Studio\18\Preview\VC\Tools\MSVC\14.50.35503\bin\Hostx64\x64\lib.exe' /def:$(MSBuildThisFileDirectory)coreclr.def /out:$(MSBuildThisFileDirectory)coreclr.lib /machine:X64" />
   </Target>
 
   <Target Name="_Clean"

--- a/src/java-interop/java-interop.targets
+++ b/src/java-interop/java-interop.targets
@@ -88,7 +88,7 @@
       Condition="  $([MSBuild]::IsOSPlatform ('windows'))  And '$(NativeToolchainSupported)' == 'True' "
       Inputs="$(MSBuildThisFileDirectory)coreclr.def"
       Outputs="$(MSBuildThisFileDirectory)coreclr.lib">
-    <Exec Command="'C:\Program Files\Microsoft Visual Studio\18\Preview\VC\Tools\MSVC\14.50.35503\bin\Hostx64\x64\lib.exe' /def:$(MSBuildThisFileDirectory)coreclr.def /out:$(MSBuildThisFileDirectory)coreclr.lib /machine:X64" />
+    <Exec Command="lib /def:$(MSBuildThisFileDirectory)coreclr.def /out:$(MSBuildThisFileDirectory)coreclr.lib /machine:X64" />
   </Target>
 
   <Target Name="_Clean"

--- a/tests/NativeTiming/NativeTiming.targets
+++ b/tests/NativeTiming/NativeTiming.targets
@@ -57,7 +57,7 @@
       <_Cmake Include="CmakePath=$(CmakePath)" />
       <_Cmake Include="CmakeGenerator=$(CmakeGenerator)" />
       <_Cmake Include="CmakeSourceDir=$(MSBuildThisFileDirectory)" />
-      <_Cmake Include="CmakeBuildDir=$(MSBuildThisFileDirectory)$(IntermediateOutputPath)%(_NativeTimingLib.Dir)" />
+      <_Cmake Include="CmakeBuildDir=$(IntermediateOutputPath)%(_NativeTimingLib.Dir)" />
       <_Cmake Include="CmakeExtraArgs=$(_JdkDirs)" />
     </ItemGroup>
     <MSBuild


### PR DESCRIPTION
This is a proof of concept for using the TypeMap API from .NET 10 as the source of .NET - Java type mapping. The TypeMap API only allows for a one-to-one relationship between .NET and Java types. To test the viability of it, this branch removes all conditional logic in mapping a Java object to a .NET type, and follows the algorithm in Android's NativeAOT TypeMappingStep to find the single best type for the Java class, and creates an instance of that type. I didn't find any cases where this fails in tests locally.