### PR TITLE
Fix GetFieldID UTF-8 test for Android

### DIFF
--- a/tests/Java.Interop-Tests/Java.Interop/JniTypeUtf8Test.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JniTypeUtf8Test.cs
@@ -90,9 +90,11 @@ namespace Java.InteropTests
 		[Test]
 		public void GetFieldID_Utf8_MatchesStringOverload ()
 		{
-			using (var Integer_class = new JniType ("java/lang/Integer"u8)) {
-				var fromString = JniEnvironment.InstanceFields.GetFieldID (Integer_class.PeerReference, "value", "I");
-				var fromUtf8   = JniEnvironment.InstanceFields.GetFieldID (Integer_class.PeerReference, "value"u8, "I"u8);
+			// Integer.value is private and blocked by ART hidden API restrictions.
+			// StreamTokenizer.ttype is a public instance field available on both JVM and Android.
+			using (var StreamTokenizer_class = new JniType ("java/io/StreamTokenizer"u8)) {
+				var fromString = JniEnvironment.InstanceFields.GetFieldID (StreamTokenizer_class.PeerReference, "ttype", "I");
+				var fromUtf8   = JniEnvironment.InstanceFields.GetFieldID (StreamTokenizer_class.PeerReference, "ttype"u8, "I"u8);
 				Assert.AreEqual (fromString.ID, fromUtf8.ID);
 			}
 		}


### PR DESCRIPTION
Use `StreamTokenizer.ttype` (public instance field, available since API level 1)
instead of `Integer.value` (private) in `GetFieldID_Utf8_MatchesStringOverload`.

ART's hidden API restrictions block JNI `GetFieldID` access to private fields,
causing `NoSuchFieldError` on Android. `StreamTokenizer.ttype` is public and
works on both desktop JVM and Android — no `#if __ANDROID__` conditional needed.

The fix in #1398 added `#if __ANDROID__` guards for `FindClass` and
`GetMethodID` UTF-8 tests but missed this `GetFieldID` case.

Fixes dotnet/android#11005