### PR TITLE
[Java.Interop] Make JavaProxyObject.RegisterNativeMembers private again

### DIFF
--- a/samples/Hello-NativeAOTFromAndroid/NativeAotTypeManager.cs
+++ b/samples/Hello-NativeAOTFromAndroid/NativeAotTypeManager.cs
@@ -31,8 +31,8 @@ partial class NativeAotTypeManager : JniRuntime.ReflectionJniTypeManager {
 		["my/MainActivity"]                     = typeof (MainActivity),
 	};
 
-	[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "Reflection-based registration used by this NativeAOT sample does not require unreferenced code.")]
-	[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "Reflection-based registration used by this NativeAOT sample does not require runtime code generation.")]
+	[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "Sample only (see class comment): this assembly is rooted via TrimmerRootAssembly and the members reflected over during registration are preserved by the [DynamicallyAccessedMembers] annotations on the RegisterNativeMembers(Type) -> FindAndCallRegisterMethod path, so trimming does not remove what reflection needs.")]
+	[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "Sample only (see class comment): built-in member registration calls CreateDelegate on compile-time-known static methods (no MakeGenericType / expression compilation), so no runtime code generation is required.")]
 	public NativeAotTypeManager ()
 	{
 	}

--- a/samples/Hello-NativeAOTFromAndroid/NativeAotTypeManager.cs
+++ b/samples/Hello-NativeAOTFromAndroid/NativeAotTypeManager.cs
@@ -6,6 +6,11 @@ namespace Java.Interop.Samples.NativeAotFromAndroid;
 
 partial class NativeAotTypeManager : JniRuntime.ReflectionJniTypeManager {
 
+	const DynamicallyAccessedMemberTypes MethodsConstructors =
+		DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods |
+		DynamicallyAccessedMemberTypes.NonPublicNestedTypes |
+		DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
+
 	Dictionary<string, Type> typeMappings = new () {
 		["android/app/Activity"]                = typeof (Android.App.Activity),
 		["android/content/Context"]             = typeof (Android.Content.Context),
@@ -20,6 +25,16 @@ partial class NativeAotTypeManager : JniRuntime.ReflectionJniTypeManager {
 	[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "Reflection-based registration used by this NativeAOT sample does not require runtime code generation.")]
 	public NativeAotTypeManager ()
 	{
+	}
+
+	// GetType() dispatches through GetTypeForSimpleReference (singular), so the sample's own type
+	// map has to be applied here; the base ReflectionJniTypeManager only knows the built-in types.
+	[return: DynamicallyAccessedMembers (MethodsConstructors)]
+	protected override Type? GetTypeForSimpleReference (string jniSimpleReference)
+	{
+		if (typeMappings.TryGetValue (jniSimpleReference, out var target))
+			return target;
+		return base.GetTypeForSimpleReference (jniSimpleReference);
 	}
 
 	protected override IEnumerable<Type> GetTypesForSimpleReference (string jniSimpleReference)

--- a/samples/Hello-NativeAOTFromAndroid/NativeAotTypeManager.cs
+++ b/samples/Hello-NativeAOTFromAndroid/NativeAotTypeManager.cs
@@ -4,13 +4,6 @@ using Java.Interop;
 
 namespace Java.Interop.Samples.NativeAotFromAndroid;
 
-// See the comment in Hello-NativeAOTFromJNI/NativeAotTypeManager.cs: this derives from the
-// reflection-based JniRuntime.ReflectionJniTypeManager (the pre-dotnet/java-interop#1441 base
-// behavior) so built-in runtime types such as JavaProxyObject get their native members registered
-// automatically. ReflectionJniTypeManager is annotated [RequiresDynamicCode]/[RequiresUnreferencedCode];
-// the reflection paths this sample exercises do not require runtime code generation, so the
-// constructor suppresses the resulting trimming/AOT warnings via [UnconditionalSuppressMessage]
-// (a #pragma would not survive the ILLink/ILC publish passes).
 partial class NativeAotTypeManager : JniRuntime.ReflectionJniTypeManager {
 
 	Dictionary<string, Type> typeMappings = new () {
@@ -23,8 +16,8 @@ partial class NativeAotTypeManager : JniRuntime.ReflectionJniTypeManager {
 		["my/MainActivity"]                     = typeof (MainActivity),
 	};
 
-	[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "Reflection-based registration used by this NativeAOT sample does not require unreferenced code; see class comment.")]
-	[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "Reflection-based registration used by this NativeAOT sample does not require runtime code generation; see class comment.")]
+	[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "Reflection-based registration used by this NativeAOT sample does not require unreferenced code.")]
+	[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "Reflection-based registration used by this NativeAOT sample does not require runtime code generation.")]
 	public NativeAotTypeManager ()
 	{
 	}

--- a/samples/Hello-NativeAOTFromAndroid/NativeAotTypeManager.cs
+++ b/samples/Hello-NativeAOTFromAndroid/NativeAotTypeManager.cs
@@ -4,11 +4,14 @@ using Java.Interop;
 
 namespace Java.Interop.Samples.NativeAotFromAndroid;
 
