### PR TITLE
[ci] Use PublishTestResults@2 instead of DotNetCoreCLI@2 built-in publishing

### DIFF
--- a/build-tools/automation/templates/core-tests.yaml
+++ b/build-tools/automation/templates/core-tests.yaml
@@ -10,7 +10,7 @@ steps:
   inputs:
     command: test
     publishTestResults: false
-    arguments: --logger trx --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/generator-Tests.dll
+    arguments: --logger "trx;LogFileName=generator.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/generator-Tests.dll
   continueOnError: true
   
 - task: DotNetCoreCLI@2
@@ -18,7 +18,7 @@ steps:
   inputs:
     command: test
     publishTestResults: false
-    arguments: --logger trx --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Tools.JavaCallableWrappers-Tests.dll
+    arguments: --logger "trx;LogFileName=JavaCallableWrappers.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Tools.JavaCallableWrappers-Tests.dll
   continueOnError: true
    
 - task: DotNetCoreCLI@2
@@ -26,7 +26,7 @@ steps:
   inputs:
     command: test
     publishTestResults: false
-    arguments: --logger trx --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/logcat-parse-Tests.dll
+    arguments: --logger "trx;LogFileName=logcat-parse.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/logcat-parse-Tests.dll
   continueOnError: true
   
 - task: DotNetCoreCLI@2
@@ -34,7 +34,7 @@ steps:
   inputs:
     command: test
     publishTestResults: false
-    arguments: --logger trx --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Xamarin.Android.Tools.ApiXmlAdjuster-Tests.dll
+    arguments: --logger "trx;LogFileName=ApiXmlAdjuster.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Xamarin.Android.Tools.ApiXmlAdjuster-Tests.dll
   continueOnError: true
   
 - task: DotNetCoreCLI@2
@@ -42,7 +42,7 @@ steps:
   inputs:
     command: test
     publishTestResults: false
-    arguments: --logger trx --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Tools.JavaTypeSystem-Tests.dll
+    arguments: --logger "trx;LogFileName=JavaTypeSystem.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Tools.JavaTypeSystem-Tests.dll
   continueOnError: true
   
 - task: DotNetCoreCLI@2
@@ -50,7 +50,7 @@ steps:
   inputs:
     command: test
     publishTestResults: false
-    arguments: --logger trx --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Xamarin.Android.Tools.Bytecode-Tests.dll
+    arguments: --logger "trx;LogFileName=Bytecode.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Xamarin.Android.Tools.Bytecode-Tests.dll
   continueOnError: true
 
 - task: DotNetCoreCLI@2
@@ -58,7 +58,7 @@ steps:
   inputs:
     command: test
     publishTestResults: false
-    arguments: --logger trx --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Tools.Generator-Tests.dll
+    arguments: --logger "trx;LogFileName=Java.Interop.Tools.Generator.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Tools.Generator-Tests.dll
   continueOnError: true
 
 - task: DotNetCoreCLI@2
@@ -66,7 +66,7 @@ steps:
   inputs:
     command: test
     publishTestResults: false
-    arguments: --logger trx --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Tools.JavaSource-Tests.dll
+    arguments: --logger "trx;LogFileName=Java.Interop.Tools.JavaSource.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Tools.JavaSource-Tests.dll
   continueOnError: true
 
 - task: DotNetCoreCLI@2
@@ -74,7 +74,7 @@ steps:
   inputs:
     command: test
     publishTestResults: false
-    arguments: --logger trx --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Xamarin.SourceWriter-Tests.dll
+    arguments: --logger "trx;LogFileName=Xamarin.SourceWriter.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Xamarin.SourceWriter-Tests.dll
   continueOnError: true
 
 - task: DotNetCoreCLI@2
@@ -82,7 +82,7 @@ steps:
   inputs:
     command: test
     publishTestResults: false
-    arguments: --logger trx --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Tools.Maven-Tests.dll
+    arguments: --logger "trx;LogFileName=Java.Interop.Tools.Maven.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Tools.Maven-Tests.dll
   continueOnError: true
 
 - task: DotNetCoreCLI@2
@@ -91,7 +91,7 @@ steps:
   inputs:
     command: test
     publishTestResults: false
-    arguments: --logger trx --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop-Tests.dll
+    arguments: --logger "trx;LogFileName=Java.Interop.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop-Tests.dll
   continueOnError: true
   retryCountOnTaskFailure: 1
 
@@ -101,7 +101,7 @@ steps:
   inputs:
     command: test
     publishTestResults: false
-    arguments: --logger trx --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Dynamic-Tests.dll
+    arguments: --logger "trx;LogFileName=Java.Interop.Dynamic.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Dynamic-Tests.dll
   continueOnError: true
   retryCountOnTaskFailure: 1
 
@@ -111,7 +111,7 @@ steps:
   inputs:
     command: test
     publishTestResults: false
-    arguments: --logger trx --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Export-Tests.dll
+    arguments: --logger "trx;LogFileName=Java.Interop.Export.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Export-Tests.dll
   continueOnError: true
   retryCountOnTaskFailure: 1
 
@@ -131,7 +131,7 @@ steps:
   inputs:
     command: test
     publishTestResults: false
-    arguments: --logger trx --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Export-Tests.dll
+    arguments: --logger "trx;LogFileName=Java.Interop.Export-jnimarshalmethod.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Export-Tests.dll
   continueOnError: true
   retryCountOnTaskFailure: 1
 
@@ -141,7 +141,7 @@ steps:
   inputs:
     command: test
     publishTestResults: false
-    arguments: --logger trx --results-directory $(Agent.TempDirectory) --logger "console;verbosity=detailed" bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop-PerformanceTests.dll
+    arguments: --logger "trx;LogFileName=Java.Interop-Performance.trx" --results-directory $(Agent.TempDirectory) --logger "console;verbosity=detailed" bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop-PerformanceTests.dll
   continueOnError: true
   retryCountOnTaskFailure: 1
 
@@ -151,7 +151,7 @@ steps:
   inputs:
     command: test
     publishTestResults: false
-    arguments: --logger trx --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Base-Tests.dll
+    arguments: --logger "trx;LogFileName=Java.Base.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Base-Tests.dll
   continueOnError: true
   retryCountOnTaskFailure: 1
 
@@ -171,7 +171,7 @@ steps:
   inputs:
     command: test
     publishTestResults: false
