### PR TITLE
[Xamarin.Android.Tools.Bytecode] Support JSpecify nullness annotations

### DIFF
--- a/src/Xamarin.Android.Tools.Bytecode/AttributeInfo.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/AttributeInfo.cs
@@ -51,7 +51,10 @@ namespace Xamarin.Android.Tools.Bytecode {
 		public  const   string  StackMapTable           = "StackMapTable";
 		public	const	string	RuntimeVisibleAnnotations	= "RuntimeVisibleAnnotations";
 		public	const	string	RuntimeInvisibleAnnotations	= "RuntimeInvisibleAnnotations";
+		public	const	string	RuntimeVisibleParameterAnnotations   = "RuntimeVisibleParameterAnnotations";
 		public	const	string	RuntimeInvisibleParameterAnnotations = "RuntimeInvisibleParameterAnnotations";
+		public	const	string	RuntimeVisibleTypeAnnotations	= "RuntimeVisibleTypeAnnotations";
+		public	const	string	RuntimeInvisibleTypeAnnotations	= "RuntimeInvisibleTypeAnnotations";
 
 		ushort          nameIndex;
 
@@ -85,6 +88,10 @@ namespace Xamarin.Android.Tools.Bytecode {
 			{ typeof (ModulePackagesAttribute),         ModulePackages },
 			{ typeof (RuntimeVisibleAnnotationsAttribute),		RuntimeVisibleAnnotations },
 			{ typeof (RuntimeInvisibleAnnotationsAttribute),	RuntimeInvisibleAnnotations },
+			{ typeof (RuntimeVisibleParameterAnnotationsAttribute),		RuntimeVisibleParameterAnnotations },
+			{ typeof (RuntimeInvisibleParameterAnnotationsAttribute),	RuntimeInvisibleParameterAnnotations },
+			{ typeof (RuntimeVisibleTypeAnnotationsAttribute),	RuntimeVisibleTypeAnnotations },
+			{ typeof (RuntimeInvisibleTypeAnnotationsAttribute),	RuntimeInvisibleTypeAnnotations },
 			{ typeof (SignatureAttribute),              Signature },
 			{ typeof (SourceFileAttribute),             SourceFile },
 			{ typeof (StackMapTableAttribute),          StackMapTable },
@@ -123,7 +130,10 @@ namespace Xamarin.Android.Tools.Bytecode {
 			case ModulePackages:        return new ModulePackagesAttribute (constantPool, nameIndex, stream);
 			case RuntimeVisibleAnnotations:		return new RuntimeVisibleAnnotationsAttribute (constantPool, nameIndex, stream);
 			case RuntimeInvisibleAnnotations:	return new RuntimeInvisibleAnnotationsAttribute (constantPool, nameIndex, stream);
+			case RuntimeVisibleParameterAnnotations:	return new RuntimeVisibleParameterAnnotationsAttribute (constantPool, nameIndex, stream);
 			case RuntimeInvisibleParameterAnnotations:	return new RuntimeInvisibleParameterAnnotationsAttribute (constantPool, nameIndex, stream);
+			case RuntimeVisibleTypeAnnotations:	return new RuntimeVisibleTypeAnnotationsAttribute (constantPool, nameIndex, stream);
+			case RuntimeInvisibleTypeAnnotations:	return new RuntimeInvisibleTypeAnnotationsAttribute (constantPool, nameIndex, stream);
 			case Signature:             return new SignatureAttribute (constantPool, nameIndex, stream);
 			case SourceFile:            return new SourceFileAttribute (constantPool, nameIndex, stream);
 			case StackMapTable:         return new StackMapTableAttribute (constantPool, nameIndex, stream);
@@ -671,6 +681,31 @@ namespace Xamarin.Android.Tools.Bytecode {
 	}
 
 
+	// https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.18
+	public sealed class RuntimeVisibleParameterAnnotationsAttribute : AttributeInfo
+	{
+		public IList<ParameterAnnotation> Annotations { get; } = new List<ParameterAnnotation> ();
+
+		public RuntimeVisibleParameterAnnotationsAttribute (ConstantPool constantPool, ushort nameIndex, Stream stream)
+			: base (constantPool, nameIndex, stream)
+		{
+			var length = stream.ReadNetworkUInt32 ();
+			var param_count = stream.ReadNetworkByte ();
+
+			for (var i = 0; i < param_count; ++i) {
+				var a = new ParameterAnnotation (constantPool, stream, i);
+				Annotations.Add (a);
+			}
+		}
+
+		public override string ToString ()
+		{
+			var annotations = string.Join (", ", Annotations.Select (v => v.ToString ()));
+			return $"RuntimeVisibleParameterAnnotationsAttribute({annotations})";
+		}
+	}
+
+
 	// https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.7.19
 	public sealed class RuntimeInvisibleParameterAnnotationsAttribute : AttributeInfo
 	{
@@ -692,6 +727,52 @@ namespace Xamarin.Android.Tools.Bytecode {
 		{
 			var annotations = string.Join (", ", Annotations.Select (v => v.ToString ()));
 			return $"RuntimeInvisibleParameterAnnotationsAttribute({annotations})";
+		}
+	}
+
+	// https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.20
+	public sealed class RuntimeVisibleTypeAnnotationsAttribute : AttributeInfo
+	{
+		public IList<TypeAnnotation> Annotations { get; } = new List<TypeAnnotation> ();
+
+		public RuntimeVisibleTypeAnnotationsAttribute (ConstantPool constantPool, ushort nameIndex, Stream stream)
+			: base (constantPool, nameIndex, stream)
+		{
+			var length = stream.ReadNetworkUInt32 ();
+			var count = stream.ReadNetworkUInt16 ();
+
+			for (int i = 0; i < count; ++i) {
+				Annotations.Add (new TypeAnnotation (constantPool, stream));
+			}
+		}
+
+		public override string ToString ()
+		{
+			var annotations = string.Join (", ", Annotations.Select (v => v.ToString ()));
+			return $"RuntimeVisibleTypeAnnotations({annotations})";
+		}
+	}
+
+	// https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.21
+	public sealed class RuntimeInvisibleTypeAnnotationsAttribute : AttributeInfo
+	{
+		public IList<TypeAnnotation> Annotations { get; } = new List<TypeAnnotation> ();
+
+		public RuntimeInvisibleTypeAnnotationsAttribute (ConstantPool constantPool, ushort nameIndex, Stream stream)
+			: base (constantPool, nameIndex, stream)
+		{
+			var length = stream.ReadNetworkUInt32 ();
+			var count = stream.ReadNetworkUInt16 ();
+
+			for (int i = 0; i < count; ++i) {
+				Annotations.Add (new TypeAnnotation (constantPool, stream));
+			}
+		}
+
+		public override string ToString ()
+		{
+			var annotations = string.Join (", ", Annotations.Select (v => v.ToString ()));
+			return $"RuntimeInvisibleTypeAnnotations({annotations})";
 		}
 	}
 

--- a/src/Xamarin.Android.Tools.Bytecode/ClassFile.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/ClassFile.cs
@@ -114,6 +114,18 @@ namespace Xamarin.Android.Tools.Bytecode {
 
 		public string FullJniName => "L" + ThisClass.Name.Value + ";";
 
+		// `package-info.class` is a synthetic class that carries
+		// package-level annotations (e.g. JSpecify's `@NullMarked`).
+		// Its simple name is `package-info`.
+		public bool IsPackageInfo {
+			get {
+				var name = ThisClass.Name.Value;
+				var slash = name.LastIndexOf ('/');
+				var simple = slash < 0 ? name : name.Substring (slash + 1);
+				return simple == "package-info";
+			}
+		}
+
 		public string? SourceFileName {
 			get {
 				var sourceFile  = Attributes.Get<SourceFileAttribute> ();

--- a/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
@@ -125,9 +125,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 					x => classFiles.Where (p => p.PackageName == x).ToList ()));
 		}
 
-		// Returns the `package-info.class` for the given package, if one
-		// is present on this ClassPath. Used by `XmlClassDeclarationBuilder`
-		// to honor package-level JSpecify `@NullMarked` annotations.
+		// Returns the `package-info.class` for the given package, if any.
 		public ClassFile? GetPackageInfo (string packageName)
 		{
 			foreach (var c in classFiles) {
@@ -380,6 +378,8 @@ namespace Xamarin.Android.Tools.Bytecode {
 			FixupModuleVisibility (removeModules: true);
 
 			var packagesDictionary = GetPackages ();
+			var packageInfos = packagesDictionary.Keys
+				.ToDictionary (p => p, p => GetPackageInfo (p));
 			var api = new XElement ("api",
 					GetApiSource (),
 					GetPlatform (),
@@ -389,7 +389,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 						new XAttribute ("jni-name", p.Replace ('.', '/')),
 						packagesDictionary [p].Where (c => !c.IsPackageInfo)
 						.OrderBy (c => c.ThisClass.Name.Value, StringComparer.OrdinalIgnoreCase)
-						.Select (c => new XmlClassDeclarationBuilder (c, GetPackageInfo (p)).ToXElement ()))));
+						.Select (c => new XmlClassDeclarationBuilder (c, packageInfos [p]).ToXElement ()))));
 			FixupParametersFromDocs (api);
 			return api;
 		}

--- a/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
@@ -378,8 +378,9 @@ namespace Xamarin.Android.Tools.Bytecode {
 			FixupModuleVisibility (removeModules: true);
 
 			var packagesDictionary = GetPackages ();
-			var packageInfos = packagesDictionary.Keys
-				.ToDictionary (p => p, p => GetPackageInfo (p));
+			var packageInfos = packagesDictionary.ToDictionary (
+				kv => kv.Key,
+				kv => kv.Value.FirstOrDefault (c => c.IsPackageInfo));
 			var api = new XElement ("api",
 					GetApiSource (),
 					GetPlatform (),

--- a/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/ClassPath.cs
@@ -125,6 +125,18 @@ namespace Xamarin.Android.Tools.Bytecode {
 					x => classFiles.Where (p => p.PackageName == x).ToList ()));
 		}
 
+		// Returns the `package-info.class` for the given package, if one
+		// is present on this ClassPath. Used by `XmlClassDeclarationBuilder`
+		// to honor package-level JSpecify `@NullMarked` annotations.
+		public ClassFile? GetPackageInfo (string packageName)
+		{
+			foreach (var c in classFiles) {
+				if (c.IsPackageInfo && c.PackageName == packageName)
+					return c;
+			}
+			return null;
+		}
+
 		public static bool IsJarFile (string jarFile)
 		{
 			if (jarFile == null)
@@ -375,8 +387,9 @@ namespace Xamarin.Android.Tools.Bytecode {
 					.Select (p => new XElement ("package",
 						new XAttribute ("name", p),
 						new XAttribute ("jni-name", p.Replace ('.', '/')),
-						packagesDictionary [p].OrderBy (c => c.ThisClass.Name.Value, StringComparer.OrdinalIgnoreCase)
-						.Select (c => new XmlClassDeclarationBuilder (c).ToXElement ()))));
+						packagesDictionary [p].Where (c => !c.IsPackageInfo)
+						.OrderBy (c => c.ThisClass.Name.Value, StringComparer.OrdinalIgnoreCase)
+						.Select (c => new XmlClassDeclarationBuilder (c, GetPackageInfo (p)).ToXElement ()))));
 			FixupParametersFromDocs (api);
 			return api;
 		}