-partial class NativeAotTypeManager : JniRuntime.JniTypeManager {
-
-	internal const DynamicallyAccessedMemberTypes Methods = DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods;
-	internal const DynamicallyAccessedMemberTypes MethodsAndPrivateNested = Methods | DynamicallyAccessedMemberTypes.NonPublicNestedTypes;
-	internal const DynamicallyAccessedMemberTypes MethodsConstructors = MethodsAndPrivateNested | DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
+// See the comment in Hello-NativeAOTFromJNI/NativeAotTypeManager.cs: this derives from the
+// reflection-based JniRuntime.ReflectionJniTypeManager (the pre-dotnet/java-interop#1441 base
+// behavior) so built-in runtime types such as JavaProxyObject get their native members registered
+// automatically. ReflectionJniTypeManager is annotated [RequiresDynamicCode]/[RequiresUnreferencedCode];
+// the reflection paths this sample exercises do not require runtime code generation, so the
+// constructor suppresses the resulting trimming/AOT warnings via [UnconditionalSuppressMessage]
+// (a #pragma would not survive the ILLink/ILC publish passes).
+partial class NativeAotTypeManager : JniRuntime.ReflectionJniTypeManager {
 
 	Dictionary<string, Type> typeMappings = new () {
 		["android/app/Activity"]                = typeof (Android.App.Activity),
@@ -20,75 +23,24 @@ partial class NativeAotTypeManager : JniRuntime.JniTypeManager {
 		["my/MainActivity"]                     = typeof (MainActivity),
 	};
 
-	public override void RegisterNativeMembers (
-			JniType nativeClass,
-			[DynamicallyAccessedMembers (MethodsAndPrivateNested)]
-			Type type,
-			ReadOnlySpan<char> methods)
+	[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "Reflection-based registration used by this NativeAOT sample does not require unreferenced code; see class comment.")]
+	[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "Reflection-based registration used by this NativeAOT sample does not require runtime code generation; see class comment.")]
+	public NativeAotTypeManager ()
 	{
-		if (TryRegisterBuiltInNativeMembers (nativeClass, nativeClass.Name, methods))
-			return;
-		if (!methods.IsEmpty)
-			throw new NotSupportedException ($"Could not register native members for type '{type.FullName}'.");
-	}
-
-	[Obsolete ("Use RegisterNativeMembers(JniType, Type, ReadOnlySpan<char>)")]
-	public override void RegisterNativeMembers (
-			JniType nativeClass,
-			[DynamicallyAccessedMembers (MethodsAndPrivateNested)]
-			Type type,
-			string? methods)
-	{
-		RegisterNativeMembers (nativeClass, type, methods.AsSpan ());
 	}
 
 	protected override IEnumerable<Type> GetTypesForSimpleReference (string jniSimpleReference)
 	{
-		var target = GetTypeForSimpleReference (jniSimpleReference);
-		if (target != null)
+		if (typeMappings.TryGetValue (jniSimpleReference, out var target))
 			yield return target;
-	}
-
-	protected override string? GetSimpleReference (Type type)
-	{
-		return GetSimpleReferences (type).FirstOrDefault ();
-	}
-
-	[return: DynamicallyAccessedMembers (MethodsConstructors)]
-	protected override Type? GetTypeForSimpleReference (string jniSimpleReference)
-	{
-		return jniSimpleReference switch {
-			"V"                                  => typeof (void),
-			"Z"                                  => typeof (bool),
-			"java/lang/Boolean"                  => typeof (bool?),
-			"B"                                  => typeof (sbyte),
-			"java/lang/Byte"                     => typeof (sbyte?),
-			"C"                                  => typeof (char),
-			"java/lang/Character"                => typeof (char?),
-			"S"                                  => typeof (short),
-			"java/lang/Short"                    => typeof (short?),
-			"I"                                  => typeof (int),
-			"java/lang/Integer"                  => typeof (int?),
-			"J"                                  => typeof (long),
-			"java/lang/Long"                     => typeof (long?),
-			"F"                                  => typeof (float),
-			"java/lang/Float"                    => typeof (float?),
-			"D"                                  => typeof (double),
-			"java/lang/Double"                   => typeof (double?),
-			"android/app/Activity"                => typeof (Android.App.Activity),
-			"android/content/Context"             => typeof (Android.Content.Context),
-			"android/content/ContextWrapper"      => typeof (Android.Content.ContextWrapper),
-			"android/os/BaseBundle"               => typeof (Android.OS.BaseBundle),
-			"android/os/Bundle"                   => typeof (Android.OS.Bundle),
-			"android/view/ContextThemeWrapper"    => typeof (Android.View.ContextThemeWrapper),
-			"my/MainActivity"                     => typeof (MainActivity),
-			_                                     => null,
-		};
+		foreach (var t in base.GetTypesForSimpleReference (jniSimpleReference))
+			yield return t;
 	}
 
 	protected override IEnumerable<string> GetSimpleReferences (Type type)
 	{
-		return CreateSimpleReferencesEnumerator (type);
+		return base.GetSimpleReferences (type)
+			.Concat (CreateSimpleReferencesEnumerator (type));
 	}
 
 	IEnumerable<string> CreateSimpleReferencesEnumerator (Type type)
@@ -99,57 +51,5 @@ partial class NativeAotTypeManager : JniRuntime.JniTypeManager {
 			if (e.Value == type)
 				yield return e.Key;
 		}
-	}
-
-	public override IEnumerable<Type> GetTypes (JniTypeSignature typeSignature)
-	{
-		if (!typeSignature.IsValid || typeSignature.ArrayRank != 0 || typeSignature.SimpleReference == null)
-			return [];
-		return GetTypesForSimpleReference (typeSignature.SimpleReference);
-	}
-
-	public override IEnumerable<JniRuntime.JniTypeManager.ReflectionConstructibleType> GetReflectionConstructibleTypes (JniTypeSignature typeSignature)
-	{
-		if (!typeSignature.IsValid || typeSignature.ArrayRank != 0 || typeSignature.SimpleReference == null)
-			yield break;
-		var target = GetTypeForSimpleReference (typeSignature.SimpleReference);
-		if (target != null)
-			yield return new JniRuntime.JniTypeManager.ReflectionConstructibleType (target);
-	}
-
-	protected override JniTypeSignature GetTypeSignatureCore (Type type)
-	{
-		var simpleReference = GetSimpleReferences (type).FirstOrDefault ();
-		return simpleReference == null ? default : new JniTypeSignature (simpleReference, 0, false);
-	}
-
-	protected override IEnumerable<JniTypeSignature> GetTypeSignaturesCore (Type type)
-	{
-		var signature = GetTypeSignatureCore (type);
-		if (signature.IsValid)
-			yield return signature;
-	}
-
-	[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
-	protected override Type? GetInvokerTypeCore (
-			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
-			Type type)
-	{
-		return null;
-	}
-
-	protected override IReadOnlyList<string>? GetStaticMethodFallbackTypesCore (string jniSimpleReference)
-	{
-		return null;
-	}
-
-	protected override string? GetReplacementTypeCore (string jniSimpleReference)
-	{
-		return null;
-	}
-
-	protected override JniRuntime.ReplacementMethodInfo? GetReplacementMethodInfoCore (string jniSourceType, string jniMethodName, string jniMethodSignature)
-	{
-		return null;
 	}
 }