-    arguments: --logger trx --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Base-Tests.dll
+    arguments: --logger "trx;LogFileName=Java.Base-jnimarshalmethod.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Base-Tests.dll
   continueOnError: true
   retryCountOnTaskFailure: 1
 
@@ -209,5 +209,4 @@ steps:
   inputs:
     testResultsFormat: VSTest
     testResultsFiles: '$(Agent.TempDirectory)/**/*.trx'
-    testRunTitle: .NET Tests (${{ parameters.platformName }})
   continueOnError: true

--- a/build-tools/automation/templates/core-tests.yaml
+++ b/build-tools/automation/templates/core-tests.yaml
@@ -9,80 +9,80 @@ steps:
   displayName: 'Tests: generator'
   inputs:
     command: test
-    testRunTitle: generator (${{ parameters.platformName }})
-    arguments: bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/generator-Tests.dll
+    publishTestResults: false
+    arguments: --logger trx --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/generator-Tests.dll
   continueOnError: true
   
 - task: DotNetCoreCLI@2
   displayName: 'Tests: JavaCallableWrappers'
   inputs:
     command: test
-    testRunTitle: Java.Interop.Tools.JavaCallableWrappers (${{ parameters.platformName }})
-    arguments: bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Tools.JavaCallableWrappers-Tests.dll
+    publishTestResults: false
+    arguments: --logger trx --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Tools.JavaCallableWrappers-Tests.dll
   continueOnError: true
    
 - task: DotNetCoreCLI@2
   displayName: 'Tests: logcat-parse'
   inputs:
     command: test
-    testRunTitle: logcat-parse (${{ parameters.platformName }})
-    arguments: bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/logcat-parse-Tests.dll
+    publishTestResults: false
+    arguments: --logger trx --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/logcat-parse-Tests.dll
   continueOnError: true
   
 - task: DotNetCoreCLI@2
   displayName: 'Tests: ApiXmlAdjuster'
   inputs:
     command: test
-    testRunTitle: Xamarin.Android.Tools.ApiXmlAdjuster (${{ parameters.platformName }})
-    arguments: bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Xamarin.Android.Tools.ApiXmlAdjuster-Tests.dll
+    publishTestResults: false
+    arguments: --logger trx --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Xamarin.Android.Tools.ApiXmlAdjuster-Tests.dll
   continueOnError: true
   
 - task: DotNetCoreCLI@2
   displayName: 'Tests: JavaTypeSystem'
   inputs:
     command: test
-    testRunTitle: Xamarin.Android.Tools.JavaTypeSystem (${{ parameters.platformName }})
-    arguments: bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Tools.JavaTypeSystem-Tests.dll
+    publishTestResults: false
+    arguments: --logger trx --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Tools.JavaTypeSystem-Tests.dll
   continueOnError: true
   
 - task: DotNetCoreCLI@2
   displayName: 'Tests: Bytecode'
   inputs:
     command: test
-    testRunTitle: Xamarin.Android.Tools.Bytecode (${{ parameters.platformName }})
-    arguments: bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Xamarin.Android.Tools.Bytecode-Tests.dll
+    publishTestResults: false
+    arguments: --logger trx --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Xamarin.Android.Tools.Bytecode-Tests.dll
   continueOnError: true
 
 - task: DotNetCoreCLI@2
   displayName: 'Tests: Java.Interop.Tools.Generator'
   inputs:
     command: test
-    testRunTitle: Java.Interop.Tools.Generator (${{ parameters.platformName }})
-    arguments: bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Tools.Generator-Tests.dll
+    publishTestResults: false
+    arguments: --logger trx --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Tools.Generator-Tests.dll
   continueOnError: true
 
 - task: DotNetCoreCLI@2
   displayName: 'Tests: Java.Interop.Tools.JavaSource'
   inputs:
     command: test
-    testRunTitle: Java.Interop.Tools.JavaSource (${{ parameters.platformName }})
-    arguments: bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Tools.JavaSource-Tests.dll
+    publishTestResults: false
+    arguments: --logger trx --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Tools.JavaSource-Tests.dll
   continueOnError: true
 
 - task: DotNetCoreCLI@2
   displayName: 'Tests: Xamarin.SourceWriter'
   inputs:
     command: test
-    testRunTitle: Xamarin.SourceWriter (${{ parameters.platformName }})
-    arguments: bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Xamarin.SourceWriter-Tests.dll
+    publishTestResults: false
+    arguments: --logger trx --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Xamarin.SourceWriter-Tests.dll
   continueOnError: true
 
 - task: DotNetCoreCLI@2
   displayName: 'Tests: Java.Interop.Tools.Maven'
   inputs:
     command: test
-    testRunTitle: Java.Interop.Tools.Maven (${{ parameters.platformName }})
-    arguments: bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Tools.Maven-Tests.dll
+    publishTestResults: false
+    arguments: --logger trx --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Tools.Maven-Tests.dll
   continueOnError: true
 
 - task: DotNetCoreCLI@2
@@ -90,8 +90,8 @@ steps:
   condition: or(eq('${{ parameters.runNativeDotnetTests }}', 'true'), eq('${{ parameters.runNativeTests }}', 'true'))
   inputs:
     command: test
-    testRunTitle: Java.Interop ($(DotNetTargetFramework) - ${{ parameters.platformName }})
-    arguments: bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop-Tests.dll
+    publishTestResults: false
+    arguments: --logger trx --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop-Tests.dll
   continueOnError: true
   retryCountOnTaskFailure: 1
 
@@ -100,8 +100,8 @@ steps:
   condition: eq('${{ parameters.runNativeTests }}', 'true')
   inputs:
     command: test
-    testRunTitle: Java.Interop.Dynamic (${{ parameters.platformName }})
-    arguments: bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Dynamic-Tests.dll
+    publishTestResults: false
+    arguments: --logger trx --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Dynamic-Tests.dll
   continueOnError: true
   retryCountOnTaskFailure: 1
 
@@ -110,8 +110,8 @@ steps:
   condition: or(eq('${{ parameters.runNativeDotnetTests }}', 'true'), eq('${{ parameters.runNativeTests }}', 'true'))
   inputs:
     command: test
-    testRunTitle: Java.Interop.Export (${{ parameters.platformName }})
-    arguments: bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Export-Tests.dll
+    publishTestResults: false
+    arguments: --logger trx --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Export-Tests.dll
   continueOnError: true
   retryCountOnTaskFailure: 1
 
