### PR TITLE
Use simple assertion for ManagedPeer test

### DIFF
--- a/tests/Java.Interop-Tests/Java.Interop/JniRuntimeTest.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JniRuntimeTest.cs
@@ -70,7 +70,7 @@ namespace Java.InteropTests
 		public void BuiltInSimpleReferenceMap_ContainsManagedPeerByDefault ()
 		{
 			var types = JniRuntime.CurrentRuntime.TypeManager.GetTypes (new JniTypeSignature (ManagedPeer.JniTypeName));
-			CollectionAssert.Contains (types, typeof (ManagedPeer));
+			Assert.IsTrue (types.Contains (typeof (ManagedPeer)));
 		}
 
 #if !__ANDROID__

--- a/tests/Java.Interop-Tests/Java.Interop/JniRuntimeTest.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JniRuntimeTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Reflection;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 
 using Java.Interop;


### PR DESCRIPTION
Follow-up to #1434
Related to https://github.com/dotnet/android/pull/11503

Replaces `CollectionAssert.Contains` with `Assert.IsTrue (...Contains (...))` so the ManagedPeer built-in map test compiles in dotnet/android, where `CollectionAssert` is not available.

Validation:
- `dotnet test tests/Java.Interop-Tests/Java.Interop-Tests.csproj --filter FullyQualifiedName~Java.InteropTests.JniRuntimeTest.BuiltInSimpleReferenceMap_ContainsManagedPeerByDefault --no-restore`