### PR TITLE
Fix FileStream leak in ClassPath.IsJmodFile

### DIFF
--- a/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
@@ -145,7 +145,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 			if (jmodFile == null)
 				throw new ArgumentNullException (nameof (jmodFile));
 			try {
-				var f = File.OpenRead (jmodFile);
+				using var f = File.OpenRead (jmodFile);
 				var h = new byte[4];
 				if (f.Read (h, 0, h.Length) != 4) {
 					return false;


### PR DESCRIPTION
## Summary

`IsJmodFile` opened a `FileStream` via `File.OpenRead` but never disposed it. Both the early-return path (when fewer than 4 bytes are read) and the normal-return path left the handle open, leaking a file descriptor on every call. Under high-volume classpath scanning this can exhaust OS file descriptors.

## Change

In `src/Xamarin.Android.Tools.Bytecode/ClassPath.cs`, add `using` to the stream declaration in `IsJmodFile`:

```diff
-var f = File.OpenRead (jmodFile);
+using var f = File.OpenRead (jmodFile);
```

This matches the pattern already used by the companion method `IsJarFile` (line 133), which correctly wraps its stream in a `using` statement.

## Verification

- `dotnet build -t:Prepare && dotnet build` — ✅ 0 errors
- `dotnet test tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj` — ✅ 75 passed, 2 skipped