@@ -130,8 +130,8 @@ steps:
   condition: or(eq('${{ parameters.runNativeDotnetTests }}', 'true'), eq('${{ parameters.runNativeTests }}', 'true'))
   inputs:
     command: test
-    testRunTitle: Java.Interop.Export (jnimarshalmethod-gen + ${{ parameters.platformName }})
-    arguments: bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Export-Tests.dll
+    publishTestResults: false
+    arguments: --logger trx --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Export-Tests.dll
   continueOnError: true
   retryCountOnTaskFailure: 1
 
@@ -140,8 +140,8 @@ steps:
   condition: eq('${{ parameters.runNativeTests }}', 'true')
   inputs:
     command: test
-    testRunTitle: Java.Interop-Performance ($(DotNetTargetFramework) - ${{ parameters.platformName }})
-    arguments: --logger "console;verbosity=detailed" bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop-PerformanceTests.dll
+    publishTestResults: false
+    arguments: --logger trx --results-directory $(Agent.TempDirectory) --logger "console;verbosity=detailed" bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop-PerformanceTests.dll
   continueOnError: true
   retryCountOnTaskFailure: 1
 
@@ -150,8 +150,8 @@ steps:
   condition: or(eq('${{ parameters.runNativeDotnetTests }}', 'true'), eq('${{ parameters.runNativeTests }}', 'true'))
   inputs:
     command: test
-    testRunTitle: Java.Base ($(DotNetTargetFramework) - ${{ parameters.platformName }})
-    arguments: bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Base-Tests.dll
+    publishTestResults: false
+    arguments: --logger trx --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Base-Tests.dll
   continueOnError: true
   retryCountOnTaskFailure: 1
 
@@ -166,12 +166,12 @@ steps:
   retryCountOnTaskFailure: 1
 
 - task: DotNetCoreCLI@2
-  displayName: 'Tests: Java.Base'
+  displayName: 'Tests: Java.Base w/ jnimarshalmethod-gen!'
   condition: or(eq('${{ parameters.runNativeDotnetTests }}', 'true'), eq('${{ parameters.runNativeTests }}', 'true'))
   inputs:
     command: test
-    testRunTitle: Java.Base ($(DotNetTargetFramework) - ${{ parameters.platformName }})
-    arguments: bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Base-Tests.dll
+    publishTestResults: false
+    arguments: --logger trx --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Base-Tests.dll
   continueOnError: true
   retryCountOnTaskFailure: 1
 
@@ -201,4 +201,13 @@ steps:
     testResultsFormat: JUnit
     testResultsFiles: 'tools/java-source-utils/build/test-results/**/TEST-*.xml'
     testRunTitle: java-source-utils (${{ parameters.platformName }})
+  continueOnError: true
+
+- task: PublishTestResults@2
+  displayName: Publish .NET Test Results
+  condition: succeededOrFailed()
+  inputs:
+    testResultsFormat: VSTest
+    testResultsFiles: '$(Agent.TempDirectory)/**/*.trx'
+    testRunTitle: .NET Tests (${{ parameters.platformName }})
   continueOnError: true

--- a/build-tools/automation/templates/core-tests.yaml
+++ b/build-tools/automation/templates/core-tests.yaml
@@ -5,232 +5,76 @@ parameters:
   nativeAotRid:
 
 steps:
-- task: DotNetCoreCLI@2
-  displayName: 'Tests: generator'
-  inputs:
-    command: test
-    publishTestResults: false
-    arguments: --logger "trx;LogFileName=generator.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/generator-Tests.dll
-  continueOnError: true
-
-- task: PublishTestResults@2
-  displayName: 'Publish: generator'
-  condition: succeededOrFailed()
-  inputs:
-    testResultsFormat: VSTest
-    testResultsFiles: '$(Agent.TempDirectory)/generator.trx'
+- template: run-dotnet-test.yaml
+  parameters:
     testRunTitle: generator (${{ parameters.platformName }})
-  continueOnError: true
+    testAssemblyName: generator-Tests
 
-- task: DotNetCoreCLI@2
-  displayName: 'Tests: JavaCallableWrappers'
-  inputs:
-    command: test
-    publishTestResults: false
-    arguments: --logger "trx;LogFileName=JavaCallableWrappers.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Tools.JavaCallableWrappers-Tests.dll
-  continueOnError: true
-
-- task: PublishTestResults@2
-  displayName: 'Publish: JavaCallableWrappers'
-  condition: succeededOrFailed()
-  inputs:
-    testResultsFormat: VSTest
-    testResultsFiles: '$(Agent.TempDirectory)/JavaCallableWrappers.trx'
+- template: run-dotnet-test.yaml
+  parameters:
     testRunTitle: Java.Interop.Tools.JavaCallableWrappers (${{ parameters.platformName }})
-  continueOnError: true
+    testAssemblyName: Java.Interop.Tools.JavaCallableWrappers-Tests
 
-- task: DotNetCoreCLI@2
-  displayName: 'Tests: logcat-parse'
-  inputs:
-    command: test
-    publishTestResults: false
-    arguments: --logger "trx;LogFileName=logcat-parse.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/logcat-parse-Tests.dll
-  continueOnError: true
-
-- task: PublishTestResults@2
-  displayName: 'Publish: logcat-parse'
-  condition: succeededOrFailed()
-  inputs:
-    testResultsFormat: VSTest
-    testResultsFiles: '$(Agent.TempDirectory)/logcat-parse.trx'
+- template: run-dotnet-test.yaml
+  parameters:
     testRunTitle: logcat-parse (${{ parameters.platformName }})
-  continueOnError: true
+    testAssemblyName: logcat-parse-Tests
 
-- task: DotNetCoreCLI@2
-  displayName: 'Tests: ApiXmlAdjuster'
-  inputs:
-    command: test
-    publishTestResults: false
-    arguments: --logger "trx;LogFileName=ApiXmlAdjuster.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Xamarin.Android.Tools.ApiXmlAdjuster-Tests.dll
-  continueOnError: true
-
-- task: PublishTestResults@2
-  displayName: 'Publish: ApiXmlAdjuster'
-  condition: succeededOrFailed()
-  inputs:
-    testResultsFormat: VSTest
-    testResultsFiles: '$(Agent.TempDirectory)/ApiXmlAdjuster.trx'
+- template: run-dotnet-test.yaml
+  parameters:
     testRunTitle: Xamarin.Android.Tools.ApiXmlAdjuster (${{ parameters.platformName }})
