### PR TITLE
Remove unnecessary DAM attributes

### DIFF
--- a/samples/Hello-NativeAOTFromAndroid/Hello-NativeAOTFromAndroid.csproj
+++ b/samples/Hello-NativeAOTFromAndroid/Hello-NativeAOTFromAndroid.csproj
@@ -22,6 +22,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <RuntimeHostConfigurationOption Include="Java.Interop.RuntimeFeature.ManagedPeerNativeRegistration" Value="false" Trim="true" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- https://github.com/exelix11/SysDVR/blob/master/Client/Client.csproj -->
     <!-- Android needs a proper soname property or it will refuse to load the library -->
     <LinkerArg Include="-Wl,-soname,lib$(AssemblyName)$(NativeBinaryExt)" />

--- a/samples/Hello-NativeAOTFromAndroid/Hello-NativeAOTFromAndroid.csproj
+++ b/samples/Hello-NativeAOTFromAndroid/Hello-NativeAOTFromAndroid.csproj
@@ -22,10 +22,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <RuntimeHostConfigurationOption Include="Java.Interop.RuntimeFeature.ManagedPeerNativeRegistration" Value="false" Trim="true" />
-  </ItemGroup>
-
-  <ItemGroup>
     <!-- https://github.com/exelix11/SysDVR/blob/master/Client/Client.csproj -->
     <!-- Android needs a proper soname property or it will refuse to load the library -->
     <LinkerArg Include="-Wl,-soname,lib$(AssemblyName)$(NativeBinaryExt)" />

