### PR TITLE
[generator] Phase 2: Kotlin @JvmInline value class projection

### DIFF
--- a/src/Xamarin.Android.Tools.Bytecode/ClassFile.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/ClassFile.cs
@@ -24,6 +24,12 @@ namespace Xamarin.Android.Tools.Bytecode {
 		public Methods              Methods;
 		public AttributeCollection  Attributes;
 
+		// Set by KotlinFixups when this class is a Kotlin `@JvmInline value class`.
+		// The value is the JNI type descriptor of the single backing field
+		// (e.g. "J", "F", "I", "Ljava/lang/String;"). null otherwise.
+		// See dotnet/java-interop#1431 (Phase 2).
+		public string? KotlinInlineClassUnderlyingJniType { get; set; }
+
 		ClassSignature?             signature;
 
 

--- a/src/Xamarin.Android.Tools.Bytecode/Kotlin/KotlinFixups.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/Kotlin/KotlinFixups.cs
@@ -299,6 +299,22 @@ namespace Xamarin.Android.Tools.Bytecode
 
 			// Same projection as above, but for the return type.
 			method.KotlinInlineClassReturnJniType = GetInlineClassJniType (metadata.ReturnType?.ClassName, inlineClasses);
+
+			// Recover the unmangled Kotlin source-level name when the Kotlin
+			// compiler mangled the JVM name for inline-class binary compat
+			// (e.g. JVM name `tint-Rn_QMJI`, Kotlin name `tint`). The generator
+			// will emit this as the C# binding name (PascalCased to match
+			// `managedName` conventions); the JVM name stays the JNI invocation
+			// target. See dotnet/java-interop#1431 (Phase 2).
+			if (metadata.Name != null && metadata.JvmName != null && metadata.Name != metadata.JvmName)
+				method.KotlinName = PascalCase (metadata.Name);
+		}
+
+		static string PascalCase (string name)
+		{
+			if (string.IsNullOrEmpty (name) || char.IsUpper (name [0]))
+				return name;
+			return char.ToUpperInvariant (name [0]) + name.Substring (1);
 		}
 
 		public static (int start, int end) CreateParameterMap (MethodInfo method, KotlinFunction function, KotlinClass? kotlinClass)

--- a/src/Xamarin.Android.Tools.Bytecode/Kotlin/KotlinFixups.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/Kotlin/KotlinFixups.cs
@@ -11,6 +11,13 @@ namespace Xamarin.Android.Tools.Bytecode
 	{
 		public static void Fixup (IList<ClassFile> classes)
 		{
+			// Pre-pass: identify Kotlin `@JvmInline value class` types and record
+			// each one's JNI name -> backing primitive descriptor. We need this
+			// map before processing methods so that a method on class A that takes
+			// an inline class B as a parameter (via Kotlin metadata) can be stamped
+			// even if B is later in `classes`. See dotnet/java-interop#1431.
+			var inlineClasses = DetectInlineClasses (classes);
+
 			foreach (var c in classes) {
 				// See if this is a Kotlin class
 				var attr = c.Attributes.OfType<RuntimeVisibleAnnotationsAttribute> ().FirstOrDefault ();
@@ -51,7 +58,7 @@ namespace Xamarin.Android.Tools.Bytecode
 						// and we need to find the "best" match for each Java method.
 						foreach (var java_method in c.Methods)
 							if (FindKotlinFunctionMetadata (metadata, java_method) is KotlinFunction function_metadata)
-								FixupFunction (java_method, function_metadata, class_metadata);
+								FixupFunction (java_method, function_metadata, class_metadata, inlineClasses);
 					}
 
 					if (metadata.Properties != null) {
@@ -59,7 +66,7 @@ namespace Xamarin.Android.Tools.Bytecode
 							var getter = FindJavaPropertyGetter (metadata, prop, c);
 							var setter = FindJavaPropertySetter (metadata, prop, c);
 
-							FixupProperty (getter, setter, prop);
+							FixupProperty (getter, setter, prop, inlineClasses);
 
 							FixupField (FindJavaFieldProperty (metadata, prop, c), prop);
 						}
@@ -69,6 +76,75 @@ namespace Xamarin.Android.Tools.Bytecode
 					Log.Warning (0, $"class-parse: warning: Unable to parse Kotlin metadata on '{c.ThisClass.Name}': {ex}");
 				}
 			}
+		}
+
+		// Identifies Kotlin `@JvmInline value class` types in `classes` and stamps
+		// each `ClassFile.KotlinInlineClassUnderlyingJniType` with the JNI descriptor
+		// of its single backing field. Returns a map from the class's *Kotlin metadata*
+		// class-name representation (e.g. `com/example/MyColor;`) to that descriptor,
+		// for use when projecting `KotlinType.ClassName` references on parameters and
+		// return types of OTHER methods. See dotnet/java-interop#1431 (Phase 2).
+		static Dictionary<string, string> DetectInlineClasses (IList<ClassFile> classes)
+		{
+			var map = new Dictionary<string, string> (StringComparer.Ordinal);
+			foreach (var c in classes) {
+				var ann = c.Attributes.OfType<RuntimeVisibleAnnotationsAttribute> ().FirstOrDefault ();
+				if (ann is null)
+					continue;
+
+				// `@JvmInline` is the JVM-level marker for Kotlin inline/value classes.
+				if (!ann.Annotations.Any (a => a.Type == "Lkotlin/jvm/JvmInline;"))
+					continue;
+
+				// Sanity-check via Kotlin metadata: must be `kind == 1` (Class) and
+				// have IsInlineClass set. This filters out `@JvmInline` on things
+				// kotlinc may have emitted in the future for non-class kinds.
+				var meta = ann.Annotations.SingleOrDefault (a => a.Type == "Lkotlin/Metadata;");
+				if (meta is null)
+					continue;
+
+				try {
+					var km = KotlinMetadata.FromAnnotation (meta);
+					if (km.AsClassMetadata () is not KotlinClass kc)
+						continue;
+					if ((kc.Flags & KotlinClassFlags.IsInlineClass) == 0)
+						continue;
+
+					// The single non-synthetic, non-static instance field is the
+					// inline-class backing value. (Synthetic fields like `Companion`
+					// are filtered out.)
+					var backing = c.Fields.FirstOrDefault (f =>
+						!f.AccessFlags.HasFlag (FieldAccessFlags.Synthetic) &&
+						!f.AccessFlags.HasFlag (FieldAccessFlags.Static));
+					if (backing is null)
+						continue;
+
+					c.KotlinInlineClassUnderlyingJniType = backing.Descriptor;
+
+					// Kotlin's `KotlinType.ClassName` strings are stored without the
+					// leading `L` but with a trailing `;` (e.g. `com/example/MyColor;`).
+					// We index by that form so callers can look up directly from
+					// `kotlin_p.Type.ClassName` without string surgery.
+					var jvmName = c.ThisClass.Name.Value + ";";
+					map [jvmName] = backing.Descriptor;
+				} catch (Exception ex) {
+					Log.Warning (0, $"class-parse: warning: Unable to detect inline class on '{c.ThisClass.Name}': {ex}");
+				}
+			}
+			return map;
+		}
+
+		// JNI signature for the Kotlin inline class referenced by `kotlinTypeClassName`,
+		// or null when the name is unknown / not an inline class. The returned form
+		// has a leading `L` and trailing `;` so it matches `ClassFile.FullJniName`
+		// and other JNI-signature strings used throughout the pipeline.
+		static string? GetInlineClassJniType (string? kotlinTypeClassName, IDictionary<string, string> inlineClasses)
+		{
+			if (kotlinTypeClassName is null)
+				return null;
+			if (!inlineClasses.ContainsKey (kotlinTypeClassName))
+				return null;
+			return "L" + kotlinTypeClassName;
 		}
 
 		static void FixupClassVisibility (ClassFile klass, KotlinClass metadata)
@@ -179,7 +255,7 @@ namespace Xamarin.Android.Tools.Bytecode
 			}
 		}
 
-		static void FixupFunction (MethodInfo? method, KotlinFunction metadata, KotlinClass? kotlinClass)
+		static void FixupFunction (MethodInfo? method, KotlinFunction metadata, KotlinClass? kotlinClass, IDictionary<string, string> inlineClasses)
 		{
 			if (method is null || !method.IsPubliclyVisible)
 				return;
@@ -209,10 +285,20 @@ namespace Xamarin.Android.Tools.Bytecode
 
 				// Handle erasure of Kotlin unsigned types
 				java_p.KotlinType = GetKotlinType (java_p.Type.TypeSignature, kotlin_p.Type.ClassName);
+
+				// Inline-class projection: if the Kotlin source-level type for this
+				// parameter is a `@JvmInline value class` we know about, record its
+				// JNI signature so the generator can later swap the parameter type
+				// for a strongly-typed wrapper struct while keeping JNI marshaling
+				// on the underlying primitive. See dotnet/java-interop#1431 (Phase 2).
+				java_p.KotlinInlineClassJniType = GetInlineClassJniType (kotlin_p.Type.ClassName, inlineClasses);
 			}
 
 			// Handle erasure of Kotlin unsigned types
 			method.KotlinReturnType = GetKotlinType (method.ReturnType.TypeSignature, metadata.ReturnType?.ClassName);
+
+			// Same projection as above, but for the return type.
+			method.KotlinInlineClassReturnJniType = GetInlineClassJniType (metadata.ReturnType?.ClassName, inlineClasses);
 		}
 
 		public static (int start, int end) CreateParameterMap (MethodInfo method, KotlinFunction function, KotlinClass? kotlinClass)
@@ -267,7 +353,7 @@ namespace Xamarin.Android.Tools.Bytecode
 			}
 		}
 
-		static void FixupProperty (MethodInfo? getter, MethodInfo? setter, KotlinProperty metadata)
+		static void FixupProperty (MethodInfo? getter, MethodInfo? setter, KotlinProperty metadata, IDictionary<string, string> inlineClasses)
 		{
 			if (getter is null && setter is null)
 				return;
@@ -289,8 +375,10 @@ namespace Xamarin.Android.Tools.Bytecode
 			}
 
 			// Handle erasure of Kotlin unsigned types
-			if (getter != null)
+			if (getter != null) {
 				getter.KotlinReturnType = GetKotlinType (getter.ReturnType.TypeSignature, metadata.ReturnType?.ClassName);
+				getter.KotlinInlineClassReturnJniType = GetInlineClassJniType (metadata.ReturnType?.ClassName, inlineClasses);
+			}
 
 			if (setter != null) {
 				var setter_parameter = setter.GetParameters ().First ();
@@ -302,6 +390,7 @@ namespace Xamarin.Android.Tools.Bytecode
 
 				// Handle erasure of Kotlin unsigned types
 				setter_parameter.KotlinType = GetKotlinType (setter_parameter.Type.TypeSignature, metadata.ReturnType?.ClassName);
+				setter_parameter.KotlinInlineClassJniType = GetInlineClassJniType (metadata.ReturnType?.ClassName, inlineClasses);
 			}
 		}
 