-  continueOnError: true
+    testAssemblyName: Xamarin.Android.Tools.ApiXmlAdjuster-Tests
 
-- task: DotNetCoreCLI@2
-  displayName: 'Tests: JavaTypeSystem'
-  inputs:
-    command: test
-    publishTestResults: false
-    arguments: --logger "trx;LogFileName=JavaTypeSystem.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Tools.JavaTypeSystem-Tests.dll
-  continueOnError: true
-
-- task: PublishTestResults@2
-  displayName: 'Publish: JavaTypeSystem'
-  condition: succeededOrFailed()
-  inputs:
-    testResultsFormat: VSTest
-    testResultsFiles: '$(Agent.TempDirectory)/JavaTypeSystem.trx'
+- template: run-dotnet-test.yaml
+  parameters:
     testRunTitle: Xamarin.Android.Tools.JavaTypeSystem (${{ parameters.platformName }})
-  continueOnError: true
+    testAssemblyName: Java.Interop.Tools.JavaTypeSystem-Tests
 
-- task: DotNetCoreCLI@2
-  displayName: 'Tests: Bytecode'
-  inputs:
-    command: test
-    publishTestResults: false
-    arguments: --logger "trx;LogFileName=Bytecode.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Xamarin.Android.Tools.Bytecode-Tests.dll
-  continueOnError: true
-
-- task: PublishTestResults@2
-  displayName: 'Publish: Bytecode'
-  condition: succeededOrFailed()
-  inputs:
-    testResultsFormat: VSTest
-    testResultsFiles: '$(Agent.TempDirectory)/Bytecode.trx'
+- template: run-dotnet-test.yaml
+  parameters:
     testRunTitle: Xamarin.Android.Tools.Bytecode (${{ parameters.platformName }})
-  continueOnError: true
+    testAssemblyName: Xamarin.Android.Tools.Bytecode-Tests
 
-- task: DotNetCoreCLI@2
-  displayName: 'Tests: Java.Interop.Tools.Generator'
-  inputs:
-    command: test
-    publishTestResults: false
-    arguments: --logger "trx;LogFileName=Java.Interop.Tools.Generator.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Tools.Generator-Tests.dll
-  continueOnError: true
-
-- task: PublishTestResults@2
-  displayName: 'Publish: Java.Interop.Tools.Generator'
-  condition: succeededOrFailed()
-  inputs:
-    testResultsFormat: VSTest
-    testResultsFiles: '$(Agent.TempDirectory)/Java.Interop.Tools.Generator.trx'
+- template: run-dotnet-test.yaml
+  parameters:
     testRunTitle: Java.Interop.Tools.Generator (${{ parameters.platformName }})
-  continueOnError: true
+    testAssemblyName: Java.Interop.Tools.Generator-Tests
 
-- task: DotNetCoreCLI@2
-  displayName: 'Tests: Java.Interop.Tools.JavaSource'
-  inputs:
-    command: test
-    publishTestResults: false
-    arguments: --logger "trx;LogFileName=Java.Interop.Tools.JavaSource.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Tools.JavaSource-Tests.dll
-  continueOnError: true
-
-- task: PublishTestResults@2
-  displayName: 'Publish: Java.Interop.Tools.JavaSource'
-  condition: succeededOrFailed()
-  inputs:
-    testResultsFormat: VSTest
-    testResultsFiles: '$(Agent.TempDirectory)/Java.Interop.Tools.JavaSource.trx'
+- template: run-dotnet-test.yaml
+  parameters:
     testRunTitle: Java.Interop.Tools.JavaSource (${{ parameters.platformName }})
-  continueOnError: true
+    testAssemblyName: Java.Interop.Tools.JavaSource-Tests
 
-- task: DotNetCoreCLI@2
-  displayName: 'Tests: Xamarin.SourceWriter'
-  inputs:
-    command: test
-    publishTestResults: false
-    arguments: --logger "trx;LogFileName=Xamarin.SourceWriter.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Xamarin.SourceWriter-Tests.dll
-  continueOnError: true
-
-- task: PublishTestResults@2
-  displayName: 'Publish: Xamarin.SourceWriter'
-  condition: succeededOrFailed()
-  inputs:
-    testResultsFormat: VSTest
-    testResultsFiles: '$(Agent.TempDirectory)/Xamarin.SourceWriter.trx'
+- template: run-dotnet-test.yaml
+  parameters:
     testRunTitle: Xamarin.SourceWriter (${{ parameters.platformName }})
-  continueOnError: true
+    testAssemblyName: Xamarin.SourceWriter-Tests
 
-- task: DotNetCoreCLI@2
-  displayName: 'Tests: Java.Interop.Tools.Maven'
-  inputs:
-    command: test
-    publishTestResults: false
-    arguments: --logger "trx;LogFileName=Java.Interop.Tools.Maven.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Tools.Maven-Tests.dll
-  continueOnError: true
-
-- task: PublishTestResults@2
-  displayName: 'Publish: Java.Interop.Tools.Maven'
-  condition: succeededOrFailed()
-  inputs:
-    testResultsFormat: VSTest
-    testResultsFiles: '$(Agent.TempDirectory)/Java.Interop.Tools.Maven.trx'
+- template: run-dotnet-test.yaml
+  parameters:
     testRunTitle: Java.Interop.Tools.Maven (${{ parameters.platformName }})
-  continueOnError: true
+    testAssemblyName: Java.Interop.Tools.Maven-Tests
 
-- task: DotNetCoreCLI@2
-  displayName: 'Tests: Java.Interop'
-  condition: or(eq('${{ parameters.runNativeDotnetTests }}', 'true'), eq('${{ parameters.runNativeTests }}', 'true'))
-  inputs:
-    command: test
-    publishTestResults: false
-    arguments: --logger "trx;LogFileName=Java.Interop.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop-Tests.dll
-  continueOnError: true
-  retryCountOnTaskFailure: 1
-
-- task: PublishTestResults@2
-  displayName: 'Publish: Java.Interop'
-  condition: or(eq('${{ parameters.runNativeDotnetTests }}', 'true'), eq('${{ parameters.runNativeTests }}', 'true'))
-  inputs:
-    testResultsFormat: VSTest
-    testResultsFiles: '$(Agent.TempDirectory)/Java.Interop.trx'
+- template: run-dotnet-test.yaml
+  parameters:
     testRunTitle: Java.Interop ($(DotNetTargetFramework) - ${{ parameters.platformName }})
