### PR TITLE
Fix UTF-8 JniType class lookup fallback

### DIFF
--- a/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
+++ b/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
@@ -402,17 +402,12 @@ namespace Java.Interop
 					if (!throwOnError)
 						return default;
 
-					throw new InvalidOperationException ($"Could not find Java class '{GetStringClassName (classname)}'.");
+					var terminator = classname.IndexOf ((byte) 0);
+					var errorClassName = terminator >= 0
+						? Encoding.UTF8.GetString (classname.Slice (0, terminator))
+						: Encoding.UTF8.GetString (classname);
+					throw new InvalidOperationException ($"Could not find Java class '{errorClassName}'.");
 				}
-			}
-
-			static string GetStringClassName (ReadOnlySpan<byte> classname)
-			{
-				var terminator = classname.IndexOf ((byte) 0);
-				if (terminator >= 0)
-					classname = classname.Slice (0, terminator);
-
-				return Encoding.UTF8.GetString (classname);
 			}
 #endif  // FEATURE_JNIENVIRONMENT_JI_FUNCTION_POINTERS
 		}

--- a/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
+++ b/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
@@ -56,43 +56,7 @@ namespace Java.Interop
 					return r;
 				}
 				RawExceptionClear (info.EnvironmentPointer);
-
-				var findClassThrown     = new JniObjectReference (thrown, JniObjectReferenceType.Local);
-				LogCreateLocalRef (findClassThrown);
-				var pendingException    = info.Runtime.GetExceptionForThrowable (ref findClassThrown, JniObjectReferenceOptions.CopyAndDispose);
-
-				if (Class_forName.IsValid) {
-					var java    = info.ToJavaName (classname);
-					var __args  = stackalloc JniArgumentValue [3];
-					__args [0]  = new JniArgumentValue (java);
-					__args [1]  = new JniArgumentValue (true);  // initialize the class
-					__args [2]  = new JniArgumentValue (info.Runtime.ClassLoader);
-
-					c = RawCallStaticObjectMethodA (info.EnvironmentPointer, out thrown, Class_reference.Handle, Class_forName.ID, (IntPtr) __args);
-					JniObjectReference.Dispose (ref java);
-					if (thrown == IntPtr.Zero) {
-						(pendingException as IJavaPeerable)?.Dispose ();
-						var r = new JniObjectReference (c, JniObjectReferenceType.Local);
-						JniEnvironment.LogCreateLocalRef (r);
-						return r;
-					}
-					RawExceptionClear (info.EnvironmentPointer);
-
-					if (pendingException != null) {
-						JniEnvironment.References.RawDeleteLocalRef (info.EnvironmentPointer, thrown);
-					}
-					else {
-						var loadClassThrown = new JniObjectReference (thrown, JniObjectReferenceType.Local);
-						LogCreateLocalRef (loadClassThrown);
-						pendingException    = info.Runtime.GetExceptionForThrowable (ref loadClassThrown, JniObjectReferenceOptions.CopyAndDispose);
-					}
-				}
-
-				if (!throwOnError) {
-					(pendingException as IJavaPeerable)?.Dispose ();
-					return default;
-				}
-				throw pendingException!;
+				return TryLoadClassWithFallback (info, thrown, classname, throwOnError);
 #endif  // !(FEATURE_JNIENVIRONMENT_JI_PINVOKES || FEATURE_JNIENVIRONMENT_JI_FUNCTION_POINTERS)
 #if FEATURE_JNIOBJECTREFERENCE_SAFEHANDLES
 				var c       = info.Invoker.FindClass (info.EnvironmentPointer, classname);
@@ -133,6 +97,48 @@ namespace Java.Interop
 				}
 				throw pendingException!;
 #endif  // !FEATURE_JNIOBJECTREFERENCE_SAFEHANDLES
