### PR TITLE
Register JNI natives via blittable JniNativeMethod

### DIFF
--- a/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
+++ b/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
@@ -305,7 +305,7 @@ namespace Java.Interop
 						unmanagedStrings [i * 2] = name;
 						IntPtr sig  = Marshal.StringToCoTaskMemUTF8 (m.Signature);
 						unmanagedStrings [i * 2 + 1] = sig;
-						natives [i] = new JniNativeMethod ((byte*) name, (byte*) sig, GetFunctionPointerForDelegate (m.Marshaler));
+						natives [i] = new JniNativeMethod ((byte*) name, (byte*) sig, Marshal.GetFunctionPointerForDelegate (m.Marshaler));
 					}
 					RegisterNatives (type, natives);
 					// Keep the Marshaler delegates alive at least until JNI has consumed the function pointers.
@@ -317,10 +317,6 @@ namespace Java.Interop
 					}
 				}
 			}
-
-			[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "RequiresDynamicCode on RegisterNatives propagates the requirement; this helper is only called from that method.")]
-			static IntPtr GetFunctionPointerForDelegate (Delegate marshaler) =>
-				Marshal.GetFunctionPointerForDelegate (marshaler);
 
 			/// <summary>
 			/// Registers JNI native methods using blittable <see cref="JniNativeMethod"/> structs

--- a/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
+++ b/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
@@ -297,12 +297,13 @@ namespace Java.Interop
 				Span<IntPtr> unmanagedStrings = useStackAllocatedBuffers
 					? stackalloc IntPtr [numMethods * 2]
 					: new IntPtr [numMethods * 2];
+				unmanagedStrings.Clear ();
 				try {
 					for (int i = 0; i < numMethods; ++i) {
 						var m       = methods [i];
 						IntPtr name = Marshal.StringToCoTaskMemUTF8 (m.Name);
+						unmanagedStrings [i * 2] = name;
 						IntPtr sig  = Marshal.StringToCoTaskMemUTF8 (m.Signature);
-						unmanagedStrings [i * 2]     = name;
 						unmanagedStrings [i * 2 + 1] = sig;
 						natives [i] = new JniNativeMethod ((byte*) name, (byte*) sig, GetFunctionPointerForDelegate (m.Marshaler));
 					}
@@ -345,7 +346,7 @@ namespace Java.Interop
 
 				// Surface (and clear) any pending Java exception raised by JNI::RegisterNatives()
 				// — e.g. NoSuchMethodError — before falling back to the return-code check, matching
-				// the behavior of the generated `_RegisterNatives` wrapper. Leaving a pending
+				// the behavior of the prior JniNativeMethodRegistration[] registration path. Leaving a pending
 				// exception in the JNIEnv would make subsequent JNI calls fail or abort.
 				var thrown = JniEnvironment.GetExceptionForLastThrowable ();
 				if (thrown != null)

--- a/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
+++ b/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
@@ -287,8 +287,14 @@ namespace Java.Interop
 				// miscompiled by crossgen2 under composite ReadyToRun + PGO: the JniNativeMethod `name`
 				// pointers end up referencing the managed `string` objects instead of marshalled UTF-8
 				// data, which corrupts the registered method names. See https://github.com/dotnet/android/issues/11633.
-				var natives = new JniNativeMethod [numMethods];
-				var unmanagedStrings = new IntPtr [numMethods * 2];
+				const int MaxStackAllocatedNativeMethods = 32;
+				bool useStackAllocatedBuffers = numMethods <= MaxStackAllocatedNativeMethods;
+				Span<JniNativeMethod> natives = useStackAllocatedBuffers
+					? stackalloc JniNativeMethod [numMethods]
+					: new JniNativeMethod [numMethods];
+				Span<IntPtr> unmanagedStrings = useStackAllocatedBuffers
+					? stackalloc IntPtr [numMethods * 2]
+					: new IntPtr [numMethods * 2];
 				try {
 					for (int i = 0; i < numMethods; ++i) {
 						var m       = methods [i];
@@ -298,7 +304,7 @@ namespace Java.Interop
 						unmanagedStrings [i * 2 + 1] = sig;
 						natives [i] = new JniNativeMethod ((byte*) name, (byte*) sig, GetFunctionPointerForDelegate (m.Marshaler));
 					}
-					RegisterNatives (type, new ReadOnlySpan<JniNativeMethod> (natives, 0, numMethods));
+					RegisterNatives (type, natives);
 					// Keep the Marshaler delegates alive at least until JNI has consumed the function pointers.
 					GC.KeepAlive (methods);
 				} finally {

--- a/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
+++ b/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
@@ -252,11 +252,13 @@ namespace Java.Interop
 				return value.Replace ('.', '/');
 			}
 
+			[RequiresDynamicCode ("Native method registration via JniNativeMethodRegistration[] requires dynamic code generation. Use the blittable RegisterNatives(JniObjectReference, ReadOnlySpan<JniNativeMethod>) overload with statically-compiled function pointers for Native AOT compatibility.")]
 			public static void RegisterNatives (JniObjectReference type, JniNativeMethodRegistration [] methods)
 			{
 				RegisterNatives (type, methods, methods == null ? 0 : methods.Length);
 			}
 
+			[RequiresDynamicCode ("Native method registration via JniNativeMethodRegistration[] requires dynamic code generation. Use the blittable RegisterNatives(JniObjectReference, ReadOnlySpan<JniNativeMethod>) overload with statically-compiled function pointers for Native AOT compatibility.")]
 			public static unsafe void RegisterNatives (JniObjectReference type, JniNativeMethodRegistration [] methods, int numMethods)
 			{
 				if ((numMethods < 0) ||
@@ -314,10 +316,7 @@ namespace Java.Interop
 				}
 			}
 
-			// Native method registration via JniNativeMethodRegistration[] only runs on JIT-capable
-			// runtimes (MonoVM/CoreCLR). Under NativeAOT, native methods are registered through the
-			// trimmable type map using statically-compiled function pointers, so this path is never reached.
-			[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "Not reached under NativeAOT; only JIT-capable runtimes register via JniNativeMethodRegistration[].")]
+			[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "RequiresDynamicCode on RegisterNatives propagates the requirement; this helper is only called from that method.")]
 			static IntPtr GetFunctionPointerForDelegate (Delegate marshaler) =>
 				Marshal.GetFunctionPointerForDelegate (marshaler);
 