--- a/src/Xamarin.Android.Tools.Bytecode/Kotlin/KotlinFixups.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/Kotlin/KotlinFixups.cs
@@ -63,8 +63,8 @@ namespace Xamarin.Android.Tools.Bytecode
 
 					if (metadata.Properties != null) {
 						foreach (var prop in metadata.Properties) {
-							var getter = FindJavaPropertyGetter (metadata, prop, c);
-							var setter = FindJavaPropertySetter (metadata, prop, c);
+							var getter = FindJavaPropertyGetter (metadata, prop, c, inlineClasses);
+							var setter = FindJavaPropertySetter (metadata, prop, c, inlineClasses);
 
 							FixupProperty (getter, setter, prop, inlineClasses);
 
@@ -527,7 +527,7 @@ namespace Xamarin.Android.Tools.Bytecode
 			return possible_methods.FirstOrDefault ();
 		}
 
-		static MethodInfo? FindJavaPropertyGetter (KotlinFile kotlinClass, KotlinProperty property, ClassFile klass)
+		static MethodInfo? FindJavaPropertyGetter (KotlinFile kotlinClass, KotlinProperty property, ClassFile klass, IDictionary<string, string> inlineClasses)
 		{
 			// Private properties do not have getters
 			if (property.IsPrivateVisibility)
@@ -544,12 +544,12 @@ namespace Xamarin.Android.Tools.Bytecode
 			possible_methods = possible_methods.Where (method =>
 					method.GetParameters ().Length == 0 &&
 					property.ReturnType != null &&
-					TypesMatch (method.ReturnType, property.ReturnType, kotlinClass));
+					TypesMatch (method.ReturnType, property.ReturnType, kotlinClass, inlineClasses));
 
 			return possible_methods.FirstOrDefault ();
 		}
 
-		static MethodInfo? FindJavaPropertySetter (KotlinFile kotlinClass, KotlinProperty property, ClassFile klass)
+		static MethodInfo? FindJavaPropertySetter (KotlinFile kotlinClass, KotlinProperty property, ClassFile klass, IDictionary<string, string> inlineClasses)
 		{
 			// Private properties do not have setters
 			if (property.IsPrivateVisibility)
@@ -567,7 +567,7 @@ namespace Xamarin.Android.Tools.Bytecode
 						property.ReturnType != null &&
 						method.GetParameters ().Length == 1 &&
 						method.ReturnType.BinaryName == "V" &&
-						TypesMatch (method.GetParameters () [0].Type, property.ReturnType, kotlinClass));
+						TypesMatch (method.GetParameters () [0].Type, property.ReturnType, kotlinClass, inlineClasses));
 
 			return possible_methods.FirstOrDefault ();
 		}
@@ -590,7 +590,7 @@ namespace Xamarin.Android.Tools.Bytecode
 			return true;
 		}
 
-		static bool TypesMatch (TypeInfo javaType, KotlinType kotlinType, KotlinFile? kotlinFile)
+		static bool TypesMatch (TypeInfo javaType, KotlinType kotlinType, KotlinFile? kotlinFile, IDictionary<string, string>? inlineClasses = null)
 		{
 			// Generic type
 			if (!string.IsNullOrWhiteSpace (kotlinType.TypeParameterName) && $"T{kotlinType.TypeParameterName};" == javaType.TypeSignature)
@@ -601,6 +601,18 @@ namespace Xamarin.Android.Tools.Bytecode
 
 			// Could be a generic type erasure
 			if (javaType.BinaryName == "Ljava/lang/Object;")
+				return true;
+
+			// dotnet/java-interop#1431 (Phase 2): the JVM erases @JvmInline value
+			// class types to their underlying primitive descriptor, so e.g. a
+			// `MyColor` property (ULong-backed) appears in the bytecode as `()J`
+			// even though the Kotlin metadata still says `MyColor`. Accept the
+			// match when the JVM primitive matches the inline class's recorded
+			// underlying-primitive descriptor.
+			if (inlineClasses != null && IsJvmPrimitiveDescriptor (javaType.BinaryName) &&
+					kotlinType.ClassName != null &&
+					inlineClasses.TryGetValue (kotlinType.ClassName, out var underlying) &&
+					underlying == javaType.BinaryName)
 				return true;
 
 			// Sometimes Kotlin keeps its native types rather than converting them to Java native types

--- a/src/Xamarin.Android.Tools.Bytecode/Kotlin/KotlinFixups.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/Kotlin/KotlinFixups.cs
@@ -112,11 +112,24 @@ namespace Xamarin.Android.Tools.Bytecode
 
 					// The single non-synthetic, non-static instance field is the
 					// inline-class backing value. (Synthetic fields like `Companion`
-					// are filtered out.)
-					var backing = c.Fields.FirstOrDefault (f =>
+					// are filtered out.) We additionally require:
+					//   - exactly one such field exists (Kotlin inline classes have
+					//     a single property; multiple non-synthetic instance fields
+					//     means something else is going on and we shouldn't trust
+					//     this as the backing field).
+					//   - the field is a JVM *primitive* descriptor — the wrapper
+					//     struct currently emits the underlying as a primitive
+					//     C# type, so reference-backed inline classes (e.g.
+					//     `value class Tag(val s: String)`) would produce wrong
+					//     bindings. Skip these for now; they fall back to the
+					//     standard peer-class binding path.
+					var instance_fields = c.Fields.Where (f =>
 						!f.AccessFlags.HasFlag (FieldAccessFlags.Synthetic) &&
-						!f.AccessFlags.HasFlag (FieldAccessFlags.Static));
-					if (backing is null)
+						!f.AccessFlags.HasFlag (FieldAccessFlags.Static)).ToList ();
+					if (instance_fields.Count != 1)
+						continue;
+					var backing = instance_fields [0];
+					if (!IsJvmPrimitiveDescriptor (backing.Descriptor))
 						continue;
 
 					c.KotlinInlineClassUnderlyingJniType = backing.Descriptor;
@@ -135,16 +148,40 @@ namespace Xamarin.Android.Tools.Bytecode
 		}
 
 		// JNI signature for the Kotlin inline class referenced by `kotlinTypeClassName`,
-		// or null when the name is unknown / not an inline class. The returned form
-		// has a leading `L` and trailing `;` so it matches `ClassFile.FullJniName`
+		// or null when projection should not apply. The returned form has a
+		// leading `L` and trailing `;` so it matches `ClassFile.FullJniName`
 		// and other JNI-signature strings used throughout the pipeline.
-		static string? GetInlineClassJniType (string? kotlinTypeClassName, IDictionary<string, string> inlineClasses)
+		//
+		// `jvmDescriptor` is the *JVM-erased* descriptor of the actual position
+		// (parameter / return / property) we're considering. We only project
+		// when it equals the inline class's underlying primitive: that's the
+		// case where Kotlin truly erased to the primitive and our wrapper
+		// struct's `implicit operator <primitive>` makes JNI marshaling work
+		// transparently. Boxed / nullable / generic positions keep their JVM
+		// reference signature (`L...MyColor;` or `Ljava/lang/Object;`); for
+		// those, projecting to a struct would mismatch JNI marshaling, so we
+		// fall through and let them keep the legacy peer-class binding path.
+		static string? GetInlineClassJniType (string? kotlinTypeClassName, string? jvmDescriptor, IDictionary<string, string> inlineClasses)
 		{
-			if (kotlinTypeClassName is null)
+			if (kotlinTypeClassName is null || jvmDescriptor is null)
 				return null;
-			if (!inlineClasses.ContainsKey (kotlinTypeClassName))
+			if (!inlineClasses.TryGetValue (kotlinTypeClassName, out var underlying))
+				return null;
+			if (jvmDescriptor != underlying)
 				return null;
 			return "L" + kotlinTypeClassName;
+		}
+
+		// Returns true for JVM primitive descriptors (Z/B/C/D/F/I/J/S). Excludes
+		// `V` (void), reference (`L...;`), and array (`[...`) descriptors.
+		static bool IsJvmPrimitiveDescriptor (string? descriptor)
+		{
+			if (descriptor is null || descriptor.Length != 1)
+				return false;
+			return descriptor [0] switch {
+				'Z' or 'B' or 'C' or 'D' or 'F' or 'I' or 'J' or 'S' => true,
+				_ => false,
+			};
 		}
 
 		static void FixupClassVisibility (ClassFile klass, KotlinClass metadata)
@@ -287,18 +324,21 @@ namespace Xamarin.Android.Tools.Bytecode
 				java_p.KotlinType = GetKotlinType (java_p.Type.TypeSignature, kotlin_p.Type.ClassName);
 
 				// Inline-class projection: if the Kotlin source-level type for this
-				// parameter is a `@JvmInline value class` we know about, record its
-				// JNI signature so the generator can later swap the parameter type
-				// for a strongly-typed wrapper struct while keeping JNI marshaling
-				// on the underlying primitive. See dotnet/java-interop#1431 (Phase 2).
-				java_p.KotlinInlineClassJniType = GetInlineClassJniType (kotlin_p.Type.ClassName, inlineClasses);
+				// parameter is a `@JvmInline value class` we know about AND the
+				// JVM-erased parameter descriptor is the inline class's
+				// underlying primitive, record its JNI signature so the
+				// generator can later swap the parameter type for a strongly-
+				// typed wrapper struct while keeping JNI marshaling on the
+				// underlying primitive. Boxed positions are skipped.
+				// See dotnet/java-interop#1431 (Phase 2).
+				java_p.KotlinInlineClassJniType = GetInlineClassJniType (kotlin_p.Type.ClassName, java_p.Type.TypeSignature, inlineClasses);
 			}
 
 			// Handle erasure of Kotlin unsigned types
 			method.KotlinReturnType = GetKotlinType (method.ReturnType.TypeSignature, metadata.ReturnType?.ClassName);
 
 			// Same projection as above, but for the return type.
-			method.KotlinInlineClassReturnJniType = GetInlineClassJniType (metadata.ReturnType?.ClassName, inlineClasses);
+			method.KotlinInlineClassReturnJniType = GetInlineClassJniType (metadata.ReturnType?.ClassName, method.ReturnType.TypeSignature, inlineClasses);
 
 			// Recover the unmangled Kotlin source-level name when the Kotlin
 			// compiler mangled the JVM name for inline-class binary compat
@@ -393,7 +433,7 @@ namespace Xamarin.Android.Tools.Bytecode
 			// Handle erasure of Kotlin unsigned types
 			if (getter != null) {
 				getter.KotlinReturnType = GetKotlinType (getter.ReturnType.TypeSignature, metadata.ReturnType?.ClassName);
-				getter.KotlinInlineClassReturnJniType = GetInlineClassJniType (metadata.ReturnType?.ClassName, inlineClasses);
+				getter.KotlinInlineClassReturnJniType = GetInlineClassJniType (metadata.ReturnType?.ClassName, getter.ReturnType.TypeSignature, inlineClasses);
 			}
 
 			if (setter != null) {
@@ -406,7 +446,7 @@ namespace Xamarin.Android.Tools.Bytecode
 
 				// Handle erasure of Kotlin unsigned types
 				setter_parameter.KotlinType = GetKotlinType (setter_parameter.Type.TypeSignature, metadata.ReturnType?.ClassName);
-				setter_parameter.KotlinInlineClassJniType = GetInlineClassJniType (metadata.ReturnType?.ClassName, inlineClasses);
+				setter_parameter.KotlinInlineClassJniType = GetInlineClassJniType (metadata.ReturnType?.ClassName, setter_parameter.Type.TypeSignature, inlineClasses);
 			}
 		}
 