+			}
+
+			static unsafe JniObjectReference TryLoadClassWithFallback (JniEnvironmentInfo info, IntPtr thrown, string classname, bool throwOnError)
+			{
+				var findClassThrown     = new JniObjectReference (thrown, JniObjectReferenceType.Local);
+				LogCreateLocalRef (findClassThrown);
+				Exception? pendingException = info.Runtime.GetExceptionForThrowable (ref findClassThrown, JniObjectReferenceOptions.CopyAndDispose);
+
+				if (Class_forName.IsValid) {
+					var java    = info.ToJavaName (classname);
+					var __args  = stackalloc JniArgumentValue [3];
+					__args [0]  = new JniArgumentValue (java);
+					__args [1]  = new JniArgumentValue (true);  // initialize the class
+					__args [2]  = new JniArgumentValue (info.Runtime.ClassLoader);
+
+					var c = RawCallStaticObjectMethodA (info.EnvironmentPointer, out thrown, Class_reference.Handle, Class_forName.ID, (IntPtr) __args);
+					JniObjectReference.Dispose (ref java);
+					if (thrown == IntPtr.Zero) {
+						(pendingException as IJavaPeerable)?.Dispose ();
+						var r = new JniObjectReference (c, JniObjectReferenceType.Local);
+						JniEnvironment.LogCreateLocalRef (r);
+						return r;
+					}
+					RawExceptionClear (info.EnvironmentPointer);
+
+					if (pendingException != null) {
+						JniEnvironment.References.RawDeleteLocalRef (info.EnvironmentPointer, thrown);
+					} else {
+						var loadClassThrown = new JniObjectReference (thrown, JniObjectReferenceType.Local);
+						LogCreateLocalRef (loadClassThrown);
+						pendingException = info.Runtime.GetExceptionForThrowable (ref loadClassThrown, JniObjectReferenceOptions.CopyAndDispose);
+					}
+				}
+
+				if (!throwOnError) {
+					(pendingException as IJavaPeerable)?.Dispose ();
+					return default;
+				}
+				if (pendingException != null)
+					throw pendingException;
+
+				throw new InvalidOperationException ($"Could not find Java class '{classname}'.");
 			}
 
 			static bool TryRawFindClass (IntPtr env, string classname, out IntPtr klass, out IntPtr thrown)
@@ -331,6 +337,9 @@ namespace Java.Interop
 
 			static unsafe JniObjectReference TryFindClass (ReadOnlySpan<byte> classname, bool throwOnError)
 			{
+				if (classname.Length == 0)
+					throw new ArgumentException ("'classname' cannot be a zero-length string.", nameof (classname));
+
 				var info = JniEnvironment.CurrentInfo;
 				fixed (byte* _classname_ptr = classname) {
 					var c      = JniNativeMethods.FindClass (info.EnvironmentPointer, (IntPtr) _classname_ptr);
@@ -342,20 +351,19 @@ namespace Java.Interop
 					}
 
 					RawExceptionClear (info.EnvironmentPointer);
-
-					var findClassThrown  = new JniObjectReference (thrown, JniObjectReferenceType.Local);
-					LogCreateLocalRef (findClassThrown);
-					var pendingException = info.Runtime.GetExceptionForThrowable (ref findClassThrown, JniObjectReferenceOptions.CopyAndDispose);
-
-					if (!throwOnError) {
-						(pendingException as IJavaPeerable)?.Dispose ();
-						return default;
-					}
-					throw pendingException!;
+					return TryLoadClassWithFallback (info, thrown, GetStringClassName (classname), throwOnError);
 				}
+			}
+
+			static string GetStringClassName (ReadOnlySpan<byte> classname)
+			{
+				var terminator = classname.IndexOf ((byte)0);
+				if (terminator >= 0)
+					classname = classname.Slice (0, terminator);
+
+				return Encoding.UTF8.GetString (classname);
 			}
 #endif  // FEATURE_JNIENVIRONMENT_JI_FUNCTION_POINTERS
 		}
 	}
 }
-

--- a/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
+++ b/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
@@ -411,7 +411,12 @@ namespace Java.Interop
 					}
 
 					RawExceptionClear (info.EnvironmentPointer);