--- a/samples/Hello-NativeAOTFromAndroid/NativeAotTypeManager.cs
+++ b/samples/Hello-NativeAOTFromAndroid/NativeAotTypeManager.cs
@@ -53,8 +53,6 @@ partial class NativeAotTypeManager : JniRuntime.ReflectionJniTypeManager {
 
 	IEnumerable<string> CreateSimpleReferencesEnumerator (Type type)
 	{
-		if (typeMappings == null)
-			yield break;
 		foreach (var e in typeMappings) {
 			if (e.Value == type)
 				yield return e.Key;

--- a/samples/Hello-NativeAOTFromAndroid/NativeAotTypeManager.cs
+++ b/samples/Hello-NativeAOTFromAndroid/NativeAotTypeManager.cs
@@ -4,6 +4,16 @@ using Java.Interop;
 
 namespace Java.Interop.Samples.NativeAotFromAndroid;
 
+// This sample derives from the reflection-based JniRuntime.ReflectionJniTypeManager, which is
+// annotated [RequiresDynamicCode]/[RequiresUnreferencedCode], so the constructor below suppresses
+// the resulting IL2026/IL3050 trim/AOT warnings.
+//
+// Suppressing here is intentional and good enough: these NativeAOT projects are *samples*, not
+// product code. .NET for Android (what we actually ship) does not pair ReflectionJniTypeManager
+// with NativeAOT, so it isn't worth the effort to make these samples fully trim/AOT-clean right now.
+// The reflection paths were always trim/AOT-unsafe: before dotnet/java-interop#1441 the equivalent
+// suppressions lived (buried) inside JniTypeManager itself, justified "NotUsedInAndroid"; #1441 just
+// moved that responsibility to callers via [RequiresDynamicCode]/[RequiresUnreferencedCode].
 partial class NativeAotTypeManager : JniRuntime.ReflectionJniTypeManager {
 
 	const DynamicallyAccessedMemberTypes MethodsConstructors =

--- a/samples/Hello-NativeAOTFromJNI/NativeAotTypeManager.cs
+++ b/samples/Hello-NativeAOTFromJNI/NativeAotTypeManager.cs
@@ -21,8 +21,8 @@ class NativeAotTypeManager : JniRuntime.ReflectionJniTypeManager {
 		DynamicallyAccessedMemberTypes.NonPublicNestedTypes |
 		DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
 
-	[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "Reflection-based registration used by this NativeAOT sample does not require unreferenced code.")]
-	[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "Reflection-based registration used by this NativeAOT sample does not require runtime code generation.")]
+	[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "Sample only (see class comment): this assembly is rooted via TrimmerRootAssembly and the members reflected over during registration are preserved by the [DynamicallyAccessedMembers] annotations on the RegisterNativeMembers(Type) -> FindAndCallRegisterMethod path, so trimming does not remove what reflection needs.")]
+	[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "Sample only (see class comment): built-in member registration calls CreateDelegate on compile-time-known static methods (no MakeGenericType / expression compilation), so no runtime code generation is required.")]
 	public NativeAotTypeManager ()
 	{
 	}

--- a/samples/Hello-NativeAOTFromJNI/NativeAotTypeManager.cs
+++ b/samples/Hello-NativeAOTFromJNI/NativeAotTypeManager.cs
@@ -6,9 +6,10 @@ namespace Hello_NativeAOTFromJNI;
 
 class NativeAotTypeManager : JniRuntime.ReflectionJniTypeManager {
 
-	Dictionary<string, Type> typeMappings = new () {
-		[Example.ManagedType.JniTypeName]   = typeof (Example.ManagedType),
-	};
+	const DynamicallyAccessedMemberTypes MethodsConstructors =
+		DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods |
+		DynamicallyAccessedMemberTypes.NonPublicNestedTypes |
+		DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
 
 	[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "Reflection-based registration used by this NativeAOT sample does not require unreferenced code.")]
 	[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "Reflection-based registration used by this NativeAOT sample does not require runtime code generation.")]
@@ -16,27 +17,23 @@ class NativeAotTypeManager : JniRuntime.ReflectionJniTypeManager {
 	{
 	}
 
+	// The base ReflectionJniTypeManager resolves built-in types (primitives, java/lang/String,
+	// JavaProxyObject, ...) and handles registration and the reverse Type->JNI mapping (via the
+	// [JniTypeSignature] attribute) for us. We only need to teach it about this sample's own
+	// managed types.
+	[return: DynamicallyAccessedMembers (MethodsConstructors)]
+	protected override Type? GetTypeForSimpleReference (string jniSimpleReference)
+	{
+		if (jniSimpleReference == Example.ManagedType.JniTypeName)
+			return typeof (Example.ManagedType);
+		return base.GetTypeForSimpleReference (jniSimpleReference);
+	}
+
 	protected override IEnumerable<Type> GetTypesForSimpleReference (string jniSimpleReference)
 	{
-		if (typeMappings.TryGetValue (jniSimpleReference, out var target))
-			yield return target;
+		if (jniSimpleReference == Example.ManagedType.JniTypeName)
+			yield return typeof (Example.ManagedType);
 		foreach (var t in base.GetTypesForSimpleReference (jniSimpleReference))
 			yield return t;
-	}
-
-	protected override IEnumerable<string> GetSimpleReferences (Type type)
-	{
-		return base.GetSimpleReferences (type)
-			.Concat (CreateSimpleReferencesEnumerator (type));
-	}
-
-	IEnumerable<string> CreateSimpleReferencesEnumerator (Type type)
-	{
-		if (typeMappings == null)
-			yield break;
-		foreach (var e in typeMappings) {
-			if (e.Value == type)
-				yield return e.Key;
-		}
 	}
 }