--- a/src/Xamarin.Android.Tools.Bytecode/Methods.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/Methods.cs
@@ -35,6 +35,14 @@ namespace Xamarin.Android.Tools.Bytecode {
 		public  AttributeCollection Attributes      {get; private set;}
 		public  string?             KotlinReturnType {get; set;}
 
+		// JNI signature of the Kotlin `@JvmInline` class that this method's return
+		// type was originally declared as in Kotlin source, when the JVM-erased
+		// return type is the inline class's underlying primitive. e.g.
+		// `Lcom/example/MyColor;` for a method declared `fun f(): MyColor` whose
+		// JVM signature is `()J`. null when no projection applies.
+		// See dotnet/java-interop#1431 (Phase 2).
+		public  string?             KotlinInlineClassReturnJniType { get; set; }
+
 		public MethodInfo (ConstantPool constantPool, ClassFile declaringType, Stream stream)
 		{
 			ConstantPool    = constantPool;
@@ -377,6 +385,14 @@ namespace Xamarin.Android.Tools.Bytecode {
 		public  int         Position;
 		public  TypeInfo    Type;
 		public  string?     KotlinType;
+
+		// JNI signature of the Kotlin `@JvmInline` class that this parameter was
+		// originally declared as in Kotlin source, when the JVM-erased parameter
+		// type is the inline class's underlying primitive. e.g.
+		// `Lcom/example/MyColor;` for a Kotlin parameter declared `color: MyColor`
+		// whose JVM type is `J`. null when no projection applies.
+		// See dotnet/java-interop#1431 (Phase 2).
+		public  string?     KotlinInlineClassJniType;
 
 		public  MethodParameterAccessFlags      AccessFlags;
 

--- a/src/Xamarin.Android.Tools.Bytecode/Methods.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/Methods.cs
@@ -43,6 +43,15 @@ namespace Xamarin.Android.Tools.Bytecode {
 		// See dotnet/java-interop#1431 (Phase 2).
 		public  string?             KotlinInlineClassReturnJniType { get; set; }
 
+		// Unmangled Kotlin source-level method name when it differs from the
+		// JVM-level `Name`. Populated for methods that the Kotlin compiler
+		// mangles for inline-class binary compatibility (e.g. JVM name
+		// `tint-Rn_QMJI`, Kotlin name `tint`). Surfaced into api.xml as
+		// `managedName` so the generator emits a clean C# overload while the
+		// JVM `Name` stays in `name`/`jni-signature` for native invocation.
+		// See dotnet/java-interop#1431 (Phase 2).
+		public  string?             KotlinName { get; set; }
+
 		public MethodInfo (ConstantPool constantPool, ClassFile declaringType, Stream stream)
 		{
 			ConstantPool    = constantPool;

--- a/src/Xamarin.Android.Tools.Bytecode/XmlClassDeclarationBuilder.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/XmlClassDeclarationBuilder.cs
@@ -356,6 +356,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 				new XAttribute ("deprecated",   GetDeprecatedValue (method.Attributes)),
 				new XAttribute ("final",        (method.AccessFlags & MethodAccessFlags.Final) != 0),
 				new XAttribute ("name",         name),
+				GetManagedName (method),
 				GetNative (method),
 				ret,
 				jniRet,
@@ -371,6 +372,18 @@ namespace Xamarin.Android.Tools.Bytecode {
 				GetTypeParmeters (msig == null ? null : msig.TypeParameters),
 				GetMethodParameters (method),
 				GetExceptions (method));
+		}
+
+		// dotnet/java-interop#1431 (Phase 2): when the Kotlin compiler mangled
+		// the JVM method name for inline-class binary compatibility (e.g.
+		// `tint-Rn_QMJI`), expose the unmangled Kotlin source name via
+		// `managedName` so the generator emits a clean C# overload. The JVM
+		// name remains in `name`/`jni-signature` for JNI invocation.
+		static XAttribute? GetManagedName (MethodInfo method)
+		{
+			if (string.IsNullOrEmpty (method.KotlinName))
+				return null;
+			return new XAttribute ("managedName", method.KotlinName!);
 		}
 
 		// dotnet/java-interop#1431 (Phase 2): when a method's Kotlin source-level

--- a/src/Xamarin.Android.Tools.Bytecode/XmlClassDeclarationBuilder.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/XmlClassDeclarationBuilder.cs
@@ -59,7 +59,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 			if (string.IsNullOrEmpty (underlying))
 				yield break;
 			yield return new XAttribute ("kotlin-inline-class", "true");
-			yield return new XAttribute ("kotlin-inline-class-underlying-jni-type", underlying!);
+			yield return new XAttribute ("kotlin-inline-class-underlying-jni-type", underlying);
 		}
 
 		string GetElementName ()
@@ -383,7 +383,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 		{
 			if (string.IsNullOrEmpty (method.KotlinName))
 				return null;
-			return new XAttribute ("managedName", method.KotlinName!);
+			return new XAttribute ("managedName", method.KotlinName);
 		}
 
 		// dotnet/java-interop#1431 (Phase 2): when a method's Kotlin source-level
@@ -393,7 +393,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 		{
 			if (string.IsNullOrEmpty (method.KotlinInlineClassReturnJniType))
 				return null;
-			return new XAttribute ("kotlin-inline-class-return-jni-type", method.KotlinInlineClassReturnJniType!);
+			return new XAttribute ("kotlin-inline-class-return-jni-type", method.KotlinInlineClassReturnJniType);
 		}
 
 		static XAttribute? GetNative (MethodInfo method)
@@ -464,7 +464,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 		{
 			if (string.IsNullOrEmpty (p.KotlinInlineClassJniType))
 				return null;
-			return new XAttribute ("kotlin-inline-class-jni-type", p.KotlinInlineClassJniType!);
+			return new XAttribute ("kotlin-inline-class-jni-type", p.KotlinInlineClassJniType);
 		}
 
 		IEnumerable<XElement> GetExceptions (MethodInfo method)

--- a/src/Xamarin.Android.Tools.Bytecode/XmlClassDeclarationBuilder.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/XmlClassDeclarationBuilder.cs
@@ -41,12 +41,25 @@ namespace Xamarin.Android.Tools.Bytecode {
 					new XAttribute ("static",                   classFile.IsStatic),
 					new XAttribute ("visibility",               GetVisibility (classFile.Visibility)),
 					GetAnnotatedVisibility (classFile.Visibility, classFile.Attributes),
+					GetKotlinInlineClassAttributes (),
 					GetTypeParmeters (signature == null ? null : signature.TypeParameters),
 					GetImplementedInterfaces (),
 					GetConstructors (),
 					GetMethods (),
 					GetFields ()
 			);
+		}
+
+		// dotnet/java-interop#1431 (Phase 2): when this class is a Kotlin
+		// `@JvmInline value class`, emit two extra attributes that drive
+		// generator-side wrapper-struct emission and parameter/return projection.
+		IEnumerable<XAttribute> GetKotlinInlineClassAttributes ()
+		{
+			var underlying = classFile.KotlinInlineClassUnderlyingJniType;
+			if (string.IsNullOrEmpty (underlying))
+				yield break;
+			yield return new XAttribute ("kotlin-inline-class", "true");
+			yield return new XAttribute ("kotlin-inline-class-underlying-jni-type", underlying!);
 		}
 
 		string GetElementName ()
@@ -346,6 +359,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 				GetNative (method),
 				ret,
 				jniRet,
+				GetKotlinInlineClassReturnJniType (method),
 				new XAttribute ("static",       (method.AccessFlags & MethodAccessFlags.Static) != 0),
 				GetSynchronized (method),
 				new XAttribute ("visibility",   GetVisibility (method.AccessFlags)),
@@ -357,6 +371,16 @@ namespace Xamarin.Android.Tools.Bytecode {
 				GetTypeParmeters (msig == null ? null : msig.TypeParameters),
 				GetMethodParameters (method),
 				GetExceptions (method));
+		}
+
+		// dotnet/java-interop#1431 (Phase 2): when a method's Kotlin source-level
+		// return type was a `@JvmInline value class`, surface that type's JNI
+		// signature so the generator can project the return type to a wrapper struct.
+		static XAttribute? GetKotlinInlineClassReturnJniType (MethodInfo method)
+		{
+			if (string.IsNullOrEmpty (method.KotlinInlineClassReturnJniType))
+				return null;
+			return new XAttribute ("kotlin-inline-class-return-jni-type", method.KotlinInlineClassReturnJniType!);
 		}
 
 		static XAttribute? GetNative (MethodInfo method)
@@ -415,8 +439,19 @@ namespace Xamarin.Android.Tools.Bytecode {
 						new XAttribute ("name", p.Name),
 						new XAttribute ("type",     genericType),
 						new XAttribute ("jni-type", p.Type.TypeSignature ?? p.Type.BinaryName),
+						GetKotlinInlineClassJniType (p),
 						GetNotNull (annotations, i));
 			}
+		}
+
+		// dotnet/java-interop#1431 (Phase 2): when the parameter's Kotlin source-level
+		// type was a `@JvmInline value class`, surface that type's JNI signature so
+		// the generator can project the parameter to a strongly-typed wrapper struct.
+		static XAttribute? GetKotlinInlineClassJniType (ParameterInfo p)
+		{
+			if (string.IsNullOrEmpty (p.KotlinInlineClassJniType))
+				return null;
+			return new XAttribute ("kotlin-inline-class-jni-type", p.KotlinInlineClassJniType!);
 		}
 
 		IEnumerable<XElement> GetExceptions (MethodInfo method)

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/KotlinInlineClassCollisionTests.cs
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/KotlinInlineClassCollisionTests.cs
@@ -149,6 +149,30 @@ namespace Xamarin.Android.Tools.BytecodeTests
 				$"All `pad` overloads return MyDp; got: [{string.Join (", ", pads.Select (m => m.KotlinInlineClassReturnJniType ?? "<null>"))}]");
 		}
 
+		// dotnet/java-interop#1431 (Phase 2): KotlinFixups.FixupProperty must also
+		// stamp inline-class JNI types on property getter return values and setter
+		// parameters, not just on function parameters/returns.
+		[Test]
+		public void Fixup_StampsPropertyInlineClassJniType ()
+		{
+			var classes = LoadInlineClassFixture ();
+			KotlinFixups.Fixup (classes);
+
+			var widgets = classes.Single (c => c.ThisClass.Name.Value == "xat/bytecode/tests/Widgets");
+
+			// `var tintColor: MyColor` emits a mangled getter/setter pair —
+			// the property finder must look past the inline-class mangled name
+			// suffix (`-<hash>`) AND past the erased primitive return/parameter
+			// to bind these to the Kotlin property.
+			var getter = widgets.Methods.Single (m => m.Name.StartsWith ("getTintColor-", StringComparison.Ordinal));
+			var setter = widgets.Methods.Single (m => m.Name.StartsWith ("setTintColor-", StringComparison.Ordinal));
+
+			Assert.AreEqual ("Lxat/bytecode/tests/MyColor;", getter.KotlinInlineClassReturnJniType,
+				"Inline-class typed property getter must be stamped with the wrapper's JNI signature.");
+			Assert.AreEqual ("Lxat/bytecode/tests/MyColor;", setter.GetParameters ().Single ().KotlinInlineClassJniType,
+				"Inline-class typed property setter parameter must be stamped with the wrapper's JNI signature.");
+		}
+
 		// dotnet/java-interop#1431 (Phase 2): the new fields must round-trip
 		// through XmlClassDeclarationBuilder onto the api.xml that the generator
 		// consumes.

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/KotlinInlineClassCollisionTests.cs
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/KotlinInlineClassCollisionTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using Xamarin.Android.Tools.Bytecode;
@@ -66,5 +67,117 @@ namespace Xamarin.Android.Tools.BytecodeTests
 
 			Assert.Contains ("Lkotlin/jvm/JvmInline;", annotations);
 		}