-					return TryLoadClassWithFallback (info, thrown, classname, throwOnError);
+					var javaName = NewJavaNameFromUtf8 (info.EnvironmentPointer, classname);
+					try {
+						return TryLoadClassWithFallback (info, thrown, javaName, GetStringClassName (classname), throwOnError);
+					} finally {
+						JniObjectReference.Dispose (ref javaName);
+					}
 				}
 			}
 #endif  // FEATURE_JNIENVIRONMENT_JI_FUNCTION_POINTERS

--- a/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
+++ b/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Collections.Generic;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace Java.Interop
 {
@@ -141,6 +142,7 @@ namespace Java.Interop
 				throw new InvalidOperationException ($"Could not find Java class '{classname}'.");
 			}
 
+#if FEATURE_JNIENVIRONMENT_JI_FUNCTION_POINTERS
 			static unsafe JniObjectReference TryLoadClassWithFallback (JniEnvironmentInfo info, IntPtr thrown, ReadOnlySpan<byte> classname, bool throwOnError)
 			{
 				var findClassThrown     = new JniObjectReference (thrown, JniObjectReferenceType.Local);
@@ -183,7 +185,7 @@ namespace Java.Interop
 				if (pendingException != null)
 					throw pendingException;
 
-				throw new InvalidOperationException ("Could not find Java class from the supplied UTF-8 name.");
+				throw new InvalidOperationException ($"Could not find Java class '{GetStringClassName (classname)}'.");
 			}
 
 			static unsafe JniObjectReference NewJavaNameFromUtf8 (IntPtr env, ReadOnlySpan<byte> classname)
@@ -214,6 +216,16 @@ namespace Java.Interop
 				}
 			}
 
+			static string GetStringClassName (ReadOnlySpan<byte> classname)
+			{
+				var terminator = classname.IndexOf ((byte) 0);
+				if (terminator >= 0)
+					classname = classname.Slice (0, terminator);
+
+				return Encoding.UTF8.GetString (classname);
+			}
+#endif
+
 			static bool TryRawFindClass (IntPtr env, string classname, out IntPtr klass, out IntPtr thrown)
 			{
 #if FEATURE_JNIENVIRONMENT_JI_PINVOKES
@@ -234,14 +246,12 @@ namespace Java.Interop
 				return false;
 			}
 
+#if FEATURE_JNIENVIRONMENT_JI_FUNCTION_POINTERS
 			static unsafe IntPtr RawNewStringUTF (IntPtr env, IntPtr bytes)
 			{
-#if FEATURE_JNIENVIRONMENT_JI_FUNCTION_POINTERS
 				return (*((JNIEnv**) env))->NewStringUTF (env, bytes);
-#else
-#error Unsupported backend
-#endif
 			}
+#endif
 
 			static void RawExceptionClear (IntPtr env)
 			{

--- a/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
+++ b/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
@@ -146,16 +146,6 @@ namespace Java.Interop
 			}
 
 #if FEATURE_JNIENVIRONMENT_JI_FUNCTION_POINTERS
-			static unsafe JniObjectReference TryLoadClassWithFallback (JniEnvironmentInfo info, IntPtr thrown, ReadOnlySpan<byte> classname, bool throwOnError)
-			{
-				var javaName = NewJavaNameFromUtf8 (info.EnvironmentPointer, classname);
-				try {
-					return TryLoadClassWithFallback (info, thrown, javaName, GetStringClassName (classname), throwOnError);
-				} finally {
-					JniObjectReference.Dispose (ref javaName);
-				}
-			}
-
 			static unsafe JniObjectReference NewJavaNameFromUtf8 (IntPtr env, ReadOnlySpan<byte> classname)
 			{
 				var terminator = classname.IndexOf ((byte) 0);

--- a/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
+++ b/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Diagnostics;
 using System.Collections.Generic;
-using System.Text;
+using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 
 namespace Java.Interop
@@ -141,6 +141,79 @@ namespace Java.Interop
 				throw new InvalidOperationException ($"Could not find Java class '{classname}'.");
 			}
 