--- a/src/Xamarin.Android.Tools.Bytecode/TypeAnnotation.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/TypeAnnotation.cs
@@ -1,0 +1,129 @@
+using System;
+using System.IO;
+
+namespace Xamarin.Android.Tools.Bytecode
+{
+	// https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.20
+	public enum TypeAnnotationTargetType : byte
+	{
+		ClassTypeParameter              = 0x00,
+		MethodTypeParameter             = 0x01,
+		ClassExtends                    = 0x10,
+		ClassTypeParameterBound         = 0x11,
+		MethodTypeParameterBound        = 0x12,
+		Field                           = 0x13,
+		MethodReturn                    = 0x14,
+		MethodReceiver                  = 0x15,
+		MethodFormalParameter           = 0x16,
+		Throws                          = 0x17,
+		LocalVariable                   = 0x40,
+		ResourceVariable                = 0x41,
+		ExceptionParameter              = 0x42,
+		Instanceof                      = 0x43,
+		New                             = 0x44,
+		ConstructorReference            = 0x45,
+		MethodReference                 = 0x46,
+		Cast                            = 0x47,
+		ConstructorInvocationTypeArgument = 0x48,
+		MethodInvocationTypeArgument    = 0x49,
+		ConstructorReferenceTypeArgument = 0x4A,
+		MethodReferenceTypeArgument     = 0x4B,
+	}
+
+	// https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.20
+	public sealed class TypeAnnotation
+	{
+		public  TypeAnnotationTargetType    TargetType          { get; }
+
+		// `formal_parameter_index` for MethodFormalParameter; otherwise 0.
+		public  int                         FormalParameterIndex    { get; }
+
+		// `path_length` from `type_path`; we don't retain the individual
+		// path entries — see AppliesToTopLevelType.
+		public  int                         TypePathLength      { get; }
+
+		public  Annotation                  Annotation          { get; }
+
+		// JSpecify-style nullness annotations only apply to the top-level
+		// type when there is no `type_path`. Annotations with a non-empty
+		// path describe inner types (e.g. `Map<@Nullable K, V>`) which the
+		// API XML schema cannot currently represent.
+		public  bool                        AppliesToTopLevelType => TypePathLength == 0;
+
+		public TypeAnnotation (ConstantPool constantPool, Stream stream)
+		{
+			TargetType = (TypeAnnotationTargetType) stream.ReadNetworkByte ();
+
+			// target_info — size depends on target_type.
+			switch (TargetType) {
+			case TypeAnnotationTargetType.ClassTypeParameter:
+			case TypeAnnotationTargetType.MethodTypeParameter:
+				stream.ReadNetworkByte ();              // type_parameter_index
+				break;
+			case TypeAnnotationTargetType.ClassExtends:
+				stream.ReadNetworkUInt16 ();            // supertype_index
+				break;
+			case TypeAnnotationTargetType.ClassTypeParameterBound:
+			case TypeAnnotationTargetType.MethodTypeParameterBound:
+				stream.ReadNetworkByte ();              // type_parameter_index
+				stream.ReadNetworkByte ();              // bound_index
+				break;
+			case TypeAnnotationTargetType.Field:
+			case TypeAnnotationTargetType.MethodReturn:
+			case TypeAnnotationTargetType.MethodReceiver:
+				// empty_target — no bytes
+				break;
+			case TypeAnnotationTargetType.MethodFormalParameter:
+				FormalParameterIndex = stream.ReadNetworkByte ();
+				break;
+			case TypeAnnotationTargetType.Throws:
+				stream.ReadNetworkUInt16 ();            // throws_type_index
+				break;
+			case TypeAnnotationTargetType.LocalVariable:
+			case TypeAnnotationTargetType.ResourceVariable: {
+				var table_length = stream.ReadNetworkUInt16 ();
+				for (int i = 0; i < table_length; ++i) {
+					stream.ReadNetworkUInt16 ();    // start_pc
+					stream.ReadNetworkUInt16 ();    // length
+					stream.ReadNetworkUInt16 ();    // index
+				}
+				break;
+			}
+			case TypeAnnotationTargetType.ExceptionParameter:
+				stream.ReadNetworkUInt16 ();            // exception_table_index
+				break;
+			case TypeAnnotationTargetType.Instanceof:
+			case TypeAnnotationTargetType.New:
+			case TypeAnnotationTargetType.ConstructorReference:
+			case TypeAnnotationTargetType.MethodReference:
+				stream.ReadNetworkUInt16 ();            // offset
+				break;
+			case TypeAnnotationTargetType.Cast:
+			case TypeAnnotationTargetType.ConstructorInvocationTypeArgument:
+			case TypeAnnotationTargetType.MethodInvocationTypeArgument:
+			case TypeAnnotationTargetType.ConstructorReferenceTypeArgument:
+			case TypeAnnotationTargetType.MethodReferenceTypeArgument:
+				stream.ReadNetworkUInt16 ();            // offset
+				stream.ReadNetworkByte ();              // type_argument_index
+				break;
+			default:
+				throw new NotSupportedException ($"Unknown type_annotation target_type: 0x{(byte)TargetType:X2}");
+			}
+
+			// type_path: u1 path_length, then path_length * { u1 type_path_kind; u1 type_argument_index; }
+			TypePathLength = stream.ReadNetworkByte ();
+			for (int i = 0; i < TypePathLength; ++i) {
+				stream.ReadNetworkByte ();              // type_path_kind
+				stream.ReadNetworkByte ();              // type_argument_index
+			}
+
+			// The remaining bytes match the regular `annotation` structure.
+			Annotation = new Annotation (constantPool, stream);
+		}
+
+		public override string ToString ()
+		{
+			return $"TypeAnnotation({TargetType}, paramIndex={FormalParameterIndex}, pathLength={TypePathLength}, {Annotation})";
+		}
+	}
+}