+
+		// dotnet/java-interop#1431 (Phase 2): KotlinFixups must surface the inline
+		// class's underlying primitive on each `@JvmInline value class` ClassFile so
+		// the generator can later emit a strongly-typed wrapper struct.
+		[Test]
+		public void Fixup_StampsKotlinInlineClassUnderlyingJniType ()
+		{
+			var classes = LoadInlineClassFixture ();
+
+			KotlinFixups.Fixup (classes);
+
+			var byName = classes.ToDictionary (c => c.ThisClass.Name.Value);
+
+			// MyColor and MyAlpha are both ULong-backed -> JNI primitive `J`.
+			Assert.AreEqual ("J", byName ["xat/bytecode/tests/MyColor"].KotlinInlineClassUnderlyingJniType);
+			Assert.AreEqual ("J", byName ["xat/bytecode/tests/MyAlpha"].KotlinInlineClassUnderlyingJniType);
+
+			// MyDp is Float-backed -> JNI primitive `F`.
+			Assert.AreEqual ("F", byName ["xat/bytecode/tests/MyDp"].KotlinInlineClassUnderlyingJniType);
+
+			// Non-inline classes must NOT be stamped.
+			Assert.IsNull (byName ["xat/bytecode/tests/Widgets"].KotlinInlineClassUnderlyingJniType);
+		}
+
+		// dotnet/java-interop#1431 (Phase 2): for every Kotlin function whose
+		// source-level parameter type is a known inline class, KotlinFixups must
+		// stamp the `KotlinInlineClassJniType` on that parameter so the generator
+		// can swap the parameter's symbol for a wrapper-struct projection while
+		// keeping JNI marshaling on the underlying primitive.
+		[Test]
+		public void Fixup_StampsParameterInlineClassJniType ()
+		{
+			var classes = LoadInlineClassFixture ();
+			KotlinFixups.Fixup (classes);
+
+			var widgets = classes.Single (c => c.ThisClass.Name.Value == "xat/bytecode/tests/Widgets");
+
+			var tints = widgets.Methods
+				.Where (m => m.Name.StartsWith ("tint-", StringComparison.Ordinal))
+				.ToList ();
+
+			// Each tint() should have exactly one parameter, and that parameter
+			// should be stamped with the JNI signature of the inline class it
+			// originally came from in Kotlin source.
+			var stampedJniTypes = tints
+				.Select (m => m.GetParameters ().Single ().KotlinInlineClassJniType)
+				.Where (j => !string.IsNullOrEmpty (j))
+				.OrderBy (j => j, StringComparer.Ordinal)
+				.ToList ();
+
+			CollectionAssert.AreEquivalent (
+				new [] {
+					"Lxat/bytecode/tests/MyAlpha;",
+					"Lxat/bytecode/tests/MyColor;",
+					"Lxat/bytecode/tests/MyDp;",
+				},
+				stampedJniTypes,
+				"Each tint(<inline class>) parameter must be stamped with its inline-class JNI signature.");
+		}
+
+		// dotnet/java-interop#1431 (Phase 2): when a method's Kotlin-source-level
+		// return type is a `@JvmInline value class`, KotlinFixups must stamp the
+		// method's `KotlinInlineClassReturnJniType` so the generator can project
+		// the return type to the wrapper struct.
+		[Test]
+		public void Fixup_StampsReturnInlineClassJniType ()
+		{
+			var classes = LoadInlineClassFixture ();
+			KotlinFixups.Fixup (classes);
+
+			var widgets = classes.Single (c => c.ThisClass.Name.Value == "xat/bytecode/tests/Widgets");
+
+			var pads = widgets.Methods
+				.Where (m => m.Name.StartsWith ("pad-", StringComparison.Ordinal))
+				.ToList ();
+
+			Assert.IsTrue (pads.Count > 0, "Expected `pad` overloads in fixture.");
+			Assert.IsTrue (
+				pads.All (m => m.KotlinInlineClassReturnJniType == "Lxat/bytecode/tests/MyDp;"),
+				$"All `pad` overloads return MyDp; got: [{string.Join (", ", pads.Select (m => m.KotlinInlineClassReturnJniType ?? "<null>"))}]");
+		}
+
+		// dotnet/java-interop#1431 (Phase 2): the new fields must round-trip
+		// through XmlClassDeclarationBuilder onto the api.xml that the generator
+		// consumes.
+		[Test]
+		public void XmlOutput_ContainsKotlinInlineClassAttributes ()
+		{
+			var classes = LoadInlineClassFixture ();
+			KotlinFixups.Fixup (classes);
+
+			var classPath = new ClassPath { ApiSource = "class-parse" };
+			foreach (var c in classes)
+				classPath.Add (c);
+
+			var sw = new System.IO.StringWriter ();
+			classPath.SaveXmlDescription (sw);
+			var xml = sw.ToString ();
+
+			StringAssert.Contains ("kotlin-inline-class=\"true\"", xml);
+			StringAssert.Contains ("kotlin-inline-class-underlying-jni-type=\"J\"", xml);
+			StringAssert.Contains ("kotlin-inline-class-underlying-jni-type=\"F\"", xml);
+			StringAssert.Contains ("kotlin-inline-class-jni-type=\"Lxat/bytecode/tests/MyColor;\"", xml);
+			StringAssert.Contains ("kotlin-inline-class-return-jni-type=\"Lxat/bytecode/tests/MyDp;\"", xml);
+		}
+
+		static List<ClassFile> LoadInlineClassFixture () => new List<ClassFile> {
+			LoadClassFile ("MyColor.class"),
+			LoadClassFile ("MyAlpha.class"),
+			LoadClassFile ("MyDp.class"),
+			LoadClassFile ("Widgets.class"),
+		};
 	}
 }

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj
@@ -58,5 +58,6 @@
   </ItemGroup>
 
   <Import Project="Xamarin.Android.Tools.Bytecode-Tests.targets" />
+  <Import Project="kotlin-gradle.targets" />
 
 </Project>

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.targets
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.targets
@@ -5,11 +5,6 @@
     <TestJarNoParameters Include="java/**/*NoParameters.java" />
     <TestJar Include="java\**\*.java" Exclude="@(TestJarNoParameters);java\android\annotation\NonNull.java;" />
     <TestKotlinJar Include="kotlin\**\*.kt" />
-    <TestKotlinGradleSource Include="kotlin-gradle\src\**\*.kt;kotlin-gradle\*.gradle.kts" />
-    <TestKotlinGradleOutput Include="kotlin-gradle\classes\xat\bytecode\tests\Widgets.class" />
-    <TestKotlinGradleOutput Include="kotlin-gradle\classes\xat\bytecode\tests\MyColor.class" />
-    <TestKotlinGradleOutput Include="kotlin-gradle\classes\xat\bytecode\tests\MyAlpha.class" />
-    <TestKotlinGradleOutput Include="kotlin-gradle\classes\xat\bytecode\tests\MyDp.class" />
   </ItemGroup>
 
   <ItemGroup>
@@ -40,23 +35,10 @@
   </Target>
 
   <!--
-      Build the real Kotlin/Gradle fixture in kotlin-gradle\ using the shared
-      Gradle wrapper from build-tools/gradle. Unlike BuildKotlinClasses above,
-      this is run unconditionally (a JDK is already required for BuildClasses),
-      so the .class files do not need to be committed. The wrapper downloads
-      Gradle + Kotlin on first run.
+      Build the real Kotlin/Gradle fixture in kotlin-gradle\. The shared
+      target file is also imported by generator-Tests, which embeds the
+      same .class files.
   -->
-  <PropertyGroup>
-    <_KotlinGradleProjectDir>$(MSBuildThisFileDirectory)kotlin-gradle</_KotlinGradleProjectDir>
-  </PropertyGroup>
-
-  <Target Name="BuildKotlinGradleProject"
-        BeforeTargets="BeforeCompile"
-        Inputs="@(TestKotlinGradleSource)"
-        Outputs="@(TestKotlinGradleOutput)">
-    <Exec Command="&quot;$(GradleWPath)&quot; $(GradleArgs) -p &quot;$(_KotlinGradleProjectDir)&quot; classes"
-          EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);APP_HOME=$(GradleHome)" />
-  </Target>
 
   <Target Name="BuildJar"
       AfterTargets="BuildClasses"

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.targets
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.targets
@@ -10,7 +10,6 @@
     <TestKotlinGradleOutput Include="kotlin-gradle\classes\xat\bytecode\tests\MyColor.class" />
     <TestKotlinGradleOutput Include="kotlin-gradle\classes\xat\bytecode\tests\MyAlpha.class" />
     <TestKotlinGradleOutput Include="kotlin-gradle\classes\xat\bytecode\tests\MyDp.class" />
-    <TestKotlinGradleOutput Include="kotlin-gradle\classes\xat\bytecode\tests\InlineClassCollisionsKt.class" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/kotlin-gradle.targets
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/kotlin-gradle.targets
@@ -1,0 +1,36 @@
+<Project>
+
+  <!--
+      Shared MSBuild target for compiling the real Kotlin/Gradle fixture in
+      tests/Xamarin.Android.Tools.Bytecode-Tests/kotlin-gradle/ using the shared
+      Gradle wrapper from build-tools/gradle. The wrapper downloads Gradle +
+      Kotlin on first run, so the resulting .class files do not need to be
+      committed to source control.
+
+      This file is imported by any test project that embeds the resulting
+      .class files as resources (Bytecode-Tests and generator-Tests), so the
+      Gradle build always runs before BeforeCompile regardless of which
+      project triggers it.
+  -->
+
+  <ItemGroup>
+    <TestKotlinGradleSource Include="$(MSBuildThisFileDirectory)kotlin-gradle\src\**\*.kt;$(MSBuildThisFileDirectory)kotlin-gradle\*.gradle.kts" />
+    <TestKotlinGradleOutput Include="$(MSBuildThisFileDirectory)kotlin-gradle\classes\xat\bytecode\tests\Widgets.class" />
+    <TestKotlinGradleOutput Include="$(MSBuildThisFileDirectory)kotlin-gradle\classes\xat\bytecode\tests\MyColor.class" />
+    <TestKotlinGradleOutput Include="$(MSBuildThisFileDirectory)kotlin-gradle\classes\xat\bytecode\tests\MyAlpha.class" />
+    <TestKotlinGradleOutput Include="$(MSBuildThisFileDirectory)kotlin-gradle\classes\xat\bytecode\tests\MyDp.class" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <_KotlinGradleProjectDir>$(MSBuildThisFileDirectory)kotlin-gradle</_KotlinGradleProjectDir>
+  </PropertyGroup>
+
+  <Target Name="BuildKotlinGradleProject"
+        BeforeTargets="BeforeCompile"
+        Inputs="@(TestKotlinGradleSource)"
+        Outputs="@(TestKotlinGradleOutput)">
+    <Exec Command="&quot;$(GradleWPath)&quot; $(GradleArgs) -p &quot;$(_KotlinGradleProjectDir)&quot; classes"
+          EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);APP_HOME=$(GradleHome)" />
+  </Target>
+
+</Project>

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/kotlin-gradle/src/main/kotlin/InlineClassCollisions.kt
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/kotlin-gradle/src/main/kotlin/InlineClassCollisions.kt
@@ -31,4 +31,11 @@ object Widgets {
     // A non-colliding pair: different arity, both hash-mangled.
     fun pad(dp: MyDp): MyDp = dp
     fun pad(dp1: MyDp, dp2: MyDp): MyDp = dp1
+
+    // dotnet/java-interop#1431 (Phase 2): a mutable property typed as an
+    // inline class exercises the KotlinFixups.FixupProperty path — the
+    // getter's KotlinInlineClassReturnJniType and the setter's parameter
+    // KotlinInlineClassJniType must both be stamped so the generator emits
+    // `public static MyColor TintColor { get; set; }` instead of long.
+    var tintColor: MyColor = MyColor(0u)
 }

