### PR TITLE
[JniValueManager] Make TryConstructPeer virtual

### DIFF
--- a/src/Java.Interop/Java.Interop/JniRuntime.ReflectionJniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.ReflectionJniValueManager.cs
@@ -233,7 +233,7 @@ namespace Java.Interop
 			static  readonly    Type            ByRefJniObjectReference = typeof (JniObjectReference).MakeByRefType ();
 			static  readonly    Type[]          JIConstructorSignature  = new Type [] { ByRefJniObjectReference, typeof (JniObjectReferenceOptions) };
 
-			bool TryConstructPeer (
+			protected virtual bool TryConstructPeer (
 					IJavaPeerable self,
 					ref JniObjectReference reference,
 					JniObjectReferenceOptions options,
@@ -247,7 +247,7 @@ namespace Java.Interop
 						options,
 					};
 					c.Invoke (self, args);
-					reference   = (JniObjectReference) args [0];
+					JniObjectReference.Dispose (ref reference, options);
 					return true;
 				}
 				return false;

--- a/src/Java.Interop/Java.Interop/JniRuntime.ReflectionJniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.ReflectionJniValueManager.cs
@@ -247,6 +247,7 @@ namespace Java.Interop
 						options,
 					};
 					c.Invoke (self, args);
+					reference = (JniObjectReference) args [0];
 					JniObjectReference.Dispose (ref reference, options);
 					return true;
 				}

--- a/src/Java.Interop/PublicAPI.Unshipped.txt
+++ b/src/Java.Interop/PublicAPI.Unshipped.txt
@@ -85,3 +85,4 @@ override Java.Interop.JniRuntime.ReflectionJniTypeManager.GetTypes(Java.Interop.
 override Java.Interop.JniRuntime.ReflectionJniTypeManager.GetTypesForSimpleReference(string! jniSimpleReference) -> System.Collections.Generic.IEnumerable<System.Type!>!
 override Java.Interop.JniRuntime.ReflectionJniTypeManager.RegisterNativeMembers(Java.Interop.JniType! nativeClass, System.Type! type, string? methods) -> void
 override Java.Interop.JniRuntime.ReflectionJniTypeManager.RegisterNativeMembers(Java.Interop.JniType! nativeClass, System.Type! type, System.ReadOnlySpan<char> methods) -> void
+virtual Java.Interop.JniRuntime.ReflectionJniValueManager.TryConstructPeer(Java.Interop.IJavaPeerable! self, ref Java.Interop.JniObjectReference reference, Java.Interop.JniObjectReferenceOptions options, System.Type! type) -> bool


### PR DESCRIPTION
Follow-up to #1441 

We need this method virtual so that `JavaMarshalValueManager` can override it and try to invoke the `XAConstructorSignature`. The method was previously virtual but as an oversight I removed it in #1441:
- https://github.com/dotnet/java-interop/pull/1441/changes#diff-8ead12d157bc7712affd3d920bb93cddbff3885147fe6297957a44cc522d5430R7
- https://github.com/dotnet/java-interop/pull/1441/changes#diff-b92884de5db7f82df63b483b8319360cd9bfdac3cd97222eb9aff7292a01a07bL449-L467

I noticed we're not disposing the `reference` correctly which might cause a ref leak. In the Mono `AndroidValueManager` we never called into the base method so this would not be observed on mono previously (https://github.com/dotnet/android/blob/main/src/Mono.Android/Java.Interop/TypeManager.cs#L416-L423).