### PR TITLE
[generator] Drop Kotlin hash-mangled siblings that collide on the C# side

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -35,3 +35,9 @@ Makefile	eol=lf
 *.wixproj	eol=crlf
 *.wxs	eol=crlf
 *.rtf	eol=crlf
+
+# Gradle wrapper must stay LF on all platforms (executed under Bash on Unix)
+gradlew	eol=lf
+*.properties	eol=lf
+*.kt	eol=lf
+*.kts	eol=lf

--- a/src/Java.Interop.Localization/Resources.Designer.cs
+++ b/src/Java.Interop.Localization/Resources.Designer.cs
@@ -430,6 +430,15 @@ namespace Java.Interop.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to For type &apos;{0}&apos;, the Kotlin name-mangled method &apos;{1}&apos; (originally &apos;{2}&apos;) has multiple hash-suffixed siblings that erase to the same C# signature. Only the first will be emitted; remove the duplicate via Metadata.xml to suppress this warning..
+        /// </summary>
+        public static string Generator_BG8C02 {
+            get {
+                return ResourceManager.GetString("Generator_BG8C02", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot generate Java wrapper for type &apos;{0}&apos;. Only &apos;class&apos; types are supported..
         /// </summary>
         public static string JavaCallableWrappers_XA4200 {

--- a/src/Java.Interop.Localization/Resources.resx
+++ b/src/Java.Interop.Localization/Resources.resx
@@ -308,6 +308,10 @@ The following terms should not be translated: Metadata.xml, path.</comment>
     <value>For type '{0}', base interface '{1}' is invalid.</value>
     <comment>{0}, {1} - .NET types.</comment>
   </data>
+  <data name="Generator_BG8C02" xml:space="preserve">
+    <value>For type '{0}', the Kotlin name-mangled method '{1}' (originally '{2}') has multiple hash-suffixed siblings that erase to the same C# signature. Only the first will be emitted; remove the duplicate via Metadata.xml to suppress this warning.</value>
+    <comment>{0} - .NET type. {1} - C# method name. {2} - Original (mangled) JVM method name.</comment>
+  </data>
   <data name="JavaCallableWrappers_XA4200" xml:space="preserve">
     <value>Cannot generate Java wrapper for type '{0}'. Only 'class' types are supported.</value>
     <comment>{0} - Java type.

--- a/src/Java.Interop.Tools.Generator/Utilities/Report.cs
+++ b/src/Java.Interop.Tools.Generator/Utilities/Report.cs
@@ -74,6 +74,7 @@ namespace Java.Interop.Tools.Generator
 		public static LocalizedMessage WarningUnknownGenericConstraint => new LocalizedMessage (0x8B00, Localization.Resources.Generator_BG8B00);
 		public static LocalizedMessage WarningBaseInterfaceNotFound => new LocalizedMessage (0x8C00, Localization.Resources.Generator_BG8C00);
 		public static LocalizedMessage WarningBaseInterfaceInvalid => new LocalizedMessage (0x8C01, Localization.Resources.Generator_BG8C01);
+		public static LocalizedMessage WarningKotlinNameMangledCollision => new LocalizedMessage (0x8C02, Localization.Resources.Generator_BG8C02);
 
 		public static void LogCodedErrorAndExit (LocalizedMessage message, params string [] args)
 			=> LogCodedErrorAndExit (message, null, null, args);

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/KotlinInlineClassCollisionTests.cs
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/KotlinInlineClassCollisionTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+using Xamarin.Android.Tools.Bytecode;
+
+namespace Xamarin.Android.Tools.BytecodeTests
+{
+	// Exercises the real Kotlin bytecode produced by the Gradle fixture under
+	// kotlin-gradle/ to confirm that the JVM-level mangling we expect (and that
+	// the generator's KotlinFixups must now de-collide) is actually what kotlinc
+	// emits for @JvmInline value-class parameters. See dotnet/java-interop#1431.
+	[TestFixture]
+	public class KotlinInlineClassCollisionTests : ClassFileFixture
+	{
+		[Test]
+		public void Widgets_HasCollidingHashMangledSiblings ()
+		{
+			var klass = LoadClassFile ("Widgets.class");
+
+			// Kotlin emits one mangled method per inline-class overload:
+			//   tint-<hash>(J)V    for MyColor (ULong-backed)
+			//   tint-<hash>(J)V    for MyAlpha (ULong-backed) — collides with MyColor
+			//   tint-<hash>(F)V    for MyDp    (Float-backed) — unique
+			var tints = klass.Methods
+				.Where (m => m.Name.StartsWith ("tint-", StringComparison.Ordinal))
+				.ToList ();
+
+			Assert.AreEqual (3, tints.Count, "Expected three `tint-<hash>` overloads from the Gradle fixture.");
+
+			var longTints = tints.Where (m => m.Descriptor == "(J)V").ToList ();
+			Assert.AreEqual (2, longTints.Count,
+				"Expected two `tint-<hash>(J)V` siblings (MyColor + MyAlpha) — this is the multi-sibling collision case from dotnet/java-interop#1431.");
+
+			Assert.AreEqual (1, tints.Count (m => m.Descriptor == "(F)V"),
+				"Expected one unique `tint-<hash>(F)V` (MyDp) that should survive deduplication.");
+		}
+
+		[Test]
+		public void Widgets_HasNonCollidingHashMangledOverloads ()
+		{
+			var klass = LoadClassFile ("Widgets.class");
+
+			var pads = klass.Methods
+				.Where (m => m.Name.StartsWith ("pad-", StringComparison.Ordinal))
+				.ToList ();
+
+			Assert.AreEqual (2, pads.Count);
+			CollectionAssert.AreEquivalent (
+				new [] { "(F)F", "(FF)F" },
+				pads.Select (m => m.Descriptor).ToArray (),
+				"`pad` overloads have distinct JVM signatures and should both survive after rename.");
+		}
+
+		[Test]
+		public void InlineClasses_AreEmittedAsValueClasses ()
+		{
+			// Sanity check that @JvmInline really produced a JvmInline annotation on
+			// the inline-class type — this is what step (2) of #1431 will key on.
+			var myColor = LoadClassFile ("MyColor.class");
+
+			var annotations = myColor.Attributes
+				.OfType<RuntimeVisibleAnnotationsAttribute> ()
+				.SelectMany (a => a.Annotations)
+				.Select (a => a.Type)
+				.ToList ();
+
+			Assert.Contains ("Lkotlin/jvm/JvmInline;", annotations);
+		}
+	}
+}

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj
@@ -25,7 +25,13 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Resources\*" />
-    <EmbeddedResource Include="kotlin*\**\*.class" />
+    <EmbeddedResource Include="kotlin\**\*.class" />
+    <EmbeddedResource Include="kotlin-ThirdParty\**\*.class" />
+
+    <EmbeddedResource Include="kotlin-gradle\classes\xat\bytecode\tests\Widgets.class" LogicalName="Xamarin.Android.Tools.BytecodeTests.kotlin-gradle.Widgets.class" />
+    <EmbeddedResource Include="kotlin-gradle\classes\xat\bytecode\tests\MyColor.class" LogicalName="Xamarin.Android.Tools.BytecodeTests.kotlin-gradle.MyColor.class" />
+    <EmbeddedResource Include="kotlin-gradle\classes\xat\bytecode\tests\MyAlpha.class" LogicalName="Xamarin.Android.Tools.BytecodeTests.kotlin-gradle.MyAlpha.class" />
+    <EmbeddedResource Include="kotlin-gradle\classes\xat\bytecode\tests\MyDp.class" LogicalName="Xamarin.Android.Tools.BytecodeTests.kotlin-gradle.MyDp.class" />
 
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\xamarin\NotNullClass.class" />
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\xamarin\IJavaInterface.class" />

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.targets
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.targets
@@ -5,6 +5,12 @@
     <TestJarNoParameters Include="java/**/*NoParameters.java" />
     <TestJar Include="java\**\*.java" Exclude="@(TestJarNoParameters);java\android\annotation\NonNull.java;" />
     <TestKotlinJar Include="kotlin\**\*.kt" />
+    <TestKotlinGradleSource Include="kotlin-gradle\src\**\*.kt;kotlin-gradle\*.gradle.kts" />
+    <TestKotlinGradleOutput Include="kotlin-gradle\classes\xat\bytecode\tests\Widgets.class" />
+    <TestKotlinGradleOutput Include="kotlin-gradle\classes\xat\bytecode\tests\MyColor.class" />
+    <TestKotlinGradleOutput Include="kotlin-gradle\classes\xat\bytecode\tests\MyAlpha.class" />
+    <TestKotlinGradleOutput Include="kotlin-gradle\classes\xat\bytecode\tests\MyDp.class" />
+    <TestKotlinGradleOutput Include="kotlin-gradle\classes\xat\bytecode\tests\InlineClassCollisionsKt.class" />
   </ItemGroup>
 
   <ItemGroup>
@@ -32,6 +38,26 @@
         Inputs="@(TestKotlinJar)"
         Outputs="@(TestKotlinJar->'%(RecursiveDir)%(Filename).class')">
     <Exec Command="&quot;$(KotlinCPath)&quot; @(TestKotlinJar->'%(Identity)', ' ') -d &quot;kotlin&quot;" />
+  </Target>
+
+  <!--
+      Build the real Kotlin/Gradle fixture in kotlin-gradle\ using the committed
+      Gradle wrapper. Unlike BuildKotlinClasses above, this is run unconditionally
+      (a JDK is already required for BuildClasses), so the .class files do not need
+      to be committed. The wrapper downloads Gradle + Kotlin on first run.
+  -->
+  <PropertyGroup>
+    <_KotlinGradleProjectDir>$(MSBuildThisFileDirectory)kotlin-gradle</_KotlinGradleProjectDir>
+    <_GradleWrapperDir>$(MSBuildThisFileDirectory)..\..\build-tools\gradle</_GradleWrapperDir>
+    <_GradlewCommand Condition=" '$(OS)' == 'Windows_NT' ">$(_GradleWrapperDir)\gradlew.bat</_GradlewCommand>
+    <_GradlewCommand Condition=" '$(OS)' != 'Windows_NT' ">$(_GradleWrapperDir)/gradlew</_GradlewCommand>
+  </PropertyGroup>
+
+  <Target Name="BuildKotlinGradleProject"
+        BeforeTargets="BeforeCompile"
+        Inputs="@(TestKotlinGradleSource)"
+        Outputs="@(TestKotlinGradleOutput)">
+    <Exec Command="&quot;$(_GradlewCommand)&quot; --quiet --no-daemon -p &quot;$(_KotlinGradleProjectDir)&quot; classes" />
   </Target>
 
   <Target Name="BuildJar"

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.targets
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.targets
@@ -41,23 +41,22 @@
   </Target>
 
   <!--
-      Build the real Kotlin/Gradle fixture in kotlin-gradle\ using the committed
-      Gradle wrapper. Unlike BuildKotlinClasses above, this is run unconditionally
-      (a JDK is already required for BuildClasses), so the .class files do not need
-      to be committed. The wrapper downloads Gradle + Kotlin on first run.
+      Build the real Kotlin/Gradle fixture in kotlin-gradle\ using the shared
+      Gradle wrapper from build-tools/gradle. Unlike BuildKotlinClasses above,
+      this is run unconditionally (a JDK is already required for BuildClasses),
+      so the .class files do not need to be committed. The wrapper downloads
+      Gradle + Kotlin on first run.
   -->
   <PropertyGroup>
     <_KotlinGradleProjectDir>$(MSBuildThisFileDirectory)kotlin-gradle</_KotlinGradleProjectDir>
-    <_GradleWrapperDir>$(MSBuildThisFileDirectory)..\..\build-tools\gradle</_GradleWrapperDir>
-    <_GradlewCommand Condition=" '$(OS)' == 'Windows_NT' ">$(_GradleWrapperDir)\gradlew.bat</_GradlewCommand>
-    <_GradlewCommand Condition=" '$(OS)' != 'Windows_NT' ">$(_GradleWrapperDir)/gradlew</_GradlewCommand>
   </PropertyGroup>
 
   <Target Name="BuildKotlinGradleProject"
         BeforeTargets="BeforeCompile"
         Inputs="@(TestKotlinGradleSource)"
         Outputs="@(TestKotlinGradleOutput)">
-    <Exec Command="&quot;$(_GradlewCommand)&quot; --quiet --no-daemon -p &quot;$(_KotlinGradleProjectDir)&quot; classes" />
+    <Exec Command="&quot;$(GradleWPath)&quot; $(GradleArgs) -p &quot;$(_KotlinGradleProjectDir)&quot; classes"
+          EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);APP_HOME=$(GradleHome)" />
   </Target>
 
   <Target Name="BuildJar"

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/kotlin-gradle/.gitignore
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/kotlin-gradle/.gitignore
@@ -1,0 +1,4 @@
+# Gradle build outputs - rebuilt from source on every test build.
+.gradle/
+build/
+classes/

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/kotlin-gradle/build.gradle.kts
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/kotlin-gradle/build.gradle.kts
@@ -6,9 +6,12 @@ repositories {
     mavenCentral()
 }
 
-kotlin {
-    jvmToolchain(17)
-}
+// Don't pin a jvmToolchain -- it would force Gradle to auto-provision a
+// matching JDK and fail in CI environments without download repositories
+// configured. Use whatever JDK the caller already set in JAVA_HOME (the
+// .NET build forwards $(JavaSdkDirectory) for consistency with the rest
+// of the repo). Kotlin 2.0.21 targets JVM 11 by default, which is fine
+// for the bytecode the tests inspect.
 
 // Emit compiled classes into a stable, predictable location so the
 // .NET test harness can load them via ClassFileFixture without needing

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/kotlin-gradle/build.gradle.kts
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/kotlin-gradle/build.gradle.kts
@@ -1,0 +1,18 @@
+plugins {
+    kotlin("jvm") version "2.0.21"
+}
+
+repositories {
+    mavenCentral()
+}
+
+kotlin {
+    jvmToolchain(17)
+}
+
+// Emit compiled classes into a stable, predictable location so the
+// .NET test harness can load them via ClassFileFixture without needing
+// to know the Gradle build directory layout.
+tasks.named<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>("compileKotlin") {
+    destinationDirectory.set(file("$rootDir/classes"))
+}

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/kotlin-gradle/gradle.properties
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/kotlin-gradle/gradle.properties
@@ -1,0 +1,5 @@
+# Compile Kotlin in-process to avoid the macOS CI flake where the
+# external Kotlin compile daemon fails to start on attempt #1, emits an
+# `e :` line to stderr (which dotnet/Exec treats as an error and exit -1)
+# even though gradle reports BUILD SUCCESSFUL after the retry.
+kotlin.compiler.execution.strategy=in-process

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/kotlin-gradle/settings.gradle.kts
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/kotlin-gradle/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "kotlin-inline-class-fixtures"

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/kotlin-gradle/src/main/kotlin/InlineClassCollisions.kt
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/kotlin-gradle/src/main/kotlin/InlineClassCollisions.kt
@@ -1,0 +1,34 @@
+@file:JvmName("InlineClassCollisionsKt")
+
+package xat.bytecode.tests
+
+// Two distinct Kotlin inline classes that erase to the same JVM primitive (long).
+// Both `tint(MyColor)` and `tint(MyAlpha)` mangle to `tint-<hash>(J)V`, so they
+// collide once class-parse drops the hash suffix. This is the exact scenario
+// that Jetpack Compose triggers with Color/TextUnit/etc. and is the case
+// step (1) of dotnet/java-interop#1431 must handle.
+@JvmInline
+value class MyColor(val value: ULong)
+
+@JvmInline
+value class MyAlpha(val value: ULong)
+
+// A second inline class with a different backing primitive, so we can verify
+// that *non*-colliding hash siblings still survive.
+@JvmInline
+value class MyDp(val value: Float)
+
+object Widgets {
+
+    // Colliding pair: both erase to `tint-XXXXXXX(J)V`.
+    fun tint(color: MyColor) { /* no-op */ }
+    fun tint(alpha: MyAlpha) { /* no-op */ }
+
+    // Distinct hash-mangled sibling of the same source name — should survive
+    // alongside one of the `tint(long)` overloads.
+    fun tint(dp: MyDp) { /* no-op */ }
+
+    // A non-colliding pair: different arity, both hash-mangled.
+    fun pad(dp: MyDp): MyDp = dp
+    fun pad(dp1: MyDp, dp2: MyDp): MyDp = dp1
+}

--- a/tests/generator-Tests/Unit-Tests/KotlinFixupsTests.cs
+++ b/tests/generator-Tests/Unit-Tests/KotlinFixupsTests.cs
@@ -62,6 +62,7 @@ namespace generatortests
 
 			Assert.AreEqual (1, klass.Methods.Count, "Duplicate hash-mangled sibling should have been removed.");
 			Assert.AreEqual ("Add", klass.Methods [0].Name);
+			Assert.AreEqual ("add-AAAAAAA", klass.Methods [0].JavaName, "The first hash-mangled sibling in source order should survive.");
 			Assert.IsTrue (warnings.Messages.Any (m => m.Contains ("BG8C02")), "Expected BG8C02 warning, got: " + string.Join (Environment.NewLine, warnings.Messages));
 		}
 

--- a/tests/generator-Tests/Unit-Tests/KotlinFixupsTests.cs
+++ b/tests/generator-Tests/Unit-Tests/KotlinFixupsTests.cs
@@ -142,6 +142,31 @@ namespace generatortests
 			Assert.IsTrue (warnings.Messages.Any (m => m.Contains ("BG8C02")), "Expected BG8C02 warning.");
 		}
 
+		[Test, NonParallelizable]
+		public void MangledMethod_CollidesWithNonMangledOverload_ReversedOrder ()
+		{
+			// Same as above but with the mangled method declared FIRST. The
+			// non-mangled real Kotlin API must still win regardless of order.
+			var xml = XDocument.Parse (@"<package name='com.example.test' jni-name='com/example/test'>
+				<class name='test'>
+					<method name='add-AAAAAAA' final='false'>
+						<parameter name='p0' type='long' jni-type='J' />
+					</method>
+					<method name='add' final='false'>
+						<parameter name='p0' type='long' jni-type='J' />
+					</method>
+				</class>
+			</package>");
+			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), new CodeGenerationOptions ());
+
+			using var warnings = CaptureWarnings ();
+			KotlinFixups.Fixup (new [] { (GenBase) klass }.ToList ());
+
+			Assert.AreEqual (1, klass.Methods.Count, "Mangled duplicate should have been removed regardless of source order.");
+			Assert.AreEqual ("add", klass.Methods [0].JavaName, "The non-mangled method should survive regardless of order.");
+			Assert.IsTrue (warnings.Messages.Any (m => m.Contains ("BG8C02")), "Expected BG8C02 warning.");
+		}
+
 		static WarningCapture CaptureWarnings () => new WarningCapture ();
 
 		sealed class WarningCapture : IDisposable