--- a/tests/generator-Tests/Unit-Tests/KotlinInlineClassEndToEndTests.cs
+++ b/tests/generator-Tests/Unit-Tests/KotlinInlineClassEndToEndTests.cs
@@ -58,6 +58,12 @@ namespace generatortests
 			StringAssert.Contains ("Xat.Bytecode.Tests.MyDp Pad (Xat.Bytecode.Tests.MyDp dp)", output);
 			StringAssert.Contains ("Xat.Bytecode.Tests.MyDp Pad (Xat.Bytecode.Tests.MyDp dp1, Xat.Bytecode.Tests.MyDp dp2)", output);
 
+			// Widgets.tintColor: MyColor -> a Kotlin `var` typed as an inline
+			// class projects as a C# property typed as the wrapper struct, with
+			// the getter/setter still marshaling the underlying primitive (long)
+			// across JNI. This exercises the KotlinFixups.FixupProperty path.
+			StringAssert.Contains ("Xat.Bytecode.Tests.MyColor TintColor", output);
+
 			// And the JVM-mangled hash-suffix names must NOT leak into the
 			// generated C# (regression guard for the unmangling path).
 			StringAssert.DoesNotContain ("Tint_", output);

--- a/tests/generator-Tests/Unit-Tests/KotlinInlineClassEndToEndTests.cs
+++ b/tests/generator-Tests/Unit-Tests/KotlinInlineClassEndToEndTests.cs
@@ -1,0 +1,152 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Xml.Linq;
+using Java.Interop.Tools.Generator;
+using MonoDroid.Generation;
+using NUnit.Framework;
+using Xamarin.Android.Binder;
+using Xamarin.Android.Tools.Bytecode;
+
+namespace generatortests
+{
+	// dotnet/java-interop#1431 (Phase 2): end-to-end test that drives real
+	// Kotlin .class files (compiled by tests/Xamarin.Android.Tools.Bytecode-Tests/
+	// kotlin-gradle/) through KotlinFixups -> XmlClassDeclarationBuilder ->
+	// XmlApiImporter -> JavaInteropCodeGenerator and asserts the projected C#
+	// output uses the generated `readonly partial struct` wrapper types in
+	// method signatures while keeping the JNI marshaling on the underlying
+	// primitive.
+	[TestFixture]
+	public class KotlinInlineClassEndToEndTests
+	{
+		[Test]
+		public void GeneratorProjectsRealKotlinInlineClassesAsStructs ()
+		{
+			var apiXml = BuildApiXmlFromKotlinFixture ();
+
+			// Sanity: api.xml carries the Phase 2 attributes class-parse emits.
+			StringAssert.Contains ("kotlin-inline-class=\"true\"", apiXml);
+			StringAssert.Contains ("kotlin-inline-class-jni-type=\"Lxat/bytecode/tests/MyColor;\"", apiXml);
+			StringAssert.Contains ("kotlin-inline-class-return-jni-type=\"Lxat/bytecode/tests/MyDp;\"", apiXml);
+
+			var output = GenerateCSharp (apiXml, out var gens);
+
+			// MyColor / MyAlpha / MyDp must be projected as readonly partial structs.
+			StringAssert.Contains ("readonly partial struct MyColor", output);
+			StringAssert.Contains ("readonly partial struct MyAlpha", output);
+			StringAssert.Contains ("readonly partial struct MyDp", output);
+
+			// Underlying-primitive marshaling: MyColor/MyAlpha back J (long),
+			// MyDp backs F (float).
+			StringAssert.Contains ("public static implicit operator long (MyColor", output);
+			StringAssert.Contains ("public static implicit operator MyColor (long", output);
+			StringAssert.Contains ("public static implicit operator float (MyDp", output);
+			StringAssert.Contains ("public static implicit operator MyDp (float", output);
+
+			// Widgets.tint(MyColor) / tint(MyAlpha) / tint(MyDp) overloads must
+			// project the inline-class param in the C# signature. Phase 1
+			// (#1432) appends a JVM-name-mangle hash suffix to disambiguate.
+			StringAssert.Contains ("Tint_Rn_QMJI (Xat.Bytecode.Tests.MyColor color)", output);
+			StringAssert.Contains ("Tint_uzYZ1wI (Xat.Bytecode.Tests.MyAlpha alpha)", output);
+			StringAssert.Contains ("Tint_L3D9Hvg (Xat.Bytecode.Tests.MyDp dp)", output);
+
+			// Widgets.pad(MyDp): MyDp -> the return type uses MyDp.
+			StringAssert.Contains ("Xat.Bytecode.Tests.MyDp Pad_D3yWXm0 (Xat.Bytecode.Tests.MyDp dp)", output);
+			StringAssert.Contains ("Xat.Bytecode.Tests.MyDp Pad_Puo4k8A (Xat.Bytecode.Tests.MyDp dp1, Xat.Bytecode.Tests.MyDp dp2)", output);
+
+			// And no `Java.Lang.Object`-derived peer class for the inline classes
+			// (the wrapper struct fully replaces the peer-class binding).
+			StringAssert.DoesNotContain ("public partial class MyColor", output);
+			StringAssert.DoesNotContain ("public partial class MyAlpha", output);
+			StringAssert.DoesNotContain ("public partial class MyDp", output);
+
+			// All three inline classes survived as ClassGen entries with the
+			// IsKotlinInlineClass flag set.
+			Assert.IsTrue (gens.OfType<ClassGen> ().Count (g => g.IsKotlinInlineClass) >= 3,
+				$"Expected at least 3 inline-class ClassGens, generator output was:\n{output}");
+		}
+
+		// Run the four kotlin-gradle .class files through KotlinFixups and
+		// XmlClassDeclarationBuilder to produce the same api.xml the generator
+		// would normally consume off disk.
+		static string BuildApiXmlFromKotlinFixture ()
+		{
+			var classes = new List<ClassFile> {
+				LoadClassFile ("MyColor.class"),
+				LoadClassFile ("MyAlpha.class"),
+				LoadClassFile ("MyDp.class"),
+				LoadClassFile ("Widgets.class"),
+			};
+			KotlinFixups.Fixup (classes);
+
+			var classPath = new ClassPath { ApiSource = "class-parse" };
+			foreach (var c in classes)
+				classPath.Add (c);
+
+			var sw = new StringWriter ();
+			classPath.SaveXmlDescription (sw);
+			var xml = sw.ToString ();
+
+			// XmlApiImporter needs java.lang.Object in the symbol table so the
+			// generated peer types (and their RetVal/Parameter symbols) resolve
+			// during Validate. Splice a minimal stub package into the api root.
+			var doc = XDocument.Parse (xml);
+			doc.Root.AddFirst (XElement.Parse (
+				"<package name='java.lang' jni-name='java/lang'>" +
+				"<class abstract='false' deprecated='not deprecated' final='false' name='Object' static='false' visibility='public' jni-signature='Ljava/lang/Object;' />" +
+				"</package>"));
+			return doc.ToString ();
+		}
+
+		static ClassFile LoadClassFile (string resource)
+		{
+			var assembly = typeof (KotlinInlineClassEndToEndTests).Assembly;
+			var name = assembly.GetManifestResourceNames ()
+				.FirstOrDefault (n => n.EndsWith ("." + resource, System.StringComparison.OrdinalIgnoreCase))
+				?? throw new FileNotFoundException ($"Embedded resource '{resource}' not found.");
+			using (var stream = assembly.GetManifestResourceStream (name))
+				return new ClassFile (stream);
+		}
+
+		// Drive the parsed api.xml through XmlApiImporter + Validate + the
+		// JavaInteropCodeGenerator to produce the C# binding text.
+		static string GenerateCSharp (string apiXml, out List<GenBase> gens)
+		{
+			var options = new CodeGenerationOptions {
+				CodeGenerationTarget = CodeGenerationTarget.JavaInterop1,
+			};
+			var sb = new System.Text.StringBuilder ();
+			var writer = new StringWriter (sb);
+			var generator = options.CreateCodeGenerator (writer);
+
+			var doc = XDocument.Parse (apiXml);
+			gens = XmlApiImporter.Parse (doc, options);
+
+			foreach (var gen in gens)
+				options.SymbolTable.AddType (gen);
+
+			foreach (var gen in gens)
+				gen.FixupAccessModifiers (options);
+
+			foreach (var gen in gens)
+				gen.Validate (options, new GenericParameterDefinitionList (), generator.Context);
+
+			foreach (var gen in gens)
+				gen.FillProperties ();
+
+			foreach (var gen in gens)
+				gen.FixupMethodOverrides (options);
+
+			var info = new GenerationInfo ("", "", "MyAssembly");
+			foreach (var gen in gens) {
+				generator.Context.ContextTypes.Push (gen);
+				generator.WriteType (gen, string.Empty, info);
+				generator.Context.ContextTypes.Pop ();
+			}
+
+			return sb.ToString ();
+		}
+	}
+}

--- a/tests/generator-Tests/Unit-Tests/KotlinInlineClassEndToEndTests.cs
+++ b/tests/generator-Tests/Unit-Tests/KotlinInlineClassEndToEndTests.cs
@@ -46,15 +46,22 @@ namespace generatortests
 			StringAssert.Contains ("public static implicit operator MyDp (float", output);
 
 			// Widgets.tint(MyColor) / tint(MyAlpha) / tint(MyDp) overloads must
-			// project the inline-class param in the C# signature. Phase 1
-			// (#1432) appends a JVM-name-mangle hash suffix to disambiguate.
-			StringAssert.Contains ("Tint_Rn_QMJI (Xat.Bytecode.Tests.MyColor color)", output);
-			StringAssert.Contains ("Tint_uzYZ1wI (Xat.Bytecode.Tests.MyAlpha alpha)", output);
-			StringAssert.Contains ("Tint_L3D9Hvg (Xat.Bytecode.Tests.MyDp dp)", output);
+			// project the inline-class param in the C# signature. The Kotlin
+			// compiler mangles the JVM names for inline-class binary compat
+			// (e.g. `tint-Rn_QMJI`); we recover the unmangled name so they
+			// emit as plain C# overloads distinguished by struct type.
+			StringAssert.Contains ("Tint (Xat.Bytecode.Tests.MyColor color)", output);
+			StringAssert.Contains ("Tint (Xat.Bytecode.Tests.MyAlpha alpha)", output);
+			StringAssert.Contains ("Tint (Xat.Bytecode.Tests.MyDp dp)", output);
 
 			// Widgets.pad(MyDp): MyDp -> the return type uses MyDp.
-			StringAssert.Contains ("Xat.Bytecode.Tests.MyDp Pad_D3yWXm0 (Xat.Bytecode.Tests.MyDp dp)", output);
-			StringAssert.Contains ("Xat.Bytecode.Tests.MyDp Pad_Puo4k8A (Xat.Bytecode.Tests.MyDp dp1, Xat.Bytecode.Tests.MyDp dp2)", output);
+			StringAssert.Contains ("Xat.Bytecode.Tests.MyDp Pad (Xat.Bytecode.Tests.MyDp dp)", output);
+			StringAssert.Contains ("Xat.Bytecode.Tests.MyDp Pad (Xat.Bytecode.Tests.MyDp dp1, Xat.Bytecode.Tests.MyDp dp2)", output);
+
+			// And the JVM-mangled hash-suffix names must NOT leak into the
+			// generated C# (regression guard for the unmangling path).
+			StringAssert.DoesNotContain ("Tint_", output);
+			StringAssert.DoesNotContain ("Pad_", output);
 
 			// And no `Java.Lang.Object`-derived peer class for the inline classes
 			// (the wrapper struct fully replaces the peer-class binding).