--- a/samples/Hello-NativeAOTFromJNI/NativeAotTypeManager.cs
+++ b/samples/Hello-NativeAOTFromJNI/NativeAotTypeManager.cs
@@ -4,6 +4,16 @@ using Java.Interop;
 
 namespace Hello_NativeAOTFromJNI;
 
+// This sample derives from the reflection-based JniRuntime.ReflectionJniTypeManager, which is
+// annotated [RequiresDynamicCode]/[RequiresUnreferencedCode], so the constructor below suppresses
+// the resulting IL2026/IL3050 trim/AOT warnings.
+//
+// Suppressing here is intentional and good enough: these NativeAOT projects are *samples*, not
+// product code. .NET for Android (what we actually ship) does not pair ReflectionJniTypeManager
+// with NativeAOT, so it isn't worth the effort to make these samples fully trim/AOT-clean right now.
+// The reflection paths were always trim/AOT-unsafe: before dotnet/java-interop#1441 the equivalent
+// suppressions lived (buried) inside JniTypeManager itself, justified "NotUsedInAndroid"; #1441 just
+// moved that responsibility to callers via [RequiresDynamicCode]/[RequiresUnreferencedCode].
 class NativeAotTypeManager : JniRuntime.ReflectionJniTypeManager {
 
 	const DynamicallyAccessedMemberTypes MethodsConstructors =

--- a/samples/Hello-NativeAOTFromJNI/NativeAotTypeManager.cs
+++ b/samples/Hello-NativeAOTFromJNI/NativeAotTypeManager.cs
@@ -1,148 +1,51 @@
-using Java.Interop;
 using System.Diagnostics.CodeAnalysis;
+
+using Java.Interop;
 
 namespace Hello_NativeAOTFromJNI;
 
-class NativeAotTypeManager : JniRuntime.JniTypeManager {
-	internal const DynamicallyAccessedMemberTypes Methods = DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods;
-	internal const DynamicallyAccessedMemberTypes MethodsAndPrivateNested = Methods | DynamicallyAccessedMemberTypes.NonPublicNestedTypes;
-	internal const DynamicallyAccessedMemberTypes MethodsConstructors = MethodsAndPrivateNested | DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
+// This NativeAOT sample derives from the reflection-based JniRuntime.ReflectionJniTypeManager,
+// which is the behavior the base JniRuntime.JniTypeManager provided before dotnet/java-interop#1441.
+// Deriving from it means built-in runtime types such as JavaProxyObject/JavaProxyThrowable get
+// their native members registered automatically (via reflection over their
+// [JniAddNativeMethodRegistration] methods), so the sample does not need to register them by hand.
+// ReflectionJniTypeManager is annotated [RequiresDynamicCode]/[RequiresUnreferencedCode]; the
+// reflection paths actually exercised by this sample do not require runtime code generation, so the
+// constructor suppresses the resulting trimming/AOT warnings (a #pragma would not survive the
+// ILLink/ILC publish passes, so an [UnconditionalSuppressMessage] is required).
+class NativeAotTypeManager : JniRuntime.ReflectionJniTypeManager {
+
+	Dictionary<string, Type> typeMappings = new () {
+		[Example.ManagedType.JniTypeName]   = typeof (Example.ManagedType),
+	};
+
+	[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "Reflection-based registration used by this NativeAOT sample does not require unreferenced code; see class comment.")]
+	[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "Reflection-based registration used by this NativeAOT sample does not require runtime code generation; see class comment.")]
+	public NativeAotTypeManager ()
+	{
+	}
 
 	protected override IEnumerable<Type> GetTypesForSimpleReference (string jniSimpleReference)
 	{
-		var target = GetTypeForSimpleReference (jniSimpleReference);
-		if (target != null)
+		if (typeMappings.TryGetValue (jniSimpleReference, out var target))
 			yield return target;
-	}
-
-	[return: DynamicallyAccessedMembers (MethodsConstructors)]
-	protected override Type? GetTypeForSimpleReference (string jniSimpleReference)
-	{
-		return jniSimpleReference switch {
-			"V"                            => typeof (void),
-			"Z"                            => typeof (bool),
-			"java/lang/Boolean"            => typeof (bool?),
-			"B"                            => typeof (sbyte),
-			"java/lang/Byte"               => typeof (sbyte?),
-			"C"                            => typeof (char),
-			"java/lang/Character"          => typeof (char?),
-			"S"                            => typeof (short),
-			"java/lang/Short"              => typeof (short?),
-			"I"                            => typeof (int),
-			"java/lang/Integer"            => typeof (int?),
-			"J"                            => typeof (long),
-			"java/lang/Long"               => typeof (long?),
-			"F"                            => typeof (float),
-			"java/lang/Float"              => typeof (float?),
-			"D"                            => typeof (double),
-			"java/lang/Double"             => typeof (double?),
-			Example.ManagedType.JniTypeName => typeof (Example.ManagedType),
-			"java/lang/Object"             => typeof (Java.Lang.Object),
-			"java/lang/String"             => typeof (Java.Lang.String),
-			_                              => null,
-		};
-	}
-
-	public override IEnumerable<Type> GetTypes (JniTypeSignature typeSignature)
-	{
-		if (!typeSignature.IsValid || typeSignature.ArrayRank != 0 || typeSignature.SimpleReference == null)
-			return [];
-		return GetTypesForSimpleReference (typeSignature.SimpleReference);
-	}
-
-	public override IEnumerable<JniRuntime.JniTypeManager.ReflectionConstructibleType> GetReflectionConstructibleTypes (JniTypeSignature typeSignature)
-	{
-		if (!typeSignature.IsValid || typeSignature.ArrayRank != 0 || typeSignature.SimpleReference == null)
-			yield break;
-		var target = GetTypeForSimpleReference (typeSignature.SimpleReference);
-		if (target != null)
-			yield return new JniRuntime.JniTypeManager.ReflectionConstructibleType (target);
+		foreach (var t in base.GetTypesForSimpleReference (jniSimpleReference))
+			yield return t;
 	}
 
 	protected override IEnumerable<string> GetSimpleReferences (Type type)
 	{
-		return CreateSimpleReferencesEnumerator (type);
+		return base.GetSimpleReferences (type)
+			.Concat (CreateSimpleReferencesEnumerator (type));
 	}
 
 	IEnumerable<string> CreateSimpleReferencesEnumerator (Type type)
 	{
-		if (type == typeof (Example.ManagedType))
-			yield return Example.ManagedType.JniTypeName;
-		else if (type == typeof (Java.Lang.Object))
-			yield return "java/lang/Object";
-		else if (type == typeof (Java.Lang.String))
-			yield return "java/lang/String";
-	}
-
-	protected override string? GetSimpleReference (Type type)
-	{
-		return GetSimpleReferences (type).FirstOrDefault ();
-	}
-
-	protected override JniTypeSignature GetTypeSignatureCore (Type type)
-	{
-		var simpleReference = GetSimpleReference (type);
-		return simpleReference == null ? default : new JniTypeSignature (simpleReference, 0, false);
-	}
-
-	protected override IEnumerable<JniTypeSignature> GetTypeSignaturesCore (Type type)
-	{
-		var signature = GetTypeSignatureCore (type);
-		if (signature.IsValid)
-			yield return signature;
-	}
-
-	[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
-	protected override Type? GetInvokerTypeCore (
-			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
-			Type type)
-	{
-		return null;
-	}
-
-	protected override IReadOnlyList<string>? GetStaticMethodFallbackTypesCore (string jniSimpleReference)
-	{
-		return null;
-	}
-
-	protected override string? GetReplacementTypeCore (string jniSimpleReference)
-	{
-		return null;
-	}
-
-	protected override JniRuntime.ReplacementMethodInfo? GetReplacementMethodInfoCore (string jniSourceType, string jniMethodName, string jniMethodSignature)
-	{
-		return null;
-	}
-
-	public override void RegisterNativeMembers (
-			JniType nativeClass,
-			[DynamicallyAccessedMembers (MethodsAndPrivateNested)]
-			Type type,
-			ReadOnlySpan<char> methods)
-	{
-		if (TryRegisterBuiltInNativeMembers (nativeClass, nativeClass.Name, methods))
-			return;
-
-		if (type != typeof (Example.ManagedType)) {
-			if (!methods.IsEmpty)
-				throw new NotSupportedException ($"Could not register native members for type '{type.FullName}'.");
-			return;
+		if (typeMappings == null)
+			yield break;
+		foreach (var e in typeMappings) {
+			if (e.Value == type)
+				yield return e.Key;
 		}
-
-		var registrations = new List<JniNativeMethodRegistration> ();
-		Example.ManagedType.RegisterNativeMembers (new JniNativeMethodRegistrationArguments (registrations, null));
-		if (registrations.Count > 0)
-			nativeClass.RegisterNativeMethods (registrations.ToArray ());
-	}
-
-	[Obsolete ("Use RegisterNativeMembers(JniType, Type, ReadOnlySpan<char>)")]
-	public override void RegisterNativeMembers (
-			JniType nativeClass,
-			[DynamicallyAccessedMembers (MethodsAndPrivateNested)]
-			Type type,
-			string? methods)
-	{
-		RegisterNativeMembers (nativeClass, type, methods.AsSpan ());
 	}
 }

--- a/samples/Hello-NativeAOTFromJNI/NativeAotTypeManager.cs
+++ b/samples/Hello-NativeAOTFromJNI/NativeAotTypeManager.cs
@@ -4,23 +4,14 @@ using Java.Interop;
 
 namespace Hello_NativeAOTFromJNI;
 
-// This NativeAOT sample derives from the reflection-based JniRuntime.ReflectionJniTypeManager,
-// which is the behavior the base JniRuntime.JniTypeManager provided before dotnet/java-interop#1441.
-// Deriving from it means built-in runtime types such as JavaProxyObject/JavaProxyThrowable get
-// their native members registered automatically (via reflection over their
-// [JniAddNativeMethodRegistration] methods), so the sample does not need to register them by hand.
-// ReflectionJniTypeManager is annotated [RequiresDynamicCode]/[RequiresUnreferencedCode]; the
-// reflection paths actually exercised by this sample do not require runtime code generation, so the
-// constructor suppresses the resulting trimming/AOT warnings (a #pragma would not survive the
-// ILLink/ILC publish passes, so an [UnconditionalSuppressMessage] is required).
 class NativeAotTypeManager : JniRuntime.ReflectionJniTypeManager {
 
 	Dictionary<string, Type> typeMappings = new () {
 		[Example.ManagedType.JniTypeName]   = typeof (Example.ManagedType),
 	};
 
-	[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "Reflection-based registration used by this NativeAOT sample does not require unreferenced code; see class comment.")]
-	[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "Reflection-based registration used by this NativeAOT sample does not require runtime code generation; see class comment.")]
+	[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "Reflection-based registration used by this NativeAOT sample does not require unreferenced code.")]
+	[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "Reflection-based registration used by this NativeAOT sample does not require runtime code generation.")]
 	public NativeAotTypeManager ()
 	{
 	}

