### PR TITLE
[tests] Exclude value marshaler tests from trimmable typemap

### DIFF
--- a/tests/Java.Interop-Tests/Java.Interop/JavaObjectArrayTest.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JavaObjectArrayTest.cs
@@ -65,7 +65,6 @@ namespace Java.InteropTests
 		}
 	}
 
-
 	[TestFixture]
 	public class JavaObjectArrayContractTest : JavaObjectArrayContractTest<JavaObject> {
 		protected override JavaObject CreateValueA () {return new JavaObject ();}

--- a/tests/Java.Interop-Tests/Java.Interop/JavaObjectArrayTest.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JavaObjectArrayTest.cs
@@ -65,6 +65,7 @@ namespace Java.InteropTests
 		}
 	}
 
+
 	[TestFixture]
 	public class JavaObjectArrayContractTest : JavaObjectArrayContractTest<JavaObject> {
 		protected override JavaObject CreateValueA () {return new JavaObject ();}
@@ -150,6 +151,7 @@ namespace Java.InteropTests
 	}
 
 	[TestFixture]
+	[Category ("TrimmableTypeMapUnsupported")]
 	public class JavaObjectArray_object_ContractTest : JavaObjectArrayContractTest<object> {
 		static  readonly    object  a   = new object ();
 
@@ -185,4 +187,3 @@ namespace Java.InteropTests
 		}
 	}
 }
-

--- a/tests/Java.Interop-Tests/Java.Interop/JniPeerMembersTests.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JniPeerMembersTests.cs
@@ -18,6 +18,7 @@ namespace Java.InteropTests
 		}
 
 		[Test]
+		[Category ("TrimmableTypeMapUnsupported")]
 		public void VirtualInvokeOnBaseInvokesMostDerivedJavaMethod ()
 		{
 			var registered  = GetInstanceMethods (MyString._members.InstanceMethods);

--- a/tests/Java.Interop-Tests/Java.Interop/JniValueMarshalerContractTests.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JniValueMarshalerContractTests.cs
@@ -14,6 +14,7 @@ using NUnit.Framework;
 
 namespace Java.InteropTests {
 
+	[Category ("TrimmableTypeMapUnsupported")]
 	public abstract class JniValueMarshalerContractTests<
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
 			T


### PR DESCRIPTION
Context from dotnet/android PR dotnet/android#11617: CoreCLR trimmable typemap runs fail tests that depend on unsupported reflection/value-marshaler behavior.

This marks the following tests as `TrimmableTypeMapUnsupported`:

- `JniValueMarshalerContractTests<T>`: these directly test the reflection-based value marshaler APIs. The trimmable typemap runtime intentionally throws if `GetValueMarshalerCore()` is called.
- `JniPeerMembersTests.VirtualInvokeOnBaseInvokesMostDerivedJavaMethod`: this still unexpectedly reaches `GetValueMarshalerCore<T>()` through the test helper constructor path; it should be fixed separately.
- `JavaObjectArray_object_ContractTest`: these inherited collection/list contract tests depend on plain managed `object` values round-tripping through `JavaProxyObject`. The trimmable value manager currently falls back to `JavaConvert.ToLocalJniHandle(value)`, which wraps plain objects as `Android.Runtime.JavaObject` (`mono/android/runtime/JavaObject`) instead of `Java.Interop.JavaProxyObject` (`net/dot/jni/internal/JavaProxyObject`).

Tracking issue for the JavaProxyObject/trimmable typemap support gap: dotnet/android#11703.

Validation:
- `dotnet build external/Java.Interop/tests/Java.Interop-Tests/Java.Interop-Tests.csproj --no-restore --verbosity:minimal`
- Local dotnet/android CoreCLR trimmable device run with `-p:PublishReadyToRun=false`: after these exclusions, the run drops to 2 failures (`TrimmableTypeMapTypeManagerTests.JavaProxyObject_ObjectMethodsUseJavaIdentitySemantics` in dotnet/android and `JniTypeManagerTests.GetType`, which is unrelated to JavaProxyObject object-array contracts).