--- a/tests/generator-Tests/Unit-Tests/KotlinInlineClassEndToEndTests.cs
+++ b/tests/generator-Tests/Unit-Tests/KotlinInlineClassEndToEndTests.cs
@@ -86,7 +86,7 @@ namespace generatortests
 				LoadClassFile ("MyDp.class"),
 				LoadClassFile ("Widgets.class"),
 			};
-			KotlinFixups.Fixup (classes);
+			Xamarin.Android.Tools.Bytecode.KotlinFixups.Fixup (classes);
 
 			var classPath = new ClassPath { ApiSource = "class-parse" };
 			foreach (var c in classes)
@@ -136,6 +136,14 @@ namespace generatortests
 
 			foreach (var gen in gens)
 				gen.FixupAccessModifiers (options);
+
+			// dotnet/java-interop#1431 (Phase 2): match the real CodeGenerator
+			// pipeline (see CodeGenerator.cs line 209), which runs
+			// Java.Interop.Tools.Generator.Transformation.KotlinFixups.Fixup
+			// (including RemoveCollidingSiblings) before Validate. Without
+			// this, the test would mask the interaction between Phase 1's
+			// mangled-name dedup and Phase 2's inline-class projection.
+			Java.Interop.Tools.Generator.Transformation.KotlinFixups.Fixup (gens);
 
 			foreach (var gen in gens)
 				gen.Validate (options, new GenericParameterDefinitionList (), generator.Context);

--- a/tests/generator-Tests/Unit-Tests/KotlinInlineClassTests.cs
+++ b/tests/generator-Tests/Unit-Tests/KotlinInlineClassTests.cs
@@ -1,0 +1,101 @@
+using System.Linq;
+using System.Xml.Linq;
+using Java.Interop.Tools.Generator;
+using MonoDroid.Generation;
+using NUnit.Framework;
+
+namespace generatortests
+{
+	[TestFixture]
+	public class KotlinInlineClassTests
+	{
+		CodeGenerationOptions opt = new CodeGenerationOptions ();
+
+		[Test]
+		public void CreateClass_ReadsKotlinInlineClassAttributes ()
+		{
+			var xml = XDocument.Parse (
+				"<package name='com.example' jni-name='com/example'>" +
+				"<class name='MyColor' kotlin-inline-class='true' kotlin-inline-class-underlying-jni-type='J' />" +
+				"</package>");
+
+			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), opt);
+
+			Assert.IsTrue (klass.IsKotlinInlineClass);
+			Assert.AreEqual ("J", klass.KotlinInlineClassUnderlyingJniType);
+		}
+
+		[Test]
+		public void CreateClass_DefaultsForNonInlineClass ()
+		{
+			var xml = XDocument.Parse (
+				"<package name='com.example' jni-name='com/example'>" +
+				"<class name='Plain' />" +
+				"</package>");
+
+			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), opt);
+
+			Assert.IsFalse (klass.IsKotlinInlineClass);
+		}
+
+		[Test]
+		public void CreateParameter_ReadsKotlinInlineClassJniType ()
+		{
+			var xml = XDocument.Parse (
+				"<parameter name='c' type='long' jni-type='J' kotlin-inline-class-jni-type='Lcom/example/MyColor;' />");
+
+			var p = XmlApiImporter.CreateParameter (xml.Root, opt);
+
+			Assert.AreEqual ("Lcom/example/MyColor;", p.KotlinInlineClassJniType);
+		}
+
+		[Test]
+		public void CreateMethod_ReadsKotlinInlineClassReturnJniType ()
+		{
+			var xml = XDocument.Parse (
+				"<package name='com.example' jni-name='com/example'>" +
+				"<class name='Widgets'>" +
+				"<method name='pad' return='long' jni-return='J' static='true' final='false' " +
+				"kotlin-inline-class-return-jni-type='Lcom/example/MyDp;' />" +
+				"</class></package>");
+
+			var pkg = xml.Root;
+			var classElem = pkg.Element ("class");
+			var klass = XmlApiImporter.CreateClass (pkg, classElem, opt);
+			var method = klass.Methods.First ();
+
+			Assert.AreEqual ("Lcom/example/MyDp;", method.KotlinInlineClassReturnJniType);
+		}
+
+		[Test]
+		public void Parameter_Clone_PreservesKotlinInlineClassJniType ()
+		{
+			var xml = XDocument.Parse (
+				"<parameter name='c' type='long' jni-type='J' kotlin-inline-class-jni-type='Lcom/example/MyColor;' />");
+
+			var p = XmlApiImporter.CreateParameter (xml.Root, opt);
+			var clone = p.Clone ();
+
+			Assert.AreEqual ("Lcom/example/MyColor;", clone.KotlinInlineClassJniType);
+		}
+
+		[Test]
+		public void TypeNameUtilities_JniSignatureToJavaTypeName_HandlesReferenceTypes ()
+		{
+			Assert.AreEqual ("com.example.MyColor",
+				TypeNameUtilities.JniSignatureToJavaTypeName ("Lcom/example/MyColor;"));
+			Assert.AreEqual ("java.lang.String",
+				TypeNameUtilities.JniSignatureToJavaTypeName ("Ljava/lang/String;"));
+		}
+
+		[Test]
+		public void TypeNameUtilities_JniSignatureToJavaTypeName_RejectsPrimitivesAndArrays ()
+		{
+			Assert.IsNull (TypeNameUtilities.JniSignatureToJavaTypeName ("J"));
+			Assert.IsNull (TypeNameUtilities.JniSignatureToJavaTypeName (""));
+			Assert.IsNull (TypeNameUtilities.JniSignatureToJavaTypeName (null));
+			// Array types intentionally not supported by inline-class projection.
+			Assert.IsNull (TypeNameUtilities.JniSignatureToJavaTypeName ("[Lcom/example/MyColor;"));
+		}
+	}
+}

--- a/tests/generator-Tests/generator-Tests.csproj
+++ b/tests/generator-Tests/generator-Tests.csproj
@@ -40,6 +40,8 @@
     <EmbeddedResource Include="..\Xamarin.Android.Tools.Bytecode-Tests\kotlin-gradle\classes\xat\bytecode\tests\Widgets.class" Link="kotlin-gradle\Widgets.class" LogicalName="generatortests.kotlin-gradle.Widgets.class" />
   </ItemGroup>
 
+  <Import Project="..\Xamarin.Android.Tools.Bytecode-Tests\kotlin-gradle.targets" />
+
   <ItemGroup>
     <Compile Remove="expected\**\*" />
     <Compile Remove="expected.ji\**\*" />

--- a/tests/generator-Tests/generator-Tests.csproj
+++ b/tests/generator-Tests/generator-Tests.csproj
@@ -26,6 +26,18 @@
     <ProjectReference Include="..\..\tools\generator\generator.csproj" />
     <ProjectReference Include="..\..\src\Java.Interop.Tools.JavaCallableWrappers\Java.Interop.Tools.JavaCallableWrappers.csproj" />
     <ProjectReference Include="..\..\src\Xamarin.Android.Tools.ApiXmlAdjuster\Xamarin.Android.Tools.ApiXmlAdjuster.csproj" />
