### PR TITLE
Make JavaObject finalizer tests deterministic

### DIFF
--- a/tests/Java.Interop-Tests/Java.Interop/JavaObjectTest.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JavaObjectTest.cs
@@ -133,17 +133,15 @@ namespace Java.InteropTests
 		static async Task WaitForGC (Func<bool> predicate, string message)
 		{
 			var timeout = Stopwatch.StartNew ();
-			while (timeout.Elapsed < TimeSpan.FromSeconds (2)) {
-				if (predicate ())
-					return;
+			var completed = predicate ();
+			while (!completed && timeout.Elapsed < TimeSpan.FromSeconds (2)) {
 				GC.Collect (generation: 2, mode: GCCollectionMode.Forced, blocking: true);
 				GC.WaitForPendingFinalizers ();
 				JniEnvironment.Runtime.ValueManager.CollectPeers ();
-				if (predicate ())
-					return;
 				await Task.Yield ();
+				completed = predicate ();
 			}
-			if (predicate ())
+			if (completed)
 				return;
 			Assert.Fail (message);
 		}

--- a/tests/Java.Interop-Tests/Java.Interop/JavaObjectTest.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JavaObjectTest.cs
@@ -84,7 +84,9 @@ namespace Java.InteropTests
 					r         = new WeakReference (v);
 			});
 			JniEnvironment.Runtime.ValueManager.CollectPeers ();
-			await WaitForGC ();
+			await WaitForGC (
+					() => !r.IsAlive && JniRuntime.CurrentRuntime.ValueManager.PeekValue (oldHandle) == null,
+					"Expected the unreferenced instance to be collected.");
 			Assert.IsFalse (r.IsAlive);
 			Assert.IsNull (r.Target);
 			Assert.IsNull (JniRuntime.CurrentRuntime.ValueManager.PeekValue (oldHandle));
@@ -107,29 +109,59 @@ namespace Java.InteropTests
 		[Test]
 		public async Task Dispose_Finalized ()
 		{
-			var d = false;
-			var f = false;
+			var disposed  = new TaskCompletionSource<bool> (TaskCreationOptions.RunContinuationsAsynchronously);
+			var finalized = new TaskCompletionSource<bool> (TaskCreationOptions.RunContinuationsAsynchronously);
 			FinalizerHelpers.PerformNoPinAction (() => {
 				FinalizerHelpers.PerformNoPinAction (() => {
-					var v     = new JavaDisposedObject (() => d = true, () => f = true);
+					var v     = new JavaDisposedObject (
+							() => disposed.TrySetResult (true),
+							() => finalized.TrySetResult (true));
 					GC.KeepAlive (v);
 				});
 				JniEnvironment.Runtime.ValueManager.CollectPeers ();
 			});
 			JniEnvironment.Runtime.ValueManager.CollectPeers ();
-			await WaitForGC ();
-			Assert.IsFalse (d);
-			Assert.IsTrue (f);
+			await WaitForGC (
+					finalized.Task,
+					"Expected JavaDisposedObject.Dispose(disposing: false) to run.");
+			Assert.IsFalse (disposed.Task.IsCompleted);
+			Assert.IsTrue (finalized.Task.IsCompleted);
 		}
 #endif  // !NO_GC_BRIDGE_SUPPORT
 