--- a/src/Xamarin.Android.Tools.Bytecode/XmlClassDeclarationBuilder.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/XmlClassDeclarationBuilder.cs
@@ -607,7 +607,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 			if (typeNullness.HasValue)
 				return typeNullness;
 			if (isNullMarked && IsReferenceTypeDescriptor (GetReturnDescriptor (method.Descriptor))
-					&& !IsTopLevelTypeVariableSignature (method.GetSignature ()?.ReturnTypeSignature))
+					&& !IsTopLevelTypeVariableSignature (method.ReturnType.TypeSignature))
 				return true;
 			return null;
 		}
@@ -639,14 +639,9 @@ namespace Xamarin.Android.Tools.Bytecode {
 			if (isNullMarked) {
 				var parameters = method.GetParameters ();
 				if (parameterIndex >= 0 && parameterIndex < parameters.Length
-						&& IsReferenceTypeDescriptor (parameters [parameterIndex].Type.BinaryName)) {
-					var msig = method.GetSignature ();
-					string? paramSig = null;
-					if (msig != null && parameterIndex < msig.Parameters.Count)
-						paramSig = msig.Parameters [parameterIndex];
-					if (!IsTopLevelTypeVariableSignature (paramSig))
-						return true;
-				}
+						&& IsReferenceTypeDescriptor (parameters [parameterIndex].Type.BinaryName)
+						&& !IsTopLevelTypeVariableSignature (parameters [parameterIndex].Type.TypeSignature))
+					return true;
 			}
 			return null;
 		}