+    <ProjectReference Include="..\..\src\Xamarin.Android.Tools.Bytecode\Xamarin.Android.Tools.Bytecode.csproj" />
+  </ItemGroup>
+
+  <!-- Reuse the real Kotlin .class files compiled by the kotlin-gradle/ fixture
+       under tests/Xamarin.Android.Tools.Bytecode-Tests/ so we can exercise the
+       full class-parse -> XmlApiImporter -> generator pipeline against actual
+       Kotlin @JvmInline value classes (dotnet/java-interop#1431, Phase 2). -->
+  <ItemGroup>
+    <EmbeddedResource Include="..\Xamarin.Android.Tools.Bytecode-Tests\kotlin-gradle\classes\xat\bytecode\tests\MyColor.class" Link="kotlin-gradle\MyColor.class" LogicalName="generatortests.kotlin-gradle.MyColor.class" />
+    <EmbeddedResource Include="..\Xamarin.Android.Tools.Bytecode-Tests\kotlin-gradle\classes\xat\bytecode\tests\MyAlpha.class" Link="kotlin-gradle\MyAlpha.class" LogicalName="generatortests.kotlin-gradle.MyAlpha.class" />
+    <EmbeddedResource Include="..\Xamarin.Android.Tools.Bytecode-Tests\kotlin-gradle\classes\xat\bytecode\tests\MyDp.class" Link="kotlin-gradle\MyDp.class" LogicalName="generatortests.kotlin-gradle.MyDp.class" />
+    <EmbeddedResource Include="..\Xamarin.Android.Tools.Bytecode-Tests\kotlin-gradle\classes\xat\bytecode\tests\Widgets.class" Link="kotlin-gradle\Widgets.class" LogicalName="generatortests.kotlin-gradle.Widgets.class" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/JavaInteropCodeGenerator.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/JavaInteropCodeGenerator.cs
@@ -42,11 +42,12 @@ namespace MonoDroid.Generation
 
 			if (gen is InterfaceGen iface)
 				type_writer = new BoundInterface (iface, opt, Context, gen_info);
-			else if (gen is ClassGen klass && klass.IsKotlinInlineClass)
-				type_writer = new KotlinInlineClassStruct (klass, opt);
-			else if (gen is ClassGen klass2)
-				type_writer = new BoundClass (klass2, opt, Context, gen_info);
-			else
+			else if (gen is ClassGen klass) {
+				if (klass.IsKotlinInlineClass)
+					type_writer = new KotlinInlineClassStruct (klass, opt);
+				else
+					type_writer = new BoundClass (klass, opt, Context, gen_info);
+			} else
 				throw new InvalidOperationException ("Unknown GenBase type");
 
 			// We do this here because we only want to check for top-level types,

--- a/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/JavaInteropCodeGenerator.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.CodeGeneration/JavaInteropCodeGenerator.cs
@@ -42,8 +42,10 @@ namespace MonoDroid.Generation
 
 			if (gen is InterfaceGen iface)
 				type_writer = new BoundInterface (iface, opt, Context, gen_info);
-			else if (gen is ClassGen klass)
-				type_writer = new BoundClass (klass, opt, Context, gen_info);
+			else if (gen is ClassGen klass && klass.IsKotlinInlineClass)
+				type_writer = new KotlinInlineClassStruct (klass, opt);
+			else if (gen is ClassGen klass2)
+				type_writer = new BoundClass (klass2, opt, Context, gen_info);
 			else
 				throw new InvalidOperationException ("Unknown GenBase type");
 

--- a/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
@@ -110,6 +110,8 @@ namespace MonoDroid.Generation
 				FromXml = true,
 				IsAbstract = elem.XGetAttribute ("abstract") == "true",
 				IsFinal = elem.XGetAttribute ("final") == "true",
+				IsKotlinInlineClass = elem.XGetAttribute ("kotlin-inline-class") == "true",
+				KotlinInlineClassUnderlyingJniType = elem.XGetAttribute ("kotlin-inline-class-underlying-jni-type"),
 				PeerConstructorPartialMethod = elem.XGetAttribute ("peerConstructorPartialMethod"),
 				// Only use an explicitly set XML attribute
 				Unnest = elem.XGetAttribute ("unnest") == "true" ? true :
@@ -390,6 +392,7 @@ namespace MonoDroid.Generation
 				JavaName = elem.XGetAttribute ("name"),
 				ManagedOverride = elem.XGetAttribute ("managedOverride"),
 				ManagedReturn = elem.XGetAttribute ("managedReturn"),
+				KotlinInlineClassReturnJniType = elem.Attribute ("kotlin-inline-class-return-jni-type") != null ? elem.XGetAttribute ("kotlin-inline-class-return-jni-type") : null,
 				PropertyNameOverride = elem.XGetAttribute ("propertyName"),
 				Return = elem.XGetAttribute ("return"),
 				ReturnNotNull = elem.XGetAttribute ("return-not-null") == "true",
@@ -445,8 +448,11 @@ namespace MonoDroid.Generation
 			string enum_type = elem.Attribute ("enumType") != null ? elem.XGetAttribute ("enumType") : null;
 			string managed_type = elem.Attribute ("managedType") != null ? elem.XGetAttribute ("managedType") : null;
 			var not_null = elem.XGetAttribute ("not-null") == "true";
+			string kotlin_inline_jni = elem.Attribute ("kotlin-inline-class-jni-type") != null ? elem.XGetAttribute ("kotlin-inline-class-jni-type") : null;
 			// FIXME: "enum_type ?? java_type" should be extraneous. Somewhere in generator uses it improperly.
-			var result = new Parameter (name, enum_type ?? java_type, enum_type ?? managed_type, enum_type != null, java_type, not_null);
+			var result = new Parameter (name, enum_type ?? java_type, enum_type ?? managed_type, enum_type != null, java_type, not_null) {
+				KotlinInlineClassJniType = kotlin_inline_jni,
+			};
 			if (elem.Attribute ("sender") != null)
 				result.IsSender = true;
 			SetLineInfo (result, elem, options);

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ClassGen.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ClassGen.cs
@@ -298,6 +298,14 @@ namespace MonoDroid.Generation
 
 		public bool IsFinal { get; set; }
 
+		// Kotlin @JvmInline value class support.
+		// When IsKotlinInlineClass is true, the generator emits a `readonly struct`
+		// wrapper around KotlinInlineClassUnderlyingJniType instead of the usual
+		// peer-class binding.
+		public bool IsKotlinInlineClass { get; set; }
+
+		public string KotlinInlineClassUnderlyingJniType { get; set; }
+
 		public bool NeedsNew { get; set; }
 
 		public string PeerConstructorPartialMethod { get; set; }

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Method.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Method.cs
@@ -29,6 +29,7 @@ namespace MonoDroid.Generation
 		public string JavaName { get; set; }
 		public string ManagedOverride { get; set; }
 		public string ManagedReturn { get; set; }
+		public string KotlinInlineClassReturnJniType { get; set; }
 		public string PropertyNameOverride { get; set; }
 		public string Return { get; set; }
 		public bool ReturnNotNull { get; set; }
@@ -153,6 +154,7 @@ namespace MonoDroid.Generation
 			clone.JavaName = JavaName;
 			clone.ManagedOverride = ManagedOverride;
 			clone.ManagedReturn = ManagedReturn;
+			clone.KotlinInlineClassReturnJniType = KotlinInlineClassReturnJniType;
 			clone.PropertyNameOverride = PropertyNameOverride;
 			clone.Return = Return;
 			clone.ReturnNotNull = ReturnNotNull;

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/MethodBase.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/MethodBase.cs
@@ -119,6 +119,14 @@ namespace MonoDroid.Generation
 			for (int i = 0; i < Parameters.Count; i++) {
 				if (Parameters [i].RawNativeType != other.Parameters [i].RawNativeType)
 					return false;
+				// dotnet/java-interop#1431 (Phase 2): two Kotlin @JvmInline
+				// value classes can share the same underlying JVM primitive
+				// (e.g. multiple `ULong`-backed inline classes on Compose
+				// APIs). Their `RawNativeType` is identical (`long`), but the
+				// projected wrapper structs are distinct C# overloads, so
+				// also compare the inline-class JNI type to keep them apart.
+				if (Parameters [i].KotlinInlineClassJniType != other.Parameters [i].KotlinInlineClassJniType)
+					return false;
 			}
 
 			return true;

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Parameter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Parameter.cs
@@ -33,9 +33,17 @@ namespace MonoDroid.Generation {
 			NotNull = notNull;
 		}
 
+		// Kotlin @JvmInline value class JNI signature (e.g. "Lcom/example/MyColor;")
+		// for inline-class projection. When set, Validate replaces the managed type
+		// with the wrapper struct's full name so the C# parameter signature uses the
+		// struct, while JNI marshaling stays on the underlying primitive (the `type`).
+		public string KotlinInlineClassJniType { get; set; }
+
 		public Parameter Clone ()
 		{
-			return new Parameter (name, type, managed_type, is_enumified, rawtype, NotNull);
+			return new Parameter (name, type, managed_type, is_enumified, rawtype, NotNull) {
+				KotlinInlineClassJniType = KotlinInlineClassJniType,
+			};
 		}
 
 		public string GetCall (CodeGenerationOptions opt)
@@ -286,7 +294,26 @@ namespace MonoDroid.Generation {
 				Report.LogCodedWarning (0, Report.WarningInvalidParameterType, this, type, context.GetContextTypeMember ());
 				return false;
 			}
+			ApplyKotlinInlineClassProjection (opt, type_params);
 			return true;
+		}
+
+		// If KotlinInlineClassJniType is set, look up the wrapper ClassGen and
+		// override managed_type so the C# parameter type is the struct (e.g.
+		// "Com.Example.MyColor") while sym remains the underlying primitive
+		// for JNI marshaling.
+		void ApplyKotlinInlineClassProjection (CodeGenerationOptions opt, GenericParameterDefinitionList type_params)
+		{
+			if (string.IsNullOrEmpty (KotlinInlineClassJniType))
+				return;
+			var javaName = TypeNameUtilities.JniSignatureToJavaTypeName (KotlinInlineClassJniType);
+			if (javaName == null)
+				return;
+			var wrapper = opt.SymbolTable.Lookup (javaName, type_params) as ClassGen;
+			if (wrapper == null || !wrapper.IsKotlinInlineClass)
+				return;
+			managed_type = wrapper.FullName;
+			NotNull = true;
 		}
 
 		public bool ShouldGenerateKeepAlive ()

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Parameter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Parameter.cs
@@ -321,6 +321,15 @@ namespace MonoDroid.Generation {
 			if (Symbol.IsEnum)
 				return false;
 
+			// dotnet/java-interop#1431 (Phase 2): a Kotlin @JvmInline value
+			// class is projected as a `readonly struct` wrapping a primitive.
+			// The projection rewrites Type to the wrapper struct's FullName,
+			// which wouldn't match any case below and would fall through to
+			// `true`, generating an unnecessary GC.KeepAlive call for what is
+			// ultimately a value-type holding a primitive.
+			if (!string.IsNullOrEmpty (KotlinInlineClassJniType))
+				return false;
+
 			return Type switch {
 				"bool" => false,
 				"sbyte" => false,

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ReturnValue.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ReturnValue.cs
@@ -152,7 +152,26 @@ namespace MonoDroid.Generation {
 				Report.LogCodedWarning (0, Report.WarningInvalidReturnType, owner, java_type, context.GetContextTypeMember ());
 				return false;
 			}
+			ApplyKotlinInlineClassProjection (opt, type_params);
 			return true;
+		}
+
+		// If the owning Method has KotlinInlineClassReturnJniType set, override
+		// managed_type with the wrapper struct's full name so the C# return type
+		// is the struct, while sym remains the underlying primitive for JNI.
+		void ApplyKotlinInlineClassProjection (CodeGenerationOptions opt, GenericParameterDefinitionList type_params)
+		{
+			var jni = owner?.KotlinInlineClassReturnJniType;
+			if (string.IsNullOrEmpty (jni))
+				return;
+			var javaName = TypeNameUtilities.JniSignatureToJavaTypeName (jni);
+			if (javaName == null)
+				return;
+			var wrapper = opt.SymbolTable.Lookup (javaName, type_params) as ClassGen;
+			if (wrapper == null || !wrapper.IsKotlinInlineClass)
+				return;
+			managed_type = wrapper.FullName;
+			NotNull = true;
 		}
 	}
 }

--- a/tools/generator/SourceWriters/KotlinInlineClassStruct.cs
+++ b/tools/generator/SourceWriters/KotlinInlineClassStruct.cs
@@ -1,0 +1,79 @@
+using System;
+using MonoDroid.Generation;
+using Xamarin.SourceWriter;
+
+namespace generator.SourceWriters
+{
+	// Emits a `readonly struct` wrapper for a Kotlin @JvmInline value class.
+	// The struct holds the underlying primitive (e.g. long, float) that the
+	// JVM passes across JNI, and provides implicit conversions so the wrapper
+	// can be used directly in projected method signatures while existing JNI
+	// thunks marshal the primitive value unchanged.
+	public class KotlinInlineClassStruct : TypeWriter
+	{
+		readonly ClassGen klass;
+		readonly string underlying_csharp_type;
+
+		public KotlinInlineClassStruct (ClassGen klass, CodeGenerationOptions opt)
+		{
+			this.klass = klass;
+			underlying_csharp_type = JniPrimitiveToCSharpType (klass.KotlinInlineClassUnderlyingJniType);
+
+			Name = klass.Name;
+			SetVisibility (klass.Visibility);
+
+			klass.JavadocInfo?.AddJavadocs (Comments);
+			Comments.Add ($"// Metadata.xml XPath class reference: path=\"{klass.MetadataXPathReference}\"");
+			Comments.Add ("// Kotlin @JvmInline value class wrapper.");
+		}
+
+		public override void WriteSignature (CodeWriter writer)
+		{
+			if (IsPublic)
+				writer.Write ("public ");
+			else if (IsInternal)
+				writer.Write ("internal ");
+
+			writer.Write ("readonly partial struct ");
+			writer.Write (Name + " ");
+			writer.WriteLine (": global::System.IEquatable<" + Name + "> {");
+			writer.Indent ();
+		}
+
+		public override void WriteMembers (CodeWriter writer)
+		{
+			var t = underlying_csharp_type;
+			var n = Name;
+
+			writer.WriteLine ($"public readonly {t} Value;");
+			writer.WriteLine ();
+			writer.WriteLine ($"public {n} ({t} value) {{ Value = value; }}");
+			writer.WriteLine ();
+			writer.WriteLine ($"public static implicit operator {t} ({n} value) => value.Value;");
+			writer.WriteLine ($"public static implicit operator {n} ({t} value) => new {n} (value);");
+			writer.WriteLine ();
+			writer.WriteLine ($"public static bool operator == ({n} left, {n} right) => left.Equals (right);");
+			writer.WriteLine ($"public static bool operator != ({n} left, {n} right) => !left.Equals (right);");
+			writer.WriteLine ();
+			writer.WriteLine ($"public bool Equals ({n} other) => Value.Equals (other.Value);");
+			writer.WriteLine ($"public override bool Equals (object? obj) => obj is {n} other && Equals (other);");
+			writer.WriteLine ("public override int GetHashCode () => Value.GetHashCode ();");
+			writer.WriteLine ("public override string? ToString () => Value.ToString ();");
+		}
+
+		static string JniPrimitiveToCSharpType (string jni)
+		{
+			return jni switch {
+				"Z" => "bool",
+				"B" => "sbyte",
+				"C" => "char",
+				"D" => "double",
+				"F" => "float",
+				"I" => "int",
+				"J" => "long",
+				"S" => "short",
+				_ => "long",
+			};
+		}
+	}
+}

