### PR TITLE
Add java-interop-reviewer skill for PR code reviews

### DIFF
--- a/.github/skills/java-interop-reviewer/SKILL.md
+++ b/.github/skills/java-interop-reviewer/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: java-interop-reviewer
+description: >-
+  Review dotnet/java-interop PRs against established rules. Trigger on "review this PR",
+  a GitHub PR URL, or code review requests. Checks C#, JNI interop, nullable, async,
+  security, error handling, formatting, performance, native code, and generator codegen.
+---
+
+# Java.Interop PR Reviewer
+
+Review PRs against guidelines distilled from past reviews by senior maintainers of dotnet/java-interop.
+
+## Review Mindset
+
+Be polite but skeptical. Prioritize bugs, performance regressions, safety issues, and pattern violations over style nitpicks. **3 important comments > 15 nitpicks.**
+
+Flag severity clearly in every comment:
+- ❌ **error** — Must fix before merge. Bugs, security issues, JNI reference leaks, broken codegen.
+- ⚠️ **warning** — Should fix. Performance issues, missing validation, inconsistency with patterns.
+- 💡 **suggestion** — Consider changing. Style, readability, optional improvements.
+
+**Every review should produce at least one inline comment.** Even clean PRs have opportunities for improvement — code consolidation, missing edge-case tests, perf micro-optimizations, or documentation gaps. Use 💡 suggestions for these. A review with zero comments appears superficial and misses the chance to share knowledge. Only omit inline comments if the PR is truly trivial (e.g., a 1-line typo fix or dependency bump).
+
+## Workflow
+
+### 1. Identify the PR
+
+If triggered from an agentic workflow (slash command on a PR), use the PR from the event context. Otherwise, extract `owner`, `repo`, `pr_number` from a URL or reference provided by the user.
+Formats: `https://github.com/{owner}/{repo}/pull/{number}`, `{owner}/{repo}#{number}`, or bare number (defaults to `dotnet/java-interop`).
+
+### 2. Gather context (before reading PR description)
+
+```
+gh pr diff {number} --repo {owner}/{repo}
+gh pr view {number} --repo {owner}/{repo} --json files
+```
+
+For each changed file, read the **full source file** (not just the diff) to understand surrounding invariants, call patterns, and data flow. If the change modifies a public/internal API or utility, search for callers. Check whether sibling types need the same fix.
+
+**Form an independent assessment** of what the change does and what problems it has *before* reading the PR description.
+
+### 3. Incorporate PR narrative and reconcile
+
+```
+gh pr view {number} --repo {owner}/{repo} --json title,body
+```
+
+Now read the PR description and linked issues. Treat them as claims to verify, not facts to accept. Where your independent reading disagrees with the PR description, investigate further. If the PR claims a performance improvement, require evidence (benchmarks, profiling data). If it claims a bug fix, verify the bug exists and the fix addresses root cause — not symptoms.
+
+### 4. Check CI status
+
+```
+gh pr checks {number} --repo {owner}/{repo}
+```
+
+Review the CI results. **Never post ✅ LGTM if any required CI check is failing or if the code doesn't build.** If CI is failing:
+- Investigate the failure.
+- If the failure is caused by the PR's code changes, flag it as ❌ error.
+- If the failure is a known infrastructure issue or pre-existing flake unrelated to the PR, note it in the summary but still use ⚠️ Needs Changes — the PR isn't mergeable until CI is green.
+
+### 5. Load review rules
+
+Based on the file types identified in step 2, read the appropriate rule files from this skill's `references/` directory.
+
+**Always load:**
+- `references/repo-conventions.md` — Formatting, style, and patterns specific to this repository.
+- `references/ai-pitfalls.md` — Common AI-generated code mistakes.
+
+**Conditionally load based on changed file types:**
+- `references/csharp-rules.md` — When any `.cs` files changed. Covers nullable, async, error handling, performance, and code organization.
+- `references/interop-rules.md` — When the diff contains JNI interop code (e.g., `JniObjectReference`, `JniPeerMembers`, `[Register]`, `DllImport`, `[MarshalAs]`, `[StructLayout]`, `JNIEnv`), or when both C# and native files changed.
+- `references/native-rules.md` — When `.c`, `.cc`, `.cpp`, `.h`, or `.hpp` files changed (e.g., files under `src/java-interop/`).
+- `references/msbuild-rules.md` — When `.targets`, `.props`, `.projitems`, or `.csproj` files changed.
+- `references/testing-rules.md` — When test files changed (e.g., files under `tests/`, `*-Tests/`, or test project directories).
+- `references/security-rules.md` — When any code files changed (C#, C/C++, or MSBuild).
+
+### 6. Analyze the diff
+
+For each changed file, check against the review rules. Record issues as:
+
+```json
+{ "path": "src/Example.cs", "line": 42, "side": "RIGHT", "body": "..." }
+```
+
+**What to look for (in priority order):**
+1. **Bugs & correctness** — race conditions, null dereferences, off-by-one, logic errors, JNI reference leaks
+2. **Safety** — thread safety, resource leaks, security vulnerabilities
+3. **Performance** — O(n²) patterns, unnecessary allocations, startup time regressions
+4. **Trimmer/NativeAOT compatibility** — reflection without annotations, `Type.GetType()` misuse
+5. **Missing tests** — untested error paths, edge cases, missing regression tests for bug fixes
+6. **Code duplication** — near-identical methods that should be consolidated
+7. **Consistency** — patterns mixed within the same PR, API return types inconsistent with repo conventions
+8. **Documentation** — misleading comments, undocumented behavioral decisions
+
+Constraints:
+- Only comment on added/modified lines in the diff — the API rejects out-of-range lines.
+- `line` = line number in the NEW file (right side). Double-check against the diff.
+- One issue per comment.
+- **Don't pile on.** If the same issue appears many times, flag it once with a note listing all affected files.
+- **Don't flag what CI catches.** Skip compiler errors, formatting the linter will catch, etc.
+- **Avoid false positives.** Verify the concern actually applies given the full context. If unsure, phrase it as a question rather than a firm claim.
+
+### 7. Post the review
+
+Post your findings directly:
+
+- **Inline comments** on specific lines of the diff with the severity, category, and explanation.
+- **Review summary** with the overall verdict (✅ LGTM, ⚠️ Needs Changes, or ❌ Reject), issue counts by severity, and positive callouts.
+
+If no issues found **and CI is green**, submit with at most one or two 💡 suggestions and a positive summary. Truly trivial PRs (dependency bumps, 1-line typo fixes) may have no inline comments.
+
+**Copilot-authored PRs:** If the PR author is `Copilot` (the GitHub Copilot coding agent) and the verdict is ⚠️ Needs Changes or ❌ Reject, prefix the review summary with `@copilot ` so the comment automatically triggers Copilot to address the feedback. Do NOT add the prefix for ✅ LGTM verdicts.
+
+## Comment format
+
+```
+🤖 {severity} **{Category}** — {What's wrong and what to do instead.}
+
+_{Rule: Brief name}_
+```
+
+Where `{severity}` is ❌, ⚠️, or 💡.
+
+**Categories:** Nullable · Async pattern · Error handling · Resource management · Security · Formatting · Performance · Code organization · Naming · JNI interop · JNI references · Generator codegen · Native C/C++ · Testing · YAGNI · API design · Trimmer/AOT · Documentation

--- a/.github/skills/java-interop-reviewer/references/ai-pitfalls.md
+++ b/.github/skills/java-interop-reviewer/references/ai-pitfalls.md
@@ -1,0 +1,25 @@
+# AI Code Generation Pitfalls
+
+Patterns that AI-generated code consistently gets wrong. Always loaded during reviews.
+
+---
+
+| Pattern | What to watch for |
+|---------|------------------|
+| **Reinventing the wheel** | AI creates new infrastructure instead of using existing utilities. ALWAYS check if a similar utility exists before accepting new wrapper code. This is the most expensive AI pattern — hundreds of lines of plausible code that duplicates what's already there. |
+| **Over-engineering** | HttpClient injection "for testability", speculative helper classes, unused overloads. If no caller needs it today, remove it. |
+| **Swallowed errors** | AI catch blocks love to eat exceptions silently. Check EVERY catch block. Also check that exit codes are checked consistently. |
+| **Null-forgiving operator (`!`)** | The postfix `!` null-forgiving operator (e.g., `foo!.Bar`) is banned. If the value can be null, add a proper null check. If it can't be null, make the parameter/variable non-nullable. AI frequently sprinkles `!` to silence the compiler — this turns compile-time warnings into runtime `NullReferenceException`s. Note: this rule is about the postfix `!` operator, not the logical negation `!` (e.g., `if (!someBool)` or `if (!string.IsNullOrEmpty (s))`). |
+| **Wrong formatting** | AI generates standard C# formatting (no space before parens). This repo requires Mono style: `Foo ()`, `array [0]`. |
+| **`string.Empty` and `Array.Empty<T>()`** | AI defaults to these. Use `""` and `[]` instead. |
+| **Sloppy structure** | Multiple types in one file, block-scoped namespaces, `#region` directives, classes where records would do. New helpers marked `public` when `internal` suffices. |
+| **Docs describe intent not reality** | AI doc comments often describe what the code *should* do, not what it *actually* does. Review doc comments against the implementation. |
+| **Unused parameters** | AI adds `CancellationToken` parameters but never observes them, or accepts `additionalArgs` as a string and interpolates it into a command. Unused CancellationToken is a broken contract; string args are injection risks. |
+| **Confidently wrong domain facts** | AI makes authoritative claims about JNI behavior, Java type system details, or .NET interop semantics that are wrong. Always verify domain-specific claims against official docs (JNI spec, .NET docs). |
+| **Over-mocking** | Not everything needs to be mocked. Integration tests with `Assert.Ignore` on failure are fine and catch real API changes that mocks never will. |
+| **`Debug.WriteLine` for logging** | AI catch blocks often log with `System.Diagnostics.Debug.WriteLine()` or `Console.WriteLine()` — neither integrates with MSBuild or codebase logger patterns. |
+| **`git commit --amend`** | AI uses `--amend` on commits that are already pushed or belong to another author. Always create new commits — the maintainer will squash as needed. |
+| **Commit messages omit non-obvious choices** | Behavioral decisions ("JNI local refs are not eagerly disposed in this path") and known limitations belong in the commit message, not just the code. |
+| **Typos in user-visible strings** | Users copy-paste error messages into bug reports. Get them right. |
+| **Filler words in docs** | "So" at the start of a sentence adds nothing. Be direct. |
+| **Ignoring trimmer/AOT** | AI uses `Type.GetType()`, `Activator.CreateInstance()`, or other reflection APIs without proper `[DynamicallyAccessedMembers]` annotations. These break under trimming and NativeAOT. |

--- a/.github/skills/java-interop-reviewer/references/csharp-rules.md
+++ b/.github/skills/java-interop-reviewer/references/csharp-rules.md
@@ -1,0 +1,77 @@
+# C# Review Rules
+
+General C# guidance applicable to any .NET repository.
+
+---
+
+## Nullable Reference Types
+
+| Check | What to look for |
+|-------|-----------------|
+| **`#nullable enable`** | New files should have `#nullable enable` at the top — unless nullable is already enabled at the project level via the `Nullable` MSBuild property, in which case it is not needed per-file. |
+| **Never use `!` (null-forgiving operator)** | The postfix `!` null-forgiving operator (e.g., `foo!.Bar`) is banned. If the value can be null, add a proper null check. If it can't be null, make the type non-nullable. AI-generated code frequently sprinkles `!` to silence warnings — this turns compile-time safety into runtime `NullReferenceException`s. Note: this rule is about the postfix `!` operator, not the logical negation `!` (e.g., `if (!someBool)` or `if (!string.IsNullOrEmpty (s))`). |
+
+---
+
+## Async, Cancellation & Thread Safety Patterns
+
+| Check | What to look for |
+|-------|-----------------|
+| **CancellationToken propagation** | Every `async` method that accepts a `CancellationToken` must pass it to ALL downstream async calls. A token that's accepted but never used is a broken contract. |
+| **OperationCanceledException** | Catch-all blocks (`catch (Exception)`) must NOT swallow `OperationCanceledException`. Catch it explicitly first and rethrow, or use a type filter. |
+| **Honor the token** | If a method accepts `CancellationToken`, it must observe it — register a callback to kill processes, check `IsCancellationRequested` in loops, pass it downstream. Don't accept it just for API completeness. |
+| **Thread safety of shared state** | If a new field or property can be accessed from multiple threads (e.g., static caches, event handlers), verify thread-safe access: `ConcurrentDictionary`, `Interlocked`, or explicit locks. A `Dictionary<K,V>` read concurrently with a write is undefined behavior. |
+| **Lock ordering** | If code acquires multiple locks, the order must be consistent everywhere. Document the ordering. Inconsistent ordering → deadlock. |
+| **Avoid double-checked locking — use `Lazy<T>` or `LazyInitializer`** | The double-checked locking (DCL) pattern is error-prone and [discouraged by Microsoft](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/volatile). Prefer `Lazy<T>` or `LazyInitializer.EnsureInitialized()`. If DCL is truly necessary, verify all initialization completes before the field is assigned and no thread can observe a partially-initialized instance. |
+| **Singleton initialization completeness** | When a singleton is initialized behind a lock, ensure ALL setup steps (not just construction) complete before publishing the instance. If `Initialize()` does `instance = new Foo(); instance.Setup();`, another thread can see `instance != null` and use it before `Setup()` runs. |
+
+---
+
+## Error Handling
+
+| Check | What to look for |
+|-------|-----------------|
+| **No empty catch blocks** | Every `catch` must capture the `Exception` and log it (or rethrow). No silent swallowing. |
+| **Validate parameters** | Enum parameters and string-typed "mode" values must be validated — throw `ArgumentException` or `NotSupportedException` for unexpected values. |
+| **Fail fast on critical ops** | If a critical operation fails, throw immediately. Silently continuing leads to confusing downstream failures. |
+| **Check process exit codes** | If one operation checks the process exit code, ALL similar operations must too. Inconsistent error checking creates a false sense of safety. |
+| **Log messages must have context** | A bare `"Operation failed"` could be anything. Include *what* you were doing and relevant identifiers. |
+| **Differentiate similar error messages** | Two messages saying `"X failed"` for different operations are impossible to debug. Make each unique. |
+| **Assert boundary invariants** | If a name=value pair array must have even length, assert `(length % 2) == 0` before indexing `[i+1]`. |
+| **Include actionable details in exceptions** | Use `nameof` for parameter names. Include the unsupported value or unexpected type. Never throw empty exceptions. |
+| **Initialize output parameters in all paths** | Methods with `out` parameters must initialize them in all error paths, not just the success path. |
+| **Challenge exception swallowing** | When a PR adds `catch { continue; }` or `catch { return null; }`, question whether the exception is truly expected or masking a deeper problem. The default should be to let unexpected exceptions propagate. |
+
+---
+
+## Performance
+
+| Check | What to look for |
+|-------|-----------------|
+| **Avoid unnecessary allocations** | Don't create intermediate collections when LINQ chaining or a single list would do. Char arrays for `string.Split()` should be `static readonly` fields. |
+| **ArrayPool for large buffers** | Buffers ≥ 1 KB should use `ArrayPool<byte>.Shared.Rent()` with `try`/`finally` return. Large allocations go to the LOH and are expensive to GC. |
+| **`HashSet.Add()` already handles duplicates** | Calling `.Contains()` before `.Add()` does the hash lookup twice. Just call `.Add()`. |
+| **Don't wrap a value in an interpolated string** | `$"{someString}"` creates an unnecessary `string.Format` call when `someString` is already a string. |
+| **Pre-allocate collections when size is known** | Use `new List<T>(capacity)` or `new Dictionary<TK, TV>(count)` when the size is known or estimable. Repeated resizing is O(n) allocation waste. |
+| **Avoid closures in hot paths** | Lambdas that capture local variables allocate a closure object on every call. In loops or frequently-called methods, extract the lambda to a static method or cache the delegate. |
+| **Place cheap checks before expensive ones** | In validation chains, test simple conditions (null checks, boolean flags) before allocating strings or doing I/O. Short-circuit with `&&`/`||`. |
+| **Cache repeated accessor calls** | If `foo.Bar.Baz` is used multiple times in a block, assign it to a local. This avoids repeated property evaluation and makes intent clearer. |
+| **Watch for O(n²)** | Nested loops over the same or related collections, repeated `.Contains()` on a `List<T>`, or LINQ `.Where()` inside a loop are O(n²). Switch to `HashSet<T>` or `Dictionary<TK, TV>` for lookups. |
+| **Extract throw helpers** | Code like `if (x) throw new SomeException(...)` in a frequently-called method prevents inlining. Extract into a `[DoesNotReturn]` helper so the JIT can inline the happy path. |
+| **`Split()` with count parameter** | `line.Split(new char[]{'='}, 2)` prevents values containing `=` from being split incorrectly. Follow existing patterns. |
+
+---
+
+## Code Organization
+
+| Check | What to look for |
+|-------|-----------------|
+| **One type per file** | Each public class, struct, enum, or interface must be in its own `.cs` file named after the type. |
+| **Use `record` for data types** | Immutable data-carrier types should be `record` types — they get value equality, `ToString()`, and deconstruction for free. |
+| **Remove unused code** | Dead methods, speculative helpers, and code "for later" should be removed. Ship only what's needed. No commented-out code — Git has history. |
+| **New helpers default to `internal`** | New utility methods should be `internal` unless a confirmed external consumer needs them. Use `InternalsVisibleTo` for test access. |
+| **Use interfaces over concrete types** | Fields and parameters should prefer interfaces (`IMetadataResolver`) over concrete classes. When the implementation changes, you swap the implementation — not every call site. |
+| **Reduce indentation with early returns** | `foreach (var x in items ?? Array.Empty<T>())` eliminates a null-check nesting level. Invert logic for the common case with `continue` so complex cases have less nesting. |
+| **Don't initialize fields to default values** | `bool flag = false;` and `int count = 0;` are noise. The CLR zero-initializes all fields. Only assign when the initial value is non-default. |
+| **`sealed` classes skip full Dispose** | A `sealed` class doesn't need `Dispose(bool)` + `GC.SuppressFinalize`. Just implement `IDisposable.Dispose()` directly. The full pattern is only for unsealed base classes. |
+| **Well-named constants over magic numbers** | `if (retryCount > 3)` should be `if (retryCount > MaxRetries)`. Constants document intent and make the value easy to find and change. |

--- a/.github/skills/java-interop-reviewer/references/csharp-rules.md
+++ b/.github/skills/java-interop-reviewer/references/csharp-rules.md
@@ -58,7 +58,7 @@ General C# guidance applicable to any .NET repository.
 | **Cache repeated accessor calls** | If `foo.Bar.Baz` is used multiple times in a block, assign it to a local. This avoids repeated property evaluation and makes intent clearer. |
 | **Watch for O(n²)** | Nested loops over the same or related collections, repeated `.Contains()` on a `List<T>`, or LINQ `.Where()` inside a loop are O(n²). Switch to `HashSet<T>` or `Dictionary<TK, TV>` for lookups. |
 | **Extract throw helpers** | Code like `if (x) throw new SomeException(...)` in a frequently-called method prevents inlining. Extract into a `[DoesNotReturn]` helper so the JIT can inline the happy path. |
-| **`Split()` with count parameter** | `line.Split(new char[]{'='}, 2)` prevents values containing `=` from being split incorrectly. Follow existing patterns. |
+| **`Split()` with count parameter** | `line.Split (new char[]{'='}, 2)` prevents values containing `=` from being split incorrectly. Follow existing patterns. |
 
 ---
 
@@ -71,7 +71,7 @@ General C# guidance applicable to any .NET repository.
 | **Remove unused code** | Dead methods, speculative helpers, and code "for later" should be removed. Ship only what's needed. No commented-out code — Git has history. |
 | **New helpers default to `internal`** | New utility methods should be `internal` unless a confirmed external consumer needs them. Use `InternalsVisibleTo` for test access. |
 | **Use interfaces over concrete types** | Fields and parameters should prefer interfaces (`IMetadataResolver`) over concrete classes. When the implementation changes, you swap the implementation — not every call site. |
-| **Reduce indentation with early returns** | `foreach (var x in items ?? Array.Empty<T>())` eliminates a null-check nesting level. Invert logic for the common case with `continue` so complex cases have less nesting. |
+| **Reduce indentation with early returns** | `foreach (var x in items ?? [])` eliminates a null-check nesting level. Invert logic for the common case with `continue` so complex cases have less nesting. |
 | **Don't initialize fields to default values** | `bool flag = false;` and `int count = 0;` are noise. The CLR zero-initializes all fields. Only assign when the initial value is non-default. |
 | **`sealed` classes skip full Dispose** | A `sealed` class doesn't need `Dispose(bool)` + `GC.SuppressFinalize`. Just implement `IDisposable.Dispose()` directly. The full pattern is only for unsealed base classes. |
 | **Well-named constants over magic numbers** | `if (retryCount > 3)` should be `if (retryCount > MaxRetries)`. Constants document intent and make the value easy to find and change. |

--- a/.github/skills/java-interop-reviewer/references/interop-rules.md
+++ b/.github/skills/java-interop-reviewer/references/interop-rules.md
@@ -1,0 +1,31 @@
+# Managed ↔ Native Interop Review Rules
+
+Rules for the boundary between C# and C/C++ code — P/Invoke declarations, JNI
+bindings, and shared structs. Load when both managed and native files change, or
+when the diff contains interop markers (`JniObjectReference`, `JniPeerMembers`,
+`DllImport`, `[Register]`, `JNIEnv`, `[MarshalAs]`, `[StructLayout]`).
+
+---
+
+## JNI Interop Checks
+
+| Check | What to look for |
+|-------|-----------------|
+| **`JniObjectReference` lifecycle** | Every `JniObjectReference` obtained from JNI calls must be disposed in a `try`/`finally` block. Local references that escape their JNI frame exhaust the local reference table (default 512 entries). Global references that aren't freed are permanent leaks. |
+| **`JniPeerMembers` for method/field IDs** | Method and field IDs should be cached via `JniPeerMembers.InstanceMethods`, `JniPeerMembers.StaticMethods`, or `JniPeerMembers.InstanceFields`. Looking up IDs on every call is expensive. |
+| **Virtual vs non-virtual dispatch** | Default interface method implementations should use `InvokeNonvirtualVoidMethod()` (non-virtual). Class method overrides should use `InvokeVirtualVoidMethod()` (virtual). Getting this wrong changes dispatch semantics. |
+| **`[Register]` attribute accuracy** | `[Register]` attributes must exactly match the Java method name and JNI signature. Mismatches cause `NoSuchMethodError` at runtime. Verify against the Java API description. |
+| **`JniTransition` for native callbacks** | Entry points from Java into managed code should use `JniTransition` to properly handle exception marshaling. Without it, managed exceptions propagate into the JVM as undefined behavior. |
+| **Exception checking after JNI calls** | After JNI calls that can throw (most of them), check for pending Java exceptions via `JniEnvironment.Errors.ExceptionOccurred()` or rely on the built-in checking in `JniPeerMembers` wrappers. Don't ignore JNI error return codes. |
+
+---
+
+## P/Invoke Checks
+
+| Check | What to look for |
+|-------|-----------------|
+| **`static_cast` over C-style casts** | `static_cast<int>(val)` is checked at compile time. `(int)val` can silently reinterpret bits. Always use C++ casts in interop boundaries. |
+| **`nullptr` over `NULL`** | `NULL` is `0` in C++, which can silently convert to integral types. `nullptr` has proper pointer semantics. |
+| **Struct field ordering for padding** | When defining structs shared between managed and native code, order fields largest-to-smallest to minimize padding. Explicit `[StructLayout(LayoutKind.Sequential)]` and matching C struct must be kept in sync. |
+| **Bool marshalling** | Boolean marshalling is a common source of bugs. C++ `bool` is 1 byte, Windows `BOOL` is 4 bytes. When P/Invoking, explicitly specify `[MarshalAs(UnmanagedType.U1)]` or `[MarshalAs(UnmanagedType.Bool)]` (4-byte). |
+| **String marshalling charset** | P/Invoke string parameters should specify `CharSet.Unicode` (UTF-16) or use `[MarshalAs(UnmanagedType.LPUTF8Str)]` for UTF-8. Don't rely on the default (ANSI on Windows). |

--- a/.github/skills/java-interop-reviewer/references/msbuild-rules.md
+++ b/.github/skills/java-interop-reviewer/references/msbuild-rules.md
@@ -1,0 +1,44 @@
+# MSBuild Review Rules
+
+Guidance for MSBuild targets, props, and project files. Loaded when `.targets`,
+`.props`, `.projitems`, or `.csproj` files change.
+
+---
+
+## Task Logging
+
+| Check | What to look for |
+|-------|-----------------|
+| **Don't use `Debug.WriteLine` or `Console.WriteLine`** | MSBuild tasks must use the task's logging facilities (e.g., `Log.LogMessage`, `Log.LogWarning`, `Log.LogError`). `Debug.WriteLine()` only reaches attached debuggers (invisible in CI). `Console.WriteLine()` bypasses MSBuild's logging pipeline entirely. |
+| **Use appropriate log levels** | Use `MessageImportance.Low` for verbose diagnostics, `MessageImportance.Normal` for progress, and `MessageImportance.High` for important status. Don't spam high-importance messages. |
+
+---
+
+## Process Management in Tasks
+
+| Check | What to look for |
+|-------|-----------------|
+| **Don't redirect stdout/stderr without draining** | Background processes with `RedirectStandardOutput = true` must have async readers draining the output. Otherwise the OS pipe buffer fills and the child process deadlocks. For fire-and-forget processes, set `Redirect* = false`. |
+| **Check exit codes consistently** | If one task operation checks the process exit code, ALL similar operations must too. Inconsistent error checking creates a false sense of safety. |
+| **Include stdout in error diagnostics** | When a task captures stdout, pass it to error reporting so failure messages include all output, not just stderr. |
+
+---
+
+## MSBuild Targets & XML
+
+| Check | What to look for |
+|-------|-----------------|
+| **Underscore prefix for private names** | Internal targets, properties, and item groups should be prefixed with `_` (e.g., `_CompileJava`, `$(_JarFile)`). MSBuild has no visibility — the underscore signals "internal." |
+| **Incremental builds (`Inputs`/`Outputs`)** | Every target that *writes files* must have `Inputs` and `Outputs` so MSBuild can skip it when nothing changed. Targets that only read files, set properties, or populate item groups do NOT need them. |
+| **`FileWrites` for intermediate files** | Intermediate files must be added to `@(FileWrites)` so `IncrementalClean` doesn't delete them. |
+| **XML indentation** | MSBuild/XML files use 2 spaces for indentation (per `.editorconfig`), not tabs. |
+| **`Condition` attribute first** | On `<Target>` and task elements, put the `Condition` attribute first — it's the most important for debugging. |
+
+---
+
+## Downstream Coordination
+
+| Check | What to look for |
+|-------|-----------------|
+| **Port, don't rewrite** | If a downstream consumer already has working logic for the same task, port it rather than writing new code. The existing code has real-world edge cases already handled. |
+| **Draft downstream PR before merging** | Shared library changes should be accompanied by a draft PR in the consuming repo (dotnet/android) that proves the API actually works. |

--- a/.github/skills/java-interop-reviewer/references/native-rules.md
+++ b/.github/skills/java-interop-reviewer/references/native-rules.md
@@ -1,0 +1,35 @@
+# Native Code (C/C++) Review Rules
+
+The native interop layer (`src/java-interop/`) provides low-level JNI and
+platform integration. Bugs here cause crashes and memory leaks that are
+extremely hard to diagnose.
+
+---
+
+## Memory Management
+
+| Check | What to look for |
+|-------|-----------------|
+| **Every `new` needs a `delete` or justification** | If a `new` has no matching cleanup, document *why* the leak is acceptable and its worst-case size. |
+| **Quantify leaks** | Is the leaked path hit once per process lifetime or once per invocation? The answer determines whether a leak matters. |
+| **Use RAII (`std::unique_ptr`, etc.)** | Use smart pointers or RAII to ensure cleanup. Don't rely on manual `delete`. |
+| **Watch for leaks in external APIs** | Functions that allocate memory for the caller must have their return values freed. Check the docs for every external API call. |
+
+---
+
+## C++ Best Practices
+
+| Check | What to look for |
+|-------|-----------------|
+| **`nullptr` over `NULL`** | `NULL` is `0` in C++, which can silently convert to integral types. `nullptr` has proper pointer semantics. Use `!= nullptr` consistently in null checks. |
+| **Use C++ standard headers** | Prefer `<cstdlib>` over `<stdlib.h>`, `<cstring>` over `<string.h>`, etc. The C++ headers place names in `std::`. |
+| **Virtual destructor on base classes** | Any base class with virtual methods must have a public virtual destructor. Without one, `delete`-through-base-pointer is undefined behavior. |
+| **Delete copy/move constructors when inappropriate** | Types holding non-copyable resources (JNI references, file handles) must use `= delete` on copy constructor and assignment operator. |
+| **Prefer `private` over `protected`** | Unless the type is explicitly designed for subclassing, use `private`. Don't speculatively make things `protected`. |
+| **Use `const` where possible** | If a parameter or function argument isn't modified, declare it `const`. |
+| **Handle `EINTR` for system calls** | `read()`, `write()`, and other syscalls can return `EINTR` when interrupted by a signal. Retry in a loop. |
+| **Use `sizeof()` not magic numbers** | `16` should be `sizeof(some_type)` or equivalent. Magic numbers make code fragile. |
+| **`static_cast` over C-style casts** | `static_cast<int>(val)` is checked at compile time. `(int)val` can silently reinterpret bits. |
+| **No commented-out code** | If it's not needed, delete it. Git has history. |
+| **Don't use compiler-reserved identifiers** | Double-underscore `__` prefixed names are reserved by the C/C++ standard. |
+| **Reasonable line width** | Don't combine two 80-char lines into one 160-char line. Keep code readable. |

--- a/.github/skills/java-interop-reviewer/references/repo-conventions.md
+++ b/.github/skills/java-interop-reviewer/references/repo-conventions.md
@@ -1,0 +1,96 @@
+# Repo Conventions
+
+Formatting, style, and patterns specific to the dotnet/java-interop repository.
+Always loaded during reviews.
+
+---
+
+## Formatting & Style
+
+This project uses Mono style with tabs. Formatting violations create noisy diffs
+and merge conflicts.
+
+| Check | What to look for |
+|-------|-----------------|
+| **Tabs, not spaces** | Indentation must use tabs (width 8 in `.editorconfig`). MSBuild/XML files use 2 spaces. |
+| **Space before `(` and `[`** | Method calls: `Foo ()`, `Bar (1, 2)`. Array access: `array [0]`. This is Mono style — omitting the space is wrong here even though it's standard elsewhere. |
+| **`""` not `string.Empty`** | Use `""` for empty strings. Use `[]` not `Array.Empty<T>()` for empty arrays. |
+| **No `#region`/`#endregion`** | Region directives hide code and make reviews harder. Remove them. |
+| **`#else`/`#endif` comments** | Always annotate `#else` and `#endif` with the original expression: `#else // !NETCOREAPP` and `#endif // !NETCOREAPP`. |
+| **Minimal diffs** | Don't leave random empty lines. Preserve existing formatting and comments in files you didn't write. Only format code you add or modify; never reformat existing lines. |
+| **Reasonable line width** | Max 180 characters per `.editorconfig`. Don't merge two lines into a single 160-character monster. |
+| **Attributes on their own line** | Long attributes like `[DynamicallyAccessedMembers (...)]` should be on their own line, not inline with the method/parameter declaration. Each parameter with long attributes should get its own line. |
+| **Named parameters for many-argument calls** | When calling a method with more than 4 parameters, use named parameters for clarity. |
+
+---
+
+## Naming
+
+| Check | What to look for |
+|-------|-----------------|
+| **Disambiguate Java vs C# names** | Terms like `FullName`, `Name`, or `ReferenceType` are ambiguous in a JNI interop context. When both Java and C# interpretations exist, prefer a prefix (`JavaFullName`, `ManagedFullName`) or clear documentation. |
+| **Method names must reflect behavior** | If `CreateFoo()` sometimes returns an existing instance, rename it `GetOrCreateFoo()` or `GetFoo()`. |
+| **Named constants for string lengths** | `n.Length - 7` should be `n.Length - "Invoker".Length`. Magic numbers for string suffix lengths are fragile and unreadable. |
+| **No magic numbers** | Literal values like buffer sizes and permission masks should be named constants. `sizeof()` in native code, `const` or `static readonly` in C#. |
+| **`KeyedCollection` for name-indexed lists** | When a `List<T>` is frequently searched by a name property, consider `KeyedCollection<string, T>` or `Dictionary<string, T>` for O(1) lookups. |
+
+---
+
+## Error Messages & Localization
+
+| Check | What to look for |
+|-------|-----------------|
+| **Error/warning codes are required** | User-facing errors/warnings in generator and other tools must have codes (e.g., `BG####`, `JM####`). Error codes must not collide with existing ones. |
+| **Error messages must be actionable** | Tell the user what to do, not just what went wrong. "Unable to find type" → "Unable to find type '…'. Make sure the paths to all referenced assemblies are provided with the `-L` option." |
+| **Demote non-actionable messages** | If a warning can't suggest an action, demote it to informational. Warnings that users can't act on are noise. |
+| **Localization resource comments** | Include comments explaining what terms should NOT be translated: `The following terms should not be translated: Metadata.xml, -L.` |
+| **Don't use internal jargon in messages** | Terms like "Cecil" or "corlib" are meaningless to users. Use "referenced assemblies" or "mscorlib" instead. |
+| **Error messages in resource files** | New error/warning messages should be added to `.resx` resource files and referenced via `Properties.Resources`, not hard-coded in C# strings. |
+
+---
+
+## JNI Interop Patterns
+
+| Check | What to look for |
+|-------|-----------------|
+| **JNI reference lifecycle** | Every `JniObjectReference` must be properly disposed. Use `try`/`finally` or `using` patterns. Local references are cleaned up by the JVM at JNI frame boundaries, but explicit cleanup prevents native reference table exhaustion. |
+| **Use `JniTransition` for exception marshaling** | Native callbacks into managed code should use `JniTransition` to properly handle exception marshaling between Java and C#. |
+| **`JniPeerMembers` caching** | Method and field IDs should be accessed via `JniPeerMembers` for efficient caching. Don't look up method IDs on every call. |
+| **Thread-local JNI environments** | JNI environments are thread-local. Always use `JniEnvironment.Current` to access the current thread's environment. Don't cache `JNIEnv*` across threads. |
+| **`[Register]` attribute correctness** | `[Register]` attributes must match the Java method signature exactly. Mismatches cause runtime `NoSuchMethodError`. |
+
+---
+
+## Performance
+
+| Check | What to look for |
+|-------|-----------------|
+| **Startup time is critical** | Changes to `Java.Interop` core affect every .NET Android app startup. Minimize type loading, lazy-initialize where possible, avoid unnecessary allocations in hot paths. |
+| **Prefer arrays over dictionaries for small lookups** | For datasets with < ~50 items, linear search through an array is faster than dictionary lookup due to hash computation overhead and initialization cost. Back assertions with benchmarks. |
+| **`StringComparison.Ordinal` for identifiers** | Use `StringComparison.Ordinal` for Java/C# identifier comparisons. `string.EndsWith(string)` without a `StringComparison` is locale-aware and slower. Use `StringComparison.OrdinalIgnoreCase` only for filesystem paths. |
+| **Static `readonly` for reusable fields** | Static fields like singletons or shared instances should be `readonly` when they shouldn't be reassigned. `static HttpClient` instances are mandatory (no per-use disposal). |
+| **Consider trimmer/NativeAOT impact** | Use `[DynamicallyAccessedMembers]` for types accessed via reflection. Use `[UnconditionalSuppressMessage]` instead of `#pragma` for trimmer warnings. Avoid `Type.GetType()` with assembly-qualified names when a direct type reference or typemap lookup can be used. |
+
+---
+
+## Downstream Impact
+
+| Check | What to look for |
+|-------|-----------------|
+| **Consider dotnet/android consumers** | Changes to shared types (`JniPeerMembers`, `JavaObject`, `JniRuntime`, `JniTypeManager`) affect dotnet/android. API changes should be validated with a draft downstream PR. |
+| **Port, don't rewrite** | If dotnet/android already has working logic for the same task, port it rather than writing new code. Existing code has real-world edge cases already handled. |
+| **Target framework compatibility** | Tools shipped to customers (e.g., `generator`, `class-parse`) must target the correct .NET version. Verify against the oldest supported target framework. |
+
+---
+
+## Patterns & Conventions
+
+| Check | What to look for |
+|-------|-----------------|
+| **Comments explain "why", not "what"** | `// increment i` adds nothing. `// skip the BOM — XmlReader chokes on it` explains intent. If a comment restates the code, delete it. |
+| **Track TODOs as issues** | A `// TODO` hidden in code will be forgotten. File an issue and reference it in the comment. |
+| **Remove stale comments** | If the code changed, update the comment. Comments that describe old behavior are misleading. |
+| **Use existing utilities** | Check for existing helpers before writing new ones. Duplicating existing logic is the most expensive AI pattern. |
+| **Return `IReadOnlyList<T>`** | Public methods should return `IReadOnlyList<T>` or `IReadOnlyCollection<T>` instead of mutable `List<T>`. |
+| **Prefer C# pattern matching** | Use `is`, `switch` expressions, and property patterns instead of `if`/`else` type-check chains. |
+| **Use `record` for data types** | Immutable data-carrier types should be `record` types — they get value equality, `ToString()`, and deconstruction for free. |

--- a/.github/skills/java-interop-reviewer/references/security-rules.md
+++ b/.github/skills/java-interop-reviewer/references/security-rules.md
@@ -1,0 +1,22 @@
+# Security Review Rules
+
+Security checklist for code reviews. Applicable to any repository handling file
+I/O, archives, or process execution.
+
+---
+
+## Archive & Path Safety
+
+| Check | What to look for |
+|-------|-----------------|
+| **Zip Slip protection** | Archive extraction must validate that every entry path, after `Path.GetFullPath()`, resolves under the destination directory. Never use `ZipFile.ExtractToDirectory()` for untrusted archives without entry-by-entry validation. |
+| **Path traversal** | `StartsWith()` checks on paths must normalize with `Path.GetFullPath()` first. A path like `C:\Program Files\..\Users\evil` bypasses naive prefix checks. Also check for directory boundary issues (`C:\Program FilesX` matching `C:\Program Files`). |
+
+---
+
+## Process & Command Safety
+
+| Check | What to look for |
+|-------|-----------------|
+| **Command injection** | Arguments passed to `Process.Start` must be sanitized. Use `ArgumentList` (not string interpolation into command strings). Never interpolate user/external input into command strings. |
+| **Elevation** | Don't auto-elevate. Don't include `IsElevated()` helpers that silently re-launch elevated. The calling tool should handle elevation prompts. The library should error if it lacks permissions. |

--- a/.github/skills/java-interop-reviewer/references/testing-rules.md
+++ b/.github/skills/java-interop-reviewer/references/testing-rules.md
@@ -1,0 +1,18 @@
+# Testing Review Rules
+
+Guidance for test code in dotnet/java-interop. Loaded when test files change.
+
+---
+
+## Testing Checks
+
+| Check | What to look for |
+|-------|-----------------|
+| **NUnit conventions** | Use `[TestFixture]`, `[Test]`, `[NonParallelizable]` (for tests that hang without it). |
+| **Bug fixes need regression tests** | Every PR that fixes a bug should include a test that fails without the fix and passes with it. If the PR description says "fixes #N" but adds no test, ask for one. |
+| **Test assertions must be specific** | `Assert.IsNotNull(result)` or `Assert.IsTrue(success)` don't tell you what went wrong. Prefer `Assert.AreEqual(expected, actual)` or NUnit constraints (`Assert.That` with `Does.Contain`, `Is.EqualTo`, etc.) for richer failure messages. |
+| **Deterministic test data** | Tests should not depend on system locale, timezone, or current date. Use explicit `CultureInfo.InvariantCulture` and hardcoded dates when testing formatting. |
+| **Test edge cases** | Empty collections, null inputs, boundary values, concurrent calls, and very large inputs should all be considered. If the PR only tests the happy path, suggest edge cases. |
+| **Generator tests must include Invoker types** | Tests for generated binding code should verify both the interface/class output and the `*Invoker` type behavior. Invoker codegen has historically had subtle bugs with default interface methods and virtual dispatch. |
+| **JVM-dependent tests** | Tests that require a running JVM should be in projects that configure the JVM environment (e.g., `Java.Interop-Tests`). Verify that test classes requiring a JVM are not placed in unit-test-only projects. |
+| **Expected codegen output tests** | Generator tests that compare expected output should be updated when the expected output format changes. Stale expected output files cause spurious test failures. |


### PR DESCRIPTION
Create a code reviewer skill modeled after [dotnet/android](https://github.com/dotnet/android/tree/main/.github/skills/android-reviewer) and [dotnet/android-tools](https://github.com/dotnet/android-tools/tree/main/.github/skills/android-tools-reviewer) reviewer skills, adapted for dotnet/java-interop.

## Structure

- **`SKILL.md`** — Main workflow: gather diff → independent assessment → load conditional rules → analyze → post review
- **`references/`** — Rule files loaded conditionally based on changed file types

### Reusable reference files (globally applicable to any .NET repo)

| File | Description |
|------|-------------|
| `ai-pitfalls.md` | Common AI code generation mistakes (formatting, `!` operator, swallowed errors, over-engineering) |
| `csharp-rules.md` | Nullable, async/cancellation, error handling, performance, code organization |
| `security-rules.md` | Zip Slip, path traversal, command injection, elevation |
| `testing-rules.md` | NUnit conventions, regression tests, generator codegen tests |
| `msbuild-rules.md` | Task logging, process management, XML conventions |
| `native-rules.md` | C++ memory management, RAII, `nullptr`, `const`, standard headers |

### Repo-specific reference files (distilled from PR review history)

| File | Description |
|------|-------------|
| `repo-conventions.md` | Mono formatting style, JNI naming disambiguation, actionable error messages, localization guidance, startup performance, trimmer/AOT compatibility, downstream consumer impact |
| `interop-rules.md` | JNI reference lifecycle, `JniPeerMembers` caching, virtual vs non-virtual dispatch, `[Register]` accuracy, `JniTransition`, P/Invoke marshalling |

## PR reviews analyzed

Repo-specific rules were distilled from the PRs with the most code review comments:

| PR | Comments | Title |
|----|----------|-------|
| #849 | 112 | [generator] Replace ApiXmlAdjuster with Java.Interop.Tools.JavaTypeSystem |
| #1179 | 50 | [Java.Interop.Tools.Maven] Initial commit |
| #696 | 31 | [jnimarshalmethod-gen] Localizable errors |
| #689 | 26 | [generator] Make warning and error messages localizable |
| #459 | 21 | [generator] Support default interface methods |
| #691 | 18 | [java-interop, Java.Interop] Securely load native libs |
| #804 | 16 | [Java.Runtime.Environment] Partial support for .NET Core |
| #756 | 19 | [ApiXmlAdjuster] Use different data model structures for better performance |
| #458 | 15 | Generator changes to support api level 29 and fixes to support extended events |
| #1153 | 14 | [Hello-NativeAOTFromJNI] Add NativeAOT sample |
| #1168 | 12 | [Java.Interop] Avoid `Type.GetType()` in `ManagedPeer` |
| #988 | 14 | [build] Target `net7.0` |
| #1184 | 10 | [java.interop] address some "easy" trimmer warnings |

Key patterns distilled from these reviews:
- **Naming ambiguity** at Java/C# boundary (PR #849: `FullName`, `ReferenceType`)
- **Named constants for string lengths** instead of magic numbers (PR #849: `"Invoker".Length` not `7`)
- **`StringComparison.Ordinal`** for identifier comparisons (PR #849)
- **Actionable error messages** with codes and fix guidance (PRs #696, #689)
- **Localization resource comments** for translators (PRs #696, #689)
- **JNI virtual vs non-virtual dispatch** correctness (PR #459)
- **C++ standard headers and `nullptr`** consistency (PR #691)
- **Trimmer/NativeAOT annotations** (`[DynamicallyAccessedMembers]`, `[UnconditionalSuppressMessage]`) (PRs #1153, #1184)
- **Startup performance sensitivity** — arrays vs dictionaries for small lookups with benchmarks (PR #1168)
- **Downstream consumer impact** on dotnet/android (PRs #988, #1153)
- **`HttpClient` must be static**, `readonly` for static fields (PR #1179)

## Evaluation

Evaluated the skill against 4 PRs **not used** to build the rules:

| PR | Title | Catches | Misses | Coverage |
|----|-------|---------|--------|----------|
| #555 | [Java.Interop] remove IEnumerable iterators called at startup | 4 | 1 | **80%** |
| #323 | [java-interop] Implemented Windows version of ji_realpath | 4 | 1 | **80%** |
| #1125 | [Java.Interop.Tools.JavaSource] Improve `<code>` parsing | 3 | 2 | **60%** |
| #88 | [Java.Interop.Tools.Cecil] Fix DirectoryAssemblyResolver.Dispose() | 2 | 3 | **40%** |
| **Overall** | | **13** | **7** | **65%** |

### What the skill catches well (100% coverage):
- **Error handling** — actionable messages, assertions, fail-fast
- **Performance** — unnecessary allocations, static fields
- **Resource management** — `using` / `IDisposable`
- **Code organization** — indentation, duplication
- **Memory safety** — null checks in native code
- **Testing** — edge cases

### What the skill can't catch (misses):
| PR | Finding | Category |
|----|---------|----------|
| #88 | `.mdb` is appended not extension change | Domain knowledge |
| #88 | `ReadSymbols=true` behavior with missing symbols | Domain knowledge |
| #88 | `.ppdb` extension clarification | Domain knowledge |
| #323 | `MAX_PATH` limitations | Platform knowledge |
| #555 | `return default` vs `return null` clarity | Readability |
| #1125 | HTML tags need case-insensitive matching | Domain knowledge |
| #1125 | Alternative design: regex vs parser | Design alternative |

### Verdict

**Net positive, no significant false positive risk.** The skill captures universal code quality patterns (65% of findings) that reviewers consistently flag. The 35% it misses is domain-specific expertise that no general ruleset can replace. The skill complements human reviewers — it handles mechanical checks so humans can focus on domain expertise.
