### PR TITLE
[Trimming] Change the signature of JniValueManager.ActivatePeer

### DIFF
--- a/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -2,7 +2,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -88,7 +90,29 @@ namespace Java.Interop
 
 			public abstract List<JniSurfacedPeerInfo>   GetSurfacedPeers ();
 
-			public abstract void ActivatePeer (IJavaPeerable? self, JniObjectReference reference, ConstructorInfo cinfo, object? []? argumentValues);
+			public virtual void ActivatePeer (
+				JniObjectReference reference,
+				[DynamicallyAccessedMembers (Constructors)] Type type,
+				ConstructorInfo cinfo,
+				object?[]? argumentValues)
+			{
+				try {
+					var self = (IJavaPeerable) RuntimeHelpers.GetUninitializedObject (type);
+					self.SetPeerReference (reference);
+					cinfo.Invoke (self, argumentValues);
+				} catch (Exception e) {
+					var m = string.Format (
+							CultureInfo.InvariantCulture,
+							"Could not activate {{ PeerReference={0} IdentityHashCode=0x{1} Java.Type={2} }} for managed type '{3}'.",
+							reference,
+							GetJniIdentityHashCode (reference).ToString ("x", CultureInfo.InvariantCulture),
+							JniEnvironment.Types.GetJniTypeNameFromInstance (reference),
+							type?.FullName);
+					Debug.WriteLine (m);
+
+					throw new NotSupportedException (m, e);
+				}
+			}
 
 			public void ConstructPeer (IJavaPeerable peer, ref JniObjectReference reference, JniObjectReferenceOptions options)
 			{

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -107,7 +107,7 @@ namespace Java.Interop
 							reference,
 							GetJniIdentityHashCode (reference).ToString ("x", CultureInfo.InvariantCulture),
 							JniEnvironment.Types.GetJniTypeNameFromInstance (reference),
-							type?.FullName);
+							type.FullName);
 					Debug.WriteLine (m);
 
 					throw new NotSupportedException (m, e);
@@ -318,6 +318,7 @@ namespace Java.Interop
 				return CreatePeer (ref reference, JniObjectReferenceOptions.Copy, targetType);
 			}
 
+			// This base method implementation is NOT reachable in trimmable typemap - it is featureswitch guarded
 			public virtual IJavaPeerable? CreatePeer (
 					ref JniObjectReference reference,
 					JniObjectReferenceOptions transfer,
@@ -733,7 +734,7 @@ namespace Java.Interop
 
 				// FIXME: https://github.com/dotnet/java-interop/issues/1192
 				[UnconditionalSuppressMessage ("Trimming", "IL2060", Justification = makeGenericMethodMessage)]
-				[UnconditionalSuppressMessage ("Trimming", "IL3050", Justification = makeGenericMethodMessage)]
+				[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = makeGenericMethodMessage)]
 				static MethodInfo MakeGenericMethod (MethodInfo method, Type type) =>
 					method.MakeGenericMethod (type);
 
@@ -988,4 +989,3 @@ namespace Java.Interop
 		}
 	}
 }
-

--- a/src/Java.Interop/Java.Interop/ManagedPeer.cs
+++ b/src/Java.Interop/Java.Interop/ManagedPeer.cs
@@ -119,7 +119,7 @@ namespace Java.Interop {
 					return;
 				}
 
