### PR TITLE
Remove NuGet dependency grouping from Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,3 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
-    groups:
-      nuget-dependencies:
-        patterns:
-          - "*"


### PR DESCRIPTION
### Why

The Dependabot config currently groups every NuGet update into a single PR via a catch-all `"*"` pattern (see #1458, which bumps 4 unrelated packages at once). Grouping all dependencies makes review harder, hides per-package risk, and forces an all-or-nothing merge: if one bump regresses, the other safe updates get held up too.

### What changed

Removes the `groups: nuget-dependencies` block from `.github/dependabot.yml`. Dependabot will revert to its default behavior of one PR per dependency.

`open-pull-requests-limit: 10` is unchanged, so the queue is still capped.

### Trade-offs

More PRs per week, but each one is small, individually reviewable, and independently revertable. If routine bumps become noisy later, we can re-introduce a narrower group (for example minor/patch-only, or a specific package family) rather than grouping everything.