-		static async Task WaitForGC ()
+		static async Task WaitForGC (Func<bool> predicate, string message)
 		{
-			for (int i = 0; i < 3; i++) {
+			var timeout = Task.Delay (TimeSpan.FromSeconds (2));
+			while (true) {
+				if (predicate ())
+					return;
 				GC.Collect (generation: 2, mode: GCCollectionMode.Forced, blocking: true);
 				GC.WaitForPendingFinalizers ();
-				await Task.Yield ();
-				JniEnvironment.Runtime.ValueManager.WaitForGCBridgeProcessing ();
+				JniEnvironment.Runtime.ValueManager.CollectPeers ();
+				if (predicate ())
+					return;
+				var completed = await Task.WhenAny (Task.Delay (50), timeout);
+				if (completed == timeout)
+					Assert.Fail (message);
+			}
+		}
+
+		static async Task WaitForGC (Task task, string message)
+		{
+			var timeout = Task.Delay (TimeSpan.FromSeconds (2));
+			while (true) {
+				if (task.IsCompleted)
+					return;
+				GC.Collect (generation: 2, mode: GCCollectionMode.Forced, blocking: true);
+				GC.WaitForPendingFinalizers ();
+				JniEnvironment.Runtime.ValueManager.CollectPeers ();
+				if (task.IsCompleted)
+					return;
+				var completed = await Task.WhenAny (task, Task.Delay (50), timeout);
+				if (completed == task)
+					return;
+				if (completed == timeout)
+					Assert.Fail (message);
 			}
 		}
 
@@ -268,4 +300,3 @@ namespace Java.InteropTests
 		}
 	}
 }
-

--- a/tests/Java.Interop-Tests/Java.Interop/JavaObjectTest.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JavaObjectTest.cs
@@ -130,20 +130,18 @@ namespace Java.InteropTests
 		}
 #endif  // !NO_GC_BRIDGE_SUPPORT
 
-		static async Task WaitForGC (Func<bool> predicate, string message)
+		static async Task WaitForGC (Func<bool> predicate, string message, int timeoutMilliseconds = 2000)
 		{
-			var timeout = Stopwatch.StartNew ();
-			var completed = predicate ();
-			while (!completed && timeout.Elapsed < TimeSpan.FromSeconds (2)) {
+			var timeout   = TimeSpan.FromMilliseconds (timeoutMilliseconds);
+			var stopwatch = Stopwatch.StartNew ();
+			while (!predicate () && stopwatch.Elapsed < timeout) {
 				GC.Collect (generation: 2, mode: GCCollectionMode.Forced, blocking: true);
 				GC.WaitForPendingFinalizers ();
 				JniEnvironment.Runtime.ValueManager.CollectPeers ();
 				await Task.Yield ();
-				completed = predicate ();
 			}
-			if (completed)
-				return;
-			Assert.Fail (message);
+			if (!predicate ())
+				Assert.Fail (message);
 		}
 
 		[Test]

--- a/tests/Java.Interop-Tests/Java.Interop/JavaObjectTest.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JavaObjectTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 
 using Java.Interop;
@@ -122,7 +123,7 @@ namespace Java.InteropTests
 			});
 			JniEnvironment.Runtime.ValueManager.CollectPeers ();
 			await WaitForGC (
-					Task.WhenAny (disposed.Task, finalized.Task),
+					() => disposed.Task.IsCompleted || finalized.Task.IsCompleted,
 					"Expected JavaDisposedObject.Dispose(disposing: false) to run.");
 			Assert.IsFalse (disposed.Task.IsCompleted);
 			Assert.IsTrue (finalized.Task.IsCompleted);
@@ -131,8 +132,8 @@ namespace Java.InteropTests
 
 		static async Task WaitForGC (Func<bool> predicate, string message)
 		{
-			var deadline = DateTime.UtcNow + TimeSpan.FromSeconds (2);
-			while (true) {
+			var timeout = Stopwatch.StartNew ();
+			while (timeout.Elapsed < TimeSpan.FromSeconds (2)) {
 				if (predicate ())
 					return;
 				GC.Collect (generation: 2, mode: GCCollectionMode.Forced, blocking: true);
@@ -140,22 +141,11 @@ namespace Java.InteropTests
 				JniEnvironment.Runtime.ValueManager.CollectPeers ();
 				if (predicate ())
 					return;
-				var remaining = deadline - DateTime.UtcNow;
-				if (remaining <= TimeSpan.Zero)
-					Assert.Fail (message);
-				try {
-					await Task.Delay (TimeSpan.FromMilliseconds (50)).WaitAsync (remaining);
-				} catch (TimeoutException) {
-					if (predicate ())
-						return;
-					Assert.Fail (message);
-				}
+				await Task.Yield ();
 			}
-		}
-
-		static Task WaitForGC (Task task, string message)
-		{
-			return WaitForGC (() => task.IsCompleted, message);
+			if (predicate ())
+				return;
+			Assert.Fail (message);
 		}
 
 		[Test]

--- a/tests/Java.Interop-Tests/Java.Interop/JavaObjectTest.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JavaObjectTest.cs
@@ -122,7 +122,7 @@ namespace Java.InteropTests
 			});
 			JniEnvironment.Runtime.ValueManager.CollectPeers ();
 			await WaitForGC (
-					finalized.Task,
+					Task.WhenAny (disposed.Task, finalized.Task),
 					"Expected JavaDisposedObject.Dispose(disposing: false) to run.");
 			Assert.IsFalse (disposed.Task.IsCompleted);
 			Assert.IsTrue (finalized.Task.IsCompleted);
