### PR TITLE
Add NuGet ecosystem to Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,12 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      nuget-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
Keeps NuGet package references across the repo current automatically, so we don't accumulate stale dependencies between manual update passes.

## Approach

Adds a `nuget` entry to `.github/dependabot.yml` alongside the existing `gitsubmodule` entry. With `directory: "/"`, Dependabot recursively discovers every `*.csproj` (and `*.props` / `*.targets`) under `src/`, `tools/`, `tests/`, `samples/`, and `build-tools/`, so a single entry covers all ~45 projects in the repo.

- **Weekly schedule** for NuGet updates (less time-sensitive than submodules, which stay daily).
- **Grouped updates** via a single `nuget-dependencies` group matching `*`, so all NuGet bumps land in one PR per cycle instead of flooding the queue.
- **Open PR limit** of 10 as a safety cap.

If the grouped PR turns out to be too coarse, we can split into version-update groups (e.g. major vs minor/patch) later.