--- a/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
+++ b/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Collections.Generic;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
@@ -256,7 +257,7 @@ namespace Java.Interop
 				RegisterNatives (type, methods, methods == null ? 0 : methods.Length);
 			}
 
-			public static void RegisterNatives (JniObjectReference type, JniNativeMethodRegistration [] methods, int numMethods)
+			public static unsafe void RegisterNatives (JniObjectReference type, JniNativeMethodRegistration [] methods, int numMethods)
 			{
 				if ((numMethods < 0) ||
 						(numMethods > (methods?.Length ?? 0))) {
@@ -275,13 +276,44 @@ namespace Java.Interop
 				}
 #endif  // DEBUG
 
-				int r   = _RegisterNatives (type, methods ?? Array.Empty<JniNativeMethodRegistration>(), numMethods);
+				if (numMethods == 0 || methods == null) {
+					return;
+				}
 
-				if (r != 0) {
-					throw new InvalidOperationException (
-							string.Format ("Could not register native methods for class '{0}'; JNIEnv::RegisterNatives() returned {1}.", GetJniTypeNameFromClass (type), r));
+				// Marshal the non-blittable JniNativeMethodRegistration[] into blittable JniNativeMethod
+				// values and dispatch to the blittable overload, instead of invoking the JNI
+				// `RegisterNatives` function pointer with a non-blittable managed-array parameter.
+				// The runtime marshalling stub synthesized for such a `delegate* unmanaged<>` call is
+				// miscompiled by crossgen2 under composite ReadyToRun + PGO: the JniNativeMethod `name`
+				// pointers end up referencing the managed `string` objects instead of marshalled UTF-8
+				// data, which corrupts the registered method names. See https://github.com/dotnet/android/issues/11633.
+				var natives = new JniNativeMethod [numMethods];
+				var unmanagedStrings = new IntPtr [numMethods * 2];
+				try {
+					for (int i = 0; i < numMethods; ++i) {
+						var m       = methods [i];
+						IntPtr name = Marshal.StringToCoTaskMemUTF8 (m.Name);
+						IntPtr sig  = Marshal.StringToCoTaskMemUTF8 (m.Signature);
+						unmanagedStrings [i * 2]     = name;
+						unmanagedStrings [i * 2 + 1] = sig;
+						natives [i] = new JniNativeMethod ((byte*) name, (byte*) sig, GetFunctionPointerForDelegate (m.Marshaler));
+					}
+					RegisterNatives (type, new ReadOnlySpan<JniNativeMethod> (natives, 0, numMethods));
+					// Keep the Marshaler delegates alive at least until JNI has consumed the function pointers.
+					GC.KeepAlive (methods);
+				} finally {
+					for (int i = 0; i < unmanagedStrings.Length; ++i) {
+						Marshal.ZeroFreeCoTaskMemUTF8 (unmanagedStrings [i]);
+					}
 				}
 			}
+
+			// Native method registration via JniNativeMethodRegistration[] only runs on JIT-capable
+			// runtimes (MonoVM/CoreCLR). Under NativeAOT, native methods are registered through the
+			// trimmable type map using statically-compiled function pointers, so this path is never reached.
+			[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "Not reached under NativeAOT; only JIT-capable runtimes register via JniNativeMethodRegistration[].")]
+			static IntPtr GetFunctionPointerForDelegate (Delegate marshaler) =>
+				Marshal.GetFunctionPointerForDelegate (marshaler);
 
 			/// <summary>
 			/// Registers JNI native methods using blittable <see cref="JniNativeMethod"/> structs