--- a/tests/generator-Tests/Unit-Tests/KotlinFixupsTests.cs
+++ b/tests/generator-Tests/Unit-Tests/KotlinFixupsTests.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Xml.Linq;
+using Java.Interop.Tools.Generator;
 using Java.Interop.Tools.Generator.Transformation;
 using MonoDroid.Generation;
 using NUnit.Framework;
@@ -34,6 +37,101 @@ namespace generatortests
 			Assert.AreEqual ("Add", klass.Methods [0].Name);
 			Assert.IsTrue (klass.Methods [0].IsFinal);
 			Assert.IsFalse (klass.Methods [0].IsVirtual);
+		}
+
+		[Test]
+		public void CollidingHashSiblings_AreDeduplicated ()
+		{
+			// Two Kotlin hash-mangled siblings that erase to the same C# signature
+			// (one `long` parameter). After the rename to `Add` both would collide,
+			// so we keep only the first.
+			var xml = XDocument.Parse (@"<package name='com.example.test' jni-name='com/example/test'>
+				<class name='test'>
+					<method name='add-AAAAAAA' final='false'>
+						<parameter name='p0' type='long' jni-type='J' />
+					</method>
+					<method name='add-BBBBBBB' final='false'>
+						<parameter name='p0' type='long' jni-type='J' />
+					</method>
+				</class>
+			</package>");
+			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), new CodeGenerationOptions ());
+
+			using var warnings = CaptureWarnings ();
+			KotlinFixups.Fixup (new [] { (GenBase) klass }.ToList ());
+
+			Assert.AreEqual (1, klass.Methods.Count, "Duplicate hash-mangled sibling should have been removed.");
+			Assert.AreEqual ("Add", klass.Methods [0].Name);
+			Assert.IsTrue (warnings.Messages.Any (m => m.Contains ("BG8C02")), "Expected BG8C02 warning, got: " + string.Join (Environment.NewLine, warnings.Messages));
+		}
+
+		[Test]
+		public void NonCollidingHashSiblings_AreBothKept ()
+		{
+			// Two siblings with distinct parameter lists: both should rename to `Add`
+			// and survive as overloads.
+			var xml = XDocument.Parse (@"<package name='com.example.test' jni-name='com/example/test'>
+				<class name='test'>
+					<method name='add-AAAAAAA' final='false'>
+						<parameter name='p0' type='long' jni-type='J' />
+					</method>
+					<method name='add-BBBBBBB' final='false'>
+						<parameter name='p0' type='float' jni-type='F' />
+					</method>
+				</class>
+			</package>");
+			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), new CodeGenerationOptions ());
+
+			KotlinFixups.Fixup (new [] { (GenBase) klass }.ToList ());
+
+			Assert.AreEqual (2, klass.Methods.Count);
+			Assert.IsTrue (klass.Methods.All (m => m.Name == "Add"));
+		}
+
+		[Test]
+		public void MixedCollidingAndUniqueHashSiblings ()
+		{
+			// Three siblings of the same source-name: the long+long pair collide,
+			// the float arg is unique. Expect 2 methods to survive.
+			var xml = XDocument.Parse (@"<package name='com.example.test' jni-name='com/example/test'>
+				<class name='test'>
+					<method name='add-AAAAAAA' final='false'>
+						<parameter name='p0' type='long' jni-type='J' />
+					</method>
+					<method name='add-BBBBBBB' final='false'>
+						<parameter name='p0' type='long' jni-type='J' />
+					</method>
+					<method name='add-CCCCCCC' final='false'>
+						<parameter name='p0' type='float' jni-type='F' />
+					</method>
+				</class>
+			</package>");
+			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), new CodeGenerationOptions ());
+
+			KotlinFixups.Fixup (new [] { (GenBase) klass }.ToList ());
+
+			Assert.AreEqual (2, klass.Methods.Count);
+			Assert.IsTrue (klass.Methods.All (m => m.Name == "Add"));
+			CollectionAssert.AreEquivalent (new [] { "long", "float" }, klass.Methods.Select (m => m.Parameters [0].RawNativeType).ToArray ());
+		}
+
+		static WarningCapture CaptureWarnings () => new WarningCapture ();
+
+		sealed class WarningCapture : IDisposable
+		{
+			readonly Action<TraceLevel, string> previous;
+			public List<string> Messages { get; } = new List<string> ();
+
+			public WarningCapture ()
+			{
+				previous = Report.OutputDelegate;
+				Report.OutputDelegate = (level, msg) => Messages.Add (msg);
+			}
+
+			public void Dispose ()
+			{
+				Report.OutputDelegate = previous;
+			}
 		}
 	}
 }

