### PR TITLE
[ci] Bump hosted pool images to windows-2025 / macOS-15

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -23,8 +23,8 @@ variables:
   DotNetTargetFramework: net10.0
   NetCoreTargetFrameworkPathSuffix: -$(DotNetTargetFramework)
   HostedPoolName: Azure Pipelines
-  HostedWinImage: windows-2022
-  HostedMacImage: macOS-14
+  HostedWinImage: windows-2025
+  HostedMacImage: macOS-15
 
 jobs:
 - job: windows_dotnet_build


### PR DESCRIPTION
Bump the Microsoft-hosted images used on the dnceng-public `Azure Pipelines` pool:

- `HostedWinImage`: `windows-2022` → `windows-2025`
- `HostedMacImage`: `macOS-14` → `macOS-15`

These are the current latest Microsoft-hosted images and have more capacity / fewer deprecation warnings than the older ones. No other hardcoded references to `windows-2022` or `macOS-14` were found under `build-tools/automation/`.