--- a/samples/Hello-NativeAOTFromAndroid/NativeAotTypeManager.cs
+++ b/samples/Hello-NativeAOTFromAndroid/NativeAotTypeManager.cs
@@ -15,12 +15,6 @@ namespace Java.Interop.Samples.NativeAotFromAndroid;
 // suppressions lived (buried) inside JniTypeManager itself, justified "NotUsedInAndroid"; #1441 just
 // moved that responsibility to callers via [RequiresDynamicCode]/[RequiresUnreferencedCode].
 partial class NativeAotTypeManager : JniRuntime.ReflectionJniTypeManager {
-
-	const DynamicallyAccessedMemberTypes MethodsConstructors =
-		DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods |
-		DynamicallyAccessedMemberTypes.NonPublicNestedTypes |
-		DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
-
 	Dictionary<string, Type> typeMappings = new () {
 		["android/app/Activity"]                = typeof (Android.App.Activity),
 		["android/content/Context"]             = typeof (Android.Content.Context),
@@ -39,7 +33,6 @@ partial class NativeAotTypeManager : JniRuntime.ReflectionJniTypeManager {
 
 	// GetType() dispatches through GetTypeForSimpleReference (singular), so the sample's own type
 	// map has to be applied here; the base ReflectionJniTypeManager only knows the built-in types.
-	[return: DynamicallyAccessedMembers (MethodsConstructors)]
 	protected override Type? GetTypeForSimpleReference (string jniSimpleReference)
 	{
 		if (typeMappings.TryGetValue (jniSimpleReference, out var target))

--- a/samples/Hello-NativeAOTFromAndroid/NativeAotTypeManager.cs
+++ b/samples/Hello-NativeAOTFromAndroid/NativeAotTypeManager.cs
@@ -25,7 +25,7 @@ partial class NativeAotTypeManager : JniRuntime.ReflectionJniTypeManager {
 		["my/MainActivity"]                     = typeof (MainActivity),
 	};
 
-	[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "Sample only (see class comment): this assembly is rooted via TrimmerRootAssembly and the members reflected over during registration are preserved by the [DynamicallyAccessedMembers] annotations on the RegisterNativeMembers(Type) -> FindAndCallRegisterMethod path, so trimming does not remove what reflection needs.")]
+	[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "Sample only (see class comment): this assembly is rooted via TrimmerRootAssembly. The reflection-based registration path is not trim-clean, and this sample intentionally suppresses the warning rather than proving each reflected member to the trimmer.")]
 	[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "Sample only (see class comment): built-in member registration calls CreateDelegate on compile-time-known static methods (no MakeGenericType / expression compilation), so no runtime code generation is required.")]
 	public NativeAotTypeManager ()
 	{

--- a/samples/Hello-NativeAOTFromJNI/Hello-NativeAOTFromJNI.csproj
+++ b/samples/Hello-NativeAOTFromJNI/Hello-NativeAOTFromJNI.csproj
@@ -18,6 +18,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <RuntimeHostConfigurationOption Include="Java.Interop.RuntimeFeature.ManagedPeerNativeRegistration" Value="false" Trim="true" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Java.Interop\Java.Interop.csproj" />
     <ProjectReference Include="..\..\src\Java.Runtime.Environment\Java.Runtime.Environment.csproj" />
     <ProjectReference Include="..\..\src\Java.Base\Java.Base.csproj" />

--- a/samples/Hello-NativeAOTFromJNI/Hello-NativeAOTFromJNI.csproj
+++ b/samples/Hello-NativeAOTFromJNI/Hello-NativeAOTFromJNI.csproj
@@ -18,10 +18,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <RuntimeHostConfigurationOption Include="Java.Interop.RuntimeFeature.ManagedPeerNativeRegistration" Value="false" Trim="true" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\Java.Interop\Java.Interop.csproj" />
     <ProjectReference Include="..\..\src\Java.Runtime.Environment\Java.Runtime.Environment.csproj" />
     <ProjectReference Include="..\..\src\Java.Base\Java.Base.csproj" />

--- a/samples/Hello-NativeAOTFromJNI/NativeAotTypeManager.cs
+++ b/samples/Hello-NativeAOTFromJNI/NativeAotTypeManager.cs
@@ -16,11 +16,6 @@ namespace Hello_NativeAOTFromJNI;
 // moved that responsibility to callers via [RequiresDynamicCode]/[RequiresUnreferencedCode].
 class NativeAotTypeManager : JniRuntime.ReflectionJniTypeManager {
 
-	const DynamicallyAccessedMemberTypes MethodsConstructors =
-		DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods |
-		DynamicallyAccessedMemberTypes.NonPublicNestedTypes |
-		DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
-
 	[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "Sample only (see class comment): this assembly is rooted via TrimmerRootAssembly and the members reflected over during registration are preserved by the [DynamicallyAccessedMembers] annotations on the RegisterNativeMembers(Type) -> FindAndCallRegisterMethod path, so trimming does not remove what reflection needs.")]
 	[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "Sample only (see class comment): built-in member registration calls CreateDelegate on compile-time-known static methods (no MakeGenericType / expression compilation), so no runtime code generation is required.")]
 	public NativeAotTypeManager ()
@@ -31,7 +26,6 @@ class NativeAotTypeManager : JniRuntime.ReflectionJniTypeManager {
 	// JavaProxyObject, ...) and handles registration and the reverse Type->JNI mapping (via the
 	// [JniTypeSignature] attribute) for us. We only need to teach it about this sample's own
 	// managed types.
-	[return: DynamicallyAccessedMembers (MethodsConstructors)]
 	protected override Type? GetTypeForSimpleReference (string jniSimpleReference)
 	{
 		if (jniSimpleReference == Example.ManagedType.JniTypeName)

--- a/samples/Hello-NativeAOTFromJNI/NativeAotTypeManager.cs
+++ b/samples/Hello-NativeAOTFromJNI/NativeAotTypeManager.cs
@@ -16,7 +16,7 @@ namespace Hello_NativeAOTFromJNI;
 // moved that responsibility to callers via [RequiresDynamicCode]/[RequiresUnreferencedCode].
 class NativeAotTypeManager : JniRuntime.ReflectionJniTypeManager {
 
-	[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "Sample only (see class comment): this assembly is rooted via TrimmerRootAssembly and the members reflected over during registration are preserved by the [DynamicallyAccessedMembers] annotations on the RegisterNativeMembers(Type) -> FindAndCallRegisterMethod path, so trimming does not remove what reflection needs.")]
+	[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "Sample only (see class comment): this assembly is rooted via TrimmerRootAssembly. The reflection-based registration path is not trim-clean, and this sample intentionally suppresses the warning rather than proving each reflected member to the trimmer.")]
 	[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "Sample only (see class comment): built-in member registration calls CreateDelegate on compile-time-known static methods (no MakeGenericType / expression compilation), so no runtime code generation is required.")]
 	public NativeAotTypeManager ()
 	{

--- a/src/Java.Interop/Java.Interop/JavaArray.cs
+++ b/src/Java.Interop/Java.Interop/JavaArray.cs
@@ -364,11 +364,7 @@ namespace Java.Interop
 	}
 	
 	[JniTypeSignature ("java/lang/Object", ArrayRank=1, GenerateJavaPeer=false)]
-	public abstract class JavaPrimitiveArray<
-			[DynamicallyAccessedMembers (Constructors)]
-			T
-	>
-		: JavaArray<T>
+	public abstract class JavaPrimitiveArray<T> : JavaArray<T>
 	{
 
 		internal JavaPrimitiveArray (ref JniObjectReference reference, JniObjectReferenceOptions transfer)

--- a/src/Java.Interop/Java.Interop/JavaObjectArray.cs
+++ b/src/Java.Interop/Java.Interop/JavaObjectArray.cs
@@ -8,11 +8,7 @@ using System.Reflection;
 namespace Java.Interop
 {
 	[JniTypeSignature ("java/lang/Object", ArrayRank=1, GenerateJavaPeer=false)]
-	public class JavaObjectArray<
-			[DynamicallyAccessedMembers (Constructors)]
-			T
-	>
-		: JavaArray<T>
+	public class JavaObjectArray<[DynamicallyAccessedMembers (Constructors)] T> : JavaArray<T>
 	{
 		internal    static  readonly    ValueMarshaler   Instance           = new ValueMarshaler ();
 
@@ -171,7 +167,6 @@ namespace Java.Interop
 			public override IList<T> CreateGenericValue (
 					ref JniObjectReference reference,
 					JniObjectReferenceOptions options,
-					[DynamicallyAccessedMembers (Constructors)]
 					Type? targetType)
 			{
 				return JavaArray<T>.CreateValue (ref reference, options, targetType, (ref JniObjectReference h, JniObjectReferenceOptions t) => new JavaObjectArray<T> (ref h, t) {

--- a/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.cs
+++ b/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.cs
@@ -245,7 +245,6 @@ namespace Java.Interop {
 
 		public static object? CreateMarshaledValue (
 				IntPtr handle,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
@@ -256,7 +255,6 @@ namespace Java.Interop {
 			public override IList<Boolean> CreateGenericValue (
 					ref JniObjectReference reference,
 					JniObjectReferenceOptions options,
-					[DynamicallyAccessedMembers (Constructors)]
 					Type? targetType)
 			{
 				return JavaArray<Boolean>.CreateValue (
@@ -449,7 +447,6 @@ namespace Java.Interop {
 
 		public static object? CreateMarshaledValue (
 				IntPtr handle,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
@@ -460,7 +457,6 @@ namespace Java.Interop {
 			public override IList<SByte> CreateGenericValue (
 					ref JniObjectReference reference,
 					JniObjectReferenceOptions options,
-					[DynamicallyAccessedMembers (Constructors)]
 					Type? targetType)
 			{
 				return JavaArray<SByte>.CreateValue (
@@ -653,7 +649,6 @@ namespace Java.Interop {
 
 		public static object? CreateMarshaledValue (
 				IntPtr handle,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
@@ -664,7 +659,6 @@ namespace Java.Interop {
 			public override IList<Char> CreateGenericValue (
 					ref JniObjectReference reference,
 					JniObjectReferenceOptions options,
-					[DynamicallyAccessedMembers (Constructors)]
 					Type? targetType)
 			{
 				return JavaArray<Char>.CreateValue (
@@ -868,7 +862,6 @@ namespace Java.Interop {
 			public override IList<Int16> CreateGenericValue (
 					ref JniObjectReference reference,
 					JniObjectReferenceOptions options,
-					[DynamicallyAccessedMembers (Constructors)]
 					Type? targetType)
 			{
 				return JavaArray<Int16>.CreateValue (
@@ -1061,7 +1054,6 @@ namespace Java.Interop {
 
 		public static object? CreateMarshaledValue (
 				IntPtr handle,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
@@ -1072,7 +1064,6 @@ namespace Java.Interop {
 			public override IList<Int32> CreateGenericValue (
 					ref JniObjectReference reference,
 					JniObjectReferenceOptions options,
-					[DynamicallyAccessedMembers (Constructors)]
 					Type? targetType)
 			{
 				return JavaArray<Int32>.CreateValue (
@@ -1265,7 +1256,6 @@ namespace Java.Interop {
 
 		public static object? CreateMarshaledValue (
 				IntPtr handle,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
@@ -1276,7 +1266,6 @@ namespace Java.Interop {
 			public override IList<Int64> CreateGenericValue (
 					ref JniObjectReference reference,
 					JniObjectReferenceOptions options,
-					[DynamicallyAccessedMembers (Constructors)]
 					Type? targetType)
 			{
 				return JavaArray<Int64>.CreateValue (
@@ -1469,7 +1458,6 @@ namespace Java.Interop {
 
 		public static object? CreateMarshaledValue (
 				IntPtr handle,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
@@ -1480,7 +1468,6 @@ namespace Java.Interop {
 			public override IList<Single> CreateGenericValue (
 					ref JniObjectReference reference,
 					JniObjectReferenceOptions options,
-					[DynamicallyAccessedMembers (Constructors)]
 					Type? targetType)
 			{
 				return JavaArray<Single>.CreateValue (
@@ -1673,7 +1660,6 @@ namespace Java.Interop {
 
 		public static object? CreateMarshaledValue (
 				IntPtr handle,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
@@ -1684,7 +1670,6 @@ namespace Java.Interop {
 			public override IList<Double> CreateGenericValue (
 					ref JniObjectReference reference,
 					JniObjectReferenceOptions options,
-					[DynamicallyAccessedMembers (Constructors)]
 					Type? targetType)
 			{
 				return JavaArray<Double>.CreateValue (

--- a/src/Java.Interop/Java.Interop/JniBuiltinMarshalers.cs
+++ b/src/Java.Interop/Java.Interop/JniBuiltinMarshalers.cs
@@ -153,30 +153,33 @@ namespace Java.Interop {
 				};
 		}
 
-		static readonly Lazy<KeyValuePair<Type, JniValueMarshaler>[]> JniBuiltinMarshalers = new Lazy<KeyValuePair<Type, JniValueMarshaler>[]> (InitJniBuiltinMarshalers);
-
-		static KeyValuePair<Type, JniValueMarshaler>[] InitJniBuiltinMarshalers ()
+		partial class ReflectionJniValueManager
 		{
-			return new []{
-				new KeyValuePair<Type, JniValueMarshaler>(typeof (string), JniStringValueMarshaler.Instance),
-				new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaProxyObject), ProxyValueMarshaler.Instance),
-				new KeyValuePair<Type, JniValueMarshaler>(typeof (Boolean),   JniBooleanValueMarshaler.Instance),
-				new KeyValuePair<Type, JniValueMarshaler>(typeof (Boolean?),  JniNullableBooleanValueMarshaler.Instance),
-				new KeyValuePair<Type, JniValueMarshaler>(typeof (SByte),   JniSByteValueMarshaler.Instance),
-				new KeyValuePair<Type, JniValueMarshaler>(typeof (SByte?),  JniNullableSByteValueMarshaler.Instance),
-				new KeyValuePair<Type, JniValueMarshaler>(typeof (Char),   JniCharValueMarshaler.Instance),
-				new KeyValuePair<Type, JniValueMarshaler>(typeof (Char?),  JniNullableCharValueMarshaler.Instance),
-				new KeyValuePair<Type, JniValueMarshaler>(typeof (Int16),   JniInt16ValueMarshaler.Instance),
-				new KeyValuePair<Type, JniValueMarshaler>(typeof (Int16?),  JniNullableInt16ValueMarshaler.Instance),
-				new KeyValuePair<Type, JniValueMarshaler>(typeof (Int32),   JniInt32ValueMarshaler.Instance),
-				new KeyValuePair<Type, JniValueMarshaler>(typeof (Int32?),  JniNullableInt32ValueMarshaler.Instance),
-				new KeyValuePair<Type, JniValueMarshaler>(typeof (Int64),   JniInt64ValueMarshaler.Instance),
-				new KeyValuePair<Type, JniValueMarshaler>(typeof (Int64?),  JniNullableInt64ValueMarshaler.Instance),
-				new KeyValuePair<Type, JniValueMarshaler>(typeof (Single),   JniSingleValueMarshaler.Instance),
-				new KeyValuePair<Type, JniValueMarshaler>(typeof (Single?),  JniNullableSingleValueMarshaler.Instance),
-				new KeyValuePair<Type, JniValueMarshaler>(typeof (Double),   JniDoubleValueMarshaler.Instance),
-				new KeyValuePair<Type, JniValueMarshaler>(typeof (Double?),  JniNullableDoubleValueMarshaler.Instance),
-			};
+			static readonly Lazy<KeyValuePair<Type, JniValueMarshaler>[]> JniBuiltinMarshalers = new Lazy<KeyValuePair<Type, JniValueMarshaler>[]> (InitJniBuiltinMarshalers);
+
+			static KeyValuePair<Type, JniValueMarshaler>[] InitJniBuiltinMarshalers ()
+			{
+				return new []{
+					new KeyValuePair<Type, JniValueMarshaler>(typeof (string), JniStringValueMarshaler.Instance),
+					new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaProxyObject), ProxyValueMarshaler.Instance),
+					new KeyValuePair<Type, JniValueMarshaler>(typeof (Boolean),   JniBooleanValueMarshaler.Instance),
+					new KeyValuePair<Type, JniValueMarshaler>(typeof (Boolean?),  JniNullableBooleanValueMarshaler.Instance),
+					new KeyValuePair<Type, JniValueMarshaler>(typeof (SByte),   JniSByteValueMarshaler.Instance),
+					new KeyValuePair<Type, JniValueMarshaler>(typeof (SByte?),  JniNullableSByteValueMarshaler.Instance),
+					new KeyValuePair<Type, JniValueMarshaler>(typeof (Char),   JniCharValueMarshaler.Instance),
+					new KeyValuePair<Type, JniValueMarshaler>(typeof (Char?),  JniNullableCharValueMarshaler.Instance),
+					new KeyValuePair<Type, JniValueMarshaler>(typeof (Int16),   JniInt16ValueMarshaler.Instance),
+					new KeyValuePair<Type, JniValueMarshaler>(typeof (Int16?),  JniNullableInt16ValueMarshaler.Instance),
+					new KeyValuePair<Type, JniValueMarshaler>(typeof (Int32),   JniInt32ValueMarshaler.Instance),
+					new KeyValuePair<Type, JniValueMarshaler>(typeof (Int32?),  JniNullableInt32ValueMarshaler.Instance),
+					new KeyValuePair<Type, JniValueMarshaler>(typeof (Int64),   JniInt64ValueMarshaler.Instance),
+					new KeyValuePair<Type, JniValueMarshaler>(typeof (Int64?),  JniNullableInt64ValueMarshaler.Instance),
+					new KeyValuePair<Type, JniValueMarshaler>(typeof (Single),   JniSingleValueMarshaler.Instance),
+					new KeyValuePair<Type, JniValueMarshaler>(typeof (Single?),  JniNullableSingleValueMarshaler.Instance),
+					new KeyValuePair<Type, JniValueMarshaler>(typeof (Double),   JniDoubleValueMarshaler.Instance),
+					new KeyValuePair<Type, JniValueMarshaler>(typeof (Double?),  JniNullableDoubleValueMarshaler.Instance),
+				};
+			}
 		}
 	}
 
@@ -226,7 +229,6 @@ namespace Java.Interop {
 		public override object? CreateValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -237,7 +239,6 @@ namespace Java.Interop {
 		public override Boolean CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -299,7 +300,6 @@ namespace Java.Interop {
 		public override Boolean? CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -370,7 +370,6 @@ namespace Java.Interop {
 		public override object? CreateValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -381,7 +380,6 @@ namespace Java.Interop {
 		public override SByte CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -443,7 +441,6 @@ namespace Java.Interop {
 		public override SByte? CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -514,7 +511,6 @@ namespace Java.Interop {
 		public override object? CreateValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -525,7 +521,6 @@ namespace Java.Interop {
 		public override Char CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -587,7 +582,6 @@ namespace Java.Interop {
 		public override Char? CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -658,7 +652,6 @@ namespace Java.Interop {
 		public override object? CreateValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -669,7 +662,6 @@ namespace Java.Interop {
 		public override Int16 CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -731,7 +723,6 @@ namespace Java.Interop {
 		public override Int16? CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -802,7 +793,6 @@ namespace Java.Interop {
 		public override object? CreateValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -813,7 +803,6 @@ namespace Java.Interop {
 		public override Int32 CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -875,7 +864,6 @@ namespace Java.Interop {
 		public override Int32? CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -946,7 +934,6 @@ namespace Java.Interop {
 		public override object? CreateValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -957,7 +944,6 @@ namespace Java.Interop {
 		public override Int64 CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -1019,7 +1005,6 @@ namespace Java.Interop {
 		public override Int64? CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -1090,7 +1075,6 @@ namespace Java.Interop {
 		public override object? CreateValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -1101,7 +1085,6 @@ namespace Java.Interop {
 		public override Single CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -1163,7 +1146,6 @@ namespace Java.Interop {
 		public override Single? CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -1234,7 +1216,6 @@ namespace Java.Interop {
 		public override object? CreateValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -1245,7 +1226,6 @@ namespace Java.Interop {
 		public override Double CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -1307,7 +1287,6 @@ namespace Java.Interop {
 		public override Double? CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)

--- a/src/Java.Interop/Java.Interop/JniBuiltinMarshalers.tt
+++ b/src/Java.Interop/Java.Interop/JniBuiltinMarshalers.tt
@@ -118,22 +118,25 @@ namespace Java.Interop {
 				};
 		}
 
-		static readonly Lazy<KeyValuePair<Type, JniValueMarshaler>[]> JniBuiltinMarshalers = new Lazy<KeyValuePair<Type, JniValueMarshaler>[]> (InitJniBuiltinMarshalers);
-
-		static KeyValuePair<Type, JniValueMarshaler>[] InitJniBuiltinMarshalers ()
+		partial class ReflectionJniValueManager
 		{
-			return new []{
-				new KeyValuePair<Type, JniValueMarshaler>(typeof (string), JniStringValueMarshaler.Instance),
-				new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaProxyObject), ProxyValueMarshaler.Instance),
+			static readonly Lazy<KeyValuePair<Type, JniValueMarshaler>[]> JniBuiltinMarshalers = new Lazy<KeyValuePair<Type, JniValueMarshaler>[]> (InitJniBuiltinMarshalers);
+
+			static KeyValuePair<Type, JniValueMarshaler>[] InitJniBuiltinMarshalers ()
+			{
+				return new []{
+					new KeyValuePair<Type, JniValueMarshaler>(typeof (string), JniStringValueMarshaler.Instance),
+					new KeyValuePair<Type, JniValueMarshaler>(typeof (JavaProxyObject), ProxyValueMarshaler.Instance),
 <#
 	foreach (var type in types) {
 #>
-				new KeyValuePair<Type, JniValueMarshaler>(typeof (<#= type.Type #>),   Jni<#= type.Type #>ValueMarshaler.Instance),
-				new KeyValuePair<Type, JniValueMarshaler>(typeof (<#= type.Type #>?),  JniNullable<#= type.Type #>ValueMarshaler.Instance),
+					new KeyValuePair<Type, JniValueMarshaler>(typeof (<#= type.Type #>),   Jni<#= type.Type #>ValueMarshaler.Instance),
+					new KeyValuePair<Type, JniValueMarshaler>(typeof (<#= type.Type #>?),  JniNullable<#= type.Type #>ValueMarshaler.Instance),
 <#
 	}
 #>
-			};
+				};
+			}
 		}
 	}
 <#
@@ -186,7 +189,6 @@ namespace Java.Interop {
 		public override object? CreateValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -197,7 +199,6 @@ namespace Java.Interop {
 		public override <#= type.Type #> CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -259,7 +260,6 @@ namespace Java.Interop {
 		public override <#= type.Type #>? CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
@@ -82,8 +82,7 @@ namespace Java.Interop {
 
 			internal const DynamicallyAccessedMemberTypes Constructors = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
 			internal const DynamicallyAccessedMemberTypes Methods = DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods;
-			internal const DynamicallyAccessedMemberTypes MethodsAndPrivateNested = Methods | DynamicallyAccessedMemberTypes.NonPublicNestedTypes;
-			internal const DynamicallyAccessedMemberTypes MethodsConstructors = MethodsAndPrivateNested | DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
+			internal const DynamicallyAccessedMemberTypes MethodsConstructors = Methods | Constructors;
 
 			JniRuntime?             runtime;
 			bool                    disposed;
@@ -167,7 +166,6 @@ namespace Java.Interop {
 
 			protected virtual IEnumerable<JniTypeSignature> GetTypeSignaturesCore (Type type) => [];
 
-			[return: DynamicallyAccessedMembers (MethodsConstructors)]
 			public  Type?    GetType (JniTypeSignature typeSignature)
 			{
 				AssertValid ();
@@ -189,24 +187,8 @@ namespace Java.Interop {
 
 			protected virtual string? GetSimpleReference (Type type) => null;
 			protected virtual IEnumerable<string> GetSimpleReferences (Type type) => [];
-			[return: DynamicallyAccessedMembers (MethodsConstructors)]
 			protected virtual Type? GetTypeForSimpleReference (string jniSimpleReference) => null;
 			public virtual IEnumerable<Type> GetTypes (JniTypeSignature typeSignature) => [];
-
-			public virtual IEnumerable<ReflectionConstructibleType> GetReflectionConstructibleTypes (JniTypeSignature typeSignature) => [];
-
-			public class ReflectionConstructibleType
-			{
-				public ReflectionConstructibleType (
-						[DynamicallyAccessedMembers (Constructors)]
-						Type type)
-				{
-					Type = type;
-				}
-
-				[DynamicallyAccessedMembers (Constructors)]
-				public Type Type { get; }
-			}
 
 			protected virtual IEnumerable<Type> GetTypesForSimpleReference (string jniSimpleReference) => [];
 
@@ -219,14 +201,6 @@ namespace Java.Interop {
 				return default;
 			}
 
-			// IL2026/IL2111: The MethodsConstructors DAM annotation on the return type causes ILLink to analyze
-			// JavaProxyObject/JavaProxyThrowable/ManagedPeer's delegate-typed nested members, whose base
-			// constructors (Delegate.Delegate(Object,String)) are marked RequiresUnreferencedCode.
-			// These warnings are false positives: the delegate constructors are invoked with
-			// compile-time-known static method references, not via string-based reflection.
-			[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "Delegate constructors in JavaProxyObject/JavaProxyThrowable/ManagedPeer are invoked with compile-time-known method references, not via reflection.")]
-			[UnconditionalSuppressMessage ("Trimming", "IL2111", Justification = "Delegate constructors in JavaProxyObject/JavaProxyThrowable/ManagedPeer are invoked with compile-time-known method references, not via reflection.")]
-			[return: DynamicallyAccessedMembers (MethodsConstructors)]
 			static Type? GetBuiltInType (JniTypeSignature typeSignature)
 			{
 				if (typeSignature.ArrayRank != 0)
@@ -254,19 +228,15 @@ namespace Java.Interop {
 			}
 
 			/// <include file="../Documentation/Java.Interop/JniRuntime.JniTypeManager.xml" path="/docs/member[@name='M:GetInvokerType']/*" />
-			[return: DynamicallyAccessedMembers (Constructors)]
-			public Type? GetInvokerType (
-					[DynamicallyAccessedMembers (Constructors)]
-					Type type)
+			public Type? GetInvokerType (Type type)
 			{
 				if (type.IsAbstract || type.IsInterface) {
 					return GetInvokerTypeCore (type);
 				}
 				return null;
 			}
-			
-			[return: DynamicallyAccessedMembers (Constructors)]
-			protected virtual Type? GetInvokerTypeCore ([DynamicallyAccessedMembers (Constructors)] Type type) => null;
+
+			protected virtual Type? GetInvokerTypeCore (Type type) => null;
 
 			protected virtual IReadOnlyList<string>? GetStaticMethodFallbackTypesCore (string jniSimple) => null;
 
@@ -306,20 +276,12 @@ namespace Java.Interop {
 
 			// Default implementation is a no-op. Derived classes (e.g. `ReflectionJniTypeManager`)
 			// provide reflection-based registration. Override to provide custom registration.
-			public virtual void RegisterNativeMembers (
-					JniType nativeClass,
-					[DynamicallyAccessedMembers (MethodsAndPrivateNested)]
-					Type type,
-					ReadOnlySpan<char> methods)
+			public virtual void RegisterNativeMembers (JniType nativeClass, Type type, ReadOnlySpan<char> methods)
 			{
 			}
 
 			[Obsolete ("Use RegisterNativeMembers(JniType, Type, ReadOnlySpan<char>)")]
-			public virtual void RegisterNativeMembers (
-					JniType nativeClass,
-					[DynamicallyAccessedMembers (MethodsAndPrivateNested)]
-					Type type,
-					string? methods)
+			public virtual void RegisterNativeMembers (JniType nativeClass, Type type, string? methods)
 			{
 			}
 		}

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -42,7 +42,6 @@ namespace Java.Interop
 		}
 
 		public abstract partial class JniValueManager : ISetRuntime, IDisposable {
-
 			internal const DynamicallyAccessedMemberTypes Constructors = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
 
 			JniRuntime?             runtime;
@@ -85,7 +84,7 @@ namespace Java.Interop
 			public abstract List<JniSurfacedPeerInfo> GetSurfacedPeers ();
 			public abstract void ActivatePeer (
 				JniObjectReference reference,
-				[DynamicallyAccessedMembers (Constructors)] Type type,
+				Type type,
 				ConstructorInfo cinfo,
 				object?[]? argumentValues);
 
@@ -191,9 +190,9 @@ namespace Java.Interop
 			}
 
 			public IJavaPeerable? GetPeer (
-					JniObjectReference reference,
-					[DynamicallyAccessedMembers (Constructors)]
-					Type? targetType = null)
+				JniObjectReference reference,
+				[DynamicallyAccessedMembers (Constructors)]
+				Type? targetType = null)
 			{
 				EnsureNotDisposed ();
 
@@ -295,7 +294,6 @@ namespace Java.Interop
 				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType = null);
 
-			[return: DynamicallyAccessedMembers (Constructors)]
 			internal Type? GetRuntimeType (JniObjectReference reference)
 			{
 				if (!reference.IsValid)
@@ -309,13 +307,10 @@ namespace Java.Interop
 			public JniValueMarshaler GetValueMarshaler (Type type) => GetValueMarshalerCore (type);
 			protected abstract JniValueMarshaler GetValueMarshalerCore (Type type);
 
-			public JniValueMarshaler<T> GetValueMarshaler<[DynamicallyAccessedMembers (Constructors)] T> () => GetValueMarshalerCore<T> ();
-			protected abstract JniValueMarshaler<T> GetValueMarshalerCore<[DynamicallyAccessedMembers (Constructors)] T> ();
+			public JniValueMarshaler<T> GetValueMarshaler<T> () => GetValueMarshalerCore<T> ();
+			protected abstract JniValueMarshaler<T> GetValueMarshalerCore<T> ();
 
-			internal JniObjectReference CreateLocalObjectReferenceArgument (
-				[DynamicallyAccessedMembers (Constructors)]
-				Type type,
-				object? value)
+			internal JniObjectReference CreateLocalObjectReferenceArgument (Type type, object? value)
 			{
 				EnsureNotDisposed ();
 
@@ -324,10 +319,7 @@ namespace Java.Interop
 				return CreateLocalObjectReferenceArgumentCore (type, value);
 			}
 
-			protected abstract JniObjectReference CreateLocalObjectReferenceArgumentCore (
-				[DynamicallyAccessedMembers (Constructors)]
-				Type type,
-				object? value);
+			protected abstract JniObjectReference CreateLocalObjectReferenceArgumentCore (Type type, object? value);
 		}
 	}
 }

--- a/src/Java.Interop/Java.Interop/JniRuntime.ReflectionJniTypeManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.ReflectionJniTypeManager.cs
@@ -2,12 +2,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.Versioning;
 using System.Threading;
 
 namespace Java.Interop {
@@ -200,7 +197,6 @@ namespace Java.Interop {
 					? arrayType ?? throw new InvalidOperationException ("Should not be reached")
 					: typeof (JavaObjectArray<>).MakeGenericType (type);
 
-			[return: DynamicallyAccessedMembers (MethodsConstructors)]
 			protected override Type? GetTypeForSimpleReference (string jniSimpleReference)
 			{
 				AssertValid ();
@@ -238,13 +234,6 @@ namespace Java.Interop {
 				if (typeSignature.SimpleReference == null)
 					return EmptyTypeArray;
 				return CreateGetTypesEnumerator (typeSignature);
-			}
-
-			public override IEnumerable<ReflectionConstructibleType> GetReflectionConstructibleTypes (JniTypeSignature typeSignature)
-			{
-				foreach (var type in GetTypes (typeSignature)) {
-					yield return new ReflectionConstructibleType (type);
-				}
 			}
 
 			IEnumerable<Type> CreateGetTypesEnumerator (JniTypeSignature typeSignature)
@@ -333,10 +322,7 @@ namespace Java.Interop {
 				yield break;
 			}
 
-			[return: DynamicallyAccessedMembers (Constructors)]
-			protected override Type? GetInvokerTypeCore (
-					[DynamicallyAccessedMembers (Constructors)]
-					Type type)
+			protected override Type? GetInvokerTypeCore (Type type)
 			{
 				var signature   = type.GetCustomAttribute<JniTypeSignatureAttribute> ();
 				if (signature == null || signature.InvokerType == null) {
@@ -356,20 +342,12 @@ namespace Java.Interop {
 
 			protected override ReplacementMethodInfo? GetReplacementMethodInfoCore (string jniSimpleReference, string jniMethodName, string jniMethodSignature) => null;
 
-			public override void RegisterNativeMembers (
-					JniType nativeClass,
-					[DynamicallyAccessedMembers (MethodsAndPrivateNested)]
-					Type type,
-					ReadOnlySpan<char> methods)
+			public override void RegisterNativeMembers (JniType nativeClass, Type type, ReadOnlySpan<char> methods)
 			{
 				TryRegisterNativeMembers (nativeClass, type, methods);
 			}
 
-			protected bool TryRegisterNativeMembers (
-					JniType nativeClass,
-					[DynamicallyAccessedMembers (MethodsAndPrivateNested)]
-					Type type,
-					ReadOnlySpan<char> methods)
+			protected bool TryRegisterNativeMembers (JniType nativeClass, Type type, ReadOnlySpan<char> methods)
 			{
 				AssertValid ();
 
@@ -381,21 +359,13 @@ namespace Java.Interop {
 			}
 
 			[Obsolete ("Use RegisterNativeMembers(JniType, Type, ReadOnlySpan<char>)")]
-			public override void RegisterNativeMembers (
-					JniType nativeClass,
-					[DynamicallyAccessedMembers (MethodsAndPrivateNested)]
-					Type type,
-					string? methods)
+			public override void RegisterNativeMembers (JniType nativeClass, Type type, string? methods)
 			{
 				TryRegisterNativeMembers (nativeClass, type, methods);
 			}
 
 			[Obsolete ("Use RegisterNativeMembers(JniType, Type, ReadOnlySpan<char>)")]
-			protected bool TryRegisterNativeMembers (
-					JniType nativeClass,
-					[DynamicallyAccessedMembers (MethodsAndPrivateNested)]
-					Type type,
-					string? methods)
+			protected bool TryRegisterNativeMembers (JniType nativeClass, Type type, string? methods)
 			{
 				AssertValid ();
 

--- a/src/Java.Interop/Java.Interop/JniRuntime.ReflectionJniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.ReflectionJniValueManager.cs
@@ -22,7 +22,7 @@ namespace Java.Interop
 		{
 			public override void ActivatePeer (
 				JniObjectReference reference,
-				[DynamicallyAccessedMembers (Constructors)] Type type,
+				Type type,
 				ConstructorInfo cinfo,
 				object?[]? argumentValues)
 			{
@@ -146,8 +146,7 @@ namespace Java.Interop
 				return peer;
 			}
 
-			[return: DynamicallyAccessedMembers (Constructors)]
-			static Type GetPeerType ([DynamicallyAccessedMembers (Constructors)] Type type)
+			static Type GetPeerType (Type type)
 			{
 				if (type == typeof (object))
 					return typeof (JavaObject);
@@ -160,7 +159,6 @@ namespace Java.Interop
 
 			IJavaPeerable? CreatePeerInstance (
 					ref JniObjectReference klass,
-					[DynamicallyAccessedMembers (Constructors)]
 					Type targetType,
 					ref JniObjectReference reference,
 					JniObjectReferenceOptions transfer)
@@ -194,12 +192,11 @@ namespace Java.Interop
 
 				return TryCreatePeerInstance (ref reference, transfer, targetType);
 
-				[return: DynamicallyAccessedMembers (Constructors)]
 				Type? GetTypeAssignableTo (JniTypeSignature sig, Type targetType)
 				{
-					foreach (var t in Runtime.TypeManager.GetReflectionConstructibleTypes (sig)) {
-						if (targetType.IsAssignableFrom (t.Type)) {
-							return t.Type;
+					foreach (var t in Runtime.TypeManager.GetTypes (sig)) {
+						if (targetType.IsAssignableFrom (t)) {
+							return t;
 						}
 					}
 					return null;
@@ -209,7 +206,6 @@ namespace Java.Interop
 			IJavaPeerable? TryCreatePeerInstance (
 					ref JniObjectReference reference,
 					JniObjectReferenceOptions options,
-					[DynamicallyAccessedMembers (Constructors)]
 					Type type)
 			{
 				type    = Runtime.TypeManager.GetInvokerType (type) ?? type;
@@ -411,7 +407,7 @@ namespace Java.Interop
 		
 			Dictionary<Type, JniValueMarshaler> Marshalers = new Dictionary<Type, JniValueMarshaler> ();
 
-			protected override JniValueMarshaler<T> GetValueMarshalerCore<[DynamicallyAccessedMembers (Constructors)] T> ()
+			protected override JniValueMarshaler<T> GetValueMarshalerCore<T> ()
 			{
 				EnsureNotDisposed ();
 
@@ -472,7 +468,6 @@ namespace Java.Interop
 			}
 
 			protected override JniObjectReference CreateLocalObjectReferenceArgumentCore (
-				[DynamicallyAccessedMembers (Constructors)]
 				Type type,
 				object? value)
 			{
@@ -506,9 +501,7 @@ namespace Java.Interop
 				return direct ();
 			}
 
-			static JniValueMarshaler GetObjectArrayMarshalerHelper<
-					[DynamicallyAccessedMembers (Constructors)]
-					T> ()
+			static JniValueMarshaler GetObjectArrayMarshalerHelper<T> ()
 			{
 				return JavaObjectArray<T>.Instance;
 			}
@@ -526,7 +519,6 @@ namespace Java.Interop
 			public override object? CreateValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 			{
 				throw new NotSupportedException ();
@@ -544,6 +536,7 @@ namespace Java.Interop
 		}
 	}
 
+	[RequiresUnreferencedCode ("Uses unconstrained reflection.")]
 	sealed class JavaPeerableValueMarshaler : JniValueMarshaler<IJavaPeerable?> {
 
 		internal    static  JavaPeerableValueMarshaler      Instance    = new JavaPeerableValueMarshaler ();
@@ -552,7 +545,6 @@ namespace Java.Interop
 		public override IJavaPeerable? CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			var jvm         = JniEnvironment.Runtime;
@@ -628,11 +620,7 @@ namespace Java.Interop
 		}
 	}
 
-	sealed class DelegatingValueMarshaler<
-			[DynamicallyAccessedMembers (Constructors)]
-			T
-	>
-		: JniValueMarshaler<T>
+	sealed class DelegatingValueMarshaler<T> : JniValueMarshaler<T>
 	{
 
 		JniValueMarshaler   ValueMarshaler;
@@ -646,7 +634,6 @@ namespace Java.Interop
 		public override T CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			return (T) ValueMarshaler.CreateValue (ref reference, options, targetType ?? typeof (T))!;
@@ -683,15 +670,14 @@ namespace Java.Interop
 		}
 	}
 
+	[RequiresUnreferencedCode ("Uses unconstrained reflection.")]
 	sealed class ProxyValueMarshaler : JniValueMarshaler<object?> {
-
 		internal    static  ProxyValueMarshaler     Instance    = new ProxyValueMarshaler ();
 
 		[return: MaybeNull]
 		public override object? CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			var jvm     = JniEnvironment.Runtime;

--- a/src/Java.Interop/Java.Interop/JniRuntime.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.cs
@@ -236,6 +236,13 @@ namespace Java.Interop
 
 #if !XA_JI_EXCLUDE
 			if (RuntimeFeature.ManagedPeerNativeRegistration) {
+				InitManagedPeer ();
+			}
+
+			[UnconditionalSuppressMessage ("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+				Justification = "The code is only executed when the feature is explicitly enabled.")]
+			static void InitManagedPeer ()
+			{
 				ManagedPeer.Init ();
 			}
 #endif  // !XA_JI_EXCLUDE

--- a/src/Java.Interop/Java.Interop/JniStringValueMarshaler.cs
+++ b/src/Java.Interop/Java.Interop/JniStringValueMarshaler.cs
@@ -17,7 +17,6 @@ namespace Java.Interop {
 		public override string? CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			return JniEnvironment.Strings.ToString (ref reference, options, targetType ?? typeof (string));

--- a/src/Java.Interop/Java.Interop/JniValueMarshaler.cs
+++ b/src/Java.Interop/Java.Interop/JniValueMarshaler.cs
@@ -119,8 +119,6 @@ namespace Java.Interop {
 	}
 
 	public abstract class JniValueMarshaler {
-
-		internal const DynamicallyAccessedMemberTypes Constructors = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
 		internal const string ExpressionRequiresUnreferencedCode = "System.Linq.Expression usage may trim away required code.";
 
 		public  virtual     bool                    IsJniValueType {
@@ -135,7 +133,6 @@ namespace Java.Interop {
 		public  abstract    object?                 CreateValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType = null);
 
 		public  virtual     JniValueMarshalerState  CreateArgumentState (object? value, ParameterAttributes synchronize = 0)
@@ -148,7 +145,6 @@ namespace Java.Interop {
 
 		internal object? CreateValue (
 				IntPtr handle,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			var r = new JniObjectReference (handle);
@@ -233,18 +229,13 @@ namespace Java.Interop {
 		}
 	}
 
-	public abstract class JniValueMarshaler<
-			[DynamicallyAccessedMembers (Constructors)]
-			T
-	>
-		: JniValueMarshaler
+	public abstract class JniValueMarshaler<T> : JniValueMarshaler
 	{
 
 		[return: MaybeNull]
 		public  abstract    T                       CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType = null);
 
 		public  virtual     JniValueMarshalerState  CreateGenericArgumentState ([MaybeNull] T value, ParameterAttributes synchronize = 0)
@@ -258,7 +249,6 @@ namespace Java.Interop {
 		public override object? CreateValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType = null)
 		{
 			return CreateGenericValue (ref reference, options, targetType ?? typeof (T));

--- a/src/Java.Interop/Java.Interop/ManagedPeer.cs
+++ b/src/Java.Interop/Java.Interop/ManagedPeer.cs
@@ -15,6 +15,7 @@ using System.Text;
 namespace Java.Interop {
 
 	[JniTypeSignature (JniTypeName, GenerateJavaPeer=false)]
+	[RequiresUnreferencedCode ("Uses reflection to find constructors and invoke them.")]
 	/* static */ sealed class ManagedPeer : JavaObject {
 
 		internal const string JniTypeName = "net/dot/jni/ManagedPeer";
@@ -238,11 +239,6 @@ namespace Java.Interop {
 
 		static object?[]? GetValues (JniRuntime runtime, JniObjectReference values, ConstructorInfo cinfo)
 		{
-			// https://github.com/xamarin/xamarin-android/blob/5472eec991cc075e4b0c09cd98a2331fb93aa0f3/src/Microsoft.Android.Sdk.ILLink/MarkJavaObjects.cs#L51-L132
-			[UnconditionalSuppressMessage ("Trimming", "IL2072", Justification = "Constructors are preserved by the MarkJavaObjects trimmer step.")]
-			static object? ValueManagerGetValue (JniRuntime runtime, ref JniObjectReference value, ParameterInfo parameter) =>
-				runtime.ValueManager.GetValue (ref value, JniObjectReferenceOptions.CopyAndDispose, parameter.ParameterType);
-
 			if (!values.IsValid)
 				return null;
 
@@ -254,7 +250,7 @@ namespace Java.Interop {
 			var pvalues = new object? [len];
 			for (int i = 0; i < len; ++i) {
 				var n_value = JniEnvironment.Arrays.GetObjectArrayElement (values, i);
-				var value   = ValueManagerGetValue (runtime, ref n_value, parameters [i]);
+				var value   = runtime.ValueManager.GetValue (ref n_value, JniObjectReferenceOptions.CopyAndDispose, parameters [i].ParameterType);
 				pvalues [i] = value;
 			}
 
@@ -318,7 +314,6 @@ namespace Java.Interop {
 			}
 		}
 
-		[return: DynamicallyAccessedMembers (ConstructorsMethodsNestedTypes)]
 		static Type GetTypeFromSignature (JniRuntime.JniTypeManager typeManager, JniTypeSignature typeSignature, string? context = null)
 		{
 			return typeManager.GetType (typeSignature) ??

--- a/src/Java.Interop/Java.Interop/RuntimeFeature.cs
+++ b/src/Java.Interop/Java.Interop/RuntimeFeature.cs
@@ -9,9 +9,10 @@ namespace Java.Interop
 		const string FeatureSwitchPrefix = "Java.Interop.RuntimeFeature.";
 
 		[FeatureSwitchDefinition ($"{FeatureSwitchPrefix}{nameof (ManagedPeerNativeRegistration)}")]
-		internal static bool ManagedPeerNativeRegistration =>
+		[FeatureGuard (typeof (RequiresUnreferencedCodeAttribute))]
+		internal static bool ManagedPeerNativeRegistration { get; } =
 			AppContext.TryGetSwitch ($"{FeatureSwitchPrefix}{nameof (ManagedPeerNativeRegistration)}", out bool isEnabled)
-			? isEnabled
-			: ManagedPeerNativeRegistrationEnabledByDefault;
+				? isEnabled
+				: ManagedPeerNativeRegistrationEnabledByDefault;
 	}
 }

--- a/src/Java.Interop/PublicAPI.Unshipped.txt
+++ b/src/Java.Interop/PublicAPI.Unshipped.txt
@@ -4,7 +4,6 @@ static Java.Interop.JniEnvironment.EndMarshalMethod(ref Java.Interop.JniTransiti
 virtual Java.Interop.JniRuntime.OnEnterMarshalMethod() -> void
 virtual Java.Interop.JniRuntime.OnUserUnhandledException(ref Java.Interop.JniTransition transition, System.Exception! e) -> void
 virtual Java.Interop.JniRuntime.JniTypeManager.GetInvokerTypeCore(System.Type! type) -> System.Type?
-virtual Java.Interop.JniRuntime.JniTypeManager.GetReflectionConstructibleTypes(Java.Interop.JniTypeSignature typeSignature) -> System.Collections.Generic.IEnumerable<Java.Interop.JniRuntime.JniTypeManager.ReflectionConstructibleType!>!
 virtual Java.Interop.JniRuntime.JniTypeManager.GetTypeForSimpleReference(string! jniSimpleReference) -> System.Type?
 virtual Java.Interop.JniRuntime.JniTypeManager.GetTypeSignatureCore(System.Type! type) -> Java.Interop.JniTypeSignature
 virtual Java.Interop.JniRuntime.JniTypeManager.GetTypeSignaturesCore(System.Type! type) -> System.Collections.Generic.IEnumerable<Java.Interop.JniTypeSignature>!
@@ -16,9 +15,6 @@ Java.Interop.JniRuntime.ReflectionJniTypeManager.ReflectionJniTypeManager() -> v
 Java.Interop.JniRuntime.ReflectionJniTypeManager.TryRegisterNativeMembers(Java.Interop.JniType! nativeClass, System.Type! type, string? methods) -> bool
 Java.Interop.JniRuntime.ReflectionJniTypeManager.TryRegisterNativeMembers(Java.Interop.JniType! nativeClass, System.Type! type, System.ReadOnlySpan<char> methods) -> bool
 Java.Interop.JniRuntime.JniTypeManager.GetInvokerType(System.Type! type) -> System.Type?
-Java.Interop.JniRuntime.JniTypeManager.ReflectionConstructibleType
-Java.Interop.JniRuntime.JniTypeManager.ReflectionConstructibleType.ReflectionConstructibleType(System.Type! type) -> void
-Java.Interop.JniRuntime.JniTypeManager.ReflectionConstructibleType.Type.get -> System.Type!
 Java.Interop.JniRuntime.JniValueManager.GetPeer(Java.Interop.JniObjectReference reference, System.Type? targetType = null) -> Java.Interop.IJavaPeerable?
 Java.Interop.JniRuntime.JniValueManager.EnsureNotDisposed() -> void
 Java.Interop.JniRuntime.ReflectionJniValueManager
@@ -107,7 +103,6 @@ override Java.Interop.JniRuntime.ReflectionJniValueManager.GetValueCore<T>(ref J
 override Java.Interop.JniRuntime.ReflectionJniValueManager.GetValueMarshalerCore(System.Type! type) -> Java.Interop.JniValueMarshaler!
 override Java.Interop.JniRuntime.ReflectionJniValueManager.GetValueMarshalerCore<T>() -> Java.Interop.JniValueMarshaler<T>!
 override Java.Interop.JniRuntime.ReflectionJniTypeManager.GetInvokerTypeCore(System.Type! type) -> System.Type?
-override Java.Interop.JniRuntime.ReflectionJniTypeManager.GetReflectionConstructibleTypes(Java.Interop.JniTypeSignature typeSignature) -> System.Collections.Generic.IEnumerable<Java.Interop.JniRuntime.JniTypeManager.ReflectionConstructibleType!>!
 override Java.Interop.JniRuntime.ReflectionJniTypeManager.GetReplacementMethodInfoCore(string! jniSimpleReference, string! jniMethodName, string! jniMethodSignature) -> Java.Interop.JniRuntime.ReplacementMethodInfo?
 override Java.Interop.JniRuntime.ReflectionJniTypeManager.GetReplacementTypeCore(string! jniSimpleReference) -> string?
 override Java.Interop.JniRuntime.ReflectionJniTypeManager.GetSimpleReference(System.Type! type) -> string?

--- a/src/Java.Runtime.Environment/Java.Interop/JreTypeManager.cs
+++ b/src/Java.Runtime.Environment/Java.Interop/JreTypeManager.cs
@@ -63,7 +63,6 @@ namespace Java.Interop {
 
 		public override void RegisterNativeMembers (
 				JniType nativeClass,
-				[DynamicallyAccessedMembers (MethodsAndPrivateNested)]
 				Type type,
 				ReadOnlySpan<char> methods)
 		{

--- a/tests/Java.Interop-Tests/Java.Interop/JavaVMFixture.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JavaVMFixture.cs
@@ -68,7 +68,6 @@ namespace Java.InteropTests {
 #pragma warning restore CS8600
 		}
 
-		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods | DynamicallyAccessedMemberTypes.NonPublicNestedTypes | DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
 		protected override Type? GetTypeForSimpleReference (string jniSimpleReference)
 		{
 			return base.GetTypeForSimpleReference (jniSimpleReference) ??

--- a/tests/Java.Interop-Tests/Java.Interop/JniRuntimeTest.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JniRuntimeTest.cs
@@ -80,21 +80,6 @@ namespace Java.InteropTests
 			Assert.IsTrue (types.Contains (typeof (ManagedPeer)));
 		}
 
-#if !__ANDROID__
-		[Test]
-		public void ManagedPeerNativeRegistrationFalse_RemovesManagedPeerBuiltinMapping ()
-		{
-			var c      = JniRuntime.CurrentRuntime;
-			AppContext.SetSwitch ("Java.Interop.RuntimeFeature.ManagedPeerNativeRegistration", false);
-			try {
-				var types = c.TypeManager.GetTypes (new JniTypeSignature (ManagedPeer.JniTypeName));
-				Assert.IsEmpty (types);
-			} finally {
-				AppContext.SetSwitch ("Java.Interop.RuntimeFeature.ManagedPeerNativeRegistration", true);
-			}
-		}
-#endif  // !__ANDROID__
-
 		class JavaVMWithNullBuilder : JniRuntime {
 			public JavaVMWithNullBuilder ()
 				: base ((JniRuntime.CreationOptions) null)

--- a/tests/Java.Interop-Tests/Java.Interop/JniValueMarshalerContractTests.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JniValueMarshalerContractTests.cs
@@ -664,7 +664,6 @@ namespace Java.InteropTests {
 		public override DemoValueType CreateGenericValue (
 			ref JniObjectReference reference,
 			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (Constructors)]
 			Type targetType)
 		{
 			var v   = Int32Marshaler.CreateGenericValue (ref reference, options, typeof (int));


### PR DESCRIPTION
## Summary
- remove `DynamicallyAccessedMembers` annotations from runtime type/value manager and marshaler extensibility points where broad rooting is more harmful than useful
- update NativeAOT samples, unshipped API entries, and test overrides to match the updated signatures

## Testing
- `dotnet build tests/Java.Interop-Tests/Java.Interop-Tests.csproj --nologo -m:1`
- `dotnet build --nologo -m:1`