--- a/tools/generator/SourceWriters/KotlinInlineClassStruct.cs
+++ b/tools/generator/SourceWriters/KotlinInlineClassStruct.cs
@@ -1,3 +1,4 @@
+using System;
 using MonoDroid.Generation;
 using Xamarin.SourceWriter;
 
@@ -72,7 +73,7 @@ namespace generator.SourceWriters
 				"I" => "int",
 				"J" => "long",
 				"S" => "short",
-				_ => "long",
+				_ => throw new ArgumentOutOfRangeException (nameof (jni), jni, "Unsupported JNI primitive descriptor"),
 			};
 		}
 	}

--- a/tools/generator/SourceWriters/KotlinInlineClassStruct.cs
+++ b/tools/generator/SourceWriters/KotlinInlineClassStruct.cs
@@ -31,8 +31,12 @@ namespace generator.SourceWriters
 		{
 			if (IsPublic)
 				writer.Write ("public ");
-			else if (IsInternal)
+			if (IsProtected)
+				writer.Write ("protected ");
+			if (IsInternal)
 				writer.Write ("internal ");
+			if (IsPrivate)
+				writer.Write ("private ");
 
 			writer.Write ("readonly partial struct ");
 			writer.Write (Name + " ");

--- a/tools/generator/SourceWriters/KotlinInlineClassStruct.cs
+++ b/tools/generator/SourceWriters/KotlinInlineClassStruct.cs
@@ -1,4 +1,3 @@
-using System;
 using MonoDroid.Generation;
 using Xamarin.SourceWriter;
 
@@ -11,13 +10,13 @@ namespace generator.SourceWriters
 	// thunks marshal the primitive value unchanged.
 	public class KotlinInlineClassStruct : TypeWriter
 	{
-		readonly ClassGen klass;
 		readonly string underlying_csharp_type;
+		readonly string nullable;
 
 		public KotlinInlineClassStruct (ClassGen klass, CodeGenerationOptions opt)
 		{
-			this.klass = klass;
 			underlying_csharp_type = JniPrimitiveToCSharpType (klass.KotlinInlineClassUnderlyingJniType);
+			nullable = opt.NullableOperator;
 
 			Name = klass.Name;
 			SetVisibility (klass.Visibility);
@@ -44,6 +43,7 @@ namespace generator.SourceWriters
 		{
 			var t = underlying_csharp_type;
 			var n = Name;
+			var q = nullable;
 
 			writer.WriteLine ($"public readonly {t} Value;");
 			writer.WriteLine ();
@@ -56,9 +56,9 @@ namespace generator.SourceWriters
 			writer.WriteLine ($"public static bool operator != ({n} left, {n} right) => !left.Equals (right);");
 			writer.WriteLine ();
 			writer.WriteLine ($"public bool Equals ({n} other) => Value.Equals (other.Value);");
-			writer.WriteLine ($"public override bool Equals (object? obj) => obj is {n} other && Equals (other);");
+			writer.WriteLine ($"public override bool Equals (object{q} obj) => obj is {n} other && Equals (other);");
 			writer.WriteLine ("public override int GetHashCode () => Value.GetHashCode ();");
-			writer.WriteLine ("public override string? ToString () => Value.ToString ();");
+			writer.WriteLine ($"public override string{q} ToString () => Value.ToString ();");
 		}
 
 		static string JniPrimitiveToCSharpType (string jni)

--- a/tools/generator/Utilities/TypeNameUtilities.cs
+++ b/tools/generator/Utilities/TypeNameUtilities.cs
@@ -9,6 +9,19 @@ namespace MonoDroid.Generation
 {
 	public static class TypeNameUtilities
 	{
+		// Convert a JNI type signature like "Lcom/example/MyColor;" into the Java
+		// type name "com.example.MyColor". Returns null for non-reference signatures
+		// (primitives or arrays) since those are not used by the Kotlin inline-class
+		// projection path.
+		public static string JniSignatureToJavaTypeName (string jniSignature)
+		{
+			if (string.IsNullOrEmpty (jniSignature))
+				return null;
+			if (jniSignature.Length < 3 || jniSignature [0] != 'L' || jniSignature [jniSignature.Length - 1] != ';')
+				return null;
+			return jniSignature.Substring (1, jniSignature.Length - 2).Replace ('/', '.');
+		}
+
 		// These must be sorted for BinarySearch to work
 		// Missing "this" because it's handled elsewhere as "this_"
 		internal static string [] reserved_keywords = new [] {

--- a/tools/generator/Utilities/TypeNameUtilities.cs
+++ b/tools/generator/Utilities/TypeNameUtilities.cs
@@ -19,7 +19,9 @@ namespace MonoDroid.Generation
 				return null;
 			if (jniSignature.Length < 3 || jniSignature [0] != 'L' || jniSignature [jniSignature.Length - 1] != ';')
 				return null;
-			return jniSignature.Substring (1, jniSignature.Length - 2).Replace ('/', '.');
+			return jniSignature.Substring (1, jniSignature.Length - 2)
+				.Replace ('/', '.')
+				.Replace ('$', '.');
 		}
 
 		// These must be sorted for BinarySearch to work


### PR DESCRIPTION
Phase 2 of dotnet/android#11844. Builds on dotnet/java-interop#1432 (sibling-collision dedup) by detecting Kotlin `@JvmInline value class` types in `class-parse`, surfacing them in `api.xml`, and projecting them into generator output as `readonly struct` wrappers — while JNI marshaling stays on the underlying primitive.

## What this does

Given Kotlin source like:

```kotlin
@JvmInline
value class MyColor(val value: ULong)
@JvmInline
value class MyAlpha(val value: ULong)
@JvmInline
value class MyDp(val value: Float)

object Widgets {
    fun tint(c: MyColor) { ... }
    fun tint(a: MyAlpha) { ... }
    fun tint(d: MyDp)    { ... }
    fun pad(d: MyDp): MyDp           { ... }
    fun pad(x: MyDp, y: MyDp): MyDp  { ... }
}
```

The generator now emits:

```csharp
public readonly partial struct MyColor : System.IEquatable<MyColor> {
    public readonly long Value;
    public MyColor (long value) { Value = value; }
    public static implicit operator long (MyColor value) => value.Value;
    public static implicit operator MyColor (long value) => new MyColor (value);
    // == / != / Equals / GetHashCode / ToString
}
// ...same shape for MyAlpha (long-backed) and MyDp (float-backed).

public static class Widgets {
    public static void  Tint (MyColor c) { ... }   // was: void Tint_Rn_QMJI (long c)
    public static void  Tint (MyAlpha a) { ... }   // was: void Tint_uzYZ1wI (long a)
    public static void  Tint (MyDp d)    { ... }   // was: void Tint_L3D9Hvg (long d)
    public static MyDp  Pad  (MyDp d)            { ... }
    public static MyDp  Pad  (MyDp x, MyDp y)    { ... }
}
```

The bodies of `Tint`/`Pad` still pass the JVM-erased primitive (`long`/`float`) across JNI — the implicit conversion operators on the struct make that compile without any thunk changes.

## Bytecode layer

- New `ClassFile.KotlinInlineClassUnderlyingJniType`, `MethodInfo.KotlinInlineClassReturnJniType`, `MethodInfo.KotlinName`, `ParameterInfo.KotlinInlineClassJniType`.
- `KotlinFixups.Fixup` does a pre-pass `DetectInlineClasses` that recognizes `@JvmInline` + `KotlinClassFlags.IsInlineClass` + a **single non-synthetic instance field with a primitive descriptor**, then stamps each method's parameter/return JNI types when the Kotlin source-level type was an inline class **and** the JVM-erased descriptor matches the underlying primitive (so boxed/nullable positions are correctly skipped).
- Recovers the unmangled Kotlin source name from metadata (`tint` instead of `tint-Rn_QMJI`) and surfaces it via `MethodInfo.KotlinName`.
- `XmlClassDeclarationBuilder` emits `kotlin-inline-class`, `kotlin-inline-class-underlying-jni-type`, `kotlin-inline-class-jni-type` (parameter), `kotlin-inline-class-return-jni-type` (method), and `managedName` (unmangled Kotlin name) attributes.

## Generator layer

- `ClassGen.IsKotlinInlineClass` / `ClassGen.KotlinInlineClassUnderlyingJniType`.
- `Parameter.KotlinInlineClassJniType` / `Method.KotlinInlineClassReturnJniType`.
- `XmlApiImporter` reads the new attributes; the existing `managedName` codepath delivers the unmangled C# binding name without affecting JNI invocation.
- `Parameter.Validate` / `ReturnValue.Validate` apply the projection by looking up the wrapper `ClassGen` via `SymbolTable` and overriding `managed_type` so `Type`/`FullName` return the struct while `Symbol` (and therefore JNI marshaling) stays on the underlying primitive.
- `MethodBase.Matches` also compares `Parameters[i].KotlinInlineClassJniType` so two inline classes that share the same JVM primitive (e.g. multiple `ULong`-backed inline classes on Compose APIs) survive Phase 1's `RemoveCollidingSiblings` as distinct overloads.
- `Parameter.ShouldGenerateKeepAlive` returns `false` for projected inline-class params (avoids needless `GC.KeepAlive` on a value-type wrapping a primitive).
- New `KotlinInlineClassStruct` `TypeWriter` emits the wrapper struct.
- `JavaInteropCodeGenerator.WriteType` routes inline-class `ClassGen` instances to the new writer instead of `BoundClass`.
- New `TypeNameUtilities.JniSignatureToJavaTypeName` helper (handles nested types via `$` → `.`).

## Tests

- **Bytecode-Tests**: 82 passed (2 pre-existing skips). New `KotlinInlineClassCollisionTests` exercise the real Kotlin `.class` fixtures.
- **generator-Tests**: 7 unit tests in `KotlinInlineClassTests` plus 1 end-to-end test in `KotlinInlineClassEndToEndTests` that drives real Kotlin `.class` files (compiled by `tests/Xamarin.Android.Tools.Bytecode-Tests/kotlin-gradle/`) through `KotlinFixups` → `XmlClassDeclarationBuilder` → `XmlApiImporter` → `Java.Interop.Tools.Generator.Transformation.KotlinFixups` → `Validate` → `JavaInteropCodeGenerator`. The end-to-end test mirrors the real `CodeGenerator.Generate` pipeline and would have caught the `RemoveCollidingSiblings` regression that motivated the `MethodBase.Matches` fix.
- 23 pre-existing `generator-Tests` failures are unrelated environment issues (Roslyn / FileStream); confirmed unchanged.

## Build-system

The Kotlin/Gradle fixture target (`BuildKotlinGradleProject`) was extracted into a shared `tests/Xamarin.Android.Tools.Bytecode-Tests/kotlin-gradle.targets` file imported by both `Bytecode-Tests.csproj` and `generator-Tests.csproj`, so the `.class` files are produced regardless of which test project the build hits first.

## Out of scope / known limitations

- **Boxed inline-class positions** (nullable like `MyColor?`, generics like `List<MyColor>`, supertype implementations) still emit `Lcom/example/MyColor;` references that no longer have a peer class binding. These were rare on the targeted Compose surface; users can unblock them via Metadata.xml (`<remove-node>`) until a follow-up.
- **Reference-backed inline classes** (e.g. `value class Tag(val raw: String)`) are detected as inline classes but the projection path requires a primitive backing field; non-primitive-backed inline classes are skipped and fall through to the legacy peer-class path.
- **Generic inline classes** (`value class Wrap<T>(val v: T)`).
- **Validation against the Compose `material3-android` AAR** is not part of this PR.

Closes part of dotnet/android#11844. Phase 1 (sibling-collision dedup) was dotnet/java-interop#1432.