--- a/tests/generator-Tests/Unit-Tests/KotlinFixupsTests.cs
+++ b/tests/generator-Tests/Unit-Tests/KotlinFixupsTests.cs
@@ -39,7 +39,7 @@ namespace generatortests
 			Assert.IsFalse (klass.Methods [0].IsVirtual);
 		}
 
-		[Test]
+		[Test, NonParallelizable]
 		public void CollidingHashSiblings_AreDeduplicated ()
 		{
 			// Two Kotlin hash-mangled siblings that erase to the same C# signature
@@ -113,6 +113,32 @@ namespace generatortests
 			Assert.AreEqual (2, klass.Methods.Count);
 			Assert.IsTrue (klass.Methods.All (m => m.Name == "Add"));
 			CollectionAssert.AreEquivalent (new [] { "long", "float" }, klass.Methods.Select (m => m.Parameters [0].RawNativeType).ToArray ());
+		}
+
+		[Test, NonParallelizable]
+		public void MangledMethod_CollidesWithNonMangledOverload ()
+		{
+			// A pre-existing non-mangled overload `add(long)` plus a mangled
+			// `add-AAAAAAA(long)` that also reduces to `add(long)` after rename.
+			// The mangled one is the duplicate -- drop it, keep the non-mangled.
+			var xml = XDocument.Parse (@"<package name='com.example.test' jni-name='com/example/test'>
+				<class name='test'>
+					<method name='add' final='false'>
+						<parameter name='p0' type='long' jni-type='J' />
+					</method>
+					<method name='add-AAAAAAA' final='false'>
+						<parameter name='p0' type='long' jni-type='J' />
+					</method>
+				</class>
+			</package>");
+			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), new CodeGenerationOptions ());
+
+			using var warnings = CaptureWarnings ();
+			KotlinFixups.Fixup (new [] { (GenBase) klass }.ToList ());
+
+			Assert.AreEqual (1, klass.Methods.Count, "Mangled duplicate should have been removed, leaving the pre-existing non-mangled method.");
+			Assert.AreEqual ("add", klass.Methods [0].JavaName, "The kept method should be the non-mangled one.");
+			Assert.IsTrue (warnings.Messages.Any (m => m.Contains ("BG8C02")), "Expected BG8C02 warning.");
 		}
 
 		static WarningCapture CaptureWarnings () => new WarningCapture ();

