### PR TITLE
[Java.Interop] Defer exception creation in TryLoadClassWithFallback to fix global ref leak

### DIFF
--- a/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
+++ b/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
@@ -114,38 +114,33 @@ namespace Java.Interop
 			{
 				result = default;
 
-				var findClassThrown     = new JniObjectReference (thrown, JniObjectReferenceType.Local);
-				LogCreateLocalRef (findClassThrown);
-				Exception? pendingException = info.Runtime.GetExceptionForThrowable (ref findClassThrown, JniObjectReferenceOptions.CopyAndDispose);
-
 				if (Class_forName.IsValid) {
 					var __args  = stackalloc JniArgumentValue [3];
 					__args [0]  = new JniArgumentValue (classNameJavaString);
 					__args [1]  = new JniArgumentValue (true);  // initialize the class
 					__args [2]  = new JniArgumentValue (info.Runtime.ClassLoader);
 
-					var c = RawCallStaticObjectMethodA (info.EnvironmentPointer, out thrown, Class_reference.Handle, Class_forName.ID, (IntPtr) __args);
-					if (thrown == IntPtr.Zero) {
-						(pendingException as IJavaPeerable)?.Dispose ();
+					var c = RawCallStaticObjectMethodA (info.EnvironmentPointer, out var forNameThrown, Class_reference.Handle, Class_forName.ID, (IntPtr) __args);
+					if (forNameThrown == IntPtr.Zero) {
+						// Class.forName() succeeded; discard the FindClass throwable.
+						JniEnvironment.References.RawDeleteLocalRef (info.EnvironmentPointer, thrown);
 						result = new JniObjectReference (c, JniObjectReferenceType.Local);
 						JniEnvironment.LogCreateLocalRef (result);
 						return true;
 					}
 					RawExceptionClear (info.EnvironmentPointer);
-
-					if (pendingException != null) {
-						JniEnvironment.References.RawDeleteLocalRef (info.EnvironmentPointer, thrown);
-					} else {
-						var loadClassThrown = new JniObjectReference (thrown, JniObjectReferenceType.Local);
-						LogCreateLocalRef (loadClassThrown);
-						pendingException = info.Runtime.GetExceptionForThrowable (ref loadClassThrown, JniObjectReferenceOptions.CopyAndDispose);
-					}
+					JniEnvironment.References.RawDeleteLocalRef (info.EnvironmentPointer, forNameThrown);
 				}
 
 				if (!throwOnError) {
-					(pendingException as IJavaPeerable)?.Dispose ();
+					JniEnvironment.References.RawDeleteLocalRef (info.EnvironmentPointer, thrown);
 					return false;
 				}
+
+				// Both FindClass and Class.forName() failed; materialize a managed exception to throw.
+				var findClassThrown     = new JniObjectReference (thrown, JniObjectReferenceType.Local);
+				LogCreateLocalRef (findClassThrown);
+				Exception? pendingException = info.Runtime.GetExceptionForThrowable (ref findClassThrown, JniObjectReferenceOptions.CopyAndDispose);
 				if (pendingException != null)
 					throw pendingException;
 

--- a/tests/Java.Interop-Tests/Java.Interop/JniTypeUtf8Test.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JniTypeUtf8Test.cs
@@ -91,6 +91,26 @@ namespace Java.InteropTests
 		}
 
 		[Test]
+		public void TryFindClass_Utf8_DoesNotLeakGlobalRefs ()
+		{
+			int grefsBefore = JniEnvironment.Runtime.GlobalReferenceCount;
+			JniEnvironment.Types.TryFindClass ("does/not/Exist"u8, out _);
+			int grefsAfter = JniEnvironment.Runtime.GlobalReferenceCount;
+			Assert.AreEqual (grefsBefore, grefsAfter,
+				"TryFindClass for non-existent classes should not leak global references");
+		}
+
+		[Test]
+		public void TryFindClass_String_DoesNotLeakGlobalRefs ()
+		{
+			int grefsBefore = JniEnvironment.Runtime.GlobalReferenceCount;
+			JniEnvironment.Types.TryFindClass ("does/not/Exist", out _);
+			int grefsAfter = JniEnvironment.Runtime.GlobalReferenceCount;
+			Assert.AreEqual (grefsBefore, grefsAfter,
+				"TryFindClass for non-existent classes should not leak global references");
+		}
+
+		[Test]
 		public void GetMethodID_Utf8_MatchesStringOverload ()
 		{
 			using (var Object_class = new JniType ("java/lang/Object"u8)) {


### PR DESCRIPTION
## Summary

Fixes the JNI global reference leak introduced by #1407 by deferring managed exception creation in `TryLoadClassWithFallback`.

## Root Cause

PR #1407 added a `Class.forName()` fallback to the UTF-8 `FindClass` path, sharing `TryLoadClassWithFallback` between the `string` and `ReadOnlySpan<byte>` overloads.

The problem: `TryLoadClassWithFallback` **eagerly** calls `GetExceptionForThrowable` on the `FindClass` failure throwable *before* trying `Class.forName()`. This creates a full `JavaException` managed object which:

1. **Promotes the JNI local ref to a global ref** (via `ConstructPeer`)
2. Calls `getMessage()`, `getCause()` (recursively creating more `JavaException`s with their own global refs), and `getStackTrace()`
3. All of this happens even when `Class.forName()` succeeds immediately after, or when `throwOnError=false`

Before #1407, the UTF-8 path never entered this code, so no managed exceptions were created for failed `FindClass` calls. After #1407, every UTF-8 class lookup failure eagerly creates (and disposes) managed exceptions with global refs — causing the global ref churn and OOM observed in Debug mode on Android.

## Fix

Defer managed exception creation: try `Class.forName()` first using only raw JNI operations, and only materialize the managed exception if we actually need to throw.

| Code path | Before (old) | After (new) |
|---|---|---|
| `Class.forName()` succeeds | Create `JavaException` + global ref, then `Dispose()` | Delete local ref only — **no managed exception, no global ref** |
| `throwOnError=false` (both fail) | Create `JavaException` + global ref, then `Dispose()` | Delete local ref only — **no managed exception, no global ref** |
| `throwOnError=true` (both fail) | Create `JavaException` + throw | Same — create `JavaException` + throw |

## Testing

- All 667 `Java.Interop-Tests` pass, including all 16 UTF-8 `FindClass` tests added in #1407.
- Added two new regression tests (`TryFindClass_Utf8_DoesNotLeakGlobalRefs`, `TryFindClass_String_DoesNotLeakGlobalRefs`) that assert `GlobalReferenceCount` is unchanged after a `TryFindClass` call for a non-existent class.