-  continueOnError: true
+    testAssemblyName: Java.Interop-Tests
+    condition: or(eq('${{ parameters.runNativeDotnetTests }}', 'true'), eq('${{ parameters.runNativeTests }}', 'true'))
+    retryCount: 1
 
-- task: DotNetCoreCLI@2
-  displayName: 'Tests: Java.Interop.Dynamic'
-  condition: eq('${{ parameters.runNativeTests }}', 'true')
-  inputs:
-    command: test
-    publishTestResults: false
-    arguments: --logger "trx;LogFileName=Java.Interop.Dynamic.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Dynamic-Tests.dll
-  continueOnError: true
-  retryCountOnTaskFailure: 1
-
-- task: PublishTestResults@2
-  displayName: 'Publish: Java.Interop.Dynamic'
-  condition: eq('${{ parameters.runNativeTests }}', 'true')
-  inputs:
-    testResultsFormat: VSTest
-    testResultsFiles: '$(Agent.TempDirectory)/Java.Interop.Dynamic.trx'
+- template: run-dotnet-test.yaml
+  parameters:
     testRunTitle: Java.Interop.Dynamic (${{ parameters.platformName }})
-  continueOnError: true
+    testAssemblyName: Java.Interop.Dynamic-Tests
+    condition: eq('${{ parameters.runNativeTests }}', 'true')
+    retryCount: 1
 
-- task: DotNetCoreCLI@2
-  displayName: 'Tests: Java.Interop.Export'
-  condition: or(eq('${{ parameters.runNativeDotnetTests }}', 'true'), eq('${{ parameters.runNativeTests }}', 'true'))
-  inputs:
-    command: test
-    publishTestResults: false
-    arguments: --logger "trx;LogFileName=Java.Interop.Export.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Export-Tests.dll
-  continueOnError: true
-  retryCountOnTaskFailure: 1
-
-- task: PublishTestResults@2
-  displayName: 'Publish: Java.Interop.Export'
-  condition: or(eq('${{ parameters.runNativeDotnetTests }}', 'true'), eq('${{ parameters.runNativeTests }}', 'true'))
-  inputs:
-    testResultsFormat: VSTest
-    testResultsFiles: '$(Agent.TempDirectory)/Java.Interop.Export.trx'
+- template: run-dotnet-test.yaml
+  parameters:
     testRunTitle: Java.Interop.Export (${{ parameters.platformName }})
-  continueOnError: true
+    testAssemblyName: Java.Interop.Export-Tests
+    condition: or(eq('${{ parameters.runNativeDotnetTests }}', 'true'), eq('${{ parameters.runNativeTests }}', 'true'))
+    retryCount: 1
 
 - task: DotNetCoreCLI@2
   displayName: 'jnimarshalmethod-gen Java.Interop.Export-Tests.dll'
@@ -242,62 +86,28 @@ steps:
   continueOnError: true
   retryCountOnTaskFailure: 1
 
-- task: DotNetCoreCLI@2
-  displayName: 'Tests: Java.Interop.Export w/ jnimarshalmethod-gen!'
-  condition: or(eq('${{ parameters.runNativeDotnetTests }}', 'true'), eq('${{ parameters.runNativeTests }}', 'true'))
-  inputs:
-    command: test
-    publishTestResults: false
-    arguments: --logger "trx;LogFileName=Java.Interop.Export-jnimarshalmethod.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Export-Tests.dll
-  continueOnError: true
-  retryCountOnTaskFailure: 1
-
-- task: PublishTestResults@2
-  displayName: 'Publish: Java.Interop.Export w/ jnimarshalmethod-gen!'
-  condition: or(eq('${{ parameters.runNativeDotnetTests }}', 'true'), eq('${{ parameters.runNativeTests }}', 'true'))
-  inputs:
-    testResultsFormat: VSTest
-    testResultsFiles: '$(Agent.TempDirectory)/Java.Interop.Export-jnimarshalmethod.trx'
+- template: run-dotnet-test.yaml
+  parameters:
     testRunTitle: Java.Interop.Export (jnimarshalmethod-gen + ${{ parameters.platformName }})
-  continueOnError: true
+    testAssemblyName: Java.Interop.Export-Tests
+    trxSuffix: -jnimarshalmethod
+    condition: or(eq('${{ parameters.runNativeDotnetTests }}', 'true'), eq('${{ parameters.runNativeTests }}', 'true'))
+    retryCount: 1
 
-- task: DotNetCoreCLI@2
-  displayName: 'Tests: Java.Interop-Performance-$(DotNetTargetFramework)'
-  condition: eq('${{ parameters.runNativeTests }}', 'true')
-  inputs:
-    command: test
-    publishTestResults: false
-    arguments: --logger "trx;LogFileName=Java.Interop-Performance.trx" --results-directory $(Agent.TempDirectory) --logger "console;verbosity=detailed" bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop-PerformanceTests.dll
-  continueOnError: true
-  retryCountOnTaskFailure: 1
-
-- task: PublishTestResults@2
-  displayName: 'Publish: Java.Interop-Performance'
-  condition: eq('${{ parameters.runNativeTests }}', 'true')
-  inputs:
-    testResultsFormat: VSTest
-    testResultsFiles: '$(Agent.TempDirectory)/Java.Interop-Performance.trx'
+- template: run-dotnet-test.yaml
+  parameters:
     testRunTitle: Java.Interop-Performance ($(DotNetTargetFramework) - ${{ parameters.platformName }})
-  continueOnError: true
+    testAssemblyName: Java.Interop-PerformanceTests
+    condition: eq('${{ parameters.runNativeTests }}', 'true')
+    retryCount: 1
+    extraArguments: --logger "console;verbosity=detailed"
 