+			static unsafe JniObjectReference TryLoadClassWithFallback (JniEnvironmentInfo info, IntPtr thrown, ReadOnlySpan<byte> classname, bool throwOnError)
+			{
+				var findClassThrown     = new JniObjectReference (thrown, JniObjectReferenceType.Local);
+				LogCreateLocalRef (findClassThrown);
+				Exception? pendingException = info.Runtime.GetExceptionForThrowable (ref findClassThrown, JniObjectReferenceOptions.CopyAndDispose);
+
+				if (Class_forName.IsValid) {
+					var java    = NewJavaNameFromUtf8 (info.EnvironmentPointer, classname);
+					try {
+						var __args  = stackalloc JniArgumentValue [3];
+						__args [0]  = new JniArgumentValue (java);
+						__args [1]  = new JniArgumentValue (true);  // initialize the class
+						__args [2]  = new JniArgumentValue (info.Runtime.ClassLoader);
+
+						var c = RawCallStaticObjectMethodA (info.EnvironmentPointer, out thrown, Class_reference.Handle, Class_forName.ID, (IntPtr) __args);
+						if (thrown == IntPtr.Zero) {
+							(pendingException as IJavaPeerable)?.Dispose ();
+							var r = new JniObjectReference (c, JniObjectReferenceType.Local);
+							JniEnvironment.LogCreateLocalRef (r);
+							return r;
+						}
+						RawExceptionClear (info.EnvironmentPointer);
+					} finally {
+						JniObjectReference.Dispose (ref java);
+					}
+
+					if (pendingException != null) {
+						JniEnvironment.References.RawDeleteLocalRef (info.EnvironmentPointer, thrown);
+					} else {
+						var loadClassThrown = new JniObjectReference (thrown, JniObjectReferenceType.Local);
+						LogCreateLocalRef (loadClassThrown);
+						pendingException = info.Runtime.GetExceptionForThrowable (ref loadClassThrown, JniObjectReferenceOptions.CopyAndDispose);
+					}
+				}
+
+				if (!throwOnError) {
+					(pendingException as IJavaPeerable)?.Dispose ();
+					return default;
+				}
+				if (pendingException != null)
+					throw pendingException;
+
+				throw new InvalidOperationException ("Could not find Java class from the supplied UTF-8 name.");
+			}
+
+			static unsafe JniObjectReference NewJavaNameFromUtf8 (IntPtr env, ReadOnlySpan<byte> classname)
+			{
+				var terminator = classname.IndexOf ((byte) 0);
+				if (terminator >= 0)
+					classname = classname.Slice (0, terminator);
+
+				// Class names here are binary/JNI names, so `NewStringUTF()` lets the fallback
+				// avoid a managed UTF-16 allocation while still calling `Class.forName()`.
+				Span<byte> javaName = classname.Length + 1 <= 256
+					? stackalloc byte [classname.Length + 1]
+					: new byte [classname.Length + 1];
+
+				for (int i = 0; i < classname.Length; ++i)
+					javaName [i] = classname [i] == (byte) '/' ? (byte) '.' : classname [i];
+				javaName [classname.Length] = 0;
+
+				fixed (byte* pJavaName = javaName) {
+					var s = RawNewStringUTF (env, (IntPtr) pJavaName);
+					var e = JniEnvironment.GetExceptionForLastThrowable ();
+					if (e != null)
+						ExceptionDispatchInfo.Capture (e).Throw ();
+
+					var r = new JniObjectReference (s, JniObjectReferenceType.Local);
+					JniEnvironment.LogCreateLocalRef (r);
+					return r;
+				}
+			}
+
 			static bool TryRawFindClass (IntPtr env, string classname, out IntPtr klass, out IntPtr thrown)
 			{
 #if FEATURE_JNIENVIRONMENT_JI_PINVOKES
@@ -159,6 +232,15 @@ namespace Java.Interop
 				}
 #endif  // !FEATURE_JNIENVIRONMENT_JI_FUNCTION_POINTERS
 				return false;