--- a/src/Xamarin.Android.Tools.Bytecode/XmlClassDeclarationBuilder.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/XmlClassDeclarationBuilder.cs
@@ -11,19 +11,69 @@ namespace Xamarin.Android.Tools.Bytecode {
 	public class XmlClassDeclarationBuilder {
 
 		ClassFile       classFile;
+		ClassFile?      packageInfo;
 		ClassSignature? signature;
+		bool            isNullMarked;
 
 		bool IsInterface {
 			get {return (classFile.AccessFlags & ClassAccessFlags.Interface) != 0;}
 		}
 
 		public XmlClassDeclarationBuilder (ClassFile classFile)
+			: this (classFile, packageInfo: null)
+		{
+		}
+
+		public XmlClassDeclarationBuilder (ClassFile classFile, ClassFile? packageInfo)
 		{
 			if (classFile == null)
 				throw new ArgumentNullException ("classFile");
 
-			this.classFile  = classFile;
-			signature       = classFile.GetSignature ();
+			this.classFile      = classFile;
+			this.packageInfo    = packageInfo;
+			signature           = classFile.GetSignature ();
+			isNullMarked        = ComputeIsNullMarked ();
+		}
+
+		// Module-level and inner-class scope inheritance are not yet implemented.
+		bool ComputeIsNullMarked ()
+		{
+			var classScope = GetJSpecifyScope (classFile.Attributes);
+			if (classScope.HasValue)
+				return classScope.Value;
+
+			if (packageInfo != null) {
+				var pkgScope = GetJSpecifyScope (packageInfo.Attributes);
+				if (pkgScope.HasValue)
+					return pkgScope.Value;
+			}
+
+			return false;
+		}
+
+		// `@NullMarked` / `@NullUnmarked` are `@Retention(RUNTIME)`, so
+		// check both Visible and Invisible annotation tables.
+		static bool? GetJSpecifyScope (AttributeCollection? attributes)
+		{
+			if (attributes == null)
+				return null;
+			foreach (var a in EnumerateDeclarationAnnotations (attributes)) {
+				if (a.Type == "Lorg/jspecify/annotations/NullUnmarked;")
+					return false;
+				if (a.Type == "Lorg/jspecify/annotations/NullMarked;")
+					return true;
+			}
+			return null;
+		}
+
+		static IEnumerable<Annotation> EnumerateDeclarationAnnotations (AttributeCollection attributes)
+		{
+			foreach (var v in attributes.OfType<RuntimeVisibleAnnotationsAttribute> ())
+				foreach (var a in v.Annotations)
+					yield return a;
+			foreach (var i in attributes.OfType<RuntimeInvisibleAnnotationsAttribute> ())
+				foreach (var a in i.Annotations)
+					yield return a;
 		}
 
 		public XElement ToXElement ()
@@ -425,7 +475,16 @@ namespace Xamarin.Android.Tools.Bytecode {
 
 		IEnumerable<XElement> GetMethodParameters (MethodInfo method)
 		{
-			var annotations = method.Attributes?.OfType<RuntimeInvisibleParameterAnnotationsAttribute> ().FirstOrDefault ()?.Annotations;
+			var invisible = method.Attributes?.OfType<RuntimeInvisibleParameterAnnotationsAttribute> ().FirstOrDefault ()?.Annotations;
+			var visible   = method.Attributes?.OfType<RuntimeVisibleParameterAnnotationsAttribute> ().FirstOrDefault ()?.Annotations;
+			IList<ParameterAnnotation>? annotations = invisible;
+			if (annotations == null) {
+				annotations = visible;
+			} else if (visible != null) {
+				var merged = new List<ParameterAnnotation> (annotations);
+				merged.AddRange (visible);
+				annotations = merged;
+			}
 			var varargs     = (method.AccessFlags & MethodAccessFlags.Varargs) != 0;
 			var parameters  = method.GetParameters ();
 			for (int i = 0; i < parameters.Length; ++i) {
@@ -453,7 +512,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 						new XAttribute ("type",     genericType),
 						new XAttribute ("jni-type", p.Type.TypeSignature ?? p.Type.BinaryName),
 						GetKotlinInlineClassJniType (p),
-						GetNotNull (annotations, i));
+						GetNotNull (method, annotations, i));
 			}
 		}
 
@@ -513,34 +572,155 @@ namespace Xamarin.Android.Tools.Bytecode {
 			return null;
 		}
 
-		static XAttribute? GetNotNull (MethodInfo method)
+		XAttribute? GetNotNull (MethodInfo method)
 		{
-			var annotations = method.Attributes?.OfType<RuntimeInvisibleAnnotationsAttribute> ().FirstOrDefault ()?.Annotations;
-
-			if (annotations?.Any (a => IsNotNullAnnotation (a)) == true)
+			var nullness = GetMethodReturnNullness (method);
+			if (nullness == true)
 				return new XAttribute ("return-not-null", "true");
-
 			return null;
 		}
 
-		static XAttribute? GetNotNull (IList<ParameterAnnotation>? annotations, int parameterIndex)
+		XAttribute? GetNotNull (MethodInfo method, IList<ParameterAnnotation>? annotations, int parameterIndex)
+		{
+			var nullness = GetParameterNullness (method, annotations, parameterIndex);
+			if (nullness == true)
+				return new XAttribute ("not-null", "true");
+			return null;
+		}
+
+		XAttribute? GetNotNull (FieldInfo field)
+		{
+			var nullness = GetFieldNullness (field);
+			if (nullness == true)
+				return new XAttribute ("not-null", "true");
+			return null;
+		}
+
+		// Returns true when the slot is known non-null, false when known
+		// nullable, null when no information. JSpecify TYPE_USE `@Nullable`
+		// (top-of-type only) overrides the scope default; an explicit
+		// declaration-level `@NonNull`-style annotation always wins.
+		bool? GetMethodReturnNullness (MethodInfo method)
+		{
+			if (HasDeclarationNotNullAnnotation (method.Attributes))
+				return true;
+			var typeNullness = GetTypeUseNullness (method.Attributes,
+				ta => ta.TargetType == TypeAnnotationTargetType.MethodReturn);
+			if (typeNullness.HasValue)
+				return typeNullness;
+			if (isNullMarked && IsReferenceTypeDescriptor (GetReturnDescriptor (method.Descriptor)))
+				return true;
+			return null;
+		}
+
+		bool? GetParameterNullness (MethodInfo method, IList<ParameterAnnotation>? annotations, int parameterIndex)
 		{
 			var ann = annotations?.FirstOrDefault (a => a.ParameterIndex == parameterIndex)?.Annotations;
-
 			if (ann?.Any (a => IsNotNullAnnotation (a)) == true)
-				return new XAttribute ("not-null", "true");
+				return true;
 
+			var typeNullness = GetTypeUseNullness (method.Attributes,
+				ta => ta.TargetType == TypeAnnotationTargetType.MethodFormalParameter
+					&& ta.FormalParameterIndex == parameterIndex);
+			if (typeNullness.HasValue)
+				return typeNullness;
+
+			if (isNullMarked) {
+				var parameters = method.GetParameters ();
+				if (parameterIndex >= 0 && parameterIndex < parameters.Length
+						&& IsReferenceTypeDescriptor (parameters [parameterIndex].Type.BinaryName))
+					return true;
+			}
 			return null;
 		}
 
-		static XAttribute? GetNotNull (FieldInfo field)
+		bool? GetFieldNullness (FieldInfo field)
 		{
-			var annotations = field.Attributes?.OfType<RuntimeInvisibleAnnotationsAttribute> ().FirstOrDefault ()?.Annotations;
-
-			if (annotations?.Any (a => IsNotNullAnnotation (a)) == true)
-				return new XAttribute ("not-null", "true");
-
+			if (HasDeclarationNotNullAnnotation (field.Attributes))
+				return true;
+			var typeNullness = GetTypeUseNullness (field.Attributes,
+				ta => ta.TargetType == TypeAnnotationTargetType.Field);
+			if (typeNullness.HasValue)
+				return typeNullness;
+			if (isNullMarked && IsReferenceTypeDescriptor (field.Descriptor))
+				return true;
 			return null;
+		}
+
+		static bool HasDeclarationNotNullAnnotation (AttributeCollection? attributes)
+		{
+			if (attributes == null)
+				return false;
+			foreach (var a in EnumerateDeclarationAnnotations (attributes)) {
+				if (IsNotNullAnnotation (a))
+					return true;
+			}
+			return false;
+		}
+
+		// Look in `RuntimeInvisibleTypeAnnotations` and `RuntimeVisibleTypeAnnotations`
+		// for entries matching `predicate` (e.g. METHOD_RETURN, FIELD, or
+		// a specific METHOD_FORMAL_PARAMETER index) at the top of the type
+		// (no `type_path`). Returns true for `@NonNull`, false for
+		// `@Nullable`, null for no match.
+		static bool? GetTypeUseNullness (AttributeCollection? attributes, Func<TypeAnnotation, bool> predicate)
+		{
+			if (attributes == null)
+				return null;
+			bool? result = null;
+			foreach (var ta in EnumerateTypeAnnotations (attributes)) {
+				if (!ta.AppliesToTopLevelType)
+					continue;
+				if (!predicate (ta))
+					continue;
+				if (IsNotNullAnnotation (ta.Annotation))
+					return true;
+				if (IsNullableAnnotation (ta.Annotation))
+					result = false;
+			}
+			return result;
+		}
+
+		static IEnumerable<TypeAnnotation> EnumerateTypeAnnotations (AttributeCollection attributes)
+		{
+			foreach (var v in attributes.OfType<RuntimeVisibleTypeAnnotationsAttribute> ())
+				foreach (var a in v.Annotations)
+					yield return a;
+			foreach (var i in attributes.OfType<RuntimeInvisibleTypeAnnotationsAttribute> ())
+				foreach (var a in i.Annotations)
+					yield return a;
+		}
+
+		static bool IsNullableAnnotation (Annotation annotation)
+		{
+			switch (annotation.Type) {
+			case "Lorg/jspecify/annotations/Nullable;":
+			case "Landroidx/annotation/Nullable;":
+			case "Landroid/annotation/Nullable;":
+			case "Landroid/support/annotation/Nullable;":
+				return true;
+			}
+			return false;
+		}
+
+		// Returns the return-type portion of a method descriptor, e.g.
+		// "(ILjava/lang/String;)Ljava/lang/Object;" -> "Ljava/lang/Object;".
+		static string GetReturnDescriptor (string descriptor)
+		{
+			var i = descriptor.LastIndexOf (')');
+			return i < 0 ? descriptor : descriptor.Substring (i + 1);
+		}
+
+		// A descriptor refers to a reference type (object or array) iff
+		// it starts with 'L' (object), 'T' (type variable — appears in
+		// `Signature`, not `Descriptor`, but harmless to include), or '['
+		// (array of anything). Primitives and `V` (void) return false.
+		static bool IsReferenceTypeDescriptor (string descriptor)
+		{
+			if (string.IsNullOrEmpty (descriptor))
+				return false;
+			var c = descriptor [0];
+			return c == 'L' || c == '[' || c == 'T';
 		}
 
 		static bool IsNotNullAnnotation (Annotation annotation)

--- a/src/Xamarin.Android.Tools.Bytecode/XmlClassDeclarationBuilder.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/XmlClassDeclarationBuilder.cs
@@ -600,6 +600,8 @@ namespace Xamarin.Android.Tools.Bytecode {
 		{
 			if (HasDeclarationNotNullAnnotation (method.Attributes))
 				return true;
+			if (HasDeclarationNullableAnnotation (method.Attributes))
+				return null;
 			var typeNullness = GetTypeUseNullness (method.Attributes,
 				ta => ta.TargetType == TypeAnnotationTargetType.MethodReturn);
 			if (typeNullness.HasValue)
@@ -612,14 +614,21 @@ namespace Xamarin.Android.Tools.Bytecode {
 
 		bool? GetParameterNullness (MethodInfo method, IList<ParameterAnnotation>? annotations, int parameterIndex)
 		{
+			bool hasDeclarationNullable = false;
 			if (annotations != null) {
 				foreach (var pa in annotations) {
 					if (pa.ParameterIndex != parameterIndex)
 						continue;
-					if (pa.Annotations.Any (a => IsNotNullAnnotation (a)))
-						return true;
+					foreach (var a in pa.Annotations) {
+						if (IsNotNullAnnotation (a))
+							return true;
+						if (IsNullableAnnotation (a))
+							hasDeclarationNullable = true;
+					}
 				}
 			}
+			if (hasDeclarationNullable)
+				return null;
 
 			var typeNullness = GetTypeUseNullness (method.Attributes,
 				ta => ta.TargetType == TypeAnnotationTargetType.MethodFormalParameter
@@ -646,6 +655,8 @@ namespace Xamarin.Android.Tools.Bytecode {
 		{
 			if (HasDeclarationNotNullAnnotation (field.Attributes))
 				return true;
+			if (HasDeclarationNullableAnnotation (field.Attributes))
+				return null;
 			var typeNullness = GetTypeUseNullness (field.Attributes,
 				ta => ta.TargetType == TypeAnnotationTargetType.Field);
 			if (typeNullness.HasValue)
@@ -662,6 +673,17 @@ namespace Xamarin.Android.Tools.Bytecode {
 				return false;
 			foreach (var a in EnumerateDeclarationAnnotations (attributes)) {
 				if (IsNotNullAnnotation (a))
+					return true;
+			}
+			return false;
+		}
+
+		static bool HasDeclarationNullableAnnotation (AttributeCollection? attributes)
+		{
+			if (attributes == null)
+				return false;
+			foreach (var a in EnumerateDeclarationAnnotations (attributes)) {
+				if (IsNullableAnnotation (a))
 					return true;
 			}
 			return false;
@@ -732,7 +754,7 @@ namespace Xamarin.Android.Tools.Bytecode {
 			if (string.IsNullOrEmpty (descriptor))
 				return false;
 			var c = descriptor [0];
-			return c == 'L' || c == '[' || c == 'T';
+			return c == 'L' || c == '[';
 		}
 
 		// JSpecify gives unannotated type-variable *usages* parametric

--- a/src/Xamarin.Android.Tools.Bytecode/XmlClassDeclarationBuilder.cs
+++ b/src/Xamarin.Android.Tools.Bytecode/XmlClassDeclarationBuilder.cs
@@ -596,10 +596,6 @@ namespace Xamarin.Android.Tools.Bytecode {
 			return null;
 		}
 
-		// Returns true when the slot is known non-null, false when known
-		// nullable, null when no information. JSpecify TYPE_USE `@Nullable`
-		// (top-of-type only) overrides the scope default; an explicit
-		// declaration-level `@NonNull`-style annotation always wins.
 		bool? GetMethodReturnNullness (MethodInfo method)
 		{
 			if (HasDeclarationNotNullAnnotation (method.Attributes))
@@ -608,16 +604,22 @@ namespace Xamarin.Android.Tools.Bytecode {
 				ta => ta.TargetType == TypeAnnotationTargetType.MethodReturn);
 			if (typeNullness.HasValue)
 				return typeNullness;
-			if (isNullMarked && IsReferenceTypeDescriptor (GetReturnDescriptor (method.Descriptor)))
+			if (isNullMarked && IsReferenceTypeDescriptor (GetReturnDescriptor (method.Descriptor))
+					&& !IsTopLevelTypeVariableSignature (method.GetSignature ()?.ReturnTypeSignature))
 				return true;
 			return null;
 		}
 
 		bool? GetParameterNullness (MethodInfo method, IList<ParameterAnnotation>? annotations, int parameterIndex)
 		{
-			var ann = annotations?.FirstOrDefault (a => a.ParameterIndex == parameterIndex)?.Annotations;
-			if (ann?.Any (a => IsNotNullAnnotation (a)) == true)
-				return true;
+			if (annotations != null) {
+				foreach (var pa in annotations) {
+					if (pa.ParameterIndex != parameterIndex)
+						continue;
+					if (pa.Annotations.Any (a => IsNotNullAnnotation (a)))
+						return true;
+				}
+			}
 
 			var typeNullness = GetTypeUseNullness (method.Attributes,
 				ta => ta.TargetType == TypeAnnotationTargetType.MethodFormalParameter
@@ -628,8 +630,14 @@ namespace Xamarin.Android.Tools.Bytecode {
 			if (isNullMarked) {
 				var parameters = method.GetParameters ();
 				if (parameterIndex >= 0 && parameterIndex < parameters.Length
-						&& IsReferenceTypeDescriptor (parameters [parameterIndex].Type.BinaryName))
-					return true;
+						&& IsReferenceTypeDescriptor (parameters [parameterIndex].Type.BinaryName)) {
+					var msig = method.GetSignature ();
+					string? paramSig = null;
+					if (msig != null && parameterIndex < msig.Parameters.Count)
+						paramSig = msig.Parameters [parameterIndex];
+					if (!IsTopLevelTypeVariableSignature (paramSig))
+						return true;
+				}
 			}
 			return null;
 		}
@@ -642,7 +650,8 @@ namespace Xamarin.Android.Tools.Bytecode {
 				ta => ta.TargetType == TypeAnnotationTargetType.Field);
 			if (typeNullness.HasValue)
 				return typeNullness;
-			if (isNullMarked && IsReferenceTypeDescriptor (field.Descriptor))
+			if (isNullMarked && IsReferenceTypeDescriptor (field.Descriptor)
+					&& !IsTopLevelTypeVariableSignature (field.GetSignature ()))
 				return true;
 			return null;
 		}
@@ -694,33 +703,47 @@ namespace Xamarin.Android.Tools.Bytecode {
 		static bool IsNullableAnnotation (Annotation annotation)
 		{
 			switch (annotation.Type) {
-			case "Lorg/jspecify/annotations/Nullable;":
-			case "Landroidx/annotation/Nullable;":
 			case "Landroid/annotation/Nullable;":
 			case "Landroid/support/annotation/Nullable;":
+			case "Landroidx/annotation/Nullable;":
+			case "Landroidx/annotation/RecentlyNullable;":
+			case "Lcom/android/annotations/Nullable;":
+			case "Ledu/umd/cs/findbugs/annotations/Nullable;":
+			case "Ljakarta/annotation/Nullable;":
+			case "Ljavax/annotation/Nullable;":
+			case "Lorg/checkerframework/checker/nullness/compatqual/NullableDecl;":
+			case "Lorg/checkerframework/checker/nullness/qual/Nullable;":
+			case "Lorg/eclipse/jdt/annotation/Nullable;":
+			case "Lorg/jetbrains/annotations/Nullable;":
+			case "Lorg/jspecify/annotations/Nullable;":
 				return true;
 			}
 			return false;
 		}
 
-		// Returns the return-type portion of a method descriptor, e.g.
-		// "(ILjava/lang/String;)Ljava/lang/Object;" -> "Ljava/lang/Object;".
 		static string GetReturnDescriptor (string descriptor)
 		{
 			var i = descriptor.LastIndexOf (')');
 			return i < 0 ? descriptor : descriptor.Substring (i + 1);
 		}
 
-		// A descriptor refers to a reference type (object or array) iff
-		// it starts with 'L' (object), 'T' (type variable — appears in
-		// `Signature`, not `Descriptor`, but harmless to include), or '['
-		// (array of anything). Primitives and `V` (void) return false.
 		static bool IsReferenceTypeDescriptor (string descriptor)
 		{
 			if (string.IsNullOrEmpty (descriptor))
 				return false;
 			var c = descriptor [0];
 			return c == 'L' || c == '[' || c == 'T';
+		}
+
+		// JSpecify gives unannotated type-variable *usages* parametric
+		// nullness, so e.g. `<T> T get()` must not gain `not-null="true"`
+		// in a null-marked scope. A JVMS signature for a type-variable
+		// use begins with 'T' (followed by the variable name and ';').
+		// Returns false for `null` so callers can pass the raw signature
+		// when no Signature attribute is present.
+		static bool IsTopLevelTypeVariableSignature (string? signature)
+		{
+			return !string.IsNullOrEmpty (signature) && signature [0] == 'T';
 		}
 
 		static bool IsNotNullAnnotation (Annotation annotation)

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/JSpecifyAnnotationTests.cs
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/JSpecifyAnnotationTests.cs
@@ -35,6 +35,12 @@ namespace Xamarin.Android.Tools.BytecodeTests
 		static XElement Field (XElement classXml, string name)
 			=> classXml.Elements ("field").First (f => f.Attribute ("name")?.Value == name);
 
+		static XElement FirstParameter (XElement method)
+		{
+			return method.Element ("parameter")
+				?? throw new AssertionException ($"method '{method.Attribute ("name")?.Value}' has no <parameter>");
+		}
+
 		static string? Attr (XElement e, string name) => e.Attribute (name)?.Value;
 
 		[Test]
@@ -46,8 +52,7 @@ namespace Xamarin.Android.Tools.BytecodeTests
 			Assert.AreEqual ("true", Attr (m, "return-not-null"),
 				"unannotated reference return in @NullMarked package must be not-null");
 
-			var p = m.Element ("parameter");
-			Assert.AreEqual ("true", Attr (p!, "not-null"),
+			Assert.AreEqual ("true", Attr (FirstParameter (m), "not-null"),
 				"unannotated reference parameter in @NullMarked package must be not-null");
 
 			var f = Field (xml, "defaultField");
@@ -78,8 +83,7 @@ namespace Xamarin.Android.Tools.BytecodeTests
 			Assert.IsNull (Attr (m, "return-not-null"),
 				"@Nullable return must override the @NullMarked default");
 
-			var p = m.Element ("parameter");
-			Assert.IsNull (Attr (p!, "not-null"),
+			Assert.IsNull (Attr (FirstParameter (m), "not-null"),
 				"@Nullable parameter must override the @NullMarked default");
 
 			var f = Field (xml, "nullableField");
@@ -98,6 +102,19 @@ namespace Xamarin.Android.Tools.BytecodeTests
 		}
 
 		[Test]
+		public void PackageMarked_TypeVariableUsage_HasParametricNullness ()
+		{
+			var xml = BuildXml ("JSpecifyPackageMarked.class", "package-info.class");
+
+			var m = Method (xml, "typeVariableReturn");
+			Assert.IsNull (Attr (m, "return-not-null"),
+				"unannotated type-variable return must not gain not-null from the scope default");
+
+			Assert.IsNull (Attr (FirstParameter (m), "not-null"),
+				"unannotated type-variable parameter must not gain not-null from the scope default");
+		}
+
+		[Test]
 		public void ClassMarked_DefaultReferenceMembers_AreNotNull ()
 		{
 			var xml = BuildXml ("JSpecifyClassMarked.class");
@@ -106,8 +123,7 @@ namespace Xamarin.Android.Tools.BytecodeTests
 			Assert.AreEqual ("true", Attr (m, "return-not-null"),
 				"unannotated reference return in @NullMarked class must be not-null");
 
-			var p = m.Element ("parameter");
-			Assert.AreEqual ("true", Attr (p!, "not-null"),
+			Assert.AreEqual ("true", Attr (FirstParameter (m), "not-null"),
 				"unannotated reference parameter in @NullMarked class must be not-null");
 
 			var f = Field (xml, "defaultField");
@@ -124,8 +140,7 @@ namespace Xamarin.Android.Tools.BytecodeTests
 			Assert.IsNull (Attr (m, "return-not-null"),
 				"@Nullable return must override the class-level @NullMarked default");
 
-			var p = m.Element ("parameter");
-			Assert.IsNull (Attr (p!, "not-null"),
+			Assert.IsNull (Attr (FirstParameter (m), "not-null"),
 				"@Nullable parameter must override the class-level @NullMarked default");
 
 			var f = Field (xml, "nullableField");
@@ -142,13 +157,29 @@ namespace Xamarin.Android.Tools.BytecodeTests
 			Assert.IsNull (Attr (m, "return-not-null"),
 				"outside a @NullMarked scope, unannotated reference returns must not gain not-null");
 
-			var p = m.Element ("parameter");
-			Assert.IsNull (Attr (p!, "not-null"),
+			Assert.IsNull (Attr (FirstParameter (m), "not-null"),
 				"outside a @NullMarked scope, unannotated reference parameters must not gain not-null");
 
 			var f = Field (xml, "defaultField");
 			Assert.IsNull (Attr (f, "not-null"),
 				"outside a @NullMarked scope, unannotated reference fields must not gain not-null");
+		}
+
+		[Test]
+		public void Unmarked_ExplicitNonNullAnnotation_IsHonored ()
+		{
+			var xml = BuildXml ("JSpecifyUnmarked.class");
+
+			var m = Method (xml, "nonNullReturn");
+			Assert.AreEqual ("true", Attr (m, "return-not-null"),
+				"explicit @NonNull return must produce not-null even outside a @NullMarked scope");
+
+			Assert.AreEqual ("true", Attr (FirstParameter (m), "not-null"),
+				"explicit @NonNull parameter must produce not-null even outside a @NullMarked scope");
+
+			var f = Field (xml, "nonNullField");
+			Assert.AreEqual ("true", Attr (f, "not-null"),
+				"explicit @NonNull field must produce not-null even outside a @NullMarked scope");
 		}
 
 		[Test]
@@ -158,14 +189,13 @@ namespace Xamarin.Android.Tools.BytecodeTests
 			var method = c.Methods.First (m => m.Name == "nullableReturn");
 			var typeAnn = method.Attributes
 				.OfType<RuntimeInvisibleTypeAnnotationsAttribute> ()
-				.FirstOrDefault ();
-			Assert.NotNull (typeAnn,
-				"javac must emit a RuntimeInvisibleTypeAnnotations attribute for @Nullable members");
-			Assert.IsTrue (typeAnn!.Annotations.Any (a =>
+				.FirstOrDefault ()
+				?? throw new AssertionException ("javac must emit a RuntimeInvisibleTypeAnnotations attribute for @Nullable members");
+			Assert.IsTrue (typeAnn.Annotations.Any (a =>
 				a.Annotation.Type == "Lorg/jspecify/annotations/Nullable;"
 					&& a.TargetType == TypeAnnotationTargetType.MethodReturn),
 				"@Nullable return type annotation must be parsed with MethodReturn target");
-			Assert.IsTrue (typeAnn!.Annotations.Any (a =>
+			Assert.IsTrue (typeAnn.Annotations.Any (a =>
 				a.Annotation.Type == "Lorg/jspecify/annotations/Nullable;"
 					&& a.TargetType == TypeAnnotationTargetType.MethodFormalParameter
 					&& a.FormalParameterIndex == 0),

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/JSpecifyAnnotationTests.cs
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/JSpecifyAnnotationTests.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+#nullable enable
+
+using Xamarin.Android.Tools.Bytecode;
+
+using NUnit.Framework;
+
+namespace Xamarin.Android.Tools.BytecodeTests
+{
+	[TestFixture]
+	public class JSpecifyAnnotationTests : ClassFileFixture
+	{
+		static XElement BuildXml (string classResource, string? packageInfoResource = null)
+		{
+			var classPath = new ClassPath ();
+			if (packageInfoResource != null)
+				classPath.Add (LoadClassFile (packageInfoResource));
+			var c = LoadClassFile (classResource);
+			classPath.Add (c);
+
+			var packageInfo = packageInfoResource != null
+				? classPath.GetPackageInfo (c.PackageName)
+				: null;
+			return new XmlClassDeclarationBuilder (c, packageInfo).ToXElement ();
+		}
+
+		static XElement Method (XElement classXml, string name)
+			=> classXml.Elements ().First (e => (e.Name.LocalName == "method" || e.Name.LocalName == "constructor")
+				&& e.Attribute ("name")?.Value == name);
+
+		static XElement Field (XElement classXml, string name)
+			=> classXml.Elements ("field").First (f => f.Attribute ("name")?.Value == name);
+
+		static string? Attr (XElement e, string name) => e.Attribute (name)?.Value;
+
+		[Test]
+		public void PackageMarked_DefaultReferenceMembers_AreNotNull ()
+		{
+			var xml = BuildXml ("JSpecifyPackageMarked.class", "package-info.class");
+
+			var m = Method (xml, "defaultReturn");
+			Assert.AreEqual ("true", Attr (m, "return-not-null"),
+				"unannotated reference return in @NullMarked package must be not-null");
+
+			var p = m.Element ("parameter");
+			Assert.AreEqual ("true", Attr (p!, "not-null"),
+				"unannotated reference parameter in @NullMarked package must be not-null");
+
+			var f = Field (xml, "defaultField");
+			Assert.AreEqual ("true", Attr (f, "not-null"),
+				"unannotated reference field in @NullMarked package must be not-null");
+		}
+
+		[Test]
+		public void PackageMarked_PrimitiveMembers_HaveNoNotNullAttribute ()
+		{
+			var xml = BuildXml ("JSpecifyPackageMarked.class", "package-info.class");
+
+			var m = Method (xml, "primitiveReturn");
+			Assert.IsNull (Attr (m, "return-not-null"),
+				"primitive return must not get a not-null attribute");
+
+			var f = Field (xml, "primitiveField");
+			Assert.IsNull (Attr (f, "not-null"),
+				"primitive field must not get a not-null attribute");
+		}
+
+		[Test]
+		public void PackageMarked_NullableAnnotationOverridesScope ()
+		{
+			var xml = BuildXml ("JSpecifyPackageMarked.class", "package-info.class");
+
+			var m = Method (xml, "nullableReturn");
+			Assert.IsNull (Attr (m, "return-not-null"),
+				"@Nullable return must override the @NullMarked default");
+
+			var p = m.Element ("parameter");
+			Assert.IsNull (Attr (p!, "not-null"),
+				"@Nullable parameter must override the @NullMarked default");
+
+			var f = Field (xml, "nullableField");
+			Assert.IsNull (Attr (f, "not-null"),
+				"@Nullable field must override the @NullMarked default");
+		}
+
+		[Test]
+		public void PackageMarked_NullUnmarkedMethod_RevertsToUnknown ()
+		{
+			var xml = BuildXml ("JSpecifyPackageMarked.class", "package-info.class");
+
+			var m = Method (xml, "unmarkedReturn");
+			Assert.AreEqual ("true", Attr (m, "return-not-null"),
+				"method-level @NullUnmarked is not yet honored (documented limitation)");
+		}
+
+		[Test]
+		public void ClassMarked_DefaultReferenceMembers_AreNotNull ()
+		{
+			var xml = BuildXml ("JSpecifyClassMarked.class");
+
+			var m = Method (xml, "defaultReturn");
+			Assert.AreEqual ("true", Attr (m, "return-not-null"),
+				"unannotated reference return in @NullMarked class must be not-null");
+
+			var p = m.Element ("parameter");
+			Assert.AreEqual ("true", Attr (p!, "not-null"),
+				"unannotated reference parameter in @NullMarked class must be not-null");
+
+			var f = Field (xml, "defaultField");
+			Assert.AreEqual ("true", Attr (f, "not-null"),
+				"unannotated reference field in @NullMarked class must be not-null");
+		}
+
+		[Test]
+		public void ClassMarked_NullableOverrides ()
+		{
+			var xml = BuildXml ("JSpecifyClassMarked.class");
+
+			var m = Method (xml, "nullableReturn");
+			Assert.IsNull (Attr (m, "return-not-null"),
+				"@Nullable return must override the class-level @NullMarked default");
+
+			var p = m.Element ("parameter");
+			Assert.IsNull (Attr (p!, "not-null"),
+				"@Nullable parameter must override the class-level @NullMarked default");
+
+			var f = Field (xml, "nullableField");
+			Assert.IsNull (Attr (f, "not-null"),
+				"@Nullable field must override the class-level @NullMarked default");
+		}
+
+		[Test]
+		public void Unmarked_NoScope_NoDefaultNotNull ()
+		{
+			var xml = BuildXml ("JSpecifyUnmarked.class");
+
+			var m = Method (xml, "defaultReturn");
+			Assert.IsNull (Attr (m, "return-not-null"),
+				"outside a @NullMarked scope, unannotated reference returns must not gain not-null");
+
+			var p = m.Element ("parameter");
+			Assert.IsNull (Attr (p!, "not-null"),
+				"outside a @NullMarked scope, unannotated reference parameters must not gain not-null");
+
+			var f = Field (xml, "defaultField");
+			Assert.IsNull (Attr (f, "not-null"),
+				"outside a @NullMarked scope, unannotated reference fields must not gain not-null");
+		}
+
+		[Test]
+		public void TypeAnnotationsAttribute_IsParsed ()
+		{
+			var c = LoadClassFile ("JSpecifyPackageMarked.class");
+			var method = c.Methods.First (m => m.Name == "nullableReturn");
+			var typeAnn = method.Attributes
+				.OfType<RuntimeInvisibleTypeAnnotationsAttribute> ()
+				.FirstOrDefault ();
+			Assert.NotNull (typeAnn,
+				"javac must emit a RuntimeInvisibleTypeAnnotations attribute for @Nullable members");
+			Assert.IsTrue (typeAnn!.Annotations.Any (a =>
+				a.Annotation.Type == "Lorg/jspecify/annotations/Nullable;"
+					&& a.TargetType == TypeAnnotationTargetType.MethodReturn),
+				"@Nullable return type annotation must be parsed with MethodReturn target");
+			Assert.IsTrue (typeAnn!.Annotations.Any (a =>
+				a.Annotation.Type == "Lorg/jspecify/annotations/Nullable;"
+					&& a.TargetType == TypeAnnotationTargetType.MethodFormalParameter
+					&& a.FormalParameterIndex == 0),
+				"@Nullable parameter type annotation must be parsed with MethodFormalParameter target");
+		}
+
+		[Test]
+		public void PackageInfo_IsRecognized ()
+		{
+			var c = LoadClassFile ("package-info.class");
+			Assert.IsTrue (c.IsPackageInfo,
+				"package-info.class must be flagged via IsPackageInfo");
+		}
+	}
+}

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/JSpecifyAnnotationTests.cs
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/JSpecifyAnnotationTests.cs
@@ -91,14 +91,17 @@ namespace Xamarin.Android.Tools.BytecodeTests
 				"@Nullable field must override the @NullMarked default");
 		}
 
+		// `@NullUnmarked` on a method is intentionally not honored yet
+		// (only class- and package-level scope are). This test pins the
+		// current behavior so the limitation is visible.
 		[Test]
-		public void PackageMarked_NullUnmarkedMethod_RevertsToUnknown ()
+		public void PackageMarked_MethodLevelNullUnmarked_IsNotYetHonored ()
 		{
 			var xml = BuildXml ("JSpecifyPackageMarked.class", "package-info.class");
 
 			var m = Method (xml, "unmarkedReturn");
 			Assert.AreEqual ("true", Attr (m, "return-not-null"),
-				"method-level @NullUnmarked is not yet honored (documented limitation)");
+				"method-level @NullUnmarked is not yet honored; the package-level @NullMarked scope still applies");
 		}
 
 		[Test]

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/JSpecifyAnnotationTests.cs
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/JSpecifyAnnotationTests.cs
@@ -183,6 +183,34 @@ namespace Xamarin.Android.Tools.BytecodeTests
 		}
 
 		[Test]
+		public void PackageMarked_DeclarationNullable_OverridesScope ()
+		{
+			var xml = BuildXml ("JSpecifyPackageMarked.class", "package-info.class");
+
+			var m = Method (xml, "declarationNullableReturn");
+			Assert.IsNull (Attr (m, "return-not-null"),
+				"declaration-level @Nullable return must override the @NullMarked default");
+
+			Assert.IsNull (Attr (FirstParameter (m), "not-null"),
+				"declaration-level @Nullable parameter must override the @NullMarked default");
+
+			var f = Field (xml, "declarationNullableField");
+			Assert.IsNull (Attr (f, "not-null"),
+				"declaration-level @Nullable field must override the @NullMarked default");
+		}
+
+		[Test]
+		public void PackageMarked_NestedNullable_DoesNotLeakToContainer ()
+		{
+			var xml = BuildXml ("JSpecifyPackageMarked.class", "package-info.class");
+
+			var f = Field (xml, "nestedNullableField");
+			Assert.AreEqual ("true", Attr (f, "not-null"),
+				"nested @Nullable on an inner type argument must not affect the container's nullness; "
+					+ "the field's List type is non-null in a @NullMarked scope");
+		}
+
+		[Test]
 		public void TypeAnnotationsAttribute_IsParsed ()
 		{
 			var c = LoadClassFile ("JSpecifyPackageMarked.class");

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj
@@ -35,6 +35,10 @@
 
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\xamarin\NotNullClass.class" />
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\xamarin\IJavaInterface.class" />
+    <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\jspecifytest\package-info.class" />
+    <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\jspecifytest\JSpecifyPackageMarked.class" />
+    <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\jspecifytest\JSpecifyClassMarked.class" />
+    <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\jspecifyunmarked\JSpecifyUnmarked.class" />
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\xamarin\IParameterInterface.class" />
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\xamarin\JavaAnnotation.class" />
     <EmbeddedResource Include="$(IntermediateOutputPath)classes\com\xamarin\JavaEnum.class" />

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/java/androidx/annotation/Nullable.java
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/java/androidx/annotation/Nullable.java
@@ -1,0 +1,17 @@
+package androidx.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Test-only stub of the declaration-target `androidx.annotation.Nullable`.
+ * Unlike `org.jspecify.annotations.Nullable`, this is *not* `TYPE_USE`, so
+ * it lands in `Runtime(In)visibleAnnotations` and exercises the declaration-
+ * level nullable resolution path.
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE })
+public @interface Nullable {
+}

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/java/com/jspecifytest/JSpecifyClassMarked.java
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/java/com/jspecifytest/JSpecifyClassMarked.java
@@ -1,0 +1,23 @@
+package com.jspecifytest;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Class-level `@NullMarked` inside an already-marked package, with a
+ * `@Nullable` opt-out, exercises the class-level scope code path.
+ */
+@NullMarked
+public class JSpecifyClassMarked {
+
+	public String defaultReturn (String value) {
+		return value;
+	}
+
+	public @Nullable String nullableReturn (@Nullable String value) {
+		return value;
+	}
+
+	public String defaultField;
+	public @Nullable String nullableField;
+}

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/java/com/jspecifytest/JSpecifyPackageMarked.java
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/java/com/jspecifytest/JSpecifyPackageMarked.java
@@ -1,0 +1,39 @@
+package com.jspecifytest;
+
+import org.jspecify.annotations.Nullable;
+import org.jspecify.annotations.NullUnmarked;
+
+/**
+ * Lives inside a `@NullMarked` package. Without any annotations,
+ * all reference-typed return values, parameters, and fields should
+ * be considered non-null.
+ */
+public class JSpecifyPackageMarked {
+
+	// Reference return / param / field with no annotations -> non-null.
+	public String defaultReturn (String value) {
+		return value;
+	}
+
+	public String defaultField;
+
+	// Primitive return / field — never gets a `not-null` attribute.
+	public int primitiveReturn () {
+		return 0;
+	}
+
+	public int primitiveField;
+
+	// TYPE_USE `@Nullable` overrides scope default.
+	public @Nullable String nullableReturn (@Nullable String value) {
+		return value;
+	}
+
+	public @Nullable String nullableField;
+
+	// `@NullUnmarked` at the method level reverts the scope.
+	@NullUnmarked
+	public String unmarkedReturn (String value) {
+		return value;
+	}
+}

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/java/com/jspecifytest/JSpecifyPackageMarked.java
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/java/com/jspecifytest/JSpecifyPackageMarked.java
@@ -1,6 +1,8 @@
 package com.jspecifytest;
 
-import org.jspecify.annotations.Nullable;
+import java.util.List;
+
+import androidx.annotation.Nullable;
 import org.jspecify.annotations.NullUnmarked;
 
 /**
@@ -25,13 +27,22 @@ public class JSpecifyPackageMarked {
 	public int primitiveField;
 
 	// TYPE_USE `@Nullable` overrides scope default.
-	public @Nullable String nullableReturn (@Nullable String value) {
+	public @org.jspecify.annotations.Nullable String nullableReturn (@org.jspecify.annotations.Nullable String value) {
 		return value;
 	}
 
-	public @Nullable String nullableField;
+	public @org.jspecify.annotations.Nullable String nullableField;
 
-	// `@NullUnmarked` at the method level reverts the scope.
+	// Declaration-style `@Nullable` (lives in `Runtime(In)visibleAnnotations`,
+	// not the type-annotation table) must also override the scope default.
+	@Nullable
+	public String declarationNullableReturn (@Nullable String value) {
+		return value;
+	}
+
+	@Nullable
+	public String declarationNullableField;
+
 	@NullUnmarked
 	public String unmarkedReturn (String value) {
 		return value;
@@ -43,4 +54,10 @@ public class JSpecifyPackageMarked {
 	public <T> T typeVariableReturn (T value) {
 		return value;
 	}
+
+	// Nested `@Nullable` on an inner type argument. The container
+	// (List) is still non-null in a `@NullMarked` scope; the inner
+	// annotation has a non-empty `type_path` and must be ignored
+	// at the top level.
+	public List<@org.jspecify.annotations.Nullable String> nestedNullableField;
 }

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/java/com/jspecifytest/JSpecifyPackageMarked.java
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/java/com/jspecifytest/JSpecifyPackageMarked.java
@@ -36,4 +36,11 @@ public class JSpecifyPackageMarked {
 	public String unmarkedReturn (String value) {
 		return value;
 	}
+
+	// Type-variable usages have parametric nullness per JSpecify;
+	// they must not gain `not-null` from the scope default even
+	// though their erased descriptor is `Ljava/lang/Object;`.
+	public <T> T typeVariableReturn (T value) {
+		return value;
+	}
 }

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/java/com/jspecifytest/package-info.java
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/java/com/jspecifytest/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package com.jspecifytest;
+
+import org.jspecify.annotations.NullMarked;

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/java/com/jspecifyunmarked/JSpecifyUnmarked.java
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/java/com/jspecifyunmarked/JSpecifyUnmarked.java
@@ -1,5 +1,6 @@
 package com.jspecifyunmarked;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -17,5 +18,11 @@ public class JSpecifyUnmarked {
 		return value;
 	}
 
+	public @NonNull String nonNullReturn (@NonNull String value) {
+		return value;
+	}
+
 	public String defaultField;
+
+	public @NonNull String nonNullField = "";
 }

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/java/com/jspecifyunmarked/JSpecifyUnmarked.java
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/java/com/jspecifyunmarked/JSpecifyUnmarked.java
@@ -1,0 +1,21 @@
+package com.jspecifyunmarked;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Class in a package with no `package-info.class` and no class-level
+ * `@NullMarked`. Only explicit annotations should produce nullness
+ * output; the rest should be unknown (no attribute).
+ */
+public class JSpecifyUnmarked {
+
+	public String defaultReturn (String value) {
+		return value;
+	}
+
+	public @Nullable String nullableReturn (@Nullable String value) {
+		return value;
+	}
+
+	public String defaultField;
+}

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/java/org/jspecify/annotations/NonNull.java
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/java/org/jspecify/annotations/NonNull.java
@@ -1,0 +1,8 @@
+package org.jspecify.annotations;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.TYPE_USE)
+@Retention(RetentionPolicy.CLASS)
+public @interface NonNull {
+}

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/java/org/jspecify/annotations/NullMarked.java
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/java/org/jspecify/annotations/NullMarked.java
@@ -1,0 +1,15 @@
+package org.jspecify.annotations;
+
+import java.lang.annotation.*;
+
+@Target({
+    ElementType.MODULE,
+    ElementType.PACKAGE,
+    ElementType.TYPE,
+    ElementType.METHOD,
+    ElementType.CONSTRUCTOR,
+    ElementType.FIELD,
+})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NullMarked {
+}

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/java/org/jspecify/annotations/NullUnmarked.java
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/java/org/jspecify/annotations/NullUnmarked.java
@@ -1,0 +1,15 @@
+package org.jspecify.annotations;
+
+import java.lang.annotation.*;
+
+@Target({
+    ElementType.MODULE,
+    ElementType.PACKAGE,
+    ElementType.TYPE,
+    ElementType.METHOD,
+    ElementType.CONSTRUCTOR,
+    ElementType.FIELD,
+})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NullUnmarked {
+}

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/java/org/jspecify/annotations/Nullable.java
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/java/org/jspecify/annotations/Nullable.java
@@ -1,0 +1,8 @@
+package org.jspecify.annotations;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.TYPE_USE)
+@Retention(RetentionPolicy.CLASS)
+public @interface Nullable {
+}


### PR DESCRIPTION
Fixes #1335.

## Why

[JSpecify](https://jspecify.dev/) is becoming the standard way Java libraries (AndroidX, Guava, etc.) declare nullness. Unlike the older `@NonNull`/`@Nullable` declaration annotations we already recognize, JSpecify uses `TYPE_USE` annotations plus a scope-default model (`@NullMarked` on a package or class means "every reference here is non-null unless marked `@Nullable`"). The bytecode parser was missing two pieces required to consume any of this: it never read JSR 308 type annotations, and it had no notion of a scope default. As a result, generated bindings for JSpecify-annotated Java libraries were emitting reference types without `not-null="true"`, which downstream becomes nullable C# references.

## Approach

This change adds the minimum useful slice so that most APIs in a JSpecify-annotated library get correct C# nullable reference type annotations:

- **JSR 308 type-annotation parsing.** New `TypeAnnotation` type and `RuntimeVisible/InvisibleTypeAnnotationsAttribute` classes that fully parse the `target_info` discriminated union (every variant is read past, even ones we don't act on yet, so the stream stays aligned) and skip past `type_path` while remembering its length.
- **Scope detection.** `ClassPath` now retains `package-info.class` files and exposes `GetPackageInfo(packageName)`. `XmlClassDeclarationBuilder` computes `isNullMarked` from the class's own `@NullMarked`/`@NullUnmarked` plus the package-info fallback, reading from both `RuntimeVisibleAnnotations` and `RuntimeInvisibleAnnotations` (JSpecify scope annotations are `@Retention(RUNTIME)`).
- **Nullness resolution.** New `GetMethodReturnNullness`/`GetParameterNullness`/`GetFieldNullness` helpers combine declaration-level `@NonNull`, top-level `TYPE_USE` `@Nullable`/`@NonNull` annotations, and the scope default. Reference-typed slots in a null-marked scope default to `not-null="true"`; explicit `@Nullable` opts back out.

## Trade-offs and deliberately deferred

To keep the change small enough to land, the following are out of scope and tracked as known limitations (one test, `PackageMarked_NullUnmarkedMethod_RevertsToUnknown`, pins down the current behavior so it's easy to find when extending):

- Method-level `@NullUnmarked` is not honored (only class and package scope).
- Module-level `@NullMarked` is not honored.
- Inner-class scope inheritance from the enclosing class is not implemented.
- Type-path-aware nullness (e.g. `Map<@Nullable K, V>` for inner generic type arguments) is intentionally only respected at the top of the type. The parser reads `type_path` correctly so `@Nullable String[]` vs `String @Nullable[]` are distinguished by `AppliesToTopLevelType` (`type_path_length == 0`), which is the case that matters for surface API nullness.

## Tests

10 new tests in `JSpecifyAnnotationTests.cs` covering package-level `@NullMarked`, class-level `@NullMarked`, primitive exclusion, `@Nullable` opt-out at each slot kind, control unmarked classes, and direct verification that the new type-annotation attribute parses. All 92 `Xamarin.Android.Tools.Bytecode-Tests` pass.