--- a/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
+++ b/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
@@ -322,7 +322,11 @@ namespace Java.Interop
 			/// </summary>
 			public static unsafe void RegisterNatives (JniObjectReference type, ReadOnlySpan<JniNativeMethod> methods)
 			{
+				if (!type.IsValid)
+					throw new ArgumentException ("Handle must be valid.", nameof (type));
+
 				IntPtr env = JniEnvironment.EnvironmentPointer;
+				int r;
 				fixed (JniNativeMethod* methodsPtr = methods) {
 #if FEATURE_JNIENVIRONMENT_JI_FUNCTION_POINTERS
 					var registerNatives = (delegate* unmanaged<IntPtr, IntPtr, JniNativeMethod*, int, int>)
@@ -331,10 +335,19 @@ namespace Java.Interop
 					var registerNatives = (delegate* unmanaged<IntPtr, IntPtr, JniNativeMethod*, int, int>)
 						JniEnvironment.CurrentInfo.Invoker.env.RegisterNatives;
 #endif
-					int r = registerNatives (env, type.Handle, methodsPtr, methods.Length);
-					if (r != 0) {
-						throw new InvalidOperationException ($"Could not register native methods for class '{GetJniTypeNameFromClass (type)}'; JNIEnv::RegisterNatives() returned {r}.");
-					}
+					r = registerNatives (env, type.Handle, methodsPtr, methods.Length);
+				}
+
+				// Surface (and clear) any pending Java exception raised by JNI::RegisterNatives()
+				// — e.g. NoSuchMethodError — before falling back to the return-code check, matching
+				// the behavior of the generated `_RegisterNatives` wrapper. Leaving a pending
+				// exception in the JNIEnv would make subsequent JNI calls fail or abort.
+				var thrown = JniEnvironment.GetExceptionForLastThrowable ();
+				if (thrown != null)
+					ExceptionDispatchInfo.Capture (thrown).Throw ();
+
+				if (r != 0) {
+					throw new InvalidOperationException ($"Could not register native methods for class '{GetJniTypeNameFromClass (type)}'; JNIEnv::RegisterNatives() returned {r}.");
 				}
 			}
 

--- a/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
+++ b/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
@@ -312,7 +312,8 @@ namespace Java.Interop
 					GC.KeepAlive (methods);
 				} finally {
 					for (int i = 0; i < unmanagedStrings.Length; ++i) {
-						Marshal.ZeroFreeCoTaskMemUTF8 (unmanagedStrings [i]);
+						if (unmanagedStrings [i] != IntPtr.Zero)
+							Marshal.ZeroFreeCoTaskMemUTF8 (unmanagedStrings [i]);
 					}
 				}
 			}