-				JniEnvironment.Runtime.ValueManager.ActivatePeer (self, new JniObjectReference (n_self), cinfo, pvalues);
+				JniEnvironment.Runtime.ValueManager.ActivatePeer (new JniObjectReference (n_self), type, cinfo, pvalues);
 			}
 			catch (Exception e) {
 				__r?.OnUserUnhandledException (ref envp, e);

--- a/src/Java.Interop/PublicAPI.Unshipped.txt
+++ b/src/Java.Interop/PublicAPI.Unshipped.txt
@@ -34,3 +34,5 @@ static Java.Interop.JniEnvironment.InstanceFields.GetFieldID(Java.Interop.JniObj
 static Java.Interop.JniEnvironment.InstanceMethods.GetMethodID(Java.Interop.JniObjectReference type, System.ReadOnlySpan<byte> name, System.ReadOnlySpan<byte> signature) -> Java.Interop.JniMethodInfo!
 static Java.Interop.JniEnvironment.StaticFields.GetStaticFieldID(Java.Interop.JniObjectReference type, System.ReadOnlySpan<byte> name, System.ReadOnlySpan<byte> signature) -> Java.Interop.JniFieldInfo!
 static Java.Interop.JniEnvironment.StaticMethods.GetStaticMethodID(Java.Interop.JniObjectReference type, System.ReadOnlySpan<byte> name, System.ReadOnlySpan<byte> signature) -> Java.Interop.JniMethodInfo!
+*REMOVED*abstract Java.Interop.JniRuntime.JniValueManager.ActivatePeer(Java.Interop.IJavaPeerable? self, Java.Interop.JniObjectReference reference, System.Reflection.ConstructorInfo! cinfo, object?[]? argumentValues) -> void
+abstract Java.Interop.JniRuntime.JniValueManager.ActivatePeer(Java.Interop.JniObjectReference reference, System.Type! type, System.Reflection.ConstructorInfo! cinfo, object?[]? argumentValues) -> void

--- a/src/Java.Interop/PublicAPI.Unshipped.txt
+++ b/src/Java.Interop/PublicAPI.Unshipped.txt
@@ -35,4 +35,4 @@ static Java.Interop.JniEnvironment.InstanceMethods.GetMethodID(Java.Interop.JniO
 static Java.Interop.JniEnvironment.StaticFields.GetStaticFieldID(Java.Interop.JniObjectReference type, System.ReadOnlySpan<byte> name, System.ReadOnlySpan<byte> signature) -> Java.Interop.JniFieldInfo!
 static Java.Interop.JniEnvironment.StaticMethods.GetStaticMethodID(Java.Interop.JniObjectReference type, System.ReadOnlySpan<byte> name, System.ReadOnlySpan<byte> signature) -> Java.Interop.JniMethodInfo!
 *REMOVED*abstract Java.Interop.JniRuntime.JniValueManager.ActivatePeer(Java.Interop.IJavaPeerable? self, Java.Interop.JniObjectReference reference, System.Reflection.ConstructorInfo! cinfo, object?[]? argumentValues) -> void
-abstract Java.Interop.JniRuntime.JniValueManager.ActivatePeer(Java.Interop.JniObjectReference reference, System.Type! type, System.Reflection.ConstructorInfo! cinfo, object?[]? argumentValues) -> void
+virtual Java.Interop.JniRuntime.JniValueManager.ActivatePeer(Java.Interop.JniObjectReference reference, System.Type! type, System.Reflection.ConstructorInfo! cinfo, object?[]? argumentValues) -> void

--- a/src/Java.Runtime.Environment/Java.Interop/ManagedValueManager.cs
+++ b/src/Java.Runtime.Environment/Java.Interop/ManagedValueManager.cs
@@ -198,41 +198,6 @@ namespace Java.Interop {
 			value.Finalized ();
 		}
 
-		public override void ActivatePeer (IJavaPeerable? self, JniObjectReference reference, ConstructorInfo cinfo, object?[]? argumentValues)
-		{
-			var runtime = JniEnvironment.Runtime;
-
-			try {
-				ActivateViaReflection (reference, cinfo, argumentValues);
-			} catch (Exception e) {
-				var m = string.Format ("Could not activate {{ PeerReference={0} IdentityHashCode=0x{1} Java.Type={2} }} for managed type '{3}'.",
-						reference,
-						runtime.ValueManager.GetJniIdentityHashCode (reference).ToString ("x"),
-						JniEnvironment.Types.GetJniTypeNameFromInstance (reference),
-						cinfo.DeclaringType?.FullName);
-				Debug.WriteLine (m);
-
-				throw new NotSupportedException (m, e);
-			}
-		}
-
-		void ActivateViaReflection (JniObjectReference reference, ConstructorInfo cinfo, object?[]? argumentValues)
-		{
-			var declType  = cinfo.DeclaringType ?? throw new NotSupportedException ("Do not know the type to create!");
-
-			var self      = GetUninitializedObject (declType);
-			self.SetPeerReference (reference);
-
-			cinfo.Invoke (self, argumentValues);
-
-			// FIXME: https://github.com/dotnet/java-interop/issues/1192
-			const string getUninitializedObject = "This code path is not used in Android projects.";
-			[UnconditionalSuppressMessage ("Trimming", "IL2067", Justification = getUninitializedObject)]
-			[UnconditionalSuppressMessage ("Trimming", "IL2072", Justification = getUninitializedObject)]
-			static IJavaPeerable GetUninitializedObject (Type type) =>
-				(IJavaPeerable) System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject (type);
-		}
-
 		public override List<JniSurfacedPeerInfo> GetSurfacedPeers ()
 		{
 			if (RegisteredInstances == null)

--- a/src/Java.Runtime.Environment/Java.Interop/MonoRuntimeValueManager.cs
+++ b/src/Java.Runtime.Environment/Java.Interop/MonoRuntimeValueManager.cs
@@ -258,35 +258,6 @@ namespace Java.Interop {
 			}
 		}
 
-		const string NotUsedInAndroid = "This code path is not used in Android projects.";
-
-		public override void ActivatePeer (IJavaPeerable? self, JniObjectReference reference, ConstructorInfo cinfo, object?[]? argumentValues)
-		{
-			var runtime = JniEnvironment.Runtime;
-
-			try {
-				var declType  = cinfo.DeclaringType ?? throw new NotSupportedException ("Do not know the type to create!");
-				var instance  = GetUninitializedObject (declType);
-				instance.SetPeerReference (reference);
-				cinfo.Invoke (instance, argumentValues);
-
-				// FIXME: https://github.com/dotnet/java-interop/issues/1192
-				[UnconditionalSuppressMessage ("Trimming", "IL2067", Justification = NotUsedInAndroid)]
-				[UnconditionalSuppressMessage ("Trimming", "IL2072", Justification = NotUsedInAndroid)]
-				static IJavaPeerable GetUninitializedObject (Type type) =>
-					(IJavaPeerable) System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject (type);
-			} catch (Exception e) {
-				var m = string.Format ("Could not activate {{ PeerReference={0} IdentityHashCode=0x{1} Java.Type={2} }} for managed type '{3}'.",
-						reference,
-						runtime.ValueManager.GetJniIdentityHashCode (reference).ToString ("x"),
-						JniEnvironment.Types.GetJniTypeNameFromInstance (reference),
-						cinfo.DeclaringType?.FullName);
-				Debug.WriteLine (m);
-
-				throw new NotSupportedException (m, e);
-			}
-		}
-
 		public override void FinalizePeer (IJavaPeerable value)
 		{
 			var h = value.PeerReference;

--- a/tests/Java.Interop-Tests/Java.Interop/JniRuntime.JniValueManagerTests.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JniRuntime.JniValueManagerTests.cs
@@ -60,11 +60,6 @@ namespace Java.InteropTests {
 			{
 				return null;
 			}
-
-			public override void ActivatePeer (IJavaPeerable self, JniObjectReference reference, ConstructorInfo cinfo, object [] argumentValues)
-			{
-				throw new NotImplementedException ();
-			}
 		}
 
 		[Test]

--- a/tests/Java.Interop-Tests/Java.Interop/JniRuntimeTest.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JniRuntimeTest.cs
@@ -154,11 +154,6 @@ namespace Java.InteropTests
 				return null;
 			}
 
-			public override void ActivatePeer (IJavaPeerable self, JniObjectReference reference, ConstructorInfo cinfo, object [] argumentValues)
-			{
-				throw new NotImplementedException ();
-			}
-
 			public override void RemovePeer (IJavaPeerable peer)
 			{
 			}


### PR DESCRIPTION
Part of https://github.com/dotnet/android/issues/10794
Fixes unnecessary use of `[UnmanagedSuppressMessage]` in `ActivatePeer`.

- The only caller of this API is `ManagedPeer` and it has an instance of `type` with the right annotations, so there's no reason to rely on `cinfo.DeclaringType` which is not annotated.
- The `self` parameter is always `null` and none of the overrides of this methods use it so it should be removed
- All of the implementations in dotnet/android are identical, so there's no reason to spread the implementation over multiple classes and it can be safely implemented in the base class and subclasses which don't want to use it just override it without calling base

This PR will be followed up with a PR to dotnet/android to adjust to the new public API.

Part of #10794.
