### PR TITLE
Use function pointers for JavaVM invoker

### DIFF
--- a/src/Java.Interop/Java.Interop/JniRuntime.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.cs
@@ -12,6 +12,7 @@ using System.Threading;
 namespace Java.Interop
 {
 	[SuppressMessage ("Performance", "CA1823:Avoid unused private fields", Justification = "Fields preserve the unmanaged JavaVM vtable layout.")]
+	// These fields are populated from native memory and some are only present to preserve the JavaVM vtable layout.
 #pragma warning disable CS0169, CS0649
 	unsafe struct JavaVMInterface {
 		IntPtr reserved0;

--- a/src/Java.Interop/Java.Interop/JniRuntime.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.cs
@@ -19,11 +19,11 @@ namespace Java.Interop
 		IntPtr reserved1;
 		IntPtr reserved2;
 
-		delegate* unmanaged<IntPtr, int> destroyJavaVM; // jint       (*DestroyJavaVM)(JavaVM*);
+		delegate* unmanaged<IntPtr, int> destroyJavaVM;
 		delegate* unmanaged<IntPtr, IntPtr*, JavaVMThreadAttachArgs*, int> attachCurrentThread;
 		delegate* unmanaged<IntPtr, int> detachCurrentThread;
 		delegate* unmanaged<IntPtr, IntPtr*, int, int> getEnv;
-		delegate* unmanaged<IntPtr, IntPtr*, IntPtr, int> attachCurrentThreadAsDaemon; //jint        (*AttachCurrentThreadAsDaemon)(JavaVM*, JNIEnv**, void*);
+		delegate* unmanaged<IntPtr, IntPtr*, IntPtr, int> attachCurrentThreadAsDaemon;
 
 		public int DestroyJavaVM (IntPtr javavm)
 		{

--- a/src/Java.Interop/Java.Interop/JniRuntime.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.cs
@@ -11,23 +11,38 @@ using System.Threading;
 
 namespace Java.Interop
 {
-	delegate int DestroyJavaVMDelegate (IntPtr javavm);
-	delegate int GetEnvDelegate (IntPtr javavm, out IntPtr envptr, int version);
-	delegate int AttachCurrentThreadDelegate (IntPtr javavm, out IntPtr env, ref JavaVMThreadAttachArgs args);
-	delegate int DetachCurrentThreadDelegate (IntPtr javavm);
-	delegate int AttachCurrentThreadAsDaemonDelegate (IntPtr javavm, out IntPtr env, IntPtr args);
+	[SuppressMessage ("Performance", "CA1823:Avoid unused private fields", Justification = "Fields preserve the unmanaged JavaVM vtable layout.")]
+#pragma warning disable CS0169, CS0649
+	unsafe struct JavaVMInterface {
+		IntPtr reserved0;
+		IntPtr reserved1;
+		IntPtr reserved2;
 
-	struct JavaVMInterface {
-		public IntPtr reserved0;
-		public IntPtr reserved1;
-		public IntPtr reserved2;
+		delegate* unmanaged<IntPtr, int> destroyJavaVM; // jint       (*DestroyJavaVM)(JavaVM*);
+		delegate* unmanaged<IntPtr, IntPtr*, JavaVMThreadAttachArgs*, int> attachCurrentThread;
+		delegate* unmanaged<IntPtr, int> detachCurrentThread;
+		delegate* unmanaged<IntPtr, IntPtr*, int, int> getEnv;
+		delegate* unmanaged<IntPtr, IntPtr*, IntPtr, int> attachCurrentThreadAsDaemon; //jint        (*AttachCurrentThreadAsDaemon)(JavaVM*, JNIEnv**, void*);
 
-		public DestroyJavaVMDelegate DestroyJavaVM; // jint       (*DestroyJavaVM)(JavaVM*);
-		public AttachCurrentThreadDelegate AttachCurrentThread;
-		public DetachCurrentThreadDelegate DetachCurrentThread;
-		public GetEnvDelegate GetEnv;
-		public AttachCurrentThreadAsDaemonDelegate AttachCurrentThreadAsDaemon; //jint        (*AttachCurrentThreadAsDaemon)(JavaVM*, JNIEnv**, void*);
+		public int DestroyJavaVM (IntPtr javavm)
+		{
+			return destroyJavaVM (javavm);
+		}
+
+		public int AttachCurrentThread (IntPtr javavm, out IntPtr env, ref JavaVMThreadAttachArgs args)
+		{
+			fixed (IntPtr* envp = &env)
+			fixed (JavaVMThreadAttachArgs* argsp = &args)
+				return attachCurrentThread (javavm, envp, argsp);
+		}
+
+		public int GetEnv (IntPtr javavm, out IntPtr envptr, int version)
+		{
+			fixed (IntPtr* envp = &envptr)
+				return getEnv (javavm, envp, version);
+		}
 	}
+#pragma warning restore CS0169, CS0649
 
 	public enum JniVersion {
 		// v1_1    = 0x00010001,
@@ -179,7 +194,9 @@ namespace Java.Interop
 			} else {
 				InvocationPointer   = options.InvocationPointer;
 			}
-			Invoker             = CreateInvoker (InvocationPointer);
+			unsafe {
+				Invoker = *(JavaVMInterface*) Marshal.ReadIntPtr (InvocationPointer);
+			}
 
 			SetValueManager (options);
 
@@ -252,12 +269,6 @@ namespace Java.Interop
 		}
 
 		partial void SetValueManager (CreationOptions options);
-
-		static unsafe JavaVMInterface CreateInvoker (IntPtr handle)
-		{
-			IntPtr p = Marshal.ReadIntPtr (handle);
-			return (JavaVMInterface) Marshal.PtrToStructure<JavaVMInterface> (p)!;
-		}
 
 		~JniRuntime ()
 		{
@@ -442,4 +453,3 @@ namespace Java.Interop
 		}
 	}
 }
-


### PR DESCRIPTION
## Summary

`dotnet-trace` showed `JniRuntime.CreateInvoker` taking 10+ ms during startup of a `dotnet new maui` app on Samsung A16. The cost comes from `Marshal.PtrToStructure<JavaVMInterface>()` materializing managed delegates for the JavaVM vtable entries.

This changes the JavaVM vtable representation to unmanaged function pointers and snapshots the vtable with a direct unsafe struct copy from the JavaVM vtable pointer. Calls still go through small wrapper methods for the existing `DestroyJavaVM`, `AttachCurrentThread`, and `GetEnv` call sites.

## Impact

On Samsung A16 with a `dotnet new maui` app, this saves about 15 ms on app startup, measured across 20 cold launches to reduce noise.

The unmanaged function-pointer cast/copy is essentially free; direct measurement showed it as `0.000 ms`, compared to roughly 15 ms for the old managed delegate-marshalling path.

## Validation

- `dotnet build src/Java.Interop/Java.Interop.csproj -v:minimal`
- Rebuilt dotnet/android's local Android pack and a Release CoreCLR+trimmable MAUI APK using the changed Java.Interop assembly.
- Launched the exact APK 20 times cold on Samsung A16; every run returned `Status: ok`, `LaunchState: COLD`, and no app crash/fatal logcat rows were found.