--- a/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
+++ b/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
@@ -301,6 +301,8 @@ namespace Java.Interop
 				try {
 					for (int i = 0; i < numMethods; ++i) {
 						var m       = methods [i];
+						if (m.Marshaler == null)
+							throw new ArgumentException ($"JniNativeMethodRegistration[{i}] ({m.Name}{m.Signature}) has a null Marshaler delegate.", nameof (methods));
 						IntPtr name = Marshal.StringToCoTaskMemUTF8 (m.Name);
 						unmanagedStrings [i * 2] = name;
 						IntPtr sig  = Marshal.StringToCoTaskMemUTF8 (m.Signature);

--- a/src/Java.Interop/Java.Interop/JniType.cs
+++ b/src/Java.Interop/Java.Interop/JniType.cs
@@ -153,6 +153,7 @@ namespace Java.Interop {
 		JniNativeMethodRegistration[]? methods;
 #pragma warning restore 0414
 
+		[RequiresDynamicCode ("Native method registration via JniNativeMethodRegistration[] requires dynamic code generation. Use the blittable RegisterNatives(JniObjectReference, ReadOnlySpan<JniNativeMethod>) overload with statically-compiled function pointers for Native AOT compatibility.")]
 		public void RegisterNativeMethods (params JniNativeMethodRegistration[] methods)
 		{
 			AssertValid ();

--- a/src/Java.Interop/Java.Interop/ManagedPeer.cs
+++ b/src/Java.Interop/Java.Interop/ManagedPeer.cs
@@ -23,6 +23,7 @@ namespace Java.Interop {
 
 		static  readonly    JniPeerMembers  _members        = new JniPeerMembers (JniTypeName, typeof (ManagedPeer));
 
+		[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "ManagedPeer is not compatible with Native AOT; it's only used by reflection-based JniRuntime.JniValueManager implementations.")]
 		static ManagedPeer ()
 		{
 			_members.JniPeerType.RegisterNativeMethods (

--- a/tests/Java.Interop-Tests/Java.Interop/JniTypeTest.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JniTypeTest.cs
@@ -217,6 +217,73 @@ namespace Java.InteropTests
 
 		[UnmanagedCallersOnly]
 		static int NativeAdd (IntPtr jnienv, IntPtr self, int a, int b) => a + b;
+
+		[Test]
+		[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "Test exercises non-AOT-compatible JniNativeMethodRegistration[] registration path.")]
+		public unsafe void RegisterNativeMethods_JniNativeMethodRegistration ()
+		{
+			using (var nativeClass = new JniType ("net/dot/jni/test/RegisterNativesTestType")) {
+				// Test the JniNativeMethodRegistration[] registration path (the one that marshals to blittable)
+				var methods = new JniNativeMethodRegistration [1];
+				methods [0] = new JniNativeMethodRegistration (
+					"add",
+					"(II)I",
+					new AddDelegate (ManagedAdd));
+
+				JniEnvironment.Types.RegisterNatives (nativeClass.PeerReference, methods, methods.Length);
+
+				// Call the native method from Java to verify registration worked
+				var ctor = JniEnvironment.InstanceMethods.GetMethodID (nativeClass.PeerReference, "<init>", "()V");
+				var obj = JniEnvironment.Object.NewObject (nativeClass.PeerReference, ctor);
+				try {
+					var addMethod = JniEnvironment.InstanceMethods.GetMethodID (nativeClass.PeerReference, "add", "(II)I");
+					var args = stackalloc JniArgumentValue [2];
+					args [0] = new JniArgumentValue (5);
+					args [1] = new JniArgumentValue (6);
+					int result = JniEnvironment.InstanceMethods.CallIntMethod (obj, addMethod, args);
+					Assert.AreEqual (11, result);
+				} finally {
+					JniObjectReference.Dispose (ref obj);
+				}
+			}
+		}
+
+		delegate int AddDelegate (IntPtr jnienv, IntPtr self, int a, int b);
+
+		static int ManagedAdd (IntPtr jnienv, IntPtr self, int a, int b) => a + b;
+
+		[Test]
+		[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "Test exercises non-AOT-compatible JniNativeMethodRegistration[] registration path with many methods.")]
+		public unsafe void RegisterNativeMethods_JniNativeMethodRegistration_ManyMethods ()
+		{
+			using (var nativeClass = new JniType ("net/dot/jni/test/RegisterNativesTestType")) {
+				// Test the heap allocation path (> 32 methods) to ensure the marshalling loop handles it
+				var methods = new JniNativeMethodRegistration [40];
+				for (int i = 0; i < methods.Length; ++i) {
+					methods [i] = new JniNativeMethodRegistration (
+						"add",
+						"(II)I",
+						new AddDelegate (ManagedAdd));
+				}
+
+				// This should not crash even with > 32 methods
+				JniEnvironment.Types.RegisterNatives (nativeClass.PeerReference, methods, methods.Length);
+
+				// Verify the registration worked by calling the method
+				var ctor = JniEnvironment.InstanceMethods.GetMethodID (nativeClass.PeerReference, "<init>", "()V");
+				var obj = JniEnvironment.Object.NewObject (nativeClass.PeerReference, ctor);
+				try {
+					var addMethod = JniEnvironment.InstanceMethods.GetMethodID (nativeClass.PeerReference, "add", "(II)I");
+					var args = stackalloc JniArgumentValue [2];
+					args [0] = new JniArgumentValue (10);
+					args [1] = new JniArgumentValue (20);
+					int result = JniEnvironment.InstanceMethods.CallIntMethod (obj, addMethod, args);
+					Assert.AreEqual (30, result);
+				} finally {
+					JniObjectReference.Dispose (ref obj);
+				}
+			}
+		}
 	}
 }
 

--- a/tests/Java.Interop-Tests/Java.Interop/JniTypeTest.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JniTypeTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 using Java.Interop;
@@ -42,6 +43,7 @@ namespace Java.InteropTests
 		}
 
 		[Test]
+		[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "Test exercises non-AOT-compatible JniType.RegisterNativeMethods API.")]
 		public unsafe void Dispose_Exceptions ()
 		{
 			var t = new JniType ("java/lang/Object");
@@ -175,6 +177,7 @@ namespace Java.InteropTests
 		}
 
 		[Test]
