### PR TITLE
[tests] Add NativeAOTIgnore to InvokeVirtualFromConstructorTests

### DIFF
--- a/tests/Java.Interop-Tests/Java.Interop/InvokeVirtualFromConstructorTests.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/InvokeVirtualFromConstructorTests.cs
@@ -15,6 +15,7 @@ namespace Java.InteropTests {
 	public class InvokeVirtualFromConstructorTests : JavaVMFixture
 	{
 		[Test]
+		[Category ("NativeAOTIgnore")] // https://github.com/dotnet/android/issues/10950
 		public void CreateManagedInstanceFirst_WithAllocObject ()
 		{
 			CallVirtualFromConstructorDerived.Intermediate_FromActivationConstructor    = null;
@@ -61,6 +62,7 @@ namespace Java.InteropTests {
 		}
 
 		[Test]
+		[Category ("NativeAOTIgnore")] // https://github.com/dotnet/android/issues/10950
 		public void CreateManagedInstanceFirst_WithNewObject ()
 		{
 			CallVirtualFromConstructorDerived.Intermediate_FromActivationConstructor    = null;
@@ -111,6 +113,7 @@ namespace Java.InteropTests {
 		}
 
 		[Test]
+		[Category ("NativeAOTIgnore")] // https://github.com/dotnet/android/issues/10950
 		public void CreateJavaInstanceFirst ()
 		{
 			CallVirtualFromConstructorDerived.Intermediate_FromActivationConstructor    = null;


### PR DESCRIPTION
These 3 tests fail on NativeAOT with `DelegateMarshalling_MissingInteropData` because `PreserveRegistrations` does not handle `[JniAddNativeMethodRegistrationAttribute]` delegate types. NativeAOT cannot generate the unmanaged-callable wrapper for `CalledFromConstructorMarshalMethod` at runtime.

Tracking issue: https://github.com/dotnet/android/issues/10950
Context: https://github.com/dotnet/android/pull/10496

Tests marked:
- `InvokeVirtualFromConstructorTests.CreateJavaInstanceFirst`
- `InvokeVirtualFromConstructorTests.CreateManagedInstanceFirst_WithAllocObject`
- `InvokeVirtualFromConstructorTests.CreateManagedInstanceFirst_WithNewObject`