+			}
+
+			static unsafe IntPtr RawNewStringUTF (IntPtr env, IntPtr bytes)
+			{
+#if FEATURE_JNIENVIRONMENT_JI_FUNCTION_POINTERS
+				return (*((JNIEnv**) env))->NewStringUTF (env, bytes);
+#else
+#error Unsupported backend
+#endif
 			}
 
 			static void RawExceptionClear (IntPtr env)
@@ -351,17 +433,8 @@ namespace Java.Interop
 					}
 
 					RawExceptionClear (info.EnvironmentPointer);
-					return TryLoadClassWithFallback (info, thrown, GetStringClassName (classname), throwOnError);
+					return TryLoadClassWithFallback (info, thrown, classname, throwOnError);
 				}
-			}
-
-			static string GetStringClassName (ReadOnlySpan<byte> classname)
-			{
-				var terminator = classname.IndexOf ((byte)0);
-				if (terminator >= 0)
-					classname = classname.Slice (0, terminator);
-
-				return Encoding.UTF8.GetString (classname);
 			}
 #endif  // FEATURE_JNIENVIRONMENT_JI_FUNCTION_POINTERS
 		}

--- a/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
+++ b/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Collections.Generic;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace Java.Interop
 {
@@ -58,10 +59,15 @@ namespace Java.Interop
 				RawExceptionClear (info.EnvironmentPointer);
 				var java = info.ToJavaName (classname);
 				try {
-					return TryLoadClassWithFallback (info, thrown, java, classname, throwOnError);
+					if (TryLoadClassWithFallback (info, thrown, java, throwOnError, out var result))
+						return result;
 				} finally {
 					JniObjectReference.Dispose (ref java);
 				}
+				if (!throwOnError)
+					return default;
+
+				throw new InvalidOperationException ($"Could not find Java class '{classname}'.");
 #endif  // !(FEATURE_JNIENVIRONMENT_JI_PINVOKES || FEATURE_JNIENVIRONMENT_JI_FUNCTION_POINTERS)
 #if FEATURE_JNIOBJECTREFERENCE_SAFEHANDLES
 				var c       = info.Invoker.FindClass (info.EnvironmentPointer, classname);
@@ -104,8 +110,10 @@ namespace Java.Interop
 #endif  // !FEATURE_JNIOBJECTREFERENCE_SAFEHANDLES
 			}
 
-			static unsafe JniObjectReference TryLoadClassWithFallback (JniEnvironmentInfo info, IntPtr thrown, JniObjectReference classNameJavaString, string? classname, bool throwOnError)
+			static unsafe bool TryLoadClassWithFallback (JniEnvironmentInfo info, IntPtr thrown, JniObjectReference classNameJavaString, bool throwOnError, out JniObjectReference result)
 			{
+				result = default;
+
 				var findClassThrown     = new JniObjectReference (thrown, JniObjectReferenceType.Local);
 				LogCreateLocalRef (findClassThrown);
 				Exception? pendingException = info.Runtime.GetExceptionForThrowable (ref findClassThrown, JniObjectReferenceOptions.CopyAndDispose);
@@ -119,9 +127,9 @@ namespace Java.Interop
 					var c = RawCallStaticObjectMethodA (info.EnvironmentPointer, out thrown, Class_reference.Handle, Class_forName.ID, (IntPtr) __args);
 					if (thrown == IntPtr.Zero) {
 						(pendingException as IJavaPeerable)?.Dispose ();
-						var r = new JniObjectReference (c, JniObjectReferenceType.Local);
-						JniEnvironment.LogCreateLocalRef (r);
-						return r;
+						result = new JniObjectReference (c, JniObjectReferenceType.Local);
+						JniEnvironment.LogCreateLocalRef (result);
+						return true;
 					}
 					RawExceptionClear (info.EnvironmentPointer);
 
@@ -136,13 +144,12 @@ namespace Java.Interop
 
 				if (!throwOnError) {
 					(pendingException as IJavaPeerable)?.Dispose ();
-					return default;
+					return false;
 				}
 				if (pendingException != null)
 					throw pendingException;
 
-				classname ??= JniEnvironment.Strings.ToString (classNameJavaString) ?? "";
-				throw new InvalidOperationException ($"Could not find Java class '{classname}'.");
+				return false;
 			}
 
 #if FEATURE_JNIENVIRONMENT_JI_FUNCTION_POINTERS
