### PR TITLE
[tests] Replace legacy [TestFixtureSetUp]/[TestFixtureTearDown] with [OneTimeSetUp]/[OneTimeTearDown]

### DIFF
--- a/tests/Java.Interop-Tests/Java.Interop/JavaArrayContract.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JavaArrayContract.cs
@@ -12,21 +12,13 @@ namespace Java.InteropTests
 	{
 		int lrefStartCount;
 
-#if __ANDROID__
-		[TestFixtureSetUp]
-#else   // __ANDROID__
 		[OneTimeSetUp]
-#endif  // __ANDROID__
 		public void StartArrayTests ()
 		{
 			lrefStartCount  = JniEnvironment.LocalReferenceCount;
 		}
 
-#if __ANDROID__
-		[TestFixtureTearDown]
-#else   // __ANDROID__
 		[OneTimeTearDown]
-#endif  // __ANDROID__
 		public void EndArrayTests ()
 		{
 			int lref    = JniEnvironment.LocalReferenceCount;

--- a/tests/Java.Interop-Tests/Java.Interop/JavaObjectArrayTest.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JavaObjectArrayTest.cs
@@ -158,11 +158,7 @@ namespace Java.InteropTests
 
 		int grefStartCount;
 
-#if __ANDROID__
-		[TestFixtureSetUp]
-#else   // __ANDROID__
 		[OneTimeSetUp]
-#endif  // __ANDROID__
 		public void BeginCheckGlobalRefCount ()
 		{
 			// So that the JavaProxyObject.TypeRef GREF isn't counted.
@@ -171,11 +167,7 @@ namespace Java.InteropTests
 			grefStartCount  = JniEnvironment.Runtime.GlobalReferenceCount;
 		}
 
-#if __ANDROID__
-		[TestFixtureTearDown]
-#else   // __ANDROID__
 		[OneTimeTearDown]
-#endif  // __ANDROID__
 		public void EndCheckGlobalRefCount ()
 		{
 			int gref    = JniEnvironment.Runtime.GlobalReferenceCount;

--- a/tests/Java.Interop-Tests/Java.Interop/TestTypeTests.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/TestTypeTests.cs
@@ -13,21 +13,13 @@ namespace Java.InteropTests
 	{
 		int lrefStartCount;
 
-#if __ANDROID__
-		[TestFixtureSetUp]
-#else   // __ANDROID__
 		[OneTimeSetUp]
-#endif  // __ANDROID__
 		public void StartArrayTests ()
 		{
 			lrefStartCount  = JniEnvironment.LocalReferenceCount;
 		}
 
-#if __ANDROID__
-		[TestFixtureTearDown]
-#else   // __ANDROID__
 		[OneTimeTearDown]
-#endif  // __ANDROID__
 		public void EndArrayTests ()
 		{
 			int lref    = JniEnvironment.LocalReferenceCount;


### PR DESCRIPTION
The legacy `[TestFixtureSetUp]` and `[TestFixtureTearDown]` attributes were removed in NUnit 3 in favor of `[OneTimeSetUp]` and `[OneTimeTearDown]`. They have been kept around in NUnitLite for back-compat, which is why the on-device Android test path used them under `#if __ANDROID__`. NUnitLite also supports the modern `OneTime*` names, so the conditional is no longer needed.

This replaces the `#if __ANDROID__` / `#else` / `#endif` blocks with the unconditional modern attribute in the three affected files:

- `tests/Java.Interop-Tests/Java.Interop/TestTypeTests.cs`
- `tests/Java.Interop-Tests/Java.Interop/JavaObjectArrayTest.cs`
- `tests/Java.Interop-Tests/Java.Interop/JavaArrayContract.cs`

## Why

This unblocks [dotnet/android#11224](https://github.com/dotnet/android/pull/11224), which migrates `Mono.Android` device tests from NUnitLite to stock NUnit 3.13.3 + MTP via `dotnet test`. Stock NUnit 3.13.3's `netstandard2.0` assembly does **not** contain the legacy attribute names, so consuming Java.Interop's test code there currently requires a small compatibility shim (`NUnitCompatibility.cs`). After this change that shim can be deleted.

## Verification

`dotnet build tests/Java.Interop-Tests/Java.Interop-Tests.csproj` succeeds.