### PR TITLE
[Java.Interop.Tools.Cecil] Fix retry logic in ReadAssembly to skip symbol loading

### DIFF
--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/DirectoryAssemblyResolver.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/DirectoryAssemblyResolver.cs
@@ -162,24 +162,26 @@ namespace Java.Interop.Tools.Cecil {
 				SymbolReaderProvider            = loadReaderParameters.SymbolReaderProvider,
 			};
 			try {
-				return LoadFromMemoryMappedFile (file, reader_parameters);
+				return LoadFromMemoryMappedFile (file, reader_parameters, loadDebugSymbols);
 			} catch (Exception ex) {
+				if (!loadDebugSymbols)
+					throw;
 				logger (
 						TraceLevel.Verbose,
 						$"Failed to read '{file}' with debugging symbols. Retrying to load it without it. Error details are logged below.");
 				logger (TraceLevel.Verbose, ex.ToString ());
 				reader_parameters.ReadSymbols = false;
-				return LoadFromMemoryMappedFile (file, reader_parameters);
+				return LoadFromMemoryMappedFile (file, reader_parameters, loadSymbols: false);
 			} finally {
 				reader_parameters.SymbolStream?.Dispose ();
 			}
 		}
 
-		AssemblyDefinition LoadFromMemoryMappedFile (string file, ReaderParameters options)
+		AssemblyDefinition LoadFromMemoryMappedFile (string file, ReaderParameters options, bool loadSymbols)
 		{
 			// We can't use MemoryMappedFile when ReadWrite is true
 			if (options.ReadWrite) {
-				if (loadDebugSymbols) {
+				if (loadSymbols) {
 					LoadSymbols (file, options, File.OpenRead);
 				}
 				return AssemblyDefinition.ReadAssembly (file, options);
@@ -187,9 +189,9 @@ namespace Java.Interop.Tools.Cecil {
 
 			// We know the capacity for disposables
 			var disposables = new List<IDisposable> (
-				(1 + (loadDebugSymbols ? 1 : 0)) * OpenMemoryMappedViewStream_disposables_Add_calls);
+				(1 + (loadSymbols ? 1 : 0)) * OpenMemoryMappedViewStream_disposables_Add_calls);
 			try {
-				if (loadDebugSymbols) {
+				if (loadSymbols) {
 					LoadSymbols (file, options, f => OpenMemoryMappedViewStream (f, disposables));
 				}
 

--- a/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/DirectoryAssemblyResolverTests.cs
+++ b/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/DirectoryAssemblyResolverTests.cs
@@ -49,5 +49,21 @@ namespace Java.Interop.Tools.JavaCallableWrappersTests
 			Assert.IsNotNull (assembly);
 			Assert.AreEqual (loadDebugSymbols, assembly.MainModule.HasSymbols);
 		}
+
+		[Test]
+		public void LoadSymbols_LockedPdb ([Values (true, false)] bool readWrite)
+		{
+			// Lock the PDB file exclusively so LoadSymbols will fail with IOException
+			using var lockStream = new FileStream (symbol_path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+
+			using var resolver = new DirectoryAssemblyResolver (Log, loadDebugSymbols: true, new ReaderParameters {
+				ReadWrite = readWrite
+			});
+
+			// Should succeed by retrying without symbols instead of throwing
+			var assembly = resolver.Load (assembly_path);
+			Assert.IsNotNull (assembly);
+			Assert.IsFalse (assembly.MainModule.HasSymbols);
+		}
 	}
 }


### PR DESCRIPTION
## Summary

The retry path in `DirectoryAssemblyResolver.ReadAssembly` was broken - it set `reader_parameters.ReadSymbols = false` but `LoadFromMemoryMappedFile` checked the instance field `loadDebugSymbols` instead, so the retry would re-open the same locked PDB file and throw the same `IOException`.

## Problem

When a PDB file in the NuGet cache is locked by another process (e.g. the .NET SDK trimmer running concurrently), `LoadSymbols` throws an `IOException`. The `ReadAssembly` method has a catch block that is supposed to retry without symbols, but the retry calls `LoadFromMemoryMappedFile` which checks `loadDebugSymbols` (always `true`) and calls `LoadSymbols` again - hitting the same locked file.

This causes `error XAPTP7000 / XA0009` build failures:

````
error XAPTP7000: error XA0009: Error while loading assembly: 'Xamarin.AndroidX.Core.dll'.
   ---> System.IO.IOException: The process cannot access the file 'Xamarin.AndroidX.Core.pdb'
        because it is being used by another process.
````

## Fix

Add an explicit `bool loadSymbols` parameter to `LoadFromMemoryMappedFile` so the retry can pass `false` to actually skip symbol loading.

Context: dotnet/android#11081