### PR TITLE
Fix UTF-8 JNI lookup tests for Android

### DIFF
--- a/tests/Java.Interop-Tests/Java.Interop/JniTypeUtf8Test.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JniTypeUtf8Test.cs
@@ -46,7 +46,11 @@ namespace Java.InteropTests
 		[Test]
 		public void FindClass_Utf8_ThrowsOnNotFound ()
 		{
+#if __ANDROID__
+			Assert.Throws<Java.Lang.ClassNotFoundException> (() => JniEnvironment.Types.FindClass ("does/not/Exist"u8));
+#else   // __ANDROID__
 			Assert.Throws<JavaException> (() => JniEnvironment.Types.FindClass ("does/not/Exist"u8));
+#endif  // __ANDROID__
 		}
 
 		[Test]
@@ -172,7 +176,11 @@ namespace Java.InteropTests
 		public void InvalidSignature_Utf8_ThrowsJniException ()
 		{
 			using (var Object_class = new JniType ("java/lang/Object"u8)) {
+#if __ANDROID__
+				Assert.Throws<Java.Lang.NoSuchMethodError> (() => Object_class.GetInstanceMethod ("bogus"u8, "(Z)V"u8));
+#else   // __ANDROID__
 				Assert.Throws<JavaException> (() => Object_class.GetInstanceMethod ("bogus"u8, "(Z)V"u8));
+#endif  // __ANDROID__
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

The new UTF-8 overload tests from #1393 fail on Android because `Assert.Throws<JavaException>` expects an exact type match, but the Android runtime throws more specific exception types:

- `FindClass` → `Java.Lang.ClassNotFoundException` (not generic `JavaException`)
- `GetMethodID` → `Java.Lang.NoSuchMethodError` (not generic `JavaException`)

This happens because the UTF-8 `FindClass` overload intentionally skips the `Class.forName` fallback, so the raw JNI exceptions bubble up directly.

## Fix

Added `#if __ANDROID__` conditionals to expect the Android-specific exception types, matching the existing pattern in `JniTypeTest.Ctor_ThrowsIfTypeNotFound` and `JniTypeTest.InvalidSignatureThrowsJniException`.

Fixes dotnet/android#10993