### PR TITLE
[Java.Interop.Sdk] Rename JavacClasspathSeparator to JavaPathSeparator for consistency

### DIFF
--- a/build-tools/Java.Interop.Sdk/Sdk/Sdk.props
+++ b/build-tools/Java.Interop.Sdk/Sdk/Sdk.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
     <JavaPathSeparator Condition=" $([MSBuild]::IsOSPlatform('windows')) ">;</JavaPathSeparator>
-    <JavaPathSeparator Condition=" '$(JavacClasspathSeparator)' == '' ">:</JavaPathSeparator>
+    <JavaPathSeparator Condition=" '$(JavaPathSeparator)' == '' ">:</JavaPathSeparator>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
In build-tools/Java.Interop.Sdk/Sdk/Sdk.props, the property JavaPathSeparator is defined, but the condition for the non-Windows case references an undeclared property JavacClasspathSeparator.

It causes on Windows, javac -classpath with multiple jars fails.

This is likely a typo. This change corrects it to JavaPathSeparator to match the property being defined.