--- a/src/Java.Interop/Java.Interop/JavaProxyObject.cs
+++ b/src/Java.Interop/Java.Interop/JavaProxyObject.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -16,11 +17,23 @@ namespace Java.Interop {
 		static  readonly    ConditionalWeakTable<object, JavaProxyObject>   CachedValues    = new ConditionalWeakTable<object, JavaProxyObject> ();
 
 		[JniAddNativeMethodRegistrationAttribute]
-		internal static void RegisterNativeMembers (JniNativeMethodRegistrationArguments args)
+		static void RegisterNativeMembers (JniNativeMethodRegistrationArguments args)
 		{
 			args.Registrations.Add (new JniNativeMethodRegistration ("equals",   "(Ljava/lang/Object;)Z", new EqualsMarshalMethod (Equals)));
 			args.Registrations.Add (new JniNativeMethodRegistration ("hashCode", "()I",                   new GetHashCodeMarshalMethod (GetHashCode)));
 			args.Registrations.Add (new JniNativeMethodRegistration ("toString", "()Ljava/lang/String;",  new ToStringMarshalMethod (ToString)));
+		}
+
+		// Reflection-free registration entry point for the built-in proxy type, used by
+		// JniRuntime.JniTypeManager.TryRegisterBuiltInNativeMembers (). Keeping the
+		// [JniAddNativeMethodRegistrationAttribute] method private ensures it is stripped
+		// from the reference assembly so the trimmable typemap scanner does not flag it.
+		internal static void RegisterBuiltInNativeMembers (JniType nativeClass)
+		{
+			var registrations = new List<JniNativeMethodRegistration> ();
+			RegisterNativeMembers (new JniNativeMethodRegistrationArguments (registrations, null));
+			if (registrations.Count > 0)
+				nativeClass.RegisterNativeMethods (registrations.ToArray ());
 		}
 
 		public override JniPeerMembers JniPeerMembers {

--- a/src/Java.Interop/Java.Interop/JavaProxyObject.cs
+++ b/src/Java.Interop/Java.Interop/JavaProxyObject.cs
@@ -1,7 +1,6 @@
 #nullable enable
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -19,17 +18,9 @@ namespace Java.Interop {
 		[JniAddNativeMethodRegistrationAttribute]
 		static void RegisterNativeMembers (JniNativeMethodRegistrationArguments args)
 		{
-			AddBuiltInRegistrations (args.Registrations);
-		}
-
-		// Attribute-free entry point so the built-in registrations can be reused by the
-		// reflection-free NativeAOT path (JniRuntime.JniTypeManager.TryRegisterBuiltInNativeMembers)
-		// without exposing [JniAddNativeMethodRegistrationAttribute] in the reference assembly.
-		internal static void AddBuiltInRegistrations (ICollection<JniNativeMethodRegistration> registrations)
-		{
-			registrations.Add (new JniNativeMethodRegistration ("equals",   "(Ljava/lang/Object;)Z", new EqualsMarshalMethod (Equals)));
-			registrations.Add (new JniNativeMethodRegistration ("hashCode", "()I",                   new GetHashCodeMarshalMethod (GetHashCode)));
-			registrations.Add (new JniNativeMethodRegistration ("toString", "()Ljava/lang/String;",  new ToStringMarshalMethod (ToString)));
+			args.Registrations.Add (new JniNativeMethodRegistration ("equals",   "(Ljava/lang/Object;)Z", new EqualsMarshalMethod (Equals)));
+			args.Registrations.Add (new JniNativeMethodRegistration ("hashCode", "()I",                   new GetHashCodeMarshalMethod (GetHashCode)));
+			args.Registrations.Add (new JniNativeMethodRegistration ("toString", "()Ljava/lang/String;",  new ToStringMarshalMethod (ToString)));
 		}
 
 		public override JniPeerMembers JniPeerMembers {

--- a/src/Java.Interop/Java.Interop/JavaProxyObject.cs
+++ b/src/Java.Interop/Java.Interop/JavaProxyObject.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -18,9 +19,17 @@ namespace Java.Interop {
 		[JniAddNativeMethodRegistrationAttribute]
 		static void RegisterNativeMembers (JniNativeMethodRegistrationArguments args)
 		{
-			args.Registrations.Add (new JniNativeMethodRegistration ("equals",   "(Ljava/lang/Object;)Z", new EqualsMarshalMethod (Equals)));
-			args.Registrations.Add (new JniNativeMethodRegistration ("hashCode", "()I",                   new GetHashCodeMarshalMethod (GetHashCode)));
-			args.Registrations.Add (new JniNativeMethodRegistration ("toString", "()Ljava/lang/String;",  new ToStringMarshalMethod (ToString)));
+			AddBuiltInRegistrations (args.Registrations);
+		}
+
+		// Attribute-free entry point so the built-in registrations can be reused by the
+		// reflection-free NativeAOT path (JniRuntime.JniTypeManager.TryRegisterBuiltInNativeMembers)
+		// without exposing [JniAddNativeMethodRegistrationAttribute] in the reference assembly.
+		internal static void AddBuiltInRegistrations (ICollection<JniNativeMethodRegistration> registrations)
+		{
+			registrations.Add (new JniNativeMethodRegistration ("equals",   "(Ljava/lang/Object;)Z", new EqualsMarshalMethod (Equals)));
+			registrations.Add (new JniNativeMethodRegistration ("hashCode", "()I",                   new GetHashCodeMarshalMethod (GetHashCode)));
+			registrations.Add (new JniNativeMethodRegistration ("toString", "()Ljava/lang/String;",  new ToStringMarshalMethod (ToString)));
 		}
 
 		public override JniPeerMembers JniPeerMembers {

--- a/src/Java.Interop/Java.Interop/JavaProxyObject.cs
+++ b/src/Java.Interop/Java.Interop/JavaProxyObject.cs
@@ -1,7 +1,6 @@
 #nullable enable
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -22,18 +21,6 @@ namespace Java.Interop {
 			args.Registrations.Add (new JniNativeMethodRegistration ("equals",   "(Ljava/lang/Object;)Z", new EqualsMarshalMethod (Equals)));
 			args.Registrations.Add (new JniNativeMethodRegistration ("hashCode", "()I",                   new GetHashCodeMarshalMethod (GetHashCode)));
 			args.Registrations.Add (new JniNativeMethodRegistration ("toString", "()Ljava/lang/String;",  new ToStringMarshalMethod (ToString)));
-		}
-
-		// Reflection-free registration entry point for the built-in proxy type, used by
-		// JniRuntime.JniTypeManager.TryRegisterBuiltInNativeMembers (). Keeping the
-		// [JniAddNativeMethodRegistrationAttribute] method private ensures it is stripped
-		// from the reference assembly so the trimmable typemap scanner does not flag it.
-		internal static void RegisterBuiltInNativeMembers (JniType nativeClass)
-		{
-			var registrations = new List<JniNativeMethodRegistration> ();
-			RegisterNativeMembers (new JniNativeMethodRegistrationArguments (registrations, null));
-			if (registrations.Count > 0)
-				nativeClass.RegisterNativeMethods (registrations.ToArray ());
 		}
 
 		public override JniPeerMembers JniPeerMembers {

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
@@ -253,22 +253,6 @@ namespace Java.Interop {
 				};
 			}
 
-			protected static bool TryRegisterBuiltInNativeMembers (
-					JniType nativeClass,
-					string jniSimpleReference,
-					ReadOnlySpan<char> methods)
-			{
-				if (jniSimpleReference == JavaProxyObject.JniTypeName) {
-					var registrations = new List<JniNativeMethodRegistration> ();
-					JavaProxyObject.AddBuiltInRegistrations (registrations);
-					if (registrations.Count > 0)
-						nativeClass.RegisterNativeMethods (registrations.ToArray ());
-					return true;
-				}
-
-				return jniSimpleReference == JavaProxyThrowable.JniTypeName && methods.IsEmpty;
-			}
-
 			/// <include file="../Documentation/Java.Interop/JniRuntime.JniTypeManager.xml" path="/docs/member[@name='M:GetInvokerType']/*" />
 			[return: DynamicallyAccessedMembers (Constructors)]
 			public Type? GetInvokerType (

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
@@ -253,6 +253,22 @@ namespace Java.Interop {
 				};
 			}
 
+			protected static bool TryRegisterBuiltInNativeMembers (
+					JniType nativeClass,
+					string jniSimpleReference,
+					ReadOnlySpan<char> methods)
+			{
+				if (jniSimpleReference == JavaProxyObject.JniTypeName) {
+					var registrations = new List<JniNativeMethodRegistration> ();
+					JavaProxyObject.AddBuiltInRegistrations (registrations);
+					if (registrations.Count > 0)
+						nativeClass.RegisterNativeMethods (registrations.ToArray ());
+					return true;
+				}
+
+				return jniSimpleReference == JavaProxyThrowable.JniTypeName && methods.IsEmpty;
+			}
+
 			/// <include file="../Documentation/Java.Interop/JniRuntime.JniTypeManager.xml" path="/docs/member[@name='M:GetInvokerType']/*" />
 			[return: DynamicallyAccessedMembers (Constructors)]
 			public Type? GetInvokerType (

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
@@ -253,19 +253,6 @@ namespace Java.Interop {
 				};
 			}
 
-			protected static bool TryRegisterBuiltInNativeMembers (
-					JniType nativeClass,
-					string jniSimpleReference,
-					ReadOnlySpan<char> methods)
-			{
-				if (jniSimpleReference == JavaProxyObject.JniTypeName) {
-					JavaProxyObject.RegisterBuiltInNativeMembers (nativeClass);
-					return true;
-				}
-
-				return jniSimpleReference == JavaProxyThrowable.JniTypeName && methods.IsEmpty;
-			}
-
 			/// <include file="../Documentation/Java.Interop/JniRuntime.JniTypeManager.xml" path="/docs/member[@name='M:GetInvokerType']/*" />
 			[return: DynamicallyAccessedMembers (Constructors)]
 			public Type? GetInvokerType (

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
@@ -259,10 +259,7 @@ namespace Java.Interop {
 					ReadOnlySpan<char> methods)
 			{
 				if (jniSimpleReference == JavaProxyObject.JniTypeName) {
-					var registrations = new List<JniNativeMethodRegistration> ();
-					JavaProxyObject.RegisterNativeMembers (new JniNativeMethodRegistrationArguments (registrations, null));
-					if (registrations.Count > 0)
-						nativeClass.RegisterNativeMethods (registrations.ToArray ());
+					JavaProxyObject.RegisterBuiltInNativeMembers (nativeClass);
 					return true;
 				}
 

--- a/src/Java.Interop/PublicAPI.Unshipped.txt
+++ b/src/Java.Interop/PublicAPI.Unshipped.txt
@@ -8,7 +8,6 @@ virtual Java.Interop.JniRuntime.JniTypeManager.GetReflectionConstructibleTypes(J
 virtual Java.Interop.JniRuntime.JniTypeManager.GetTypeForSimpleReference(string! jniSimpleReference) -> System.Type?
 virtual Java.Interop.JniRuntime.JniTypeManager.GetTypeSignatureCore(System.Type! type) -> Java.Interop.JniTypeSignature
 virtual Java.Interop.JniRuntime.JniTypeManager.GetTypeSignaturesCore(System.Type! type) -> System.Collections.Generic.IEnumerable<Java.Interop.JniTypeSignature>!
-static Java.Interop.JniRuntime.JniTypeManager.TryRegisterBuiltInNativeMembers(Java.Interop.JniType! nativeClass, string! jniSimpleReference, System.ReadOnlySpan<char> methods) -> bool
 Java.Interop.JavaException.JavaException(ref Java.Interop.JniObjectReference reference, Java.Interop.JniObjectReferenceOptions transfer, Java.Interop.JniObjectReference throwableOverride) -> void
 Java.Interop.JavaException.SetJavaStackTrace(Java.Interop.JniObjectReference peerReferenceOverride = default(Java.Interop.JniObjectReference)) -> void
 Java.Interop.JniRuntime.ReflectionJniTypeManager

--- a/src/Java.Interop/PublicAPI.Unshipped.txt
+++ b/src/Java.Interop/PublicAPI.Unshipped.txt
@@ -8,6 +8,7 @@ virtual Java.Interop.JniRuntime.JniTypeManager.GetReflectionConstructibleTypes(J
 virtual Java.Interop.JniRuntime.JniTypeManager.GetTypeForSimpleReference(string! jniSimpleReference) -> System.Type?
 virtual Java.Interop.JniRuntime.JniTypeManager.GetTypeSignatureCore(System.Type! type) -> Java.Interop.JniTypeSignature
 virtual Java.Interop.JniRuntime.JniTypeManager.GetTypeSignaturesCore(System.Type! type) -> System.Collections.Generic.IEnumerable<Java.Interop.JniTypeSignature>!
+static Java.Interop.JniRuntime.JniTypeManager.TryRegisterBuiltInNativeMembers(Java.Interop.JniType! nativeClass, string! jniSimpleReference, System.ReadOnlySpan<char> methods) -> bool
 Java.Interop.JavaException.JavaException(ref Java.Interop.JniObjectReference reference, Java.Interop.JniObjectReferenceOptions transfer, Java.Interop.JniObjectReference throwableOverride) -> void
 Java.Interop.JavaException.SetJavaStackTrace(Java.Interop.JniObjectReference peerReferenceOverride = default(Java.Interop.JniObjectReference)) -> void
 Java.Interop.JniRuntime.ReflectionJniTypeManager


### PR DESCRIPTION
## Problem

dotnet/android's trimmable typemap scanner rejects any type carrying `[JniAddNativeMethodRegistrationAttribute]` with **XA4251**, and it currently fails on the built-in `Java.Interop.JavaProxyObject` — blocking the Java.Interop bump in dotnet/android#11622.

## Root cause

#1441 changed `JavaProxyObject.RegisterNativeMembers` from `private` to **`internal`** so that a new helper, `JniRuntime.JniTypeManager.TryRegisterBuiltInNativeMembers ()`, could call it directly. Private members are stripped from **reference assemblies** but internal ones are not, so the `internal` bump caused `[JniAddNativeMethodRegistration]` to leak into Java.Interop's reference assembly — which is exactly what dotnet/android's scanner reads, tripping XA4251.

`JavaProxyObject`'s natives don't actually need that direct call on the default path: the reflection-based `ReflectionJniTypeManager` registers them via `FindAndCallRegisterMethod` → `GetRuntimeMethods ()` (which finds `private` methods) → `CreateDelegate`. So restoring `private` fixes XA4251 without changing default-runtime behavior.

## Fix

- **`JavaProxyObject.RegisterNativeMembers`: `internal` → `private`** (its state before #1441). This strips `[JniAddNativeMethodRegistration]` from the reference assembly and resolves XA4251.
- **Remove `JniRuntime.JniTypeManager.TryRegisterBuiltInNativeMembers ()`** (and its `PublicAPI.Unshipped.txt` entry). It was *not* dead code — the two NativeAOT samples called it — so rather than keep a helper that re-leaks the attribute, the samples are reworked to not need it (below).
- **Rework both NativeAOT sample type managers** (`Hello-NativeAOTFromJNI`, `Hello-NativeAOTFromAndroid`) to derive from `JniRuntime.ReflectionJniTypeManager` — the behavior the base `JniTypeManager` provided before #1441. Built-in types (`JavaProxyObject`/`JavaProxyThrowable`, primitives, …) are then registered automatically via reflection, so the samples drop their hand-written registration. Each overrides `GetTypeForSimpleReference` (singular — `GetType ()` dispatches through it post-#1441) to resolve its own managed types, and suppresses IL2026/IL3050 on the ctor (the base is `[RequiresDynamicCode]`/`[RequiresUnreferencedCode]`; the reflection path it uses is preserved via `[DynamicallyAccessedMembers]` and `CreateDelegate`, so the suppression is safe for these samples).

Net change: **+69 / −269 across 5 files** — production is a one-line visibility change plus the helper/PublicAPI deletions; the rest is sample simplification.

## Behavior

- **Default runtimes (Mono/CoreCLR, including dotnet/android):** no change — `JavaProxyObject` registration still happens via reflection over the now-`private` method, exactly as before #1441.
- **NativeAOT samples:** functionally equivalent — they register built-ins via the reflection base instead of the removed helper.

## Verification

- ✅ `Java.Interop.csproj` builds clean (0/0); PublicApiAnalyzer consistent.
- ✅ Metadata inspection of the produced **reference assembly**: no method on `JavaProxyObject` carries `[JniAddNativeMethodRegistration]` (the attributed method is stripped), so dotnet/android's trimmable scanner no longer trips XA4251. The implementation assembly keeps the private attributed method for reflection.
- ✅ CI `dotnet.java-interop` is green; the `Hello-NativeAOTFromJNI` publish + `RunJavaSample` steps pass (the latter caught and validated the fix to the post-#1441 `GetType ()` → `GetTypeForSimpleReference` resolution).
- ✅ dotnet/android side validated on-device (emulator, API 36) with this Java.Interop: CoreCLR + trimmable typemap 940/0/7 and CoreCLR + managed typemap 911/0/52, including the `JavaProxyObject_*` runtime tests that exercise the now-private registration.

Unblocks dotnet/android#11622. cc @jonathanpeppers — review/approve once you're happy please? 🙏

> **On the samples:** `Hello-NativeAOTFromAndroid` isn't in `Java.Interop.sln` and isn't built or run by any pipeline (it needs an Android device), so — like the rest of the samples — it has no automated test coverage; that's the existing setup, not a gap this PR introduces. What this PR actually ships is the `JavaProxyObject` visibility fix, and that's covered by `dotnet.java-interop` CI (`Hello-NativeAOTFromJNI` publish + `RunJavaSample`) and the on-device dotnet/android runtime tests. Whether to keep one sample on the original reflection-free AOT path (rather than deriving from `ReflectionJniTypeManager`) is a separate design preference — happy to defer that to @jonathanpeppers.