@@ -387,11 +394,25 @@ namespace Java.Interop
 					RawExceptionClear (info.EnvironmentPointer);
 					var javaName = NewJavaNameFromUtf8 (info.EnvironmentPointer, classname);
 					try {
-						return TryLoadClassWithFallback (info, thrown, javaName, null, throwOnError);
+						if (TryLoadClassWithFallback (info, thrown, javaName, throwOnError, out var result))
+							return result;
 					} finally {
 						JniObjectReference.Dispose (ref javaName);
 					}
+					if (!throwOnError)
+						return default;
+
+					throw new InvalidOperationException ($"Could not find Java class '{GetStringClassName (classname)}'.");
 				}
+			}
+
+			static string GetStringClassName (ReadOnlySpan<byte> classname)
+			{
+				var terminator = classname.IndexOf ((byte) 0);
+				if (terminator >= 0)
+					classname = classname.Slice (0, terminator);
+
+				return Encoding.UTF8.GetString (classname);
 			}
 #endif  // FEATURE_JNIENVIRONMENT_JI_FUNCTION_POINTERS
 		}

--- a/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
+++ b/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
@@ -57,7 +57,12 @@ namespace Java.Interop
 					return r;
 				}
 				RawExceptionClear (info.EnvironmentPointer);
-				return TryLoadClassWithFallback (info, thrown, classname, throwOnError);
+				var java = info.ToJavaName (classname);
+				try {
+					return TryLoadClassWithFallback (info, thrown, java, classname, throwOnError);
+				} finally {
+					JniObjectReference.Dispose (ref java);
+				}
 #endif  // !(FEATURE_JNIENVIRONMENT_JI_PINVOKES || FEATURE_JNIENVIRONMENT_JI_FUNCTION_POINTERS)
 #if FEATURE_JNIOBJECTREFERENCE_SAFEHANDLES
 				var c       = info.Invoker.FindClass (info.EnvironmentPointer, classname);
@@ -100,21 +105,19 @@ namespace Java.Interop
 #endif  // !FEATURE_JNIOBJECTREFERENCE_SAFEHANDLES
 			}
 
