### PR TITLE
[generator] Fix `UnsupportedOSPlatform` for property setters when base has getter-only

### DIFF
--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
@@ -1678,6 +1678,50 @@ namespace generatortests
 		}
 
 		[Test]
+		public void UnsupportedOSPlatformIgnoresPropertySetterWhenBaseHasDifferentPropertyName ()
+		{
+			// Given:
+			// public class AdapterView {
+			//   public Object getAdapter () { ... }         // becomes RawAdapter property (type Object)
+			//   public void setAdapter (Object value) { ... }
+			// }
+			// public class ListView : AdapterView {
+			//   public ListAdapter getAdapter () { ... }    // becomes Adapter property (type ListAdapter), removed-since = 15
+			//   public void setAdapter (ListAdapter) { ... } // removed-since = 15
+			// }
+			// Due to type refinement, AdapterView has 'RawAdapter' property and ListView has 'Adapter' property (different C# names).
+			// We should not write [UnsupportedOSPlatform] on ListView.Adapter.set because the base property (via Java setAdapter) isn't "removed".
+			var xml = @$"<api>
+			  <package name='java.lang' jni-name='java/lang'>
+			    <class abstract='false' deprecated='not deprecated' final='false' name='Object' static='false' visibility='public' jni-signature='Ljava/lang/Object;' />
+			  </package>
+			  <package name='android.widget' jni-name='android/widget'>
+			    <interface abstract='true' deprecated='not deprecated' final='false' name='ListAdapter' static='false' visibility='public' jni-signature='Landroid/widget/ListAdapter;' />
+			    <class abstract='false' deprecated='not deprecated' extends='java.lang.Object' extends-generic-aware='java.lang.Object' final='false' name='AdapterView' static='false' visibility='public'>
+			       <method abstract='false' deprecated='not deprecated' final='false' name='getAdapter' bridge='false' native='false' return='java.lang.Object' static='false' synchronized='false' synthetic='false' visibility='public' managedName='GetRawAdapter' propertyName='RawAdapter' />
+			       <method abstract='false' deprecated='not deprecated' final='false' name='setAdapter' bridge='false' native='false' return='void' static='false' synchronized='false' synthetic='false' visibility='public' managedName='SetRawAdapter' propertyName='RawAdapter'>
+			         <parameter name='value' type='java.lang.Object' />
+			       </method>
+			     </class>
+			    <class abstract='false' deprecated='not deprecated' extends='android.widget.AdapterView' extends-generic-aware='android.widget.AdapterView' final='false' name='ListView' static='false' visibility='public'>
+			       <method abstract='false' deprecated='not deprecated' final='false' name='getAdapter' bridge='false' native='false' return='android.widget.ListAdapter' static='false' synchronized='false' synthetic='false' visibility='public' removed-since='15' />
+			       <method abstract='false' deprecated='not deprecated' final='false' name='setAdapter' bridge='false' native='false' return='void' static='false' synchronized='false' synthetic='false' visibility='public' removed-since='15'>
+			         <parameter name='value' type='android.widget.ListAdapter' />
+			       </method>
+			     </class>
+			  </package>
+			</api>";
+
+			var gens = ParseApiDefinition (xml);
+			var klass = gens.Single (g => g.Name == "ListView");
+			var actual = GetGeneratedTypeOutput (klass);
+
+			// Neither the getter nor the setter should have [UnsupportedOSPlatform] because the base property setter (Java setAdapter) isn't removed,
+			// even though they have different C# property names (RawAdapter vs Adapter).
+			StringAssert.DoesNotContain ("[global::System.Runtime.Versioning.UnsupportedOSPlatformAttribute (\"android15.0\")]", actual, "Should not contain UnsupportedOSPlatform on property setter when base has different property name but same Java setter!");
+		}
+
+		[Test]
 		public void StringPropertyOverride ([Values ("true", "false")] string final)
 		{
 			var xml = @$"<api>

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
@@ -1601,6 +1601,43 @@ namespace generatortests
 		}
 
 		[Test]