-- task: DotNetCoreCLI@2
-  displayName: 'Tests: Java.Base'
-  condition: or(eq('${{ parameters.runNativeDotnetTests }}', 'true'), eq('${{ parameters.runNativeTests }}', 'true'))
-  inputs:
-    command: test
-    publishTestResults: false
-    arguments: --logger "trx;LogFileName=Java.Base.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Base-Tests.dll
-  continueOnError: true
-  retryCountOnTaskFailure: 1
-
-- task: PublishTestResults@2
-  displayName: 'Publish: Java.Base'
-  condition: or(eq('${{ parameters.runNativeDotnetTests }}', 'true'), eq('${{ parameters.runNativeTests }}', 'true'))
-  inputs:
-    testResultsFormat: VSTest
-    testResultsFiles: '$(Agent.TempDirectory)/Java.Base.trx'
+- template: run-dotnet-test.yaml
+  parameters:
     testRunTitle: Java.Base ($(DotNetTargetFramework) - ${{ parameters.platformName }})
-  continueOnError: true
+    testAssemblyName: Java.Base-Tests
+    condition: or(eq('${{ parameters.runNativeDotnetTests }}', 'true'), eq('${{ parameters.runNativeTests }}', 'true'))
+    retryCount: 1
 
 - task: DotNetCoreCLI@2
   displayName: 'jnimarshalmethod-gen Java.Base-Tests.dll'
@@ -309,24 +119,13 @@ steps:
   continueOnError: true
   retryCountOnTaskFailure: 1
 
-- task: DotNetCoreCLI@2
-  displayName: 'Tests: Java.Base w/ jnimarshalmethod-gen!'
-  condition: or(eq('${{ parameters.runNativeDotnetTests }}', 'true'), eq('${{ parameters.runNativeTests }}', 'true'))
-  inputs:
-    command: test
-    publishTestResults: false
-    arguments: --logger "trx;LogFileName=Java.Base-jnimarshalmethod.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Base-Tests.dll
-  continueOnError: true
-  retryCountOnTaskFailure: 1
-
-- task: PublishTestResults@2
-  displayName: 'Publish: Java.Base w/ jnimarshalmethod-gen!'
-  condition: or(eq('${{ parameters.runNativeDotnetTests }}', 'true'), eq('${{ parameters.runNativeTests }}', 'true'))
-  inputs:
-    testResultsFormat: VSTest
-    testResultsFiles: '$(Agent.TempDirectory)/Java.Base-jnimarshalmethod.trx'
+- template: run-dotnet-test.yaml
+  parameters:
     testRunTitle: Java.Base ($(DotNetTargetFramework) - ${{ parameters.platformName }})
-  continueOnError: true
+    testAssemblyName: Java.Base-Tests
+    trxSuffix: -jnimarshalmethod
+    condition: or(eq('${{ parameters.runNativeDotnetTests }}', 'true'), eq('${{ parameters.runNativeTests }}', 'true'))
+    retryCount: 1
 
 - task: DotNetCoreCLI@2
   displayName: 'Tests: java-source-utils'

--- a/build-tools/automation/templates/core-tests.yaml
+++ b/build-tools/automation/templates/core-tests.yaml
@@ -12,7 +12,16 @@ steps:
     publishTestResults: false
     arguments: --logger "trx;LogFileName=generator.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/generator-Tests.dll
   continueOnError: true
-  
+
+- task: PublishTestResults@2
+  displayName: 'Publish: generator'
+  condition: succeededOrFailed()
+  inputs:
+    testResultsFormat: VSTest
+    testResultsFiles: '$(Agent.TempDirectory)/generator.trx'
+    testRunTitle: generator (${{ parameters.platformName }})
+  continueOnError: true
+
 - task: DotNetCoreCLI@2
   displayName: 'Tests: JavaCallableWrappers'
   inputs:
@@ -20,7 +29,16 @@ steps:
     publishTestResults: false
     arguments: --logger "trx;LogFileName=JavaCallableWrappers.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Tools.JavaCallableWrappers-Tests.dll
   continueOnError: true
-   
+
+- task: PublishTestResults@2
+  displayName: 'Publish: JavaCallableWrappers'
+  condition: succeededOrFailed()
+  inputs:
+    testResultsFormat: VSTest
+    testResultsFiles: '$(Agent.TempDirectory)/JavaCallableWrappers.trx'
+    testRunTitle: Java.Interop.Tools.JavaCallableWrappers (${{ parameters.platformName }})
+  continueOnError: true
+
 - task: DotNetCoreCLI@2
   displayName: 'Tests: logcat-parse'
   inputs:
@@ -28,7 +46,16 @@ steps:
     publishTestResults: false
     arguments: --logger "trx;LogFileName=logcat-parse.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/logcat-parse-Tests.dll
   continueOnError: true
-  
+
+- task: PublishTestResults@2
+  displayName: 'Publish: logcat-parse'
+  condition: succeededOrFailed()
+  inputs:
+    testResultsFormat: VSTest
+    testResultsFiles: '$(Agent.TempDirectory)/logcat-parse.trx'
+    testRunTitle: logcat-parse (${{ parameters.platformName }})
+  continueOnError: true
+
 - task: DotNetCoreCLI@2
   displayName: 'Tests: ApiXmlAdjuster'
   inputs:
@@ -36,7 +63,16 @@ steps:
     publishTestResults: false
     arguments: --logger "trx;LogFileName=ApiXmlAdjuster.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Xamarin.Android.Tools.ApiXmlAdjuster-Tests.dll
   continueOnError: true
-  
+
+- task: PublishTestResults@2
+  displayName: 'Publish: ApiXmlAdjuster'
+  condition: succeededOrFailed()
+  inputs:
+    testResultsFormat: VSTest
+    testResultsFiles: '$(Agent.TempDirectory)/ApiXmlAdjuster.trx'
+    testRunTitle: Xamarin.Android.Tools.ApiXmlAdjuster (${{ parameters.platformName }})
+  continueOnError: true
+
 - task: DotNetCoreCLI@2
   displayName: 'Tests: JavaTypeSystem'
   inputs:
@@ -44,13 +80,31 @@ steps:
     publishTestResults: false
     arguments: --logger "trx;LogFileName=JavaTypeSystem.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Tools.JavaTypeSystem-Tests.dll
   continueOnError: true