-			static unsafe JniObjectReference TryLoadClassWithFallback (JniEnvironmentInfo info, IntPtr thrown, string classname, bool throwOnError)
+			static unsafe JniObjectReference TryLoadClassWithFallback (JniEnvironmentInfo info, IntPtr thrown, JniObjectReference classNameJavaString, string classname, bool throwOnError)
 			{
 				var findClassThrown     = new JniObjectReference (thrown, JniObjectReferenceType.Local);
 				LogCreateLocalRef (findClassThrown);
 				Exception? pendingException = info.Runtime.GetExceptionForThrowable (ref findClassThrown, JniObjectReferenceOptions.CopyAndDispose);
 
 				if (Class_forName.IsValid) {
-					var java    = info.ToJavaName (classname);
 					var __args  = stackalloc JniArgumentValue [3];
-					__args [0]  = new JniArgumentValue (java);
+					__args [0]  = new JniArgumentValue (classNameJavaString);
 					__args [1]  = new JniArgumentValue (true);  // initialize the class
 					__args [2]  = new JniArgumentValue (info.Runtime.ClassLoader);
 
 					var c = RawCallStaticObjectMethodA (info.EnvironmentPointer, out thrown, Class_reference.Handle, Class_forName.ID, (IntPtr) __args);
-					JniObjectReference.Dispose (ref java);
 					if (thrown == IntPtr.Zero) {
 						(pendingException as IJavaPeerable)?.Dispose ();
 						var r = new JniObjectReference (c, JniObjectReferenceType.Local);
@@ -145,47 +148,12 @@ namespace Java.Interop
 #if FEATURE_JNIENVIRONMENT_JI_FUNCTION_POINTERS
 			static unsafe JniObjectReference TryLoadClassWithFallback (JniEnvironmentInfo info, IntPtr thrown, ReadOnlySpan<byte> classname, bool throwOnError)
 			{
-				var findClassThrown     = new JniObjectReference (thrown, JniObjectReferenceType.Local);
-				LogCreateLocalRef (findClassThrown);
-				Exception? pendingException = info.Runtime.GetExceptionForThrowable (ref findClassThrown, JniObjectReferenceOptions.CopyAndDispose);
-
-				if (Class_forName.IsValid) {
-					var java    = NewJavaNameFromUtf8 (info.EnvironmentPointer, classname);
-					try {
-						var __args  = stackalloc JniArgumentValue [3];
-						__args [0]  = new JniArgumentValue (java);
-						__args [1]  = new JniArgumentValue (true);  // initialize the class
-						__args [2]  = new JniArgumentValue (info.Runtime.ClassLoader);
-
-						var c = RawCallStaticObjectMethodA (info.EnvironmentPointer, out thrown, Class_reference.Handle, Class_forName.ID, (IntPtr) __args);
-						if (thrown == IntPtr.Zero) {
-							(pendingException as IJavaPeerable)?.Dispose ();
-							var r = new JniObjectReference (c, JniObjectReferenceType.Local);
-							JniEnvironment.LogCreateLocalRef (r);
-							return r;
-						}
-						RawExceptionClear (info.EnvironmentPointer);
-					} finally {
-						JniObjectReference.Dispose (ref java);
-					}
-
-					if (pendingException != null) {
-						JniEnvironment.References.RawDeleteLocalRef (info.EnvironmentPointer, thrown);
-					} else {
-						var loadClassThrown = new JniObjectReference (thrown, JniObjectReferenceType.Local);
-						LogCreateLocalRef (loadClassThrown);
-						pendingException = info.Runtime.GetExceptionForThrowable (ref loadClassThrown, JniObjectReferenceOptions.CopyAndDispose);
-					}
+				var javaName = NewJavaNameFromUtf8 (info.EnvironmentPointer, classname);
+				try {
+					return TryLoadClassWithFallback (info, thrown, javaName, GetStringClassName (classname), throwOnError);
+				} finally {
+					JniObjectReference.Dispose (ref javaName);
 				}
-
-				if (!throwOnError) {
-					(pendingException as IJavaPeerable)?.Dispose ();
-					return default;
-				}
-				if (pendingException != null)
-					throw pendingException;
-
-				throw new InvalidOperationException ($"Could not find Java class '{GetStringClassName (classname)}'.");
 			}
 
 			static unsafe JniObjectReference NewJavaNameFromUtf8 (IntPtr env, ReadOnlySpan<byte> classname)

--- a/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
+++ b/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.Collections.Generic;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace Java.Interop
 {
@@ -105,7 +104,7 @@ namespace Java.Interop
 #endif  // !FEATURE_JNIOBJECTREFERENCE_SAFEHANDLES
 			}
 
-			static unsafe JniObjectReference TryLoadClassWithFallback (JniEnvironmentInfo info, IntPtr thrown, JniObjectReference classNameJavaString, string classname, bool throwOnError)
+			static unsafe JniObjectReference TryLoadClassWithFallback (JniEnvironmentInfo info, IntPtr thrown, JniObjectReference classNameJavaString, string? classname, bool throwOnError)
 			{
 				var findClassThrown     = new JniObjectReference (thrown, JniObjectReferenceType.Local);
 				LogCreateLocalRef (findClassThrown);
@@ -142,6 +141,7 @@ namespace Java.Interop
 				if (pendingException != null)
 					throw pendingException;
 
+				classname ??= JniEnvironment.Strings.ToString (classNameJavaString) ?? "";
 				throw new InvalidOperationException ($"Could not find Java class '{classname}'.");
 			}
 
@@ -163,7 +163,7 @@ namespace Java.Interop
 				javaName [classname.Length] = 0;
 
 				fixed (byte* pJavaName = javaName) {
-					var s = RawNewStringUTF (env, (IntPtr) pJavaName);
+					var s = (*((JNIEnv**) env))->NewStringUTF (env, (IntPtr) pJavaName);
 					var e = JniEnvironment.GetExceptionForLastThrowable ();
 					if (e != null)
 						ExceptionDispatchInfo.Capture (e).Throw ();
@@ -172,15 +172,6 @@ namespace Java.Interop
 					JniEnvironment.LogCreateLocalRef (r);
 					return r;
 				}
-			}
-
-			static string GetStringClassName (ReadOnlySpan<byte> classname)
-			{
-				var terminator = classname.IndexOf ((byte) 0);
-				if (terminator >= 0)
-					classname = classname.Slice (0, terminator);
-
-				return Encoding.UTF8.GetString (classname);
 			}
 #endif
 
@@ -203,13 +194,6 @@ namespace Java.Interop
 #endif  // !FEATURE_JNIENVIRONMENT_JI_FUNCTION_POINTERS
 				return false;
 			}
-
-#if FEATURE_JNIENVIRONMENT_JI_FUNCTION_POINTERS
-			static unsafe IntPtr RawNewStringUTF (IntPtr env, IntPtr bytes)
-			{
-				return (*((JNIEnv**) env))->NewStringUTF (env, bytes);
-			}
-#endif
 
 			static void RawExceptionClear (IntPtr env)
 			{
@@ -403,7 +387,7 @@ namespace Java.Interop
 					RawExceptionClear (info.EnvironmentPointer);
 					var javaName = NewJavaNameFromUtf8 (info.EnvironmentPointer, classname);
 					try {
-						return TryLoadClassWithFallback (info, thrown, javaName, GetStringClassName (classname), throwOnError);
+						return TryLoadClassWithFallback (info, thrown, javaName, null, throwOnError);
 					} finally {
 						JniObjectReference.Dispose (ref javaName);
 					}

--- a/tests/Java.Interop-Tests/Java.Interop/JniTypeUtf8Test.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JniTypeUtf8Test.cs
@@ -44,6 +44,29 @@ namespace Java.InteropTests
 		}
 
 		[Test]
+		public void FindClass_Utf8_UsesSameFallbackAsStringOverload ()
+		{
+			var fromString = JniEnvironment.Types.FindClass ("java.lang.Object");
+			var fromUtf8   = JniEnvironment.Types.FindClass ("java.lang.Object"u8);
+			try {
+				Assert.IsTrue (JniEnvironment.Types.IsSameObject (fromString, fromUtf8));
+			} finally {
+				JniObjectReference.Dispose (ref fromString);
+				JniObjectReference.Dispose (ref fromUtf8);
+			}
+		}
+
+		[Test]
+		public void Ctor_Utf8_UsesSameFallbackAsStringOverload ()
+		{
+			using (var fromString = new JniType ("java.lang.Object"))
+			using (var fromUtf8 = new JniType ("java.lang.Object"u8)) {
+				Assert.IsTrue (JniEnvironment.Types.IsSameObject (fromString.PeerReference, fromUtf8.PeerReference));
+				Assert.AreEqual ("java/lang/Object", fromUtf8.Name);
+			}
+		}
+
+		[Test]
 		public void FindClass_Utf8_ThrowsOnNotFound ()
 		{
 #if __ANDROID__


### PR DESCRIPTION
## Summary

Make the UTF-8 `JniType(ReadOnlySpan<byte>)`/`FindClass(ReadOnlySpan<byte>)` path behave the same as the existing `string` overloads.

This change:
- keeps the raw `FindClass()` fast path
- falls back through `Class.forName(..., Runtime.ClassLoader)` when needed
- uses `NewStringUTF()` in the UTF-8 fallback path to avoid allocating a managed UTF-16 string first
- adds regression tests so both overload families stay aligned

Fixes #1406.