### PR TITLE
[Java.Interop] Fix RawCallStaticObjectMethodA PInvoke call

### DIFF
--- a/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
+++ b/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
@@ -223,7 +223,7 @@ namespace Java.Interop
 			static IntPtr RawCallStaticObjectMethodA (IntPtr env, out IntPtr thrown, IntPtr clazz, IntPtr jmethodID, IntPtr args)
 			{
 #if FEATURE_JNIENVIRONMENT_JI_PINVOKES
-				return NativeMethods.java_interop_jnienv_call_static_object_method_a (env, out thrown, clazz, instance, jmethodID, args);
+				return NativeMethods.java_interop_jnienv_call_static_object_method_a (env, out thrown, clazz, jmethodID, args);
 #elif FEATURE_JNIENVIRONMENT_JI_FUNCTION_POINTERS
 				var r   = JniNativeMethods.CallStaticObjectMethodA (env, clazz, jmethodID, args);
 				thrown  = JniNativeMethods.ExceptionOccurred (env);


### PR DESCRIPTION
## Summary

Remove undeclared `instance` variable from the PInvoke path in `RawCallStaticObjectMethodA`. The call was passing 6 arguments to a 5-parameter PInvoke: `(env, out thrown, clazz, instance, jmethodID, args)`.

The correct call should only pass: `(env, out thrown, clazz, jmethodID, args)`.

## Context

Found while investigating the `Mono.Android.NET_Tests-Debug` test failure in [dotnet/android#11171](https://github.com/dotnet/android/pull/11171). The test failure itself appears to be a flaky emulator reboot (lowmemorykiller dropped, SystemServer restarted) — not caused by the Java.Interop changes. However, this latent bug was introduced in #1410 and should be fixed.

This is currently dead code since modern builds use function pointers (`FEATURE_JNIENVIRONMENT_JI_FUNCTION_POINTERS`), but would cause a compilation error if the PInvoke path (`FEATURE_JNIENVIRONMENT_JI_PINVOKES`) is ever re-enabled.