-  
+
+- task: PublishTestResults@2
+  displayName: 'Publish: JavaTypeSystem'
+  condition: succeededOrFailed()
+  inputs:
+    testResultsFormat: VSTest
+    testResultsFiles: '$(Agent.TempDirectory)/JavaTypeSystem.trx'
+    testRunTitle: Xamarin.Android.Tools.JavaTypeSystem (${{ parameters.platformName }})
+  continueOnError: true
+
 - task: DotNetCoreCLI@2
   displayName: 'Tests: Bytecode'
   inputs:
     command: test
     publishTestResults: false
     arguments: --logger "trx;LogFileName=Bytecode.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Xamarin.Android.Tools.Bytecode-Tests.dll
+  continueOnError: true
+
+- task: PublishTestResults@2
+  displayName: 'Publish: Bytecode'
+  condition: succeededOrFailed()
+  inputs:
+    testResultsFormat: VSTest
+    testResultsFiles: '$(Agent.TempDirectory)/Bytecode.trx'
+    testRunTitle: Xamarin.Android.Tools.Bytecode (${{ parameters.platformName }})
   continueOnError: true
 
 - task: DotNetCoreCLI@2
@@ -61,12 +115,30 @@ steps:
     arguments: --logger "trx;LogFileName=Java.Interop.Tools.Generator.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Tools.Generator-Tests.dll
   continueOnError: true
 
+- task: PublishTestResults@2
+  displayName: 'Publish: Java.Interop.Tools.Generator'
+  condition: succeededOrFailed()
+  inputs:
+    testResultsFormat: VSTest
+    testResultsFiles: '$(Agent.TempDirectory)/Java.Interop.Tools.Generator.trx'
+    testRunTitle: Java.Interop.Tools.Generator (${{ parameters.platformName }})
+  continueOnError: true
+
 - task: DotNetCoreCLI@2
   displayName: 'Tests: Java.Interop.Tools.JavaSource'
   inputs:
     command: test
     publishTestResults: false
     arguments: --logger "trx;LogFileName=Java.Interop.Tools.JavaSource.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Tools.JavaSource-Tests.dll
+  continueOnError: true
+
+- task: PublishTestResults@2
+  displayName: 'Publish: Java.Interop.Tools.JavaSource'
+  condition: succeededOrFailed()
+  inputs:
+    testResultsFormat: VSTest
+    testResultsFiles: '$(Agent.TempDirectory)/Java.Interop.Tools.JavaSource.trx'
+    testRunTitle: Java.Interop.Tools.JavaSource (${{ parameters.platformName }})
   continueOnError: true
 
 - task: DotNetCoreCLI@2
@@ -77,12 +149,30 @@ steps:
     arguments: --logger "trx;LogFileName=Xamarin.SourceWriter.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Xamarin.SourceWriter-Tests.dll
   continueOnError: true
 
+- task: PublishTestResults@2
+  displayName: 'Publish: Xamarin.SourceWriter'
+  condition: succeededOrFailed()
+  inputs:
+    testResultsFormat: VSTest
+    testResultsFiles: '$(Agent.TempDirectory)/Xamarin.SourceWriter.trx'
+    testRunTitle: Xamarin.SourceWriter (${{ parameters.platformName }})
+  continueOnError: true
+
 - task: DotNetCoreCLI@2
   displayName: 'Tests: Java.Interop.Tools.Maven'
   inputs:
     command: test
     publishTestResults: false
     arguments: --logger "trx;LogFileName=Java.Interop.Tools.Maven.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Tools.Maven-Tests.dll
+  continueOnError: true
+
+- task: PublishTestResults@2
+  displayName: 'Publish: Java.Interop.Tools.Maven'
+  condition: succeededOrFailed()
+  inputs:
+    testResultsFormat: VSTest
+    testResultsFiles: '$(Agent.TempDirectory)/Java.Interop.Tools.Maven.trx'
+    testRunTitle: Java.Interop.Tools.Maven (${{ parameters.platformName }})
   continueOnError: true
 
 - task: DotNetCoreCLI@2
@@ -95,6 +185,15 @@ steps:
   continueOnError: true
   retryCountOnTaskFailure: 1
 
+- task: PublishTestResults@2
+  displayName: 'Publish: Java.Interop'
+  condition: or(eq('${{ parameters.runNativeDotnetTests }}', 'true'), eq('${{ parameters.runNativeTests }}', 'true'))
+  inputs:
+    testResultsFormat: VSTest
+    testResultsFiles: '$(Agent.TempDirectory)/Java.Interop.trx'
+    testRunTitle: Java.Interop ($(DotNetTargetFramework) - ${{ parameters.platformName }})
+  continueOnError: true
+
 - task: DotNetCoreCLI@2
   displayName: 'Tests: Java.Interop.Dynamic'
   condition: eq('${{ parameters.runNativeTests }}', 'true')
@@ -105,6 +204,15 @@ steps:
   continueOnError: true
   retryCountOnTaskFailure: 1
 
+- task: PublishTestResults@2
+  displayName: 'Publish: Java.Interop.Dynamic'
+  condition: eq('${{ parameters.runNativeTests }}', 'true')
+  inputs:
+    testResultsFormat: VSTest
+    testResultsFiles: '$(Agent.TempDirectory)/Java.Interop.Dynamic.trx'
+    testRunTitle: Java.Interop.Dynamic (${{ parameters.platformName }})
+  continueOnError: true
+
 - task: DotNetCoreCLI@2
   displayName: 'Tests: Java.Interop.Export'
   condition: or(eq('${{ parameters.runNativeDotnetTests }}', 'true'), eq('${{ parameters.runNativeTests }}', 'true'))
@@ -114,6 +222,15 @@ steps:
     arguments: --logger "trx;LogFileName=Java.Interop.Export.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Interop.Export-Tests.dll
   continueOnError: true
   retryCountOnTaskFailure: 1
+
+- task: PublishTestResults@2
+  displayName: 'Publish: Java.Interop.Export'
+  condition: or(eq('${{ parameters.runNativeDotnetTests }}', 'true'), eq('${{ parameters.runNativeTests }}', 'true'))
+  inputs:
+    testResultsFormat: VSTest
+    testResultsFiles: '$(Agent.TempDirectory)/Java.Interop.Export.trx'
+    testRunTitle: Java.Interop.Export (${{ parameters.platformName }})
+  continueOnError: true
 
 - task: DotNetCoreCLI@2
   displayName: 'jnimarshalmethod-gen Java.Interop.Export-Tests.dll'