@@ -131,7 +131,7 @@ namespace Java.InteropTests
 
 		static async Task WaitForGC (Func<bool> predicate, string message)
 		{
-			var timeout = Task.Delay (TimeSpan.FromSeconds (2));
+			var deadline = DateTime.UtcNow + TimeSpan.FromSeconds (2);
 			while (true) {
 				if (predicate ())
 					return;
@@ -140,29 +140,22 @@ namespace Java.InteropTests
 				JniEnvironment.Runtime.ValueManager.CollectPeers ();
 				if (predicate ())
 					return;
-				var completed = await Task.WhenAny (Task.Delay (50), timeout);
-				if (completed == timeout)
+				var remaining = deadline - DateTime.UtcNow;
+				if (remaining <= TimeSpan.Zero)
 					Assert.Fail (message);
+				try {
+					await Task.Delay (TimeSpan.FromMilliseconds (50)).WaitAsync (remaining);
+				} catch (TimeoutException) {
+					if (predicate ())
+						return;
+					Assert.Fail (message);
+				}
 			}
 		}
 
-		static async Task WaitForGC (Task task, string message)
+		static Task WaitForGC (Task task, string message)
 		{
-			var timeout = Task.Delay (TimeSpan.FromSeconds (2));
-			while (true) {
-				if (task.IsCompleted)
-					return;
-				GC.Collect (generation: 2, mode: GCCollectionMode.Forced, blocking: true);
-				GC.WaitForPendingFinalizers ();
-				JniEnvironment.Runtime.ValueManager.CollectPeers ();
-				if (task.IsCompleted)
-					return;
-				var completed = await Task.WhenAny (task, Task.Delay (50), timeout);
-				if (completed == task)
-					return;
-				if (completed == timeout)
-					Assert.Fail (message);
-			}
+			return WaitForGC (() => task.IsCompleted, message);
 		}
 
 		[Test]

--- a/tests/Java.Interop-Tests/Java.Interop/JavaObjectTest.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JavaObjectTest.cs
@@ -140,8 +140,7 @@ namespace Java.InteropTests
 				JniEnvironment.Runtime.ValueManager.CollectPeers ();
 				await Task.Yield ();
 			}
-			if (!predicate ())
-				Assert.Fail (message);
+			Assert.IsTrue (predicate (), message);
 		}
 
 		[Test]


### PR DESCRIPTION
## Summary
- stop relying on WaitForGCBridgeProcessing timing in JavaObjectTest
- wait on the finalizer or collection condition directly instead
- bound the wait to 2 seconds so the test cannot hang indefinitely

## Why
Dispose_Finalized is still a useful regression test, but the previous version depended on GC bridge timing rather than the actual contract under test. That became visible from dotnet/android PR #11119, where removing the bridge wait exposed the test as flaky.

This keeps the regression coverage while making the assertions deterministic and implementation-independent.

## Validation
- targeted JavaObjectTest.Dispose_Finalized
- JavaObjectTest suite
