### PR TITLE
[Hello-Java.Base] Add missing jcw-gen project dependency

### DIFF
--- a/samples/Hello-Java.Base/Hello-Java.Base.csproj
+++ b/samples/Hello-Java.Base/Hello-Java.Base.csproj
@@ -21,6 +21,7 @@
     <ProjectReference Include="..\..\src\Java.Runtime.Environment\Java.Runtime.Environment.csproj" />
     <ProjectReference Include="..\..\src\Java.Base\Java.Base.csproj" />
     <ProjectReference Include="..\..\tests\TestJVM\TestJVM.csproj" />
+    <ProjectReference Include="..\..\tools\jcw-gen\jcw-gen.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <Import Project="..\..\build-tools\Java.Interop.Sdk\Sdk\Sdk.targets" />


### PR DESCRIPTION
Fixes CI build failure: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1400748

## Problem

`Hello-Java.Base` imports `Sdk.targets` which runs `jcw-gen.dll` after `CoreCompile`, but had no `ProjectReference` to the `jcw-gen` project. This caused a build race condition where `Hello-Java.Base` could try to execute `jcw-gen.dll` before it was built, resulting in:

```
You intended to execute a .NET program, but dotnet-D:\a\1\s\bin\Release-net10.0\/jcw-gen.dll does not exist.
error MSB3073: The command "dotnet jcw-gen.dll ..." exited with code 1.
```

## Fix

Add `<ProjectReference Include="..\..\tools\jcw-gen\jcw-gen.csproj" ReferenceOutputAssembly="false" />` to ensure `jcw-gen` is built before `Hello-Java.Base` tries to use it.

Other projects that use `jcw-gen` already have this reference:
- `tests/Java.Interop-Tests/Java.Interop-Tests.csproj`
- `samples/Hello-NativeAOTFromJNI/Hello-NativeAOTFromJNI.csproj`
- `samples/Hello-NativeAOTFromAndroid/Hello-NativeAOTFromAndroid.csproj`