@@ -135,6 +252,15 @@ steps:
   continueOnError: true
   retryCountOnTaskFailure: 1
 
+- task: PublishTestResults@2
+  displayName: 'Publish: Java.Interop.Export w/ jnimarshalmethod-gen!'
+  condition: or(eq('${{ parameters.runNativeDotnetTests }}', 'true'), eq('${{ parameters.runNativeTests }}', 'true'))
+  inputs:
+    testResultsFormat: VSTest
+    testResultsFiles: '$(Agent.TempDirectory)/Java.Interop.Export-jnimarshalmethod.trx'
+    testRunTitle: Java.Interop.Export (jnimarshalmethod-gen + ${{ parameters.platformName }})
+  continueOnError: true
+
 - task: DotNetCoreCLI@2
   displayName: 'Tests: Java.Interop-Performance-$(DotNetTargetFramework)'
   condition: eq('${{ parameters.runNativeTests }}', 'true')
@@ -145,6 +271,15 @@ steps:
   continueOnError: true
   retryCountOnTaskFailure: 1
 
+- task: PublishTestResults@2
+  displayName: 'Publish: Java.Interop-Performance'
+  condition: eq('${{ parameters.runNativeTests }}', 'true')
+  inputs:
+    testResultsFormat: VSTest
+    testResultsFiles: '$(Agent.TempDirectory)/Java.Interop-Performance.trx'
+    testRunTitle: Java.Interop-Performance ($(DotNetTargetFramework) - ${{ parameters.platformName }})
+  continueOnError: true
+
 - task: DotNetCoreCLI@2
   displayName: 'Tests: Java.Base'
   condition: or(eq('${{ parameters.runNativeDotnetTests }}', 'true'), eq('${{ parameters.runNativeTests }}', 'true'))
@@ -154,6 +289,15 @@ steps:
     arguments: --logger "trx;LogFileName=Java.Base.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Base-Tests.dll
   continueOnError: true
   retryCountOnTaskFailure: 1
+
+- task: PublishTestResults@2
+  displayName: 'Publish: Java.Base'
+  condition: or(eq('${{ parameters.runNativeDotnetTests }}', 'true'), eq('${{ parameters.runNativeTests }}', 'true'))
+  inputs:
+    testResultsFormat: VSTest
+    testResultsFiles: '$(Agent.TempDirectory)/Java.Base.trx'
+    testRunTitle: Java.Base ($(DotNetTargetFramework) - ${{ parameters.platformName }})
+  continueOnError: true
 
 - task: DotNetCoreCLI@2
   displayName: 'jnimarshalmethod-gen Java.Base-Tests.dll'
@@ -174,6 +318,15 @@ steps:
     arguments: --logger "trx;LogFileName=Java.Base-jnimarshalmethod.trx" --results-directory $(Agent.TempDirectory) bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/Java.Base-Tests.dll
   continueOnError: true
   retryCountOnTaskFailure: 1
+
+- task: PublishTestResults@2
+  displayName: 'Publish: Java.Base w/ jnimarshalmethod-gen!'
+  condition: or(eq('${{ parameters.runNativeDotnetTests }}', 'true'), eq('${{ parameters.runNativeTests }}', 'true'))
+  inputs:
+    testResultsFormat: VSTest
+    testResultsFiles: '$(Agent.TempDirectory)/Java.Base-jnimarshalmethod.trx'
+    testRunTitle: Java.Base ($(DotNetTargetFramework) - ${{ parameters.platformName }})
+  continueOnError: true
 
 - task: DotNetCoreCLI@2
   displayName: 'Tests: java-source-utils'
@@ -201,12 +354,4 @@ steps:
     testResultsFormat: JUnit
     testResultsFiles: 'tools/java-source-utils/build/test-results/**/TEST-*.xml'
     testRunTitle: java-source-utils (${{ parameters.platformName }})
-  continueOnError: true
-
-- task: PublishTestResults@2
-  displayName: Publish .NET Test Results
-  condition: succeededOrFailed()
-  inputs:
-    testResultsFormat: VSTest
-    testResultsFiles: '$(Agent.TempDirectory)/**/*.trx'
   continueOnError: true

--- a/build-tools/automation/templates/run-dotnet-test.yaml
+++ b/build-tools/automation/templates/run-dotnet-test.yaml
@@ -1,0 +1,27 @@
+parameters:
+  testRunTitle:
+  testAssemblyName:
+  trxSuffix: ''
+  condition: succeededOrFailed()
+  retryCount: 0
+  extraArguments: ''
+
+steps:
+- task: DotNetCoreCLI@2
+  displayName: 'Tests: ${{ parameters.testRunTitle }}'
+  condition: ${{ parameters.condition }}
+  inputs:
+    command: test
+    publishTestResults: false
+    arguments: --logger "trx;LogFileName=${{ parameters.testAssemblyName }}${{ parameters.trxSuffix }}.trx" --results-directory $(Agent.TempDirectory) ${{ parameters.extraArguments }} bin/Test$(Build.Configuration)$(NetCoreTargetFrameworkPathSuffix)/${{ parameters.testAssemblyName }}.dll
+  continueOnError: true
+  retryCountOnTaskFailure: ${{ parameters.retryCount }}
+
+- task: PublishTestResults@2
+  displayName: 'Publish: ${{ parameters.testRunTitle }}'
+  condition: ${{ parameters.condition }}
+  inputs:
+    testResultsFormat: VSTest
+    testResultsFiles: '$(Agent.TempDirectory)/${{ parameters.testAssemblyName }}${{ parameters.trxSuffix }}.trx'
+    testRunTitle: ${{ parameters.testRunTitle }}
+  continueOnError: true


### PR DESCRIPTION
## Summary

The `DotNetCoreCLI@2` task's built-in test result publishing uploads TRX files through the Azure Storage Data Movement library, which has been hitting SSL errors (`RemoteCertificateNameMismatch`) and timing out for **~11 minutes per test step** — adding over an hour to builds.

Example: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1380182

## Changes

- Set `publishTestResults: false` on each `DotNetCoreCLI@2` test step
- Added explicit `--logger trx --results-directory $(Agent.TempDirectory)` to test arguments
- Added a single `PublishTestResults@2` step at the end to upload all `.trx` files in one batch

This uses the `PublishTestResults@2` task's upload path instead of the old blob storage mechanism, which avoids the SSL issues entirely.