--- a/tools/generator/Java.Interop.Tools.Generator.Transformation/KotlinFixups.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Transformation/KotlinFixups.cs
@@ -51,30 +51,30 @@ namespace Java.Interop.Tools.Generator.Transformation
 			RemoveCollidingSiblings (gen, mangled);
 		}
 
-		// When multiple hash-mangled siblings of the same Kotlin source-name exist
-		// (common for Jetpack Compose `@Composable` functions with inline-class
-		// parameters), the rename above produces several methods with the same
-		// name and identical C#-erased parameter lists. Emitting them all causes
+		// After the rename above, hash-mangled siblings can collide with each
+		// other AND with pre-existing non-mangled overloads. Both cases produce
 		// CS0111 in the generated code. Until step 2 of dotnet/java-interop#1431
 		// projects inline-class params as strongly-typed wrappers, drop the
-		// duplicates deterministically (keep the first) and warn so the user can
-		// override via Metadata.xml if desired.
+		// mangled duplicates deterministically and warn so the user can
+		// override via Metadata.xml if desired. Non-mangled methods are always
+		// kept; only mangled methods are ever removed.
 		private static void RemoveCollidingSiblings (GenBase gen, List<Method> renamed)
 		{
-			if (renamed.Count < 2)
+			if (renamed.Count == 0)
 				return;
 
-			foreach (var group in renamed.GroupBy (m => m.Name)) {
-				var kept = new List<Method> ();
+			foreach (var method in renamed) {
+				// Collide against every other method on the type, not just other
+				// mangled siblings, so `tint(MyInlineLong)` collapsing to
+				// `tint(long)` collides with a pre-existing non-mangled
+				// `tint(long)` too.
+				var conflict = gen.Methods.FirstOrDefault (other => other != method &&
+					other.Name == method.Name && other.Matches (method));
+				if (conflict == null)
+					continue;
 
-				foreach (var method in group) {
-					if (kept.Any (k => k.Matches (method))) {
-						Report.LogCodedWarning (0, Report.WarningKotlinNameMangledCollision, method, gen.FullName, method.Name, method.JavaName);
-						gen.Methods.Remove (method);
-					} else {
-						kept.Add (method);
-					}
-				}
+				Report.LogCodedWarning (0, Report.WarningKotlinNameMangledCollision, method, gen.FullName, method.Name, method.JavaName);
+				gen.Methods.Remove (method);
 			}
 		}
 

--- a/tools/generator/Java.Interop.Tools.Generator.Transformation/KotlinFixups.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Transformation/KotlinFixups.cs
@@ -55,7 +55,7 @@ namespace Java.Interop.Tools.Generator.Transformation
 		// other AND with pre-existing non-mangled overloads. Both cases produce
 		// CS0111 in the generated code. Until step 2 of dotnet/java-interop#1431
 		// projects inline-class params as strongly-typed wrappers, drop the
-		// mangled duplicates deterministically and warn so the user can
+		// later mangled duplicate deterministically and warn so the user can
 		// override via Metadata.xml if desired. Non-mangled methods are always
 		// kept; only mangled methods are ever removed.
 		private static void RemoveCollidingSiblings (GenBase gen, List<Method> renamed)
@@ -64,13 +64,14 @@ namespace Java.Interop.Tools.Generator.Transformation
 				return;
 
 			foreach (var method in renamed) {
-				// Collide against every other method on the type, not just other
-				// mangled siblings, so `tint(MyInlineLong)` collapsing to
-				// `tint(long)` collides with a pre-existing non-mangled
-				// `tint(long)` too.
-				var conflict = gen.Methods.FirstOrDefault (other => other != method &&
-					other.Name == method.Name && other.Matches (method));
-				if (conflict == null)
+				// Only treat `method` as the duplicate if a matching method
+				// (mangled or non-mangled) appears EARLIER in source order on
+				// the type. This keeps the first-declared overload and removes
+				// every later mangled sibling that collapses onto it.
+				var earlier = gen.Methods
+					.TakeWhile (m => m != method)
+					.FirstOrDefault (m => m.Name == method.Name && m.Matches (method));
+				if (earlier == null)
 					continue;
 
 				Report.LogCodedWarning (0, Report.WarningKotlinNameMangledCollision, method, gen.FullName, method.Name, method.JavaName);

--- a/tools/generator/Java.Interop.Tools.Generator.Transformation/KotlinFixups.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Transformation/KotlinFixups.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Java.Interop.Tools.Generator;
 using MonoDroid.Generation;
 using MonoDroid.Utils;
 
@@ -23,7 +24,9 @@ namespace Java.Interop.Tools.Generator.Transformation
 			// We need to generate C# compatible names as well as prevent overriding 
 			// them as we cannot generate JCW for them.
 
-			foreach (var method in c.Methods.Where (m => m.IsKotlinNameMangled)) {
+			var mangled = c.Methods.Where (m => m.IsKotlinNameMangled).ToList ();
+
+			foreach (var method in mangled) {
 
 				// If the method is virtual, mark it as !virtual as it can't be overridden in Java
 				if (!method.IsFinal)
@@ -34,12 +37,45 @@ namespace Java.Interop.Tools.Generator.Transformation
 
 				FixMethodName (method);
 			}
+
+			RemoveCollidingSiblings (c, mangled);
 		}
 
 		private static void FixupInterface (InterfaceGen gen)
 		{
-			foreach (var method in gen.Methods.Where (m => m.IsKotlinNameMangled))
+			var mangled = gen.Methods.Where (m => m.IsKotlinNameMangled).ToList ();
+
+			foreach (var method in mangled)
 				FixMethodName (method);
+
+			RemoveCollidingSiblings (gen, mangled);
+		}
+
+		// When multiple hash-mangled siblings of the same Kotlin source-name exist
+		// (common for Jetpack Compose `@Composable` functions with inline-class
+		// parameters), the rename above produces several methods with the same
+		// name and identical C#-erased parameter lists. Emitting them all causes
+		// CS0111 in the generated code. Until step 2 of dotnet/java-interop#1431
+		// projects inline-class params as strongly-typed wrappers, drop the
+		// duplicates deterministically (keep the first) and warn so the user can
+		// override via Metadata.xml if desired.
+		private static void RemoveCollidingSiblings (GenBase gen, List<Method> renamed)
+		{
+			if (renamed.Count < 2)
+				return;
+
+			foreach (var group in renamed.GroupBy (m => m.Name)) {
+				var kept = new List<Method> ();
+
+				foreach (var method in group) {
+					if (kept.Any (k => k.Matches (method))) {
+						Report.LogCodedWarning (0, Report.WarningKotlinNameMangledCollision, method, gen.FullName, method.Name, method.JavaName);
+						gen.Methods.Remove (method);
+					} else {
+						kept.Add (method);
+					}
+				}
+			}
 		}
 
 		private static void FixMethodName (Method method)

--- a/tools/generator/Java.Interop.Tools.Generator.Transformation/KotlinFixups.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Transformation/KotlinFixups.cs
@@ -55,24 +55,30 @@ namespace Java.Interop.Tools.Generator.Transformation
 		// other AND with pre-existing non-mangled overloads. Both cases produce
 		// CS0111 in the generated code. Until step 2 of dotnet/java-interop#1431
 		// projects inline-class params as strongly-typed wrappers, drop the
-		// later mangled duplicate deterministically and warn so the user can
-		// override via Metadata.xml if desired. Non-mangled methods are always
-		// kept; only mangled methods are ever removed.
+		// mangled duplicate deterministically and warn so the user can override
+		// via Metadata.xml if desired. Non-mangled methods are always kept; only
+		// mangled methods are ever removed.
 		private static void RemoveCollidingSiblings (GenBase gen, List<Method> renamed)
 		{
 			if (renamed.Count == 0)
 				return;
 
 			foreach (var method in renamed) {
-				// Only treat `method` as the duplicate if a matching method
-				// (mangled or non-mangled) appears EARLIER in source order on
-				// the type. This keeps the first-declared overload and removes
-				// every later mangled sibling that collapses onto it.
-				var earlier = gen.Methods
-					.TakeWhile (m => m != method)
-					.FirstOrDefault (m => m.Name == method.Name && m.Matches (method));
-				if (earlier == null)
-					continue;
+				// A mangled method is always the "lesser" choice compared to a
+				// real non-mangled Kotlin API, so drop it whenever ANY non-mangled
+				// overload matches — regardless of source order.
+				var nonMangledMatch = gen.Methods
+					.FirstOrDefault (m => m != method && !m.IsKotlinNameMangled
+						&& m.Name == method.Name && m.Matches (method));
+				if (nonMangledMatch == null) {
+					// Otherwise (only mangled siblings collide), keep the
+					// first-declared one and drop later mangled duplicates.
+					var earlierMangled = gen.Methods
+						.TakeWhile (m => m != method)
+						.FirstOrDefault (m => m.Name == method.Name && m.Matches (method));
+					if (earlierMangled == null)
+						continue;
+				}
 
 				Report.LogCodedWarning (0, Report.WarningKotlinNameMangledCollision, method, gen.FullName, method.Name, method.JavaName);
 				gen.Methods.Remove (method);


### PR DESCRIPTION
Implements step (1) of dotnet/android#11844.

## Why

When Kotlin compiles a function whose parameter is an `@JvmInline value class`, the JVM-level name is mangled with a 7-char hash suffix (e.g. `tint-Rn_QMJI(J)V`). `KotlinFixups` already strips that suffix so the C# binding sees `Tint(long)` instead of an unspellable name.

The problem: two distinct Kotlin overloads that take different inline classes erase to the **same** JVM signature, differing only in the hash. Jetpack Compose hits this constantly (`Color`, `TextUnit`, `Dp` all wrap `ULong`/`Long`/`Float`). After the existing rename both methods become `Tint(long)` and `generator` emits CS0111-broken code.

## Repro (Kotlin)

```kotlin
@JvmInline value class MyColor(val value: ULong)
@JvmInline value class MyAlpha(val value: ULong)

object Widgets {
    fun tint(color: MyColor) { }
    fun tint(alpha: MyAlpha) { }
}
```

`javap -p Widgets.class` shows two hash-distinct siblings with identical erased shape:

```
public static void tint-Rn_QMJI(long);   // MyColor
public static void tint-uzYZ1wI(long);   // MyAlpha
```

## C# binding -- before

```csharp
// CS0111: two members with the same signature
public static void Tint (long color) { ... }
public static void Tint (long alpha) { ... }
```

## C# binding -- after

```csharp
// Only the first survives; second dropped with a coded warning
public static void Tint (long color) { ... }
```

```
warning BG8C02: For type 'Widgets', the Kotlin name-mangled method 'Tint'
(originally 'tint-uzYZ1wI') has multiple hash-suffixed siblings that erase
to the same C# signature. Only the first will be emitted; remove the
duplicate via Metadata.xml to suppress this warning.
```

The dedup happens inside `KotlinFixups.RemoveCollidingSiblings` and uses `Method.Matches` (which already compares `Parameter.RawNativeType`) so non-colliding hash siblings still survive. For example, `pad(MyDp)` and `pad(MyDp, MyDp)` both bind, and `tint(MyDp)` survives alongside one of the `tint(long)` overloads because they differ in raw type (`F` vs `J`).

Step (2) of dotnet/android#11844 -- projecting inline-class parameters as their own strongly-typed wrappers so all overloads can coexist -- is left for a follow-up.

## Picking which overload survives

The first method in source order is kept by default. To choose a different one, drop the unwanted hash-mangled sibling via `Metadata.xml`. The names in `api.xml` are still the *mangled* JNI names (the rename happens later in `generator`), so the path uses the suffix you see in `javap`:

```xml
<!-- Keep `tint(MyAlpha)`, drop `tint(MyColor)` -->
<remove-node path="/api/package[@name='xat.bytecode.tests']/class[@name='Widgets']/method[@name='tint-Rn_QMJI']" />
```

You can also target by JNI signature if the hash is unstable across Kotlin versions:

```xml
<remove-node path="/api/package[@name='xat.bytecode.tests']/class[@name='Widgets']/method[@name='tint-Rn_QMJI' and @jni-signature='(J)V']" />
```

After the rule fires the remaining `tint(long)` is the one that survives the dedup pass, and `BG8C02` no longer fires for that type.

### Keeping both overloads

If you want both overloads exposed (e.g. with hand-picked C# names), use `<attr name="managedName">` to rename one or both before the dedup pass runs. `KotlinFixups` deliberately skips its auto-strip when a `managedName` is present, and the dedup groups by the *final* C# name, so renamed siblings no longer collide:

```xml
<attr path="/api/package[@name='xat.bytecode.tests']/class[@name='Widgets']/method[@name='tint-Rn_QMJI']"
      name="managedName">TintColor</attr>
<attr path="/api/package[@name='xat.bytecode.tests']/class[@name='Widgets']/method[@name='tint-uzYZ1wI']"
      name="managedName">TintAlpha</attr>
```

Produces:

```csharp
public static void TintColor (long color) { ... }
public static void TintAlpha (long alpha) { ... }
```

(You only need to rename one; renaming both makes the call sites read better.)

## Real Kotlin/Gradle fixture

To exercise this against real Kotlin compiler output rather than hand-written `.class` files, I added a small Gradle project under `tests/Xamarin.Android.Tools.Bytecode-Tests/kotlin-gradle/`:

- `build.gradle.kts` pins Kotlin 2.0.21 / JVM 17 and emits classes into `$rootDir/classes`.
- `src/main/kotlin/InlineClassCollisions.kt` declares the value classes and `Widgets` object shown above.
- A new MSBuild target `BuildKotlinGradleProject` invokes the **existing** `build-tools/gradle/gradlew(.bat)` (no duplicate wrapper) with `-p kotlin-gradle classes` before `BeforeCompile`. The produced `.class` files are embedded as test resources, so the `.class` outputs do not need to be committed.
- `.gitignore` keeps `classes/`/`build/` out of git; `.gitattributes` forces `gradlew`/`*.properties`/`*.kt`/`*.kts` to LF so the shared wrapper script keeps working on Unix.

## Tests

- `KotlinFixupsTests`: 3 new unit tests cover the collision / no-collision / mixed cases with a `WarningCapture` helper that asserts BG8C02 fires.
- `KotlinInlineClassCollisionTests`: 3 new tests load the freshly Gradle-built `Widgets.class` / `MyColor.class` and assert the expected JVM-level mangling, so we would notice if Kotlin ever changed the scheme.

All 5 `KotlinFixupsTests`, all 78 Bytecode tests, and all 453 generator tests pass.

## Review notes

- One open question: does the CI build agent have a JDK? The existing `BuildClasses` target already requires `JavaCPath`, so likely yes. The new `BuildKotlinGradleProject` only needs a JDK -- the Gradle wrapper handles downloading Gradle + Kotlin on first run.
- Only the English `Resources.resx` / `Resources.Designer.cs` were updated for BG8C02; the 14 localized resx files are left for the translation team (matches the pattern of prior added strings).
