### PR TITLE
[tests] Add missing jcw-gen project dependency to Java.Base-Tests

### DIFF
--- a/tests/Java.Base-Tests/Java.Base-Tests.csproj
+++ b/tests/Java.Base-Tests/Java.Base-Tests.csproj
@@ -26,6 +26,7 @@
     <ProjectReference Include="..\..\src\Java.Base\Java.Base.csproj" />
     <ProjectReference Include="..\..\src\Java.Runtime.Environment\Java.Runtime.Environment.csproj" />
     <ProjectReference Include="..\TestJVM\TestJVM.csproj" />
+    <ProjectReference Include="..\..\tools\jcw-gen\jcw-gen.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Follow-up to #1418, which fixed the same issue in `Hello-Java.Base`.

### Problem

The `Java.Base-Tests` project invokes `jcw-gen.dll` via the `Java.Interop.Sdk` targets ([`Sdk.targets#L195`](../blob/main/build-tools/Java.Interop.Sdk/Sdk/Sdk.targets#L195)) but does not declare a `ProjectReference` to `tools/jcw-gen/jcw-gen.csproj`. Under parallel (`-m`) MSBuild scheduling this races: `Java.Base-Tests`'s `_JavaCreateJcws` target can run before `jcw-gen.dll` has been produced, and `dotnet` fails with:

```
Could not execute because the specified command or file was not found.
  * You intended to execute a .NET program, but
    dotnet-...\bin\Release-net10.0\/jcw-gen.dll does not exist.
```

Observed on the Windows leg of [build 1448024](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1448024&view=logs&j=10b5dba2-0c78-5c70-4079-bab96311b95e&t=82cc2497-24b3-59ab-21bc-40f5d21f7d6b&l=3156). Timestamps in that log show `Java.Base-Tests` invoked `jcw-gen.dll` at `15:54:26`, but `jcw-gen.dll` wasn't produced until `15:54:42` — 16 seconds later.

### Fix

Add a `ReferenceOutputAssembly="false"` `ProjectReference` so MSBuild orders `jcw-gen` ahead of `Java.Base-Tests`, matching the pattern already used by `Hello-Java.Base` and `Java.Interop-Tests`.

`Java.Base-Tests` is the only remaining consumer of `Sdk.targets` that was missing this reference.