### PR TITLE
[Java.Interop.Tools.JavaCallableWrappers] Improve missing attribute

### DIFF
--- a/src/Java.Interop.Tools.JavaCallableWrappers/Extensions/XmlExtensions.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Extensions/XmlExtensions.cs
@@ -21,7 +21,7 @@ static class XmlExtensions
 		var value = xml.Attribute (name)?.Value;
 
 		if (string.IsNullOrWhiteSpace (value))
-			throw new InvalidOperationException ($"Missing required attribute '{name}'");
+			throw new InvalidOperationException ($"Missing required attribute '{name}' within element `{xml.ToString()}`.");
 
 		return value!;  // NRT - Guarded by IsNullOrWhiteSpace check above
 	}

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers.Adapters/XmlImporter.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers.Adapters/XmlImporter.cs
@@ -49,10 +49,10 @@ public static class XmlImporter
 	public static CallableWrapperType ImportType (XElement xml)
 	{
 		var name = xml.GetRequiredAttribute ("name");
-		var package = xml.GetRequiredAttribute ("package");
+		var package = xml.GetAttributeOrDefault ("package", (string?) "");
 		var partial_assembly_qualified_name = xml.GetRequiredAttribute ("partial_assembly_qualified_name");
 
-		var type = new CallableWrapperType (name, package, partial_assembly_qualified_name) {
+		var type = new CallableWrapperType (name, package ?? "", partial_assembly_qualified_name) {
 			ApplicationJavaClass = xml.GetAttributeOrDefault ("application_java_class", (string?) null),
 			ExtendsType = xml.GetAttributeOrDefault ("extends_type", (string?) null),
 			GenerateOnCreateOverrides = xml.GetAttributeOrDefault ("generate_on_create_overrides", false),

--- a/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/SupportDeclarations.cs
+++ b/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/SupportDeclarations.cs
@@ -109,6 +109,7 @@ namespace Xamarin.Android.ToolsTests {
 			typeof (ExampleInstrumentation),
 			typeof (ExampleOuterClass),
 			typeof (ExampleOuterClass.ExampleInnerClass),
+			typeof (GlobalClass),
 			typeof (InstrumentationName),
 			typeof (NonStaticOuterClass),
 			typeof (NonStaticOuterClass.NonStaticInnerClass),
@@ -369,4 +370,9 @@ namespace Xamarin.Android.ToolsTests {
 		[JavaCallable ("example")]
 		public void Example () {}
 	}
+}
+
+[Register (nameof (GlobalClass))]
+class GlobalClass : Java.Lang.Object
+{
 }

--- a/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/TypeNameMapGeneratorTests.cs
+++ b/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/TypeNameMapGeneratorTests.cs
@@ -57,6 +57,7 @@ namespace Xamarin.Android.ToolsTests
 				$"entry-count={types.Count - 1}\u0000" +
 				"entry-len=" + length + "\u0000" +
 				"value-offset=" + offset + "\u0000" +
+				GetJ2MEntryLine (typeof (GlobalClass),                              "GlobalClass",                                                                                  offset, length) +
 				GetJ2MEntryLine (typeof (ActivityName),                             "activity/Name",                                                                                offset, length) +
 				GetJ2MEntryLine (typeof (ApplicationName),                          "application/Name",                                                                             offset, length) +
 				GetJ2MEntryLine (typeof (ApplicationName.ActivityLifecycleCallbacks),   "application/Name_ActivityLifecycleCallbacks",                                              offset, length) +
@@ -136,6 +137,7 @@ namespace Xamarin.Android.ToolsTests
 				$"entry-count={types.Count}\u0000" +
 				"entry-len=" + length + "\u0000" +
 				"value-offset=" + offset + "\u0000" +
+				GetM2JEntryLine (typeof (GlobalClass),                              "GlobalClass",                                                                                  offset, length) +
 				GetM2JEntryLine (typeof (AbstractClass),                            "my/AbstractClass",                                                                             offset, length) +
 				GetM2JEntryLine (typeof (AbstractClassInvoker),                     "my/AbstractClass",                                                                             offset, length) +
 				GetM2JEntryLine (typeof (ActivityName),                             "activity/Name",                                                                                offset, length) +


### PR DESCRIPTION
Context: bc44f085f6785abb2e3d2a9533a70b2f63d681b8

If "something goes wrong" and the `*.jlo.xml` files contain `//jcw-types/type` elements that are *missing* the `//type/@package` attribute, then an exception is thrown:

	System.InvalidOperationException: Missing required attribute 'package'
	   at Java.Interop.Tools.JavaCallableWrappers.Extensions.XmlExtensions.GetRequiredAttribute(XElement xml, String name)
	   at Java.Interop.Tools.JavaCallableWrappers.Adapters.XmlImporter.ImportType(XElement xml)
	   at Java.Interop.Tools.JavaCallableWrappers.Adapters.XmlImporter.Import(XElement xml)
	   at Xamarin.Android.Tasks.JavaObjectsXmlFile.Import(String filename, JavaObjectsXmlFileReadType readType)
	   at Xamarin.Android.Tasks.GenerateJavaCallableWrappers.GenerateWrappers(List`1 assemblies)
	   at Xamarin.Android.Tasks.GenerateJavaCallableWrappers.RunTask()
	   at Microsoft.Android.Build.Tasks.AndroidTask.Execute()

Which is all well and good, except ***I have no idea what's broken***.

*Something* within dotnet/android should be updated so that the file causing the exception is mentioned, but we can also improve the `InvalidOperationException` to contain at least a "breadcrumb" for what's going wrong.

Update the `InvalidOperationException` to also include the contents of the `XElement.ToString()` which is missing the required attribute. We can then at least search file contents to find the "offending" file.

This provides a more useful exception message:

	System.InvalidOperationException: Missing required attribute 'package' within element `<type name="SKCanvasElementImpl" package="" application_java_class="android.support.multidex.MultiDexApplication" mono_runtime_initialization="mono.MonoPackageManager.LoadApplication (context);" extends_type="Uno.WinUI.Graphics2DSK.SKCanvasElement" partial_assembly_qualified_name="SKCanvasElementImpl, SamplesApp">
	  <constructors>
	    <constructor name="SKCanvasElementImpl" method="n_.ctor:(Landroid/content/Context;)V:" jni_signature="(Landroid/content/Context;)V" managed_parameters="Android.Content.Context, Mono.Android" params="android.content.Context p0" retval="void" is_dynamically_registered="True" super_call="p0" activate_call="p0" />
	  </constructors>
	</type>`.
	   at Java.Interop.Tools.JavaCallableWrappers.Extensions.XmlExtensions.GetRequiredAttribute(XElement xml, String name)
	   at Java.Interop.Tools.JavaCallableWrappers.Adapters.XmlImporter.ImportType(XElement xml)
	   at Java.Interop.Tools.JavaCallableWrappers.Adapters.XmlImporter.Import(XElement xml)
	   at Xamarin.Android.Tasks.JavaObjectsXmlFile.Import(String filename, JavaObjectsXmlFileReadType readType)
	   at Xamarin.Android.Tasks.GenerateJavaCallableWrappers.GenerateWrappers(List`1 assemblies)
	   at Xamarin.Android.Tasks.GenerateJavaCallableWrappers.RunTask()
	   at Microsoft.Android.Build.Tasks.AndroidTask.Execute()

Which shows *two* problems:

 1. The `package` attribute *is* present, but
 2. The `package` attribute is the empty string.

Which should be supported!  The global package is A Thing That Exists™; it should be supported!  (Has *been* supported?!)

Update `XmlImporter.ImportType()` so that `package` is *not* required.

Update `tests/Java.Interop.Tools.JavaCallableWrappers-Tests` to add an explicit test for a type in the Java global package.