+		[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "Test exercises non-AOT-compatible JniType.RegisterNativeMethods API.")]
 		public void RegisterNativeMethods ()
 		{
 			using (var TestType_class = new JniType ("net/dot/jni/test/CallNonvirtualBase")) {


### PR DESCRIPTION
## Summary

Register JNI native methods by marshalling into the **blittable** `JniNativeMethod` struct and calling the existing `RegisterNatives(JniObjectReference, ReadOnlySpan<JniNativeMethod>)` overload, instead of invoking the JNI `RegisterNatives` function pointer with a **non-blittable managed array** (`JniNativeMethodRegistration[]`).

This avoids relying on the runtime to marshal an array of a non-blittable struct across a `delegate* unmanaged<>` call — a path that is currently miscompiled by crossgen2 under composite ReadyToRun + PGO and corrupts the registered method names.

Refs https://github.com/dotnet/android/issues/11633

## Background: what breaks

The default (non-trimmable / llvm-ir typemap) registration funnels through:


```csharp
// JniEnvironment.Types
public static void RegisterNatives (JniObjectReference type, JniNativeMethodRegistration [] methods, int numMethods)
    => _RegisterNatives (type, methods, numMethods);   // generated invoker:
// delegate* unmanaged<IntPtr, jobject, JniNativeMethodRegistration[], int, int> RegisterNatives
```

`JniNativeMethodRegistration` is non-blittable (`string Name; string Signature; Delegate Marshaler`). Passing `JniNativeMethodRegistration[]` through the `delegate* unmanaged<>` requires the runtime to marshal the array element-by-element.

`ManagedPeer..cctor`, `AndroidTypeManager`, `ManagedTypeManager`, and every `JniType.RegisterNativeMethods` caller funnel through this single method (`_RegisterNatives` has exactly one caller), so fixing it here fixes all of them.

## Root cause (a crossgen2 / runtime regression)

dotnet/runtime **#126911** ("Move built-in array marshalling to managed", 2026-05-01) moved array-of-struct marshalling from native C++ into the managed generic `System.StubHelpers.StructureMarshaler<T> : IArrayElementMarshaler<T, StructureMarshaler<T>>`. Its element converter is an intrinsic with a **blittable-only fallback body**:


```csharp
// src/coreclr/System.Private.CoreLib/src/System/StubHelpers.cs
// "Non-blittable structs should have a custom IL body generated with the marshaling logic."
[Intrinsic]
private static void ConvertToUnmanagedCore (ref T managed, byte* unmanaged, ref CleanupWorkListElement? cleanupWorkList)
    => SpanHelpers.Memmove (ref *unmanaged, ref Unsafe.As<T,byte>(ref managed), (nuint)sizeof(T));
```

For non-blittable `T`, the VM generates a real per-field marshalling body at JIT time (`StructMarshalStubs::TryGenerateStructMarshallingMethod`, `dllimport.cpp`). **crossgen2 has no equivalent**, so when PGO/MIBC marks the marshaller hot and crossgen2 precompiles the shared canonical (`__Canon`) instantiation, it emits the literal `Memmove` fallback — a raw blit of the managed object references into the native struct.

Disassembly of the precompiled canonical converter from a composite-R2R + MIBC image:


```asm
StructureMarshaler`1<__Canon>.ConvertToUnmanagedCore:
    ldr  x0, [x1]     ; first 8 bytes of the managed struct = the Name string REFERENCE
    str  x0, [x2]     ; stored straight into the native JNINativeMethod.name  ← no string→char* marshalling
    ret
```

So JNI receives a managed `string` object pointer where it expects a UTF-8 `char*`, the method name is garbage, and registration fails with `NoSuchMethodError` during startup (e.g. `MauiApplication`, `net.dot.jni.ManagedPeer`).

This only manifests when crossgen2 precompiles the marshaller (MIBC marks it hot). Without a profile the JIT compiles it and registration is correct — which is why the same app works without a startup MIBC.

## Why this is the right fix

- It **eliminates the non-blittable array marshalling** at this call site entirely. The blittable `RegisterNatives(ReadOnlySpan<JniNativeMethod>)` path marshals names/signatures to UTF-8 ourselves (`Marshal.StringToCoTaskMemUTF8`) and passes a blittable `JniNativeMethod*` — there is no `StructureMarshaler<T>` involved, so it is correct regardless of the crossgen2 bug.
- It matches the **trimmable type-map path**, which already used the blittable overload and was therefore never affected.
- It is the single registration chokepoint, so it fixes `ManagedPeer`, `AndroidTypeManager`, and `ManagedTypeManager` together.

We do **not** want to marshal arrays of non-blittable types across `delegate* unmanaged<>` / P/Invoke boundaries given this runtime limitation. A scan of the shipped runtime path (Java.Interop + Mono.Android) shows `RegisterNatives` was the only such site: it is the only invoker function pointer with an array parameter, the only non-blittable-array native call; all `JValue[]` call sites already pin (`fixed (JValue* …)`) and pass a blittable pointer.

## Changes

- Rework `JniEnvironment.Types.RegisterNatives(JniObjectReference, JniNativeMethodRegistration[], int)` to marshal `Name`/`Signature` to unmanaged UTF-8 and a function pointer, then dispatch to the blittable `RegisterNatives(JniObjectReference, ReadOnlySpan<JniNativeMethod>)` overload (no more `_RegisterNatives` / non-blittable `delegate* unmanaged<>` call).
- Preserve JNI error behavior in the blittable overload: it now observes and rethrows (clearing) any pending Java exception from `JNIEnv::RegisterNatives()` — e.g. `NoSuchMethodError` — and guards `type.IsValid`, matching the generated `_RegisterNatives` wrapper it replaces. This benefits both the array-based path and the trimmable type-map path (which previously could leave a pending exception in the JNIEnv). 
- Add regression tests for the `JniNativeMethodRegistration[]` path to validate correct UTF-8 marshaling and function pointer conversion, covering both stack-allocated (≤32 methods) and heap-allocated (>32 methods) code paths.

## Implementation notes

- UTF-8 name/signature buffers are allocated with `Marshal.StringToCoTaskMemUTF8` and freed in a `finally` block with `Marshal.ZeroFreeCoTaskMemUTF8`, guarding against `IntPtr.Zero` to prevent crashes with uninitialized entries. `GC.KeepAlive (methods)` keeps the marshaler delegates alive across the native call.
- Null `Marshaler` delegates are explicitly checked with an actionable error message that includes the array index and method signature, rather than relying on the generic `ArgumentNullException` from `Marshal.GetFunctionPointerForDelegate`.
- `Marshal.GetFunctionPointerForDelegate` is called inline within the already-`RequiresDynamicCode`-annotated method. This `JniNativeMethodRegistration[]` path runs only on JIT-capable runtimes (MonoVM/CoreCLR); NativeAOT registers through the trimmable type map with statically-compiled function pointers and never reaches it.

## Verification

Reproduced and fixed in an isolated `net11.0` console app (no Java.Interop/Android types): a non-blittable `struct[]` passed through a `delegate* unmanaged<>` to a real native function corrupts only under composite R2R + MIBC (when the call site is hot); the blittable equivalent is correct under all configurations (JIT, plain R2R, composite R2R, composite R2R + MIBC).

## Tracking

- Underlying runtime regression introduced by dotnet/runtime#126911; durable fix belongs in crossgen2 (expand the marshalling intrinsic for non-blittable `__Canon`, or defer it to the JIT). This PR is the Java.Interop-side fix and is correct independent of the runtime change.