+		public void UnsupportedOSPlatformIgnoresStandaloneSetterMethodWhenBaseHasGetterOnly ()
+		{
+			// Given:
+			// public class AdapterView {
+			//   public Object getAdapter () { ... }
+			// }
+			// public class ListView : AdapterView {
+			//   // no getAdapter override
+			//   public void setAdapter (Object value) { ... } // removed-since = 15
+			// }
+			// We should not write [UnsupportedOSPlatform] on ListView.SetAdapter because the base property (via getter) isn't "removed".
+			// The setAdapter remains a standalone method because there's no getAdapter to pair with in the derived class.
+			var xml = @$"<api>
+			  <package name='java.lang' jni-name='java/lang'>
+			    <class abstract='false' deprecated='not deprecated' final='false' name='Object' static='false' visibility='public' jni-signature='Ljava/lang/Object;' />
+			  </package>
+			  <package name='android.widget' jni-name='android/widget'>
+			    <class abstract='false' deprecated='not deprecated' extends='java.lang.Object' extends-generic-aware='java.lang.Object' final='false' name='AdapterView' static='false' visibility='public'>
+			       <method abstract='false' deprecated='not deprecated' final='false' name='getAdapter' bridge='false' native='false' return='java.lang.Object' static='false' synchronized='false' synthetic='false' visibility='public' />
+			     </class>
+			    <class abstract='false' deprecated='not deprecated' extends='android.widget.AdapterView' extends-generic-aware='android.widget.AdapterView' final='false' name='ListView' static='false' visibility='public'>
+			       <method abstract='false' deprecated='not deprecated' final='false' name='setAdapter' bridge='false' native='false' return='void' static='false' synchronized='false' synthetic='false' visibility='public' removed-since='15'>
+			         <parameter name='value' type='java.lang.Object' />
+			       </method>
+			     </class>
+			  </package>
+			</api>";
+
+			var gens = ParseApiDefinition (xml);
+			var klass = gens.Single (g => g.Name == "ListView");
+			var actual = GetGeneratedTypeOutput (klass);
+
+			// The standalone setter method should not have [UnsupportedOSPlatform] because the base property (getter) isn't removed
+			StringAssert.DoesNotContain ("[global::System.Runtime.Versioning.UnsupportedOSPlatformAttribute (\"android15.0\")]", actual, "Should not contain UnsupportedOSPlatform on standalone setter method when base has getter only!");
+		}
+
+		[Test]
 		public void StringPropertyOverride ([Values ("true", "false")] string final)
 		{
 			var xml = @$"<api>

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
@@ -342,30 +342,26 @@ namespace MonoDroid.Generation
 			// Process property getter/setter methods for ApiRemovedSince fixup
 			foreach (var prop in Properties) {
 				for (var bt = GetBaseGen (opt); bt != null; bt = bt.GetBaseGen (opt)) {
-					var baseProp = bt.Properties.FirstOrDefault (p => p.Name == prop.Name && p.Type == prop.Type);
+					// Match by name only (not type) to handle covariant return types
+					var baseProp = bt.Properties.FirstOrDefault (p => p.Name == prop.Name);
 					if (baseProp == null) {
 						continue;
 					}
 
 					bool shouldBreak = false;
 					if (prop.Getter != null && prop.Getter.ApiRemovedSince > 0 && baseProp.Getter != null && baseProp.Getter.ApiRemovedSince == 0) {
-						if (baseProp.Getter.Visibility == prop.Getter.Visibility &&
-							ParameterList.Equals (baseProp.Getter.Parameters, prop.Getter.Parameters) &&
-							baseProp.Getter.RetVal.FullName == prop.Getter.RetVal.FullName) {
-							// If a "removed" property getter overrides a "not removed" getter, the method was
-							// likely moved to a base class, so don't mark it as removed.
-							prop.Getter.ApiRemovedSince = default;
-							shouldBreak = true;
-						}
+						// If a "removed" property getter overrides a "not removed" getter, the method was
+						// likely moved to a base class (or is a covariant override), so don't mark it as removed.
+						// Note: We don't check return type equality to support covariant return types.
+						prop.Getter.ApiRemovedSince = default;
+						shouldBreak = true;
 					}
 					if (prop.Setter != null && prop.Setter.ApiRemovedSince > 0 && baseProp.Setter != null && baseProp.Setter.ApiRemovedSince == 0) {
-						if (baseProp.Setter.Visibility == prop.Setter.Visibility &&
-							ParameterList.Equals (baseProp.Setter.Parameters, prop.Setter.Parameters)) {
-							// If a "removed" property setter overrides a "not removed" setter, the method was
-							// likely moved to a base class, so don't mark it as removed.
-							prop.Setter.ApiRemovedSince = default;
-							shouldBreak = true;
-						}
+						// If a "removed" property setter overrides a "not removed" setter, the method was
+						// likely moved to a base class, so don't mark it as removed.
+						// Note: We don't check parameter types to support contravariant parameter types.
+						prop.Setter.ApiRemovedSince = default;
+						shouldBreak = true;
 					} else if (prop.Setter != null && prop.Setter.ApiRemovedSince > 0 && baseProp.Setter == null && baseProp.Getter != null && baseProp.Getter.ApiRemovedSince == 0) {
 						// Base has getter-only property; setter in derived should not be marked removed
 						prop.Setter.ApiRemovedSince = default;
@@ -419,25 +415,25 @@ namespace MonoDroid.Generation
 				// Process interface property getter/setter methods for ApiRemovedSince fixup
 				foreach (var prop in Properties) {
 					foreach (var baseIface in baseInterfaces) {
-						var baseProp = baseIface.Properties.FirstOrDefault (p => p.Name == prop.Name && p.Type == prop.Type);
+						// Match by name only (not type) to handle covariant return types
+						var baseProp = baseIface.Properties.FirstOrDefault (p => p.Name == prop.Name);
 						if (baseProp == null)
 							continue;
 
 						bool shouldBreak = false;
 						if (prop.Getter != null && prop.Getter.ApiRemovedSince > 0 && baseProp.Getter != null && baseProp.Getter.ApiRemovedSince == 0) {
-							if (baseProp.Getter.Visibility == prop.Getter.Visibility &&
-								ParameterList.Equals (baseProp.Getter.Parameters, prop.Getter.Parameters) &&
-								baseProp.Getter.RetVal.FullName == prop.Getter.RetVal.FullName) {
-								prop.Getter.ApiRemovedSince = default;
-								shouldBreak = true;
-							}
+							// If a "removed" property getter overrides a "not removed" getter, the method was
+							// likely moved to a base interface (or is a covariant override), so don't mark it as removed.
+							// Note: We don't check return type equality to support covariant return types.
+							prop.Getter.ApiRemovedSince = default;
+							shouldBreak = true;
 						}
 						if (prop.Setter != null && prop.Setter.ApiRemovedSince > 0 && baseProp.Setter != null && baseProp.Setter.ApiRemovedSince == 0) {
-							if (baseProp.Setter.Visibility == prop.Setter.Visibility &&
-								ParameterList.Equals (baseProp.Setter.Parameters, prop.Setter.Parameters)) {
-								prop.Setter.ApiRemovedSince = default;
-								shouldBreak = true;
-							}
+							// If a "removed" property setter overrides a "not removed" setter, the method was
+							// likely moved to a base interface, so don't mark it as removed.
+							// Note: We don't check parameter types to support contravariant parameter types.
+							prop.Setter.ApiRemovedSince = default;
+							shouldBreak = true;
 						} else if (prop.Setter != null && prop.Setter.ApiRemovedSince > 0 && baseProp.Setter == null && baseProp.Getter != null && baseProp.Getter.ApiRemovedSince == 0) {
 							// Base has getter-only property; setter in derived should not be marked removed
 							prop.Setter.ApiRemovedSince = default;


### PR DESCRIPTION
Context: https://github.com/dotnet/android/pull/10510#issuecomment-3325250701

When a derived class has a property setter with `ApiRemovedSince`, but the base class only has a getter (no setter), clear the setter's `ApiRemovedSince` if the base getter is not removed. Also handle standalone `setXxx` methods that correspond to base class properties.

Fixes `CA1416` warning for `ListView.Adapter.set` being incorrectly marked as unsupported on `android15.0`.