### PR TITLE
Make JniTypeManager reflection fallback safe

### DIFF
--- a/samples/Hello-NativeAOTFromAndroid/NativeAotTypeManager.cs
+++ b/samples/Hello-NativeAOTFromAndroid/NativeAotTypeManager.cs
@@ -19,28 +19,19 @@ partial class NativeAotTypeManager : JniRuntime.JniTypeManager {
 		["my/MainActivity"]                     = typeof (MainActivity),
 	};
 
-	public override void RegisterNativeMembers (
-			JniType nativeClass,
-			[DynamicallyAccessedMembers (MethodsAndPrivateNested)]
-			Type type,
-			ReadOnlySpan<char> methods)
-	{
-		Console.WriteLine ($"# jonp: RegisterNativeMembers: nativeClass={nativeClass} type=`{type}`");
-		base.RegisterNativeMembers (nativeClass, type, methods);
-	}
-
-
 	protected override IEnumerable<Type> GetTypesForSimpleReference (string jniSimpleReference)
 	{
-		Console.WriteLine ($"# jonp: GetTypesForSimpleReference: jniSimpleReference=`{jniSimpleReference}`");
-		if (typeMappings.TryGetValue (jniSimpleReference, out var target)) {
-			Console.WriteLine ($"# jonp:   GetTypesForSimpleReference: jniSimpleReference=`{jniSimpleReference}` -> `{target}`");
+		if (typeMappings.TryGetValue (jniSimpleReference, out var target))
 			yield return target;
-		}
-		foreach (var t in base.GetTypesForSimpleReference (jniSimpleReference)) {
-			Console.WriteLine ($"# jonp:   GetTypesForSimpleReference: jniSimpleReference=`{jniSimpleReference}` -> `{t}`");
+		foreach (var t in base.GetTypesForSimpleReference (jniSimpleReference))
 			yield return t;
-		}
+	}
+
+	protected override Type? GetTypeForSimpleReference (string jniSimpleReference)
+	{
+		if (typeMappings.TryGetValue (jniSimpleReference, out var target))
+			return target;
+		return base.GetTypeForSimpleReference (jniSimpleReference);
 	}
 
 	protected override IEnumerable<string> GetSimpleReferences (Type type)

--- a/samples/Hello-NativeAOTFromJNI/NativeAotTypeManager.cs
+++ b/samples/Hello-NativeAOTFromJNI/NativeAotTypeManager.cs
@@ -19,6 +19,13 @@ class NativeAotTypeManager : JniRuntime.JniTypeManager {
 			yield return t;
 	}
 
+	protected override Type? GetTypeForSimpleReference (string jniSimpleReference)
+	{
+		if (typeMappings.TryGetValue (jniSimpleReference, out var target))
+			return target;
+		return base.GetTypeForSimpleReference (jniSimpleReference);
+	}
+
 	protected override IEnumerable<string> GetSimpleReferences (Type type)
 	{
 		return base.GetSimpleReferences (type)

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
@@ -261,27 +261,127 @@ namespace Java.Interop {
 
 			static  readonly    string[]    EmptyStringArray    = Array.Empty<string> ();
 			static  readonly    Type[]      EmptyTypeArray      = Array.Empty<Type> ();
-			const string NotUsedInAndroid = "This code path is not used in Android projects.";
 
-			// FIXME: https://github.com/dotnet/java-interop/issues/1192
-			[UnconditionalSuppressMessage ("Trimming", "IL3050", Justification = NotUsedInAndroid)]
-			static Type MakeArrayType (Type type) =>
-				type.MakeArrayType ();
+			readonly struct KnownArrayTypesInfo
+			{
+				public readonly Dictionary<Type, Type> ArrayTypes;
+				public readonly Dictionary<Type, Type> JavaObjectArrayTypes;
 
-			// FIXME: https://github.com/dotnet/java-interop/issues/1192
-			[UnconditionalSuppressMessage ("Trimming", "IL2055", Justification = NotUsedInAndroid)]
-			[UnconditionalSuppressMessage ("Trimming", "IL3050", Justification = NotUsedInAndroid)]
-			static Type MakeGenericType (Type type, Type arrayType) =>
-				type.MakeGenericType (arrayType);
+				public KnownArrayTypesInfo (Dictionary<Type, Type> arrayTypes, Dictionary<Type, Type> javaObjectArrayTypes)
+				{
+					ArrayTypes            = arrayTypes;
+					JavaObjectArrayTypes = javaObjectArrayTypes;
+				}
+			}
 
-			[UnconditionalSuppressMessage ("Trimming", "IL2073", Justification = "Types returned here should be preserved via other means.")]
+			static readonly Lazy<KnownArrayTypesInfo> KnownArrayTypes = new Lazy<KnownArrayTypesInfo> (InitKnownArrayTypes);
+
+			static KnownArrayTypesInfo InitKnownArrayTypes ()
+			{
+				var arrayTypes           = new Dictionary<Type, Type> ();
+				var javaObjectArrayTypes = new Dictionary<Type, Type> ();
+
+				AddKnownArrayTypes<string> (arrayTypes, javaObjectArrayTypes);
+
+				AddKnownPrimitiveArrayTypes<Boolean, JavaBooleanArray> (arrayTypes, javaObjectArrayTypes);
+				AddKnownPrimitiveArrayTypes<SByte, JavaSByteArray> (arrayTypes, javaObjectArrayTypes);
+				AddKnownPrimitiveArrayTypes<Char, JavaCharArray> (arrayTypes, javaObjectArrayTypes);
+				AddKnownPrimitiveArrayTypes<Int16, JavaInt16Array> (arrayTypes, javaObjectArrayTypes);
+				AddKnownPrimitiveArrayTypes<Int32, JavaInt32Array> (arrayTypes, javaObjectArrayTypes);
+				AddKnownPrimitiveArrayTypes<Int64, JavaInt64Array> (arrayTypes, javaObjectArrayTypes);
+				AddKnownPrimitiveArrayTypes<Single, JavaSingleArray> (arrayTypes, javaObjectArrayTypes);
+				AddKnownPrimitiveArrayTypes<Double, JavaDoubleArray> (arrayTypes, javaObjectArrayTypes);
+
+				return new KnownArrayTypesInfo (arrayTypes, javaObjectArrayTypes);
+			}
+
+			static void AddKnownPrimitiveArrayTypes<
+					[DynamicallyAccessedMembers (Constructors)]
+					T,
+					[DynamicallyAccessedMembers (Constructors)]
+					TArray> (Dictionary<Type, Type> arrayTypes, Dictionary<Type, Type> javaObjectArrayTypes)
+			{
+				AddKnownArrayTypes<T> (arrayTypes, javaObjectArrayTypes);
+				AddKnownArrayTypes<JavaArray<T>> (arrayTypes, javaObjectArrayTypes);
+				AddKnownArrayTypes<JavaPrimitiveArray<T>> (arrayTypes, javaObjectArrayTypes);
+				AddKnownArrayTypes<TArray> (arrayTypes, javaObjectArrayTypes);
+			}
+
+			static void AddKnownArrayTypes<
+					[DynamicallyAccessedMembers (Constructors)]
+					T> (Dictionary<Type, Type> arrayTypes, Dictionary<Type, Type> javaObjectArrayTypes)
+			{
+				arrayTypes [typeof (T)]                         = typeof (T[]);
+				arrayTypes [typeof (T[])]                       = typeof (T[][]);
+				arrayTypes [typeof (T[][])]                     = typeof (T[][][]);
+				javaObjectArrayTypes [typeof (T)]               = typeof (JavaObjectArray<T>);
+				javaObjectArrayTypes [typeof (JavaObjectArray<T>)] = typeof (JavaObjectArray<JavaObjectArray<T>>);
+			}
+
+			static bool TryMakeArrayType (Type type, out Type? arrayType) =>
+				KnownArrayTypes.Value.ArrayTypes.TryGetValue (type, out arrayType);
+
+			static bool TryMakeJavaObjectArrayType (Type type, out Type? arrayType) =>
+				KnownArrayTypes.Value.JavaObjectArrayTypes.TryGetValue (type, out arrayType);
+
+			static Type GetUnsupportedArrayType (Type type) =>
+				throw new NotSupportedException ($"Array type construction for `{type}` is not supported.");
+
+			static Type GetUnsupportedJavaObjectArrayType (Type type) =>
+				throw new NotSupportedException ($"Generic Java array wrapper type construction for `{type}` is not supported.");
+
 			[return: DynamicallyAccessedMembers (MethodsConstructors)]
 			public  Type?    GetType (JniTypeSignature typeSignature)
 			{
 				AssertValid ();
 
-				return GetTypes (typeSignature).FirstOrDefault ();
+				if (!typeSignature.IsValid || typeSignature.SimpleReference == null)
+					return null;
+
+				var type = GetTypeForSimpleReference (typeSignature.SimpleReference);
+				if (type == null)
+					return null;
+				if (typeSignature.ArrayRank == 0)
+					return type;
+				throw new NotSupportedException ($"DAM-annotated type lookup for array signature `{typeSignature}` is not supported. Use {nameof (GetTypes)} instead.");
 			}
+
+			[return: DynamicallyAccessedMembers (MethodsConstructors)]
+			protected virtual Type? GetTypeForSimpleReference (string jniSimpleReference)
+			{
+				AssertValid ();
+				AssertSimpleReference (jniSimpleReference);
+
+				return jniSimpleReference switch {
+					"java/lang/String"                         => TypeOf<string> (),
+					"V"                                        => TypeOfVoid (),
+					"Z"                                        => TypeOf<Boolean> (),
+					"java/lang/Boolean"                        => TypeOf<Boolean?> (),
+					"B"                                        => TypeOf<SByte> (),
+					"java/lang/Byte"                           => TypeOf<SByte?> (),
+					"C"                                        => TypeOf<Char> (),
+					"java/lang/Character"                      => TypeOf<Char?> (),
+					"S"                                        => TypeOf<Int16> (),
+					"java/lang/Short"                          => TypeOf<Int16?> (),
+					"I"                                        => TypeOf<Int32> (),
+					"java/lang/Integer"                        => TypeOf<Int32?> (),
+					"J"                                        => TypeOf<Int64> (),
+					"java/lang/Long"                           => TypeOf<Int64?> (),
+					"F"                                        => TypeOf<Single> (),
+					"java/lang/Float"                          => TypeOf<Single?> (),
+					"D"                                        => TypeOf<Double> (),
+					"java/lang/Double"                         => TypeOf<Double?> (),
+					_                                          => null,
+				};
+			}
+
+			[return: DynamicallyAccessedMembers (MethodsConstructors)]
+			static Type TypeOf<
+					[DynamicallyAccessedMembers (MethodsConstructors)]
+					T> () => typeof (T);
+
+			[return: DynamicallyAccessedMembers (MethodsConstructors)]
+			static Type TypeOfVoid () => typeof (void);
 
 			public virtual IEnumerable<Type> GetTypes (JniTypeSignature typeSignature)
 			{
@@ -313,7 +413,9 @@ namespace Java.Interop {
 						var rank        = typeSignature.ArrayRank;
 						var arrayType   = type;
 						while (rank-- > 0) {
-							arrayType   = MakeGenericType (typeof (JavaObjectArray<>), arrayType);
+							arrayType = TryMakeJavaObjectArrayType (arrayType, out var nextArrayType)
+								? nextArrayType ?? throw new InvalidOperationException ("Should not be reached")
+								: GetUnsupportedJavaObjectArrayType (arrayType);
 						}
 						yield return arrayType;
 					}
@@ -322,7 +424,9 @@ namespace Java.Interop {
 						var rank        = typeSignature.ArrayRank;
 						var arrayType   = type;
 						while (rank-- > 0) {
-							arrayType   = MakeArrayType (arrayType);
+							arrayType = TryMakeArrayType (arrayType, out var nextArrayType)
+								? nextArrayType ?? throw new InvalidOperationException ("Should not be reached")
+								: GetUnsupportedArrayType (arrayType);
 						}
 						yield return arrayType;
 					}
@@ -345,14 +449,18 @@ namespace Java.Interop {
 					var rank        = typeSignature.ArrayRank-1;
 					var arrayType   = t;
 					while (rank-- > 0) {
-						arrayType   = MakeGenericType (typeof (JavaObjectArray<>), arrayType);
+						arrayType = TryMakeJavaObjectArrayType (arrayType, out var nextArrayType)
+							? nextArrayType ?? throw new InvalidOperationException ("Should not be reached")
+							: GetUnsupportedJavaObjectArrayType (arrayType);
 					}
 					yield return arrayType;
 
 					rank            = typeSignature.ArrayRank-1;
 					arrayType       = t;
 					while (rank-- > 0) {
-						arrayType   = MakeArrayType (arrayType);
+						arrayType = TryMakeArrayType (arrayType, out var nextArrayType)
+							? nextArrayType ?? throw new InvalidOperationException ("Should not be reached")
+							: GetUnsupportedArrayType (arrayType);
 					}
 					yield return arrayType;
 				}
@@ -392,19 +500,6 @@ namespace Java.Interop {
 					[DynamicallyAccessedMembers (Constructors)]
 					Type type)
 			{
-				// https://github.com/xamarin/xamarin-android/blob/5472eec991cc075e4b0c09cd98a2331fb93aa0f3/src/Microsoft.Android.Sdk.ILLink/MarkJavaObjects.cs#L176-L186
-				const string makeGenericTypeMessage = "Generic 'Invoker' types are preserved by the MarkJavaObjects trimmer step.";
-
-				// FIXME: https://github.com/dotnet/java-interop/issues/1192
-				[UnconditionalSuppressMessage ("Trimming", "IL2055", Justification = makeGenericTypeMessage)]
-				[UnconditionalSuppressMessage ("Trimming", "IL3050", Justification = makeGenericTypeMessage)]
-				[return: DynamicallyAccessedMembers (Constructors)]
-				static Type MakeGenericType (
-						[DynamicallyAccessedMembers (Constructors)]
-						Type type,
-						Type [] arguments) =>
-					type.MakeGenericType (arguments);
-
 				var signature   = type.GetCustomAttribute<JniTypeSignatureAttribute> ();
 				if (signature == null || signature.InvokerType == null) {
 					return null;
@@ -414,7 +509,11 @@ namespace Java.Interop {
 				if (arguments.Length == 0)
 					return signature.InvokerType;
 
-				return MakeGenericType (signature.InvokerType, arguments);
+#if NET
+				throw new NotSupportedException ($"Generic invoker type construction for `{type}` is not supported.");
+#else   // NET
+				return signature.InvokerType.MakeGenericType (arguments);
+#endif  // NET
 			}
 
 #if NET
@@ -605,4 +704,3 @@ namespace Java.Interop {
 		}
 	}
 }
-

--- a/src/Java.Interop/PublicAPI.Unshipped.txt
+++ b/src/Java.Interop/PublicAPI.Unshipped.txt
@@ -4,6 +4,7 @@ static Java.Interop.JniEnvironment.EndMarshalMethod(ref Java.Interop.JniTransiti
 virtual Java.Interop.JniRuntime.OnEnterMarshalMethod() -> void
 virtual Java.Interop.JniRuntime.OnUserUnhandledException(ref Java.Interop.JniTransition transition, System.Exception! e) -> void
 virtual Java.Interop.JniRuntime.JniTypeManager.GetInvokerTypeCore(System.Type! type) -> System.Type?
+virtual Java.Interop.JniRuntime.JniTypeManager.GetTypeForSimpleReference(string! jniSimpleReference) -> System.Type?
 virtual Java.Interop.JniRuntime.JniValueManager.TryConstructPeer(Java.Interop.IJavaPeerable! self, ref Java.Interop.JniObjectReference reference, Java.Interop.JniObjectReferenceOptions options, System.Type! type) -> bool
 Java.Interop.JavaException.JavaException(ref Java.Interop.JniObjectReference reference, Java.Interop.JniObjectReferenceOptions transfer, Java.Interop.JniObjectReference throwableOverride) -> void
 Java.Interop.JavaException.SetJavaStackTrace(Java.Interop.JniObjectReference peerReferenceOverride = default(Java.Interop.JniObjectReference)) -> void

--- a/src/Java.Runtime.Environment/Java.Interop/JreTypeManager.cs
+++ b/src/Java.Runtime.Environment/Java.Interop/JreTypeManager.cs
@@ -33,6 +33,16 @@ namespace Java.Interop {
 				yield return target;
 		}
 
+		protected override Type? GetTypeForSimpleReference (string jniSimpleReference)
+		{
+			var type = base.GetTypeForSimpleReference (jniSimpleReference);
+			if (type != null)
+				return type;
+			if (typeMappings == null)
+				return null;
+			return typeMappings.TryGetValue (jniSimpleReference, out var target) ? target : null;
+		}
+
 		protected override IEnumerable<string> GetSimpleReferences (Type type)
 		{
 			return base.GetSimpleReferences (type)

--- a/tests/Java.Interop-Tests/Java.Interop/JavaVMFixture.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JavaVMFixture.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Diagnostics;
 using System.Linq;
 
 using Java.Interop;
@@ -65,6 +64,12 @@ namespace Java.InteropTests {
 #pragma warning restore CS8600
 		}
 
+		protected override Type? GetTypeForSimpleReference (string jniSimpleReference)
+		{
+			return base.GetTypeForSimpleReference (jniSimpleReference) ??
+				(TypeMappings.TryGetValue (jniSimpleReference, out var target) ? target : null);
+		}
+
 		protected override IEnumerable<string> GetSimpleReferences (Type type)
 		{
 			return base.GetSimpleReferences (type)
@@ -91,7 +96,6 @@ namespace Java.InteropTests {
 		protected override IReadOnlyList<string>? GetStaticMethodFallbackTypesCore (string jniSimpleReference)
 		{
 			RequestedFallbackTypesForSimpleReference = jniSimpleReference;
-			Debug.WriteLine ($"# GetStaticMethodFallbackTypes (jniSimpleReference={jniSimpleReference})");
 
 			var slash       = jniSimpleReference.LastIndexOf ('/');
 			var desugarType = slash <= 0
@@ -167,4 +171,3 @@ namespace Java.InteropTests {
 #endif  // NET
 	}
 }
-

--- a/tests/Java.Interop-Tests/Java.Interop/JniRuntime.JniTypeManagerTests.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JniRuntime.JniTypeManagerTests.cs
@@ -26,8 +26,30 @@ namespace Java.InteropTests {
 			}
 		}
 
+#if NET
+		[Test]
+		public void GetInvokerType_GenericType_Throws ()
+		{
+			using (var vm  = new MyTypeManager ()) {
+				Assert.Throws<NotSupportedException> (() => vm.GetInvokerType (typeof (IGenericJavaInterface<string>)));
+			}
+		}
+#endif  // NET
+
 		class MyTypeManager : JniRuntime.JniTypeManager {
 		}
-    }
-}
 
+		[JniTypeSignature ("example/GenericInterface", GenerateJavaPeer=false, InvokerType=typeof (IGenericJavaInterfaceInvoker<>))]
+		interface IGenericJavaInterface<T> : IJavaPeerable {
+		}
+
+		[JniTypeSignature ("example/GenericInterface", GenerateJavaPeer=false)]
+		class IGenericJavaInterfaceInvoker<T> : JavaObject, IGenericJavaInterface<T> {
+
+			public IGenericJavaInterfaceInvoker (ref JniObjectReference reference, JniObjectReferenceOptions options)
+				: base (ref reference, options)
+			{
+			}
+		}
+	}
+}

--- a/tests/Java.Interop-Tests/Java.Interop/JniTypeManagerTests.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JniTypeManagerTests.cs
@@ -137,6 +137,11 @@ namespace Java.InteropTests
 			Assert.AreEqual (typeof (double),   GetType ("D"));
 			Assert.AreEqual (typeof (string),   GetType ("java/lang/String"));
 			Assert.AreEqual (typeof (float?),   GetType ("java/lang/Float"));
+#if !__ANDROID__
+			Assert.AreEqual (typeof (GenericHolder<>), GetType (GenericHolder<int>.JniTypeName));
+#endif  // !__ANDROID__
+			Assert.Throws<NotSupportedException> (() => GetType ("[I"));
+			Assert.Throws<NotSupportedException> (() => GetType ("[Ljava/lang/String;"));
 			Assert.AreEqual (null,              GetType ("com/example/does/not/exist"));
 			Assert.AreEqual (null,              GetType ("Lcom/example/does/not/exist;"));
 			Assert.AreEqual (null,              GetType ("[Lcom/example/does/not/exist;"));
@@ -246,4 +251,3 @@ namespace Java.InteropTests
 		public  T   Value   {get; set;}
 	}
 }
-


### PR DESCRIPTION
## Summary
- make JniTypeManager static fallback type reflection tolerate unavailable types
- update NativeAOT type manager samples/subclass overrides for safe lookup
- add PublicAPI.Unshipped entry and focused JniTypeManager tests

## Validation
- `git diff --check` passed
- `dotnet test tests/Java.Interop-Tests/Java.Interop-Tests.csproj -v minimal --filter "Name~JniTypeManager"` blocked locally by missing `bin/BuildDebug/Java.Interop.BootstrapTasks.dll